### PR TITLE
Made load balancer and public ip extended location aware.

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -133,6 +133,12 @@ type Config struct {
 	ResourceGroup string `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
 	// The location of the resource group that the cluster is deployed in
 	Location string `json:"location,omitempty" yaml:"location,omitempty"`
+	// The name of site where the cluster will be deployed to that is more granular than the region specified by the "location" field.
+	// Currently only public ip and load balancer support this.
+	ExtendedLocationName string `json:"extendedLocationName,omitempty" yaml:"extendedLocationName,omitempty"`
+	// The type of site that is being targeted.
+	// Currently only public ip and load balancer support this.
+	ExtendedLocationType string `json:"extendedLocationType,omitempty" yaml:"extendedLocationType,omitempty"`
 	// The name of the VNet that the cluster is deployed in
 	VnetName string `json:"vnetName,omitempty" yaml:"vnetName,omitempty"`
 	// The name of the resource group that the Vnet is deployed in
@@ -234,6 +240,11 @@ type Config struct {
 	// includes load balancer, security group and route table. The supported format is `a=b,c=d,...`. After updated
 	// this config, the old tags would be replaced by the new ones.
 	Tags string `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// HasExtendedLocation returns true if extendedlocation prop are specified.
+func (config *Config) HasExtendedLocation() bool {
+	return config.ExtendedLocationName != "" && config.ExtendedLocationType != ""
 }
 
 var (

--- a/pkg/provider/azure_fakes.go
+++ b/pkg/provider/azure_fakes.go
@@ -94,3 +94,11 @@ func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 
 	return az
 }
+
+// GetTestCloudWithExtendedLocation returns a fake azure cloud for unit tests in Azure related CSI drivers with extended location.
+func GetTestCloudWithExtendedLocation(ctrl *gomock.Controller) (az *Cloud) {
+	az = GetTestCloud(ctrl)
+	az.Config.ExtendedLocationName = "microsoftlosangeles1"
+	az.Config.ExtendedLocationType = "EdgeZone"
+	return az
+}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -550,6 +550,12 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 				Name: network.LoadBalancerSkuNameStandard,
 			}
 		}
+		if az.HasExtendedLocation() {
+			defaultLB.ExtendedLocation = &network.ExtendedLocation{
+				Name: &az.ExtendedLocationName,
+				Type: &az.ExtendedLocationType,
+			}
+		}
 	}
 
 	return defaultLB, nil, false, nil
@@ -592,6 +598,12 @@ func (az *Cloud) selectLoadBalancer(clusterName string, service *v1.Service, exi
 				Location:                     &az.Location,
 				Sku:                          &network.LoadBalancerSku{Name: loadBalancerSKU},
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
+			}
+			if az.HasExtendedLocation() {
+				selectedLB.ExtendedLocation = &network.ExtendedLocation{
+					Name: &az.ExtendedLocationName,
+					Type: &az.ExtendedLocationType,
+				}
 			}
 
 			return selectedLB, false, nil
@@ -823,6 +835,12 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		}
 		pip.Name = to.StringPtr(pipName)
 		pip.Location = to.StringPtr(az.Location)
+		if az.HasExtendedLocation() {
+			pip.ExtendedLocation = &network.ExtendedLocation{
+				Name: &az.ExtendedLocationName,
+				Type: &az.ExtendedLocationType,
+			}
+		}
 		pip.PublicIPAddressPropertiesFormat = &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.Static,
 			IPTags:                   getServiceIPTagRequestForPublicIP(service).IPTags,


### PR DESCRIPTION

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Adds extended location to the cloud config. 
If extended location is provided and a service is created, the corresponding slb and public ip are deployed with extended location.


**Special notes for your reviewer**:


**Release note**:
```
Adds extended location to the cloud config. 
If extended location is provided and a service is created, the corresponding slb and public ip are deployed with extended location.
```
