### PR TITLE
fix: fix autoscaling job

### DIFF
--- a/hack/log-dump/log-dump.sh
+++ b/hack/log-dump/log-dump.sh
@@ -96,7 +96,7 @@ function dump-log() {
   for log_file in "${log_files[@]}"; do
     if [[ "$(should-export-log "${log_file}" "${is_master}")" == "true" ]]; then
       echo "Dumping ${log_file}"
-      kubectl exec "${pod_name}" -- cat "${log_dir}/${log_file}" || true > "${dir}/${log_file}"
+      kubectl exec "${pod_name}" -- cat "${log_dir}/${log_file}" > "${dir}/${log_file}"
     fi
   done
 
@@ -111,7 +111,7 @@ function dump-systemd-log() {
   local -r dir="${2}"
   for systemd_service in "${systemd_services[@]}"; do
     echo "Dumping ${systemd_service}.log"
-    kubectl exec "${pod_name}" -- journalctl --output=short-precise -u "${systemd_service}" || true > "${dir}/${systemd_service}.log"
+    kubectl exec "${pod_name}" -- journalctl --output=short-precise -u "${systemd_service}" > "${dir}/${systemd_service}.log"
   done
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -27,6 +28,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"k8s.io/klog"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	_ "sigs.k8s.io/cloud-provider-azure/tests/e2e/auth"
 	_ "sigs.k8s.io/cloud-provider-azure/tests/e2e/autoscaling"
@@ -38,7 +40,19 @@ const (
 	defaultReportDir = "_report/"
 )
 
+// handleFlags sets up all flags and parses the command line.
+func handleFlags() {
+	framework.RegisterCommonFlags(flag.CommandLine)
+	framework.RegisterClusterFlags(flag.CommandLine)
+	flag.Parse()
+}
+
 func TestAzureTest(t *testing.T) {
+	// Register test flags, then parse flags.
+	handleFlags()
+
+	framework.AfterReadingAllFlags(&framework.TestContext)
+
 	RegisterFailHandler(Fail)
 	reportDir := os.Getenv(reportDirEnv)
 	if reportDir == "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes test regression (https://testgrid.k8s.io/provider-azure-cloud-provider-azure#cloud-provider-azure-autoscaling) introduced by https://github.com/kubernetes-sigs/cloud-provider-azure/pull/345.

**Special notes for your reviewer**:


**Release note**:
```
None
```
