### PR TITLE
test: fix flaky autoscaler e2e test

### DIFF
--- a/tests/e2e/autoscaling/autoscaler.go
+++ b/tests/e2e/autoscaling/autoscaler.go
@@ -87,7 +87,7 @@ var _ = Describe("Cluster size autoscaler [Serial][Slow]", func() {
 		}
 		utils.Logf("Initial number of cores: %vm", initNodeCapacity.MilliValue())
 
-		runningQuantity, err := utils.GetAvailableNodeCapacity(cs)
+		runningQuantity, err := utils.GetAvailableNodeCapacity(cs, initNodesNames)
 		Expect(err).NotTo(HaveOccurred())
 		emptyQuantity := initNodeCapacity.DeepCopy()
 		emptyQuantity.Sub(runningQuantity)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

In `GetAvailableNodeCapacity()`, we should check whether a pod is in a schedulable node instead of master node. It looks like the function could include some pods that are from nodes that are in the process of being eliminated by a previous test case, causing it to return a higher-than-expected number and scale-up is not being triggered in the next test case. This only happens when `should scale up or down if deployment replicas leave nodes busy or idle` scaled down from 3 nodes to 1 node.

Example failures:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/cloud-provider-azure-autoscaling/1229531331432550402
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/cloud-provider-azure-autoscaling/1229168176424554497

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
None
```
