### PR TITLE
Fixes flakiness in cloud-provider-azure-autoscaling job

### DIFF
--- a/tests/e2e/autoscaling/autoscaler.go
+++ b/tests/e2e/autoscaling/autoscaler.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -116,7 +116,7 @@ var _ = Describe("Cluster size autoscaler [Serial][Slow]", func() {
 
 		By("Scale up")
 		targetNodeCount := initNodeCount + 1
-		err = utils.WaitAutoScaleNodes(cs, targetNodeCount)
+		err = utils.WaitAutoScaleNodes(cs, targetNodeCount, false)
 		Expect(err).NotTo(HaveOccurred())
 		err = utils.LogPodStatus(cs, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
@@ -128,7 +128,7 @@ var _ = Describe("Cluster size autoscaler [Serial][Slow]", func() {
 		_, err = cs.AppsV1().Deployments(ns.Name).Update(deployment)
 		Expect(err).NotTo(HaveOccurred())
 		targetNodeCount = initNodeCount
-		err = utils.WaitAutoScaleNodes(cs, targetNodeCount)
+		err = utils.WaitAutoScaleNodes(cs, targetNodeCount, true)
 		Expect(err).NotTo(HaveOccurred())
 		err = utils.LogPodStatus(cs, ns.Name)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/utils/node_utils.go
+++ b/tests/e2e/utils/node_utils.go
@@ -159,7 +159,7 @@ func deleteNode(cs clientset.Interface, name string) error {
 }
 
 // WaitAutoScaleNodes returns nodes count after autoscaling in 30 minutes
-func WaitAutoScaleNodes(cs clientset.Interface, targetNodeCount int) error {
+func WaitAutoScaleNodes(cs clientset.Interface, targetNodeCount int, isScaleDown bool) error {
 	Logf(fmt.Sprintf("waiting for auto-scaling the node... Target node count: %v", targetNodeCount))
 	var nodes []v1.Node
 	var err error
@@ -178,7 +178,7 @@ func WaitAutoScaleNodes(cs clientset.Interface, targetNodeCount int) error {
 			return false, err
 		}
 		Logf("Detect %v nodes, target %v", len(nodes), targetNodeCount)
-		return targetNodeCount == len(nodes), nil
+		return (targetNodeCount > len(nodes) && isScaleDown) || targetNodeCount == len(nodes), nil
 	}) == wait.ErrWaitTimeout {
 		return fmt.Errorf("Fail to get target node count in limited time")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
The job fails sometimes because the test case assumes a scale-down operation from 3 nodes to 2 nodes. However, kube-system pods are occasionally all scheduled to one worker nodes, causing 2 out of the 3 nodes to be eligible for removal. E.g.
```
cluster.go:107] Fast evaluation: node k8s-agentpool1-12501402-vmss000000 cannot be removed: non-daemonset, non-mirrored, non-pdb-assigned kube-system pod present: csi-azurefile-controller-7d4c748f9d-r4jnj
cluster.go:107] Fast evaluation: node k8s-agentpool1-12501402-vmss000000 cannot be removed: non-daemonset, non-mirrored, non-pdb-assigned kube-system pod present: kubernetes-dashboard-65966766b9-vpn4t
scale_down.go:716] k8s-agentpool1-12501402-vmss000001 was unneeded for 10m0.254198459s
scale_down.go:716] k8s-agentpool1-12501402-vmss000002 was unneeded for 10m0.254198459s
scale_down.go:944] Scale-down: removing empty node k8s-agentpool1-12501402-vmss000001
scale_down.go:944] Scale-down: removing empty node k8s-agentpool1-12501402-vmss000002
```
With this scenario, CA will scale down from 3 nodes to 1 node, causing the test case to time out and fail. This PR tolerates this scenario, i.e. allow CA to scale down to node count lower than `targetNodeCount`.

/assign @feiskyer 

**Special notes for your reviewer**:


**Release note**:
```

```
