### PR TITLE
Increase timeout to 30 min when waiting the statefulsets to be ready

### DIFF
--- a/tests/e2e/autoscaling/autoscaler.go
+++ b/tests/e2e/autoscaling/autoscaler.go
@@ -36,10 +36,10 @@ import (
 )
 
 const (
-	podSize     int64 = 200 // podSize to create, 200m, 0.2 core
-	poll              = 10 * time.Second
-	pollTimeout       = 10 * time.Minute
-	execTimeout       = 10 * time.Second
+	podSize            int64 = 200 // podSize to create, 200m, 0.2 core
+	poll                     = 10 * time.Second
+	statefulSetTimeout       = 30 * time.Minute
+	execTimeout              = 10 * time.Second
 
 	agentpoolLabelKey               = "agentpool"
 	kubeSystemNamespace             = "kube-system"
@@ -523,7 +523,7 @@ func createStatefulSetWithPVCManifest(name string, replicas int32, label map[str
 }
 
 func waitForStatefulSetComplete(cs clientset.Interface, ns *v1.Namespace, ss *appsv1.StatefulSet) error {
-	err := wait.PollImmediate(poll, pollTimeout, func() (bool, error) {
+	err := wait.PollImmediate(poll, statefulSetTimeout, func() (bool, error) {
 		var err error
 		statefulSet, err := cs.AppsV1().StatefulSets(ns.Name).Get(context.TODO(), ss.Name, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Increase timeout to 30 min when waiting the statefulsets to be ready.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
