### PR TITLE
test: prevent nil pointer dereference in nsg test case

### DIFF
--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -181,8 +181,9 @@ var _ = Describe("Network security group", func() {
 		Expect(len(*rules)).NotTo(Equal(0))
 		var found bool
 		for _, rule := range *rules {
-			if strings.Contains(*rule.SourceAddressPrefix, "AzureCloud") {
+			if rule.SourceAddressPrefix != nil && strings.Contains(*rule.SourceAddressPrefix, "AzureCloud") {
 				found = true
+				break
 			}
 		}
 		Expect(found).To(BeTrue())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fixes the following error:

```
2020-02-29T02:31:03.2173802Z Network security group
2020-02-29T02:31:03.2175059Z [90m/home/azureuser/agent_5/_work/28/s/go/src/sigs.k8s.io/cloud-provider-azure/tests/e2e/network/network_security_group.go:39[0m
2020-02-29T02:31:03.2175815Z   can share a rule for multiple services
2020-02-29T02:31:03.2177370Z   [90m/home/azureuser/agent_5/_work/28/s/go/src/sigs.k8s.io/cloud-provider-azure/tests/e2e/network/network_security_group.go:137[0m
2020-02-29T02:31:03.2179996Z [90m------------------------------[0m
2020-02-29T02:31:03.2180779Z [0mNetwork security group[0m 
2020-02-29T02:31:03.2181744Z   [1mcan set source IP prefixes automatically according to corresponding service tag[0m
2020-02-29T02:31:03.2183155Z   [37m/home/azureuser/agent_5/_work/28/s/go/src/sigs.k8s.io/cloud-provider-azure/tests/e2e/network/network_security_group.go:168[0m
2020-02-29T02:31:03.2184001Z Feb 29 02:31:03.216: INFO: Creating a kubernetes client
2020-02-29T02:31:03.2194251Z Feb 29 02:31:03.217: INFO: Creating a test namespace
2020-02-29T02:31:03.2505652Z Feb 29 02:31:03.250: INFO: Creating a kubernetes client
2020-02-29T02:31:03.3098707Z Feb 29 02:31:03.309: INFO: Creating deployment nsg-test
2020-02-29T02:31:03.3399003Z [1mSTEP[0m: Creating service and wait it to expose
2020-02-29T02:31:03.4133100Z Feb 29 02:31:03.412: INFO: Successfully created LoadBalancer service nsg-test in namespace e2e-tests-nsg-4qkr4
2020-02-29T02:31:03.4134569Z Feb 29 02:31:03.412: INFO: waiting for service nsg-test to be exposured
2020-02-29T02:31:03.4567759Z Feb 29 02:31:03.456: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:31:13.4891808Z Feb 29 02:31:13.488: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:31:23.4927557Z Feb 29 02:31:23.492: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:31:33.4868016Z Feb 29 02:31:33.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:31:43.4869302Z Feb 29 02:31:43.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:31:53.4867462Z Feb 29 02:31:53.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:32:03.4867248Z Feb 29 02:32:03.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:32:13.4867398Z Feb 29 02:32:13.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:32:23.4872769Z Feb 29 02:32:23.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:32:33.4868980Z Feb 29 02:32:33.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:32:43.4876047Z Feb 29 02:32:43.487: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:32:53.4876238Z Feb 29 02:32:53.487: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:33:03.4875376Z Feb 29 02:33:03.487: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:33:13.4882220Z Feb 29 02:33:13.487: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:33:23.4879234Z Feb 29 02:33:23.487: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:33:33.4871855Z Feb 29 02:33:33.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:33:43.4872822Z Feb 29 02:33:43.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:33:53.4871889Z Feb 29 02:33:53.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:34:03.4871766Z Feb 29 02:34:03.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:34:13.4875457Z Feb 29 02:34:13.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:34:23.4871004Z Feb 29 02:34:23.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:34:33.4869803Z Feb 29 02:34:33.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:34:43.4872034Z Feb 29 02:34:43.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:34:53.4874468Z Feb 29 02:34:53.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:35:03.4873962Z Feb 29 02:35:03.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:35:13.4870922Z Feb 29 02:35:13.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:35:23.4877232Z Feb 29 02:35:23.487: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:35:33.4873522Z Feb 29 02:35:33.486: INFO: Fail to find ingress, retry it in 10 seconds
2020-02-29T02:35:43.4876959Z Feb 29 02:35:43.487: INFO: Exposure successfully, get external ip: 52.138.65.125
2020-02-29T02:35:43.4880592Z [1mSTEP[0m: Validating if the corresponding IP prefix existing in nsg
2020-02-29T02:35:43.4881426Z Feb 29 02:35:43.487: INFO: Getting virtual network list
2020-02-29T02:35:43.9159050Z Feb 29 02:35:43.915: INFO: Deleting namespace e2e-tests-nsg-4qkr4
2020-02-29T02:41:50.0152861Z 
2020-02-29T02:41:50.0155636Z [91m[1mâ€¢! Panic [646.798 seconds][0m
2020-02-29T02:41:50.0156338Z Network security group
2020-02-29T02:41:50.0157917Z [90m/home/azureuser/agent_5/_work/28/s/go/src/sigs.k8s.io/cloud-provider-azure/tests/e2e/network/network_security_group.go:39[0m
2020-02-29T02:41:50.0160483Z   [91m[1mcan set source IP prefixes automatically according to corresponding service tag [It][0m
2020-02-29T02:41:50.0167144Z   [90m/home/azureuser/agent_5/_work/28/s/go/src/sigs.k8s.io/cloud-provider-azure/tests/e2e/network/network_security_group.go:168[0m
2020-02-29T02:41:50.0167926Z 
2020-02-29T02:41:50.0168900Z   [91m[1mTest Panicked[0m
2020-02-29T02:41:50.0170188Z   [91mruntime error: invalid memory address or nil pointer dereference[0m
2020-02-29T02:41:50.0171751Z   /usr/lib/go-1.13/src/runtime/panic.go:199
2020-02-29T02:41:50.0172256Z 
2020-02-29T02:41:50.0173132Z   [91mFull Stack Trace[0m
2020-02-29T02:41:50.0174006Z   sigs.k8s.io/cloud-provider-azure/tests/e2e/network.glob..func2.5()
2020-02-29T02:41:50.0175328Z   	/home/azureuser/agent_5/_work/28/s/go/src/sigs.k8s.io/cloud-provider-azure/tests/e2e/network/network_security_group.go:184 +0x575
2020-02-29T02:41:50.0176849Z   github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc00033bc80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-02-29T02:41:50.0178505Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/leafnodes/runner.go:113 +0xb8
2020-02-29T02:41:50.0179915Z   github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0xc00033bc80, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-02-29T02:41:50.0180858Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/leafnodes/runner.go:64 +0xcf
2020-02-29T02:41:50.0182174Z   github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run(0xc0003233c0, 0x20ceca0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-02-29T02:41:50.0183240Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/leafnodes/it_node.go:26 +0x64
2020-02-29T02:41:50.0184117Z   github.com/onsi/ginkgo/internal/spec.(*Spec).runSample(0xc000364d20, 0x0, 0x20ceca0, 0xc000112880)
2020-02-29T02:41:50.0185002Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/spec/spec.go:215 +0x5b5
2020-02-29T02:41:50.0185833Z   github.com/onsi/ginkgo/internal/spec.(*Spec).Run(0xc000364d20, 0x20ceca0, 0xc000112880)
2020-02-29T02:41:50.0186661Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/spec/spec.go:138 +0x101
2020-02-29T02:41:50.0187537Z   github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec(0xc0005e6780, 0xc000364d20, 0x0)
2020-02-29T02:41:50.0188435Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/specrunner/spec_runner.go:200 +0x10f
2020-02-29T02:41:50.0189316Z   github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs(0xc0005e6780, 0x1)
2020-02-29T02:41:50.0190202Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/specrunner/spec_runner.go:170 +0x120
2020-02-29T02:41:50.0191073Z   github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0xc0005e6780, 0xc00056d238)
2020-02-29T02:41:50.0191964Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/specrunner/spec_runner.go:66 +0x117
2020-02-29T02:41:50.0193067Z   github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc0000e2280, 0x7f941a378f98, 0xc00023ae00, 0x1e3ae3d, 0x1e, 0xc0000ed0e0, 0x2, 0x2, 0x2127e20, 0xc000112880, ...)
2020-02-29T02:41:50.0194164Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/internal/suite/suite.go:62 +0x42b
2020-02-29T02:41:50.0195112Z   github.com/onsi/ginkgo.RunSpecsWithCustomReporters(0x20d0480, 0xc00023ae00, 0x1e3ae3d, 0x1e, 0xc0000ecfa0, 0x2, 0x2, 0x2)
2020-02-29T02:41:50.0196019Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/ginkgo_dsl.go:221 +0x217
2020-02-29T02:41:50.0196975Z   github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters(0x20d0480, 0xc00023ae00, 0x1e3ae3d, 0x1e, 0xc0001b2300, 0x1, 0x1, 0x1)
2020-02-29T02:41:50.0197910Z   	/home/azureuser/agent_5/_work/28/s/go/pkg/mod/github.com/onsi/ginkgo@v1.10.1/ginkgo_dsl.go:209 +0xad
2020-02-29T02:41:50.0199367Z   sigs.k8s.io/cloud-provider-azure/tests/e2e.TestAzureTest(0xc00023ae00)
2020-02-29T02:41:50.0200583Z   	/home/azureuser/agent_5/_work/28/s/go/src/sigs.k8s.io/cloud-provider-azure/tests/e2e/e2e_test.go:55 +0xff
2020-02-29T02:41:50.0201271Z   testing.tRunner(0xc00023ae00, 0x1ef62b0)
2020-02-29T02:41:50.0202143Z   	/usr/lib/go-1.13/src/testing/testing.go:909 +0xc9
2020-02-29T02:41:50.0202620Z   created by testing.(*T).Run
2020-02-29T02:41:50.0203443Z   	/usr/lib/go-1.13/src/testing/testing.go:960 +0x350
```

/assign @feiskyer 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
