### PR TITLE
Increase the e2e test coverage for cluster autoscaler

### DIFF
--- a/tests/e2e/network/node.go
+++ b/tests/e2e/network/node.go
@@ -35,11 +35,16 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
 )
 
-var vmProviderIDRE = regexp.MustCompile(`azure:///subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachines/(.+)`)
-var vmssVMProviderIDRE = regexp.MustCompile(`azure:///subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(\d+)`)
-var vmNameRE = regexp.MustCompile(`(k8s-.+-\d+)-.+`)
-var vmssVMZoneLabelKey = "failure-domain.beta.kubernetes.io/zone"
-var vmssScaleUpCelling = 10
+const (
+	vmssVMZoneLabelKey = "failure-domain.beta.kubernetes.io/zone"
+	vmssScaleUpCelling = 10
+)
+
+var (
+	vmProviderIDRE     = regexp.MustCompile(`azure:///subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachines/(.+)`)
+	vmssVMProviderIDRE = regexp.MustCompile(`azure:///subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(\d+)`)
+	vmNameRE           = regexp.MustCompile(`(k8s-.+-\d+)-.+`)
+)
 
 var _ = Describe("Azure node resources", func() {
 	basename := "node-resources"

--- a/tests/e2e/utils/pod_utils.go
+++ b/tests/e2e/utils/pod_utils.go
@@ -36,8 +36,8 @@ const (
 // PodIPRE tests if there's a valid IP in a easy way
 var PodIPRE = regexp.MustCompile(`\d{0,3}\.\d{0,3}\.\d{0,3}\.\d{0,3}`)
 
-// getPodList is a wrapper around listing pods
-func getPodList(cs clientset.Interface, ns string) (*v1.PodList, error) {
+// GetPodList is a wrapper around listing pods
+func GetPodList(cs clientset.Interface, ns string) (*v1.PodList, error) {
 	var pods *v1.PodList
 	var err error
 	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
@@ -57,7 +57,7 @@ func getPodList(cs clientset.Interface, ns string) (*v1.PodList, error) {
 
 // LogPodStatus logs the rate of pending
 func LogPodStatus(cs clientset.Interface, ns string) error {
-	pods, err := getPodList(cs, ns)
+	pods, err := GetPodList(cs, ns)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func LogPodStatus(cs clientset.Interface, ns string) error {
 // DeletePodsInNamespace deletes all pods in the namespace
 func DeletePodsInNamespace(cs clientset.Interface, ns string) error {
 	Logf("Deleting all pods in namespace %s", ns)
-	pods, err := getPodList(cs, ns)
+	pods, err := GetPodList(cs, ns)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -180,8 +180,8 @@ func obtainConfig() *clientcmdapi.Config {
 	return c
 }
 
-// stringInSlice check if string in a list
-func stringInSlice(s string, list []string) bool {
+// StringInSlice check if string in a list
+func StringInSlice(s string, list []string) bool {
 	for _, item := range list {
 		if item == s {
 			return true

--- a/tests/e2e/utils/vmss_utils.go
+++ b/tests/e2e/utils/vmss_utils.go
@@ -28,8 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var vmssVMRE = regexp.MustCompile(`/subscriptions/(?:.*)/resourceGroups/(?:.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(?:\d+)`)
-var errVMSSNotFound = fmt.Errorf("cannot find any VMSS")
+var (
+	vmssVMRE        = regexp.MustCompile(`/subscriptions/(?:.*)/resourceGroups/(?:.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(?:\d+)`)
+	errVMSSNotFound = fmt.Errorf("cannot find any VMSS")
+)
 
 // FindTestVMSS returns the first VMSS in the resource group,
 // assume the VMSS is in the cluster
@@ -220,4 +222,9 @@ func GetVMSSVMComputerName(vm *azcompute.VirtualMachineScaleSetVM) (string, erro
 	}
 
 	return *vm.OsProfile.ComputerName, nil
+}
+
+// IsSpotVMSS checks whether the vmss support azure spot vm instance
+func IsSpotVMSS(vmss *azcompute.VirtualMachineScaleSet) bool {
+	return vmss.VirtualMachineProfile.Priority == azcompute.Spot
 }

--- a/tests/k8s-azure/manifest/linux.json
+++ b/tests/k8s-azure/manifest/linux.json
@@ -14,7 +14,8 @@
                 },
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
-                }
+                },
+                "loadBalancerSku": "standard"
             }
         },
         "masterProfile": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug


/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Add several E2E cases for cluster autoscaler, which includes:

- scale multiple node groups together with `--balance-node-groups=true`
- scale single node group slowly
- scale multiple node groups quickly
- scale Spot VMSS
- scale node groups with GPU consumptions

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
