### PR TITLE
Ensure subnet is deleted

### DIFF
--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -83,13 +83,12 @@ var _ = Describe("Network security group", func() {
 
 	It("should add the rule when expose a service", func() {
 		By("Creating a service and expose it")
-		ip, err := createAndWaitServiceExposure(cs, ns.Name, serviceName, map[string]string{}, labels, ports)
+		ip := createDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, map[string]string{}, ports)
 		defer func() {
 			By("Cleaning up")
-			err = utils.DeleteServiceIfExists(cs, ns.Name, serviceName)
+			err := utils.DeleteServiceIfExists(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating ip exists in Security Group")
 		port := fmt.Sprintf("%v", nginxPort)
@@ -101,6 +100,7 @@ var _ = Describe("Network security group", func() {
 		var code int
 		url := fmt.Sprintf("http://%s:%v", ip, ports[0].Port)
 		for i := 1; i <= 30; i++ {
+			utils.Logf("round %d, GET %s", i, url)
 			resp, err := http.Get(url)
 			if err == nil {
 				defer func() {
@@ -134,44 +134,12 @@ var _ = Describe("Network security group", func() {
 		Expect(isDeleted).To(BeTrue(), "Fail to automatically delete the rule")
 	})
 
-	It("can share a rule for multiple services", func() {
-		By("Exposing two services with shared security rule")
-		annotation := map[string]string{
-			azure.ServiceAnnotationSharedSecurityRule: "true",
-		}
-		ip1, err := createAndWaitServiceExposure(cs, ns.Name, serviceName, annotation, labels, ports)
-
-		defer func() {
-			err = utils.DeleteServiceIfExists(cs, ns.Name, serviceName)
-			Expect(err).NotTo(HaveOccurred())
-		}()
-		Expect(err).NotTo(HaveOccurred())
-
-		serviceName2 := serviceName + "-share"
-		ip2, err := createAndWaitServiceExposure(cs, ns.Name, serviceName2, annotation, labels, ports)
-		defer func() {
-			By("Cleaning up")
-			err = utils.DeleteServiceIfExists(cs, ns.Name, serviceName2)
-			Expect(err).NotTo(HaveOccurred())
-		}()
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Validate shared security rule exists")
-		port := fmt.Sprintf("%v", nginxPort)
-		nsg, err := tc.GetClusterSecurityGroup()
-		Expect(err).NotTo(HaveOccurred())
-
-		ipList := []string{ip1, ip2}
-		Expect(validateSharedSecurityRuleExists(nsg, ipList, port)).To(BeTrue(), "Security rule for service %s not exists", serviceName)
-	})
-
 	It("can set source IP prefixes automatically according to corresponding service tag", func() {
 		By("Creating service and wait it to expose")
 		annotation := map[string]string{
 			azure.ServiceAnnotationAllowedServiceTag: "AzureCloud",
 		}
-		_, err := createAndWaitServiceExposure(cs, ns.Name, serviceName, annotation, labels, ports)
-		Expect(err).NotTo(HaveOccurred())
+		_ = createDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
 
 		By("Validating if the corresponding IP prefix existing in nsg")
 		nsg, err := tc.GetClusterSecurityGroup()
@@ -211,7 +179,7 @@ func validateSharedSecurityRuleExists(nsg *aznetwork.SecurityGroup, ips []string
 		if strings.EqualFold(to.String(securityRule.DestinationPortRange), port) {
 			isFind := true
 			for _, ip := range ips {
-				if !stringInListPtr(securityRule.DestinationAddressPrefixes, ip) {
+				if !utils.StringInSlice(ip, *securityRule.DestinationAddressPrefixes) {
 					utils.Logf("Find target security rule")
 					isFind = false
 					break
@@ -220,31 +188,6 @@ func validateSharedSecurityRuleExists(nsg *aznetwork.SecurityGroup, ips []string
 			if isFind {
 				return true
 			}
-		}
-	}
-	return false
-}
-
-func createAndWaitServiceExposure(cs clientset.Interface, ns string, serviceName string, annotation map[string]string, labels map[string]string, ports []v1.ServicePort) (string, error) {
-	ip := ""
-	service := utils.CreateLoadBalancerServiceManifest(cs, serviceName, annotation, labels, ns, ports)
-	if _, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{}); err != nil {
-		return ip, err
-	}
-	utils.Logf("Successfully created LoadBalancer service " + serviceName + " in namespace " + ns)
-	utils.Logf("waiting for service %s to be exposured", serviceName)
-	ip, err := utils.WaitServiceExposure(cs, ns, serviceName)
-	return ip, err
-}
-
-// stringInListPtr check if string in a list
-func stringInListPtr(list *[]string, s string) bool {
-	if list == nil {
-		return false
-	}
-	for _, item := range *list {
-		if strings.EqualFold(item, s) {
-			return true
 		}
 	}
 	return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In basic LB e2e tests, newly created subnets may not be deleted correctly for some reason, this pr ensures the subnet is deleted after moving forward. Also refactoring some test cases.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
