### PR TITLE
Add build-images and push-images targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ build-ccm-image:
 build-node-image:
 	docker build -t $(NODE_MANAGER_IMAGE) -f Dockerfile.node .
 
+.PHONY: build-images
+build-images: build-ccm-image build-node-image
+
 .PHONY: image
 image: build-ccm-image build-node-image
 
@@ -90,6 +93,9 @@ push-node-image:
 
 .PHONY: push
 push: push-ccm-image push-node-image
+
+.PHONY: push-images
+push-images: push-ccm-image push-node-image
 
 hyperkube:
 ifneq ($(K8S_BRANCH), )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

 /kind failing-test

**What this PR does / why we need it**:

Add build-images and push-images targets, which is required for test job `post-provider-azure-push-images`.

Refer the build logs [here](https://storage.googleapis.com/kubernetes-jenkins/logs/post-provider-azure-push-images/1210164482425229312/artifacts/build.log):

```sh
IMAGE_REGISTRY=gcr.io/k8s-staging-provider-azure make build-images push-images
make[1]: Entering directory '/workspace'
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
make[1]: Leaving directory '/workspace'
make[1]: *** No rule to make target 'build-images'.  Stop.
make: *** [Makefile:193: release-staging] Error 2
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```

/assign @nilo19 