### PR TITLE
Add more configuration options for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ IMAGE_REGISTRY ?= local
 K8S_VERSION ?= v1.13.0-alpha.3
 ACSENGINE_VERSION ?= v0.25.0
 HYPERKUBE_IMAGE ?= "gcrio.azureedge.net/google_containers/hyperkube-amd64:$(K8S_VERSION)"
+# manifest name under tests/e2e/k8s-azure/manifest
+TEST_MANIFEST ?= linux
+# build hyperkube image when specified
+K8S_BRANCH ?=
 
 IMAGE_NAME=azure-cloud-controller-manager
 IMAGE_TAG=$(shell git rev-parse --short=7 HEAD)
@@ -34,6 +38,12 @@ $(BIN_DIR)/azure-cloud-controller-manager: $(PKG_CONFIG) $(wildcard cloud-contro
 
 image:
 	docker build -t $(IMAGE) .
+
+hyperkube:
+ifneq ($(K8S_BRANCH), )
+	$(eval K8S_VERSION=$(shell REGISTRY=$(IMAGE_REGISTRY) BRANCH=$(K8S_BRANCH) scripts/build-hyperkube.sh))
+	$(eval HYPERKUBE_IMAGE=$(IMAGE_REGISTRY)/hyperkube-amd64:$(K8S_VERSION))
+endif
 
 $(PKG_CONFIG):
 	scripts/pkg-config.sh > $@
@@ -67,7 +77,7 @@ test-update: update-prepare update
 		exit 1; \
 	} \
 
-test-e2e: image
+test-e2e: image hyperkube
 	docker push $(IMAGE)
 	docker build -t $(TEST_IMAGE) \
 		--build-arg K8S_VERSION=$(K8S_VERSION) \
@@ -79,4 +89,5 @@ test-e2e: image
 		$(TEST_IMAGE) e2e -v -caccm_image=$(IMAGE) \
 		-ctype=$(SUITE) \
 		-csubject=$(SUBJECT) \
+		-cmanifest=$(TEST_MANIFEST) \
 		-chyperkube_image=$(HYPERKUBE_IMAGE)

--- a/scripts/build-hyperkube.sh
+++ b/scripts/build-hyperkube.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+TEMPPATH=$(mktemp -d)
+REGISTRY=${REGISTRY:-""}
+BRANCH=${BRANCH:-"master"}
+
+cleanup() {
+    rm -rf $TEMPPATH
+}
+
+export GOPATH=$TEMPPATH/gopath
+mkdir -p $GOPATH/src/k8s.io
+git clone https://github.com/kubernetes/kubernetes $GOPATH/src/k8s.io/kubernetes >&2
+cd $GOPATH/src/k8s.io/kubernetes
+
+trap cleanup EXIT
+
+# prefix 'origin/' is required for checking out branches.
+if ! [[ "${BRANCH}" =~ "^origin/" ]]; then
+    BRANCH="origin/$BRANCH"
+fi
+
+if [ "$BRANCH" != "" ]; then
+    git checkout -b temp $BRANCH >&2
+fi
+
+VERSION=$(git rev-parse --short=7 HEAD)
+VERSION=$VERSION REGISTRY=$REGISTRY hack/dev-push-hyperkube.sh >&2
+echo -n $VERSION

--- a/tests/k8s-azure/manifest/linux-kcm.json
+++ b/tests/k8s-azure/manifest/linux-kcm.json
@@ -1,0 +1,45 @@
+{
+    "apiVersion": "vlabs",
+    "location": "",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "1.12",
+            "kubernetesConfig": {
+                "customHyperkubeImage": "gcrio.azureedge.net/google_containers/hyperkube-amd64:v1.13.0-alpha.3",
+                "networkPolicy": "none",
+                "apiServerConfig": {
+                    "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
+                }
+            }
+        },
+        "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "{dnsPrefix}",
+            "vmSize": "Standard_F2"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "agentpool1",
+                "count": 2,
+                "vmSize": "Standard_F2",
+                "availabilityProfile": "VirtualMachineScaleSets",
+                "storageProfile": "ManagedDisks"
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "k8s-ci",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": "{keyData}"
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientID": "{servicePrincipalClientID}",
+            "secret": "{servicePrincipalClientSecret}"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds more configuration options for e2e tests, which enables to run the e2e tests with kube-controller-manager mode, e.g.

```sh
export IMAGE_REGISTRY=<registry>
export K8S_BRANCH=release-1.12
export TEST_MANIFEST=linux-kcm
make test-e2e
```

