### PR TITLE
Enable more linters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,12 @@ public/
 /bazel-genfiles
 /bazel-out
 /bazel-testlogs
+
+# ssh keys
+.ssh*
+
+# vscode
+.vscode
+
+# goland
+.idea

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     - ineffassign
 #    - interfacer
 #    - maligned
-#    - misspell
+    - misspell
 #    - nakedret
 #    - prealloc
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
 #    - errorlint
 #    - goconst
 #    - gocyclo
-#    - gofmt
+    - gofmt
     - goimports
 #    - golint
 #    - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
 #    - gocyclo
     - gofmt
     - goimports
-#    - golint
+    - golint
 #    - gosec
     - gosimple
     - govet
@@ -30,3 +30,15 @@ linters:
     - varcheck
   # Run with --fast=false for more extensive checks
   fast: true
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - unused
+    - path: tests/e2e
+      linters:
+        - golint
+  #include:
+  #  - EXC0002 # include "missing comments" issues from golint
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,30 @@
 run:
   deadline: 10m
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+#    - errorlint
+#    - goconst
+#    - gocyclo
+#    - gofmt
+#    - goimports
+#    - golint
+#    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+#    - interfacer
+#    - maligned
+#    - misspell
+#    - nakedret
+#    - prealloc
+    - staticcheck
+    - structcheck
+    - typecheck
+#    - unconvert
+    - unused
+    - varcheck
+  # Run with --fast=false for more extensive checks
+  fast: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
   deadline: 10m
+skip-dirs:
+    - vendor
 linters:
   disable-all: true
   enable:
@@ -9,7 +11,7 @@ linters:
 #    - goconst
 #    - gocyclo
 #    - gofmt
-#    - goimports
+    - goimports
 #    - golint
 #    - gosec
     - gosimple

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
   enable:
     - deadcode
     - errcheck
-#    - errorlint
+    - errorlint
 #    - goconst
 #    - gocyclo
     - gofmt
@@ -32,9 +32,6 @@ linters:
   fast: true
 issues:
   exclude-rules:
-    - path: _test\.go
-      linters:
-        - unused
     - path: tests/e2e
       linters:
         - golint

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,6 @@ BIN_DIR=bin
 PKG_CONFIG=.pkg_config
 PKG_CONFIG_CONTENT=$(shell cat $(PKG_CONFIG))
 
-# TODO: fix code and enable more options
-# -E deadcode -E gocyclo -E vetshadow -E gas -E ineffassign
-GOMETALINTER_OPTION=--tests --disable-all -E gofmt -E vet -E golint -e "don't use underscores in Go names"
-
 AKSENGINE_VERSION ?= master
 
 TEST_RESULTS_DIR=testResults

--- a/cmd/cloud-controller-manager/app/core.go
+++ b/cmd/cloud-controller-manager/app/core.go
@@ -212,7 +212,7 @@ func startNodeIpamController(ctx *cloudcontrollerconfig.CompletedConfig, cloud c
 		// should be dual stack (from different IPFamilies)
 		dualstackServiceCIDR, err := netutils.IsDualStackCIDRs([]*net.IPNet{serviceCIDR, secondaryServiceCIDR})
 		if err != nil {
-			return nil, false, fmt.Errorf("failed to perform dualstack check on serviceCIDR and secondaryServiceCIDR error:%v", err)
+			return nil, false, fmt.Errorf("failed to perform dualstack check on serviceCIDR and secondaryServiceCIDR error:%w", err)
 		}
 		if !dualstackServiceCIDR {
 			return nil, false, fmt.Errorf("serviceCIDR and secondaryServiceCIDR are not dualstack (from different IPfamiles)")

--- a/cmd/cloud-controller-manager/app/core.go
+++ b/cmd/cloud-controller-manager/app/core.go
@@ -45,10 +45,10 @@ import (
 )
 
 const (
+	// IPv6DualStack enables ipv6 dual stack
+	//
 	// owner: @khenidak
 	// alpha: v1.15
-	//
-	// Enables ipv6 dual stack
 	IPv6DualStack featuregate.Feature = "IPv6DualStack"
 )
 

--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -277,7 +277,7 @@ func (o *CloudControllerManagerOptions) Config(allControllers, disabledByDefault
 	}
 
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
-		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+		return nil, fmt.Errorf("error creating self-signed certificates: %w", err)
 	}
 
 	c := &cloudcontrollerconfig.Config{}

--- a/cmd/cloud-controller-manager/app/testing/testserver.go
+++ b/cmd/cloud-controller-manager/app/testing/testserver.go
@@ -75,7 +75,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 
 	result.TmpDir, err = ioutil.TempDir("", "cloud-controller-manager")
 	if err != nil {
-		return result, fmt.Errorf("failed to create temp dir: %v", err)
+		return result, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
 	fs := pflag.NewFlagSet("test", pflag.PanicOnError)
@@ -97,7 +97,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 	if s.SecureServing.BindPort != 0 {
 		s.SecureServing.Listener, s.SecureServing.BindPort, err = createListenerOnFreePort()
 		if err != nil {
-			return result, fmt.Errorf("failed to create listener: %v", err)
+			return result, fmt.Errorf("failed to create listener: %w", err)
 		}
 		s.SecureServing.ServerCert.CertDirectory = result.TmpDir
 
@@ -107,7 +107,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 	if s.InsecureServing.BindPort != 0 {
 		s.InsecureServing.Listener, s.InsecureServing.BindPort, err = createListenerOnFreePort()
 		if err != nil {
-			return result, fmt.Errorf("failed to create listener: %v", err)
+			return result, fmt.Errorf("failed to create listener: %w", err)
 		}
 
 		t.Logf("cloud-controller-manager will listen insecurely on port %d...", s.InsecureServing.BindPort)
@@ -115,7 +115,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 
 	config, err := s.Config(all, disabled)
 	if err != nil {
-		return result, fmt.Errorf("failed to create config from options: %v", err)
+		return result, fmt.Errorf("failed to create config from options: %w", err)
 	}
 
 	errCh := make(chan error)
@@ -128,7 +128,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 	t.Logf("Waiting for /healthz to be ok...")
 	client, err := kubernetes.NewForConfig(config.LoopbackClientConfig)
 	if err != nil {
-		return result, fmt.Errorf("failed to create a client: %v", err)
+		return result, fmt.Errorf("failed to create a client: %w", err)
 	}
 	err = wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
 		select {
@@ -146,7 +146,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		return false, nil
 	})
 	if err != nil {
-		return result, fmt.Errorf("failed to wait for /healthz to return ok: %v", err)
+		return result, fmt.Errorf("failed to wait for /healthz to return ok: %w", err)
 	}
 
 	// from here the caller must call tearDown
@@ -165,7 +165,7 @@ func StartTestServerOrDie(t Logger, flags []string) *TestServer {
 		return &result
 	}
 
-	t.Fatalf("failed to launch server: %v", err)
+	t.Fatalf("failed to launch server: %w", err)
 	return nil
 }
 

--- a/cmd/cloud-node-manager/app/options/options.go
+++ b/cmd/cloud-node-manager/app/options/options.go
@@ -196,7 +196,7 @@ func resyncPeriod(c *cloudnodeconfig.Config) func() time.Duration {
 // Config return a cloud controller manager config objective
 func (o *CloudNodeManagerOptions) Config() (*cloudnodeconfig.Config, error) {
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
-		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+		return nil, fmt.Errorf("error creating self-signed certificates: %w", err)
 	}
 
 	c := &cloudnodeconfig.Config{}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-00010101000000-000000000000 // indirect
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 if [[ -z "$(command -v golangci-lint)" ]]; then
   echo "Cannot find golangci-lint. Installing golangci-lint..."
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.1
   export PATH=$PATH:$(go env GOPATH)/bin
 fi
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -25,6 +25,6 @@ fi
 echo "Verifying golint"
 readonly PKG_ROOT="$(git rev-parse --show-toplevel)"
 
-golangci-lint run --config ${PKG_ROOT}/.golangci.yml
+golangci-lint run -v --config ${PKG_ROOT}/.golangci.yml
 
 echo "Congratulations! Lint check completed for all Go source files."

--- a/pkg/azureclients/armclient/mockarmclient/interface.go
+++ b/pkg/azureclients/armclient/mockarmclient/interface.go
@@ -17,14 +17,15 @@ limitations under the License.
 package mockarmclient
 
 import (
-	context "context"
-	autorest "github.com/Azure/go-autorest/autorest"
-	azure "github.com/Azure/go-autorest/autorest/azure"
-	gomock "github.com/golang/mock/gomock"
-	http "net/http"
-	reflect "reflect"
-	armclient "sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"net/http"
+	"reflect"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/containerserviceclient/mockcontainerserviceclient/interface.go
+++ b/pkg/azureclients/containerserviceclient/mockcontainerserviceclient/interface.go
@@ -17,11 +17,12 @@ limitations under the License.
 package mockcontainerserviceclient
 
 import (
-	context "context"
-	containerservice "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-04-01/containerservice"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-04-01/containerservice"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/deploymentclient/mockdeploymentclient/interface.go
+++ b/pkg/azureclients/deploymentclient/mockdeploymentclient/interface.go
@@ -17,11 +17,12 @@ limitations under the License.
 package mockdeploymentclient
 
 import (
-	context "context"
-	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/diskclient/mockdiskclient/interface.go
+++ b/pkg/azureclients/diskclient/mockdiskclient/interface.go
@@ -17,11 +17,12 @@ limitations under the License.
 package mockdiskclient
 
 import (
-	context "context"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/fileclient/azure_fileclient.go
+++ b/pkg/azureclients/fileclient/azure_fileclient.go
@@ -61,7 +61,7 @@ func (c *Client) CreateFileShare(resourceGroupName, accountName string, shareOpt
 		klog.V(2).Infof("file share(%s) under account(%s) rg(%s) already exists", shareOptions.Name, accountName, resourceGroupName)
 		return nil
 	} else if result.Response.Response == nil || (err != nil && result.Response.Response.StatusCode != http.StatusNotFound && !strings.Contains(err.Error(), "ShareNotFound")) {
-		return fmt.Errorf("failed to get file share(%s), err: %v", shareOptions.Name, err)
+		return fmt.Errorf("failed to get file share(%s), err: %w", shareOptions.Name, err)
 	}
 
 	quota := int32(shareOptions.RequestGiB)
@@ -93,7 +93,7 @@ func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, si
 
 	share, err := c.fileSharesClient.Get(context.Background(), resourceGroupName, accountName, name, storage.Stats)
 	if err != nil {
-		return fmt.Errorf("failed to get file share(%s), : %v", name, err)
+		return fmt.Errorf("failed to get file share (%s): %w", name, err)
 	}
 	if *share.FileShareProperties.ShareQuota >= quota {
 		klog.Warningf("file share size(%dGi) is already greater or equal than requested size(%dGi), accountName: %s, shareName: %s",
@@ -105,7 +105,7 @@ func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, si
 	share.FileShareProperties.ShareQuota = &quota
 	_, err = c.fileSharesClient.Update(context.Background(), resourceGroupName, accountName, name, share)
 	if err != nil {
-		return fmt.Errorf("failed to update quota on file share(%s), err: %v", name, err)
+		return fmt.Errorf("failed to update quota on file share(%s), err: %w", name, err)
 	}
 
 	klog.V(4).Infof("resize file share completed, resourceGroupName(%s), accountName: %s, shareName: %s, sizeGiB: %d", resourceGroupName, accountName, name, sizeGiB)

--- a/pkg/azureclients/fileclient/mockfileclient/interface.go
+++ b/pkg/azureclients/fileclient/mockfileclient/interface.go
@@ -17,10 +17,11 @@ limitations under the License.
 package mockfileclient
 
 import (
-	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	fileclient "sigs.k8s.io/cloud-provider-azure/pkg/azureclients/fileclient"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/fileclient"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/interfaceclient/mockinterfaceclient/interface.go
+++ b/pkg/azureclients/interfaceclient/mockinterfaceclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mockinterfaceclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/loadbalancerclient/mockloadbalancerclient/interface.go
+++ b/pkg/azureclients/loadbalancerclient/mockloadbalancerclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mockloadbalancerclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/publicipclient/mockpublicipclient/interface.go
+++ b/pkg/azureclients/publicipclient/mockpublicipclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mockpublicipclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/routeclient/mockrouteclient/interface.go
+++ b/pkg/azureclients/routeclient/mockrouteclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mockrouteclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/routetableclient/mockroutetableclient/interface.go
+++ b/pkg/azureclients/routetableclient/mockroutetableclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mockroutetableclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/securitygroupclient/mocksecuritygroupclient/interface.go
+++ b/pkg/azureclients/securitygroupclient/mocksecuritygroupclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mocksecuritygroupclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/snapshotclient/mocksnapshotclient/interface.go
+++ b/pkg/azureclients/snapshotclient/mocksnapshotclient/interface.go
@@ -17,11 +17,12 @@ limitations under the License.
 package mocksnapshotclient
 
 import (
-	context "context"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/storageaccountclient/mockstorageaccountclient/interface.go
+++ b/pkg/azureclients/storageaccountclient/mockstorageaccountclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mockstorageaccountclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
-	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/subnetclient/mocksubnetclient/interface.go
+++ b/pkg/azureclients/subnetclient/mocksubnetclient/interface.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mocksubnetclient
 
 import (
-	context "context"
-	reflect "reflect"
+	"context"
+	"reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/vmclient/azure_vmclient_test.go
+++ b/pkg/azureclients/vmclient/azure_vmclient_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -427,7 +428,9 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		vmssClient := getTestVMClient(armClient)
 		result, err := vmssClient.listNextResults(context.TODO(), lastResult)
 		if err != nil {
-			assert.Equal(t, err.(autorest.DetailedError).Message, test.expectedErrMsg)
+			detailedErr := &autorest.DetailedError{}
+			assert.True(t, errors.As(err, detailedErr))
+			assert.Equal(t, detailedErr.Message, test.expectedErrMsg)
 		} else {
 			assert.NoError(t, err)
 		}

--- a/pkg/azureclients/vmclient/mockvmclient/interface.go
+++ b/pkg/azureclients/vmclient/mockvmclient/interface.go
@@ -17,11 +17,12 @@ limitations under the License.
 package mockvmclient
 
 import (
-	context "context"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/vmsizeclient/mockvmsizeclient/interface.go
+++ b/pkg/azureclients/vmsizeclient/mockvmsizeclient/interface.go
@@ -17,11 +17,12 @@ limitations under the License.
 package mockvmsizeclient
 
 import (
-	context "context"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/vmssclient/azure_vmssclient_test.go
+++ b/pkg/azureclients/vmssclient/azure_vmssclient_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -428,7 +429,9 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		vmssClient := getTestVMSSClient(armClient)
 		result, err := vmssClient.listNextResults(context.TODO(), lastResult)
 		if err != nil {
-			assert.Equal(t, err.(autorest.DetailedError).Message, test.expectedErrMsg)
+			detailedErr := &autorest.DetailedError{}
+			assert.True(t, errors.As(err, detailedErr))
+			assert.Equal(t, detailedErr.Message, test.expectedErrMsg)
 		} else {
 			assert.NoError(t, err)
 		}

--- a/pkg/azureclients/vmssclient/mockvmssclient/interface.go
+++ b/pkg/azureclients/vmssclient/mockvmssclient/interface.go
@@ -17,13 +17,14 @@ limitations under the License.
 package mockvmssclient
 
 import (
-	context "context"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
-	azure "github.com/Azure/go-autorest/autorest/azure"
-	gomock "github.com/golang/mock/gomock"
-	http "net/http"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"net/http"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/azureclients/vmssvmclient/azure_vmssvmclient_test.go
+++ b/pkg/azureclients/vmssvmclient/azure_vmssvmclient_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -427,7 +428,9 @@ func TestListNextResultsMultiPages(t *testing.T) {
 		vmssClient := getTestVMSSVMClient(armClient)
 		result, err := vmssClient.listNextResults(context.TODO(), lastResult)
 		if err != nil {
-			assert.Equal(t, err.(autorest.DetailedError).Message, test.expectedErrMsg)
+			detailedErr := &autorest.DetailedError{}
+			assert.True(t, errors.As(err, detailedErr))
+			assert.Equal(t, detailedErr.Message, test.expectedErrMsg)
 		} else {
 			assert.NoError(t, err)
 		}
@@ -726,7 +729,7 @@ func TestUpdateVMsThrottle(t *testing.T) {
 	vmssvmClient := getTestVMSSVMClient(armClient)
 	rerr := vmssvmClient.UpdateVMs(context.TODO(), "rg", "vmss1", instances, "test")
 	assert.NotNil(t, rerr)
-	assert.Equal(t, throttleErr.Error(), fmt.Errorf(rerr.RawError.Error()))
+	assert.EqualError(t, throttleErr.Error(), rerr.RawError.Error())
 }
 
 func getTestVMSSVM(vmssName, instanceID string) compute.VirtualMachineScaleSetVM {

--- a/pkg/azureclients/vmssvmclient/mockvmssvmclient/interface.go
+++ b/pkg/azureclients/vmssvmclient/mockvmssvmclient/interface.go
@@ -17,11 +17,12 @@ limitations under the License.
 package mockvmssvmclient
 
 import (
-	context "context"
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
-	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	retry "sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"context"
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // MockInterface is a mock of Interface interface

--- a/pkg/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/nodeipam/ipam/cidr_allocator.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"time"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -75,9 +75,9 @@ type CIDRAllocator interface {
 	// AllocateOrOccupyCIDR looks at the given node, assigns it a valid
 	// CIDR if it doesn't currently have one or mark the CIDR as used if
 	// the node already have one.
-	AllocateOrOccupyCIDR(node *v1.Node) error
+	AllocateOrOccupyCIDR(node *corev1.Node) error
 	// ReleaseCIDR releases the CIDR of the removed node
-	ReleaseCIDR(node *v1.Node) error
+	ReleaseCIDR(node *corev1.Node) error
 	// Run starts all the working logic of the allocator.
 	Run(stopCh <-chan struct{})
 }
@@ -112,8 +112,8 @@ func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInfo
 	}
 }
 
-func listNodes(kubeClient clientset.Interface) (*v1.NodeList, error) {
-	var nodeList *v1.NodeList
+func listNodes(kubeClient clientset.Interface) (*corev1.NodeList, error) {
+	var nodeList *corev1.NodeList
 	// We must poll because apiserver might not be up. This error causes
 	// controller manager to restart.
 	if pollErr := wait.Poll(10*time.Second, apiserverStartupGracePeriod, func() (bool, error) {

--- a/pkg/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/nodeipam/ipam/cloud_cidr_allocator.go
@@ -255,7 +255,7 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 	cidrs, err := ca.cloud.AliasRangesByProviderID(node.Spec.ProviderID)
 	if err != nil {
 		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
-		return fmt.Errorf("failed to allocate cidr: %v", err)
+		return fmt.Errorf("failed to allocate cidr: %w", err)
 	}
 	if len(cidrs) == 0 {
 		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
@@ -263,7 +263,7 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 	}
 	_, cidr, err := net.ParseCIDR(cidrs[0])
 	if err != nil {
-		return fmt.Errorf("failed to parse string '%s' as a CIDR: %v", cidrs[0], err)
+		return fmt.Errorf("failed to parse string '%s' as a CIDR: %w", cidrs[0], err)
 	}
 	podCIDR := cidr.String()
 

--- a/pkg/nodeipam/node_ipam_controller.go
+++ b/pkg/nodeipam/node_ipam_controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package nodeipam
 
 import (
+	"net"
+
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -27,7 +29,6 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog/v2"
-	"net"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/ipam"
 )

--- a/pkg/nodeipam/node_ipam_controller_test.go
+++ b/pkg/nodeipam/node_ipam_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeipam
 
 import (
+	"errors"
 	"net"
 	"os"
 	"os/exec"
@@ -96,7 +97,8 @@ func TestNewNodeIpamControllerWithCIDRMasks(t *testing.T) {
 			err := cmd.Run()
 			var gotFatal bool
 			if err != nil {
-				exitErr, ok := err.(*exec.ExitError)
+				var exitErr *exec.ExitError
+				ok := errors.As(err, &exitErr)
 				if !ok {
 					t.Fatalf("Failed to run subprocess: %v", err)
 				}

--- a/pkg/nodemanager/mock/mock_node_provider.go
+++ b/pkg/nodemanager/mock/mock_node_provider.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mock
 
 import (
-	context "context"
+	"context"
 
 	cloudprovider "k8s.io/cloud-provider"
 

--- a/pkg/nodemanager/nodemanager_test.go
+++ b/pkg/nodemanager/nodemanager_test.go
@@ -622,7 +622,7 @@ func Test_reconcileNodeLabels(t *testing.T) {
 			factory.WaitForCacheSync(nil)
 
 			err := cnc.reconcileNodeLabels("node01")
-			if err != test.expectedErr {
+			if !errors.Is(err, test.expectedErr) {
 				t.Logf("actual err: %v", err)
 				t.Logf("expected err: %v", test.expectedErr)
 				t.Errorf("unexpected error")

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -411,11 +412,11 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 	}
 
 	servicePrincipalToken, err := auth.GetServicePrincipalToken(&config.AzureAuthConfig, env)
-	if err == auth.ErrorNoAuth {
+	if errors.Is(err, auth.ErrorNoAuth) {
 		// Only controller-manager would lazy-initialize from secret, and credentials are required for such case.
 		if fromSecret {
 			err := fmt.Errorf("no credentials provided for Azure cloud provider")
-			klog.Fatalf("%v", err)
+			klog.Fatal(err)
 			return err
 		}
 

--- a/pkg/provider/azure_config.go
+++ b/pkg/provider/azure_config.go
@@ -70,7 +70,7 @@ func (az *Cloud) getConfigFromSecret() (*Config, error) {
 
 	secret, err := az.KubeClient.CoreV1().Secrets(cloudConfigNamespace).Get(context.TODO(), cloudConfigSecretName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get secret %s: %v", cloudConfigSecretName, err)
+		return nil, fmt.Errorf("failed to get secret %s: %w", cloudConfigSecretName, err)
 	}
 
 	cloudConfigData, ok := secret.Data[cloudConfigKey]
@@ -86,7 +86,7 @@ func (az *Cloud) getConfigFromSecret() (*Config, error) {
 
 	err = yaml.Unmarshal(cloudConfigData, &config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse Azure cloud-config: %v", err)
+		return nil, fmt.Errorf("failed to parse Azure cloud-config: %w", err)
 	}
 
 	return &config, nil

--- a/pkg/provider/azure_controller_vmss_test.go
+++ b/pkg/provider/azure_controller_vmss_test.go
@@ -87,7 +87,7 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 			isManagedDisk:  false,
 			existedDisk:    compute.Disk{Name: to.StringPtr("disk-name")},
 			expectedErr:    true,
-			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: instance not found"),
+			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: %w", fmt.Errorf("instance not found")),
 		},
 	}
 
@@ -142,7 +142,9 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 		}
 		err = ss.AttachDisk(test.vmssvmName, diskMap)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
-		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected error: %v, return error: %v", i, test.desc, test.expectedErrMsg, err)
+		if test.expectedErr {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected error: %v, return error: %v", i, test.desc, test.expectedErrMsg, err)
+		}
 	}
 }
 
@@ -186,7 +188,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 			vmssvmName:     "vmss00-vm-000000",
 			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
 			expectedErr:    true,
-			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: instance not found"),
+			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: %w", fmt.Errorf("instance not found")),
 		},
 		{
 			desc:        "no error shall be returned if everything is good and the attaching disk does not match data disk",
@@ -241,7 +243,9 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 		}
 		err = ss.DetachDisk(test.vmssvmName, diskMap)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, err: %v", i, test.desc, err)
-		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected error: %v, return error: %v", i, test.desc, test.expectedErrMsg, err)
+		if test.expectedErr {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected error: %v, return error: %v", i, test.desc, test.expectedErrMsg, err)
+		}
 
 		if !test.expectedErr {
 			dataDisks, err := ss.GetDataDisks(test.vmssvmName, azcache.CacheReadTypeDefault)

--- a/pkg/provider/azure_instances.go
+++ b/pkg/provider/azure_instances.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -190,7 +191,7 @@ func (az *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID stri
 
 	name, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 		return false, err
@@ -198,7 +199,7 @@ func (az *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID stri
 
 	_, err = az.InstanceID(ctx, name)
 	if err != nil {
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 		return false, err
@@ -235,7 +236,7 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 	nodeName, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		// Returns false, so the controller manager will continue to check InstanceExistsByProviderID().
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 
@@ -245,7 +246,7 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 	powerStatus, err := az.VMSet.GetPowerStatusByNodeName(string(nodeName))
 	if err != nil {
 		// Returns false, so the controller manager will continue to check InstanceExistsByProviderID().
-		if err == cloudprovider.InstanceNotFound {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
 			return false, nil
 		}
 
@@ -345,7 +346,7 @@ func (az *Cloud) InstanceID(ctx context.Context, name types.NodeName) (string, e
 func (az *Cloud) getNodeProviderIDByNodeName(ctx context.Context, name types.NodeName) (string, error) {
 	providerID, err := cloudprovider.GetInstanceProviderID(ctx, az, name)
 	if err != nil {
-		return "", fmt.Errorf("failed to get the provider ID of the node %s: %v", string(name), err)
+		return "", fmt.Errorf("failed to get the provider ID of the node %s: %w", string(name), err)
 	}
 
 	return providerID, nil
@@ -364,7 +365,7 @@ func (az *Cloud) getLocalInstanceProviderID(metadata *InstanceMetadata, nodeName
 	// Get scale set name and instanceID from vmName for vmss.
 	ssName, instanceID, err := extractVmssVMName(metadata.Compute.Name)
 	if err != nil {
-		if err == ErrorNotVmssInstance {
+		if errors.Is(err, ErrorNotVmssInstance) {
 			// Compose machineID for standard Node.
 			return az.getStandardMachineID(subscriptionID, resourceGroup, nodeName), nil
 		}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -649,7 +649,7 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 	for _, ipConfiguration := range *lb.FrontendIPConfigurations {
 		owns, isPrimaryService, err := az.serviceOwnsFrontendIP(ipConfiguration, service)
 		if err != nil {
-			return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to filter frontend IP configs with error: %v", serviceName, to.String(lb.Name), err)
+			return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to filter frontend IP configs with error: %w", serviceName, to.String(lb.Name), err)
 		}
 		if owns {
 			klog.V(2).Infof("get(%s): lb(%s) - found frontend IP config, primary service: %v", serviceName, to.String(lb.Name), isPrimaryService)
@@ -1029,7 +1029,7 @@ func getIdleTimeout(s *v1.Service) (*int32, error) {
 	errInvalidTimeout := fmt.Errorf("idle timeout value must be a whole number representing minutes between %d and %d", min, max)
 	to, err := strconv.Atoi(val)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing idle timeout value: %v: %v", err, errInvalidTimeout)
+		return nil, fmt.Errorf("error parsing idle timeout value: %w: %v", err, errInvalidTimeout)
 	}
 	to32 := int32(to)
 

--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -122,7 +122,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 		if options.DiskIOPSReadWrite != "" {
 			v, err := strconv.Atoi(options.DiskIOPSReadWrite)
 			if err != nil {
-				return "", fmt.Errorf("AzureDisk - failed to parse DiskIOPSReadWrite: %v", err)
+				return "", fmt.Errorf("AzureDisk - failed to parse DiskIOPSReadWrite: %w", err)
 			}
 			diskIOPSReadWrite = int64(v)
 		}
@@ -132,7 +132,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 		if options.DiskMBpsReadWrite != "" {
 			v, err := strconv.Atoi(options.DiskMBpsReadWrite)
 			if err != nil {
-				return "", fmt.Errorf("AzureDisk - failed to parse DiskMBpsReadWrite: %v", err)
+				return "", fmt.Errorf("AzureDisk - failed to parse DiskMBpsReadWrite: %w", err)
 			}
 			diskMBpsReadWrite = int64(v)
 		}
@@ -387,7 +387,7 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 	zones := *disk.Zones
 	zoneID, err := strconv.Atoi(zones[0])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse zone %v for AzureDisk %v: %v", zones, diskName, err)
+		return nil, fmt.Errorf("failed to parse zone %v for AzureDisk %v: %w", zones, diskName, err)
 	}
 
 	zone := c.makeZone(c.Location, zoneID)

--- a/pkg/provider/azure_managedDiskController_test.go
+++ b/pkg/provider/azure_managedDiskController_test.go
@@ -172,7 +172,9 @@ func TestCreateManagedDisk(t *testing.T) {
 		actualDiskID, err := managedDiskController.CreateManagedDisk(volumeOptions)
 		assert.Equal(t, test.expectedDiskID, actualDiskID, "TestCase[%d]: %s", i, test.desc)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
-		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected error: %v, return error: %v", i, test.desc, test.expectedErrMsg, err)
+		if test.expectedErr {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected error: %v, return error: %v", i, test.desc, test.expectedErrMsg, err)
+		}
 	}
 }
 
@@ -231,7 +233,9 @@ func TestDeleteManagedDisk(t *testing.T) {
 
 		err := managedDiskController.DeleteManagedDisk(diskURI)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
-		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		if test.expectedErr {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		}
 	}
 }
 
@@ -281,7 +285,9 @@ func TestGetDisk(t *testing.T) {
 
 		provisioningState, diskid, err := managedDiskController.GetDisk(testCloud.ResourceGroup, test.diskName)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
-		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		if test.expectedErr {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		}
 		assert.Equal(t, test.expectedProvisioningState, provisioningState, "TestCase[%d]: %s, expected ProvisioningState: %v, return ProvisioningState: %v", i, test.desc, test.expectedProvisioningState, provisioningState)
 		assert.Equal(t, test.expectedDiskID, diskid, "TestCase[%d]: %s, expected DiskID: %v, return DiskID: %v", i, test.desc, test.expectedDiskID, diskid)
 	}
@@ -385,7 +391,9 @@ func TestResizeDisk(t *testing.T) {
 
 		result, err := managedDiskController.ResizeDisk(diskURI, test.oldSize, test.newSize)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
-		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		if test.expectedErr {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		}
 		assert.Equal(t, test.expectedQuantity.Value(), result.Value(), "TestCase[%d]: %s, expected Quantity: %v, return Quantity: %v", i, test.desc, test.expectedQuantity, result)
 	}
 }
@@ -546,6 +554,8 @@ func TestGetLabelsForVolume(t *testing.T) {
 		result, err := testCloud.GetLabelsForVolume(context.TODO(), test.pv)
 		assert.Equal(t, test.expected, result, "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expected, result)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
-		assert.Equal(t, test.expectedErrMsg, err, "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		if test.expectedErr {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)
+		}
 	}
 }

--- a/pkg/provider/azure_mock_vmsets.go
+++ b/pkg/provider/azure_mock_vmsets.go
@@ -17,11 +17,11 @@ limitations under the License.
 package provider
 
 import (
-	reflect "reflect"
+	"reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"

--- a/pkg/provider/azure_routes_test.go
+++ b/pkg/provider/azure_routes_test.go
@@ -303,7 +303,9 @@ func TestCreateRoute(t *testing.T) {
 
 		err := cloud.CreateRoute(context.TODO(), "cluster", "unused", &route)
 		assert.Equal(t, cloud.routeCIDRs, test.expectedRouteCIDRs, test.name)
-		assert.Equal(t, test.expectedErrMsg, err, test.name)
+		if err != nil {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), test.name)
+		}
 	}
 }
 
@@ -657,6 +659,8 @@ func TestListRoutes(t *testing.T) {
 
 		routes, err := cloud.ListRoutes(context.TODO(), "cluster")
 		assert.Equal(t, test.expectedRoutes, routes, test.name)
-		assert.Equal(t, test.expectedErrMsg, err, test.name)
+		if test.expectedErrMsg != nil {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), test.name)
+		}
 	}
 }

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -898,7 +898,9 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 		}, nil).AnyTimes()
 
 		instanceID, err := cloud.VMSet.GetInstanceIDByNodeName(test.nodeName)
-		assert.Equal(t, test.expectedErrMsg, err, test.name)
+		if test.expectedErrMsg != nil {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), test.name)
+		}
 		assert.Equal(t, test.expectedID, instanceID, test.name)
 	}
 }
@@ -1054,7 +1056,9 @@ func TestGetStandardVMZoneByNodeName(t *testing.T) {
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, test.nodeName, gomock.Any()).Return(test.vm, test.getErr).AnyTimes()
 
 		zone, err := cloud.VMSet.GetZoneByNodeName(test.nodeName)
-		assert.Equal(t, test.expectedErrMsg, err, test.name)
+		if test.expectedErrMsg != nil {
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), test.name)
+		}
 		assert.Equal(t, test.expectedZone, zone, test.name)
 	}
 }
@@ -1355,7 +1359,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 		nicID          string
 		vmSetName      string
 		expectedErr    bool
-		expectedErrMsg string
+		expectedErrMsg error
 	}{
 		{
 			name:     "EnsureHostsInPool should return nil if there's no error when invoke EnsureHostInPool",
@@ -1446,7 +1450,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 			nicID:          "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic5",
 			vmSetName:      "myAvailabilitySet",
 			expectedErr:    true,
-			expectedErrMsg: fmt.Sprintf("ensure(default/svc): backendPoolID(%s) - failed to ensure host in pool: %q", backendAddressPoolID, fmt.Errorf("failed to determine the ipconfig(IPv6=true). nicname=%q", "nic5")),
+			expectedErrMsg: fmt.Errorf("ensure(default/svc): backendPoolID(%s) - failed to ensure host in pool: %w", backendAddressPoolID, fmt.Errorf("failed to determine the ipconfig(IPv6=true). nicname=%q", "nic5")),
 		},
 	}
 
@@ -1468,7 +1472,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 
 		err := cloud.VMSet.EnsureHostsInPool(test.service, test.nodes, test.backendPoolID, test.vmSetName, false)
 		if test.expectedErr {
-			assert.Equal(t, test.expectedErrMsg, err.Error(), test.name)
+			assert.EqualError(t, test.expectedErrMsg, err.Error(), test.name)
 		} else {
 			assert.Nil(t, err, test.name)
 		}

--- a/pkg/provider/azure_storage.go
+++ b/pkg/provider/azure_storage.go
@@ -54,11 +54,11 @@ func (az *Cloud) CreateFileShare(accountOptions *AccountOptions, shareOptions *f
 
 	accountName, accountKey, err := az.EnsureStorageAccount(accountOptions, fileShareAccountNamePrefix)
 	if err != nil {
-		return "", "", fmt.Errorf("could not get storage key for storage account %s: %v", accountOptions.Name, err)
+		return "", "", fmt.Errorf("could not get storage key for storage account %s: %w", accountOptions.Name, err)
 	}
 
 	if err := az.createFileShare(accountOptions.ResourceGroup, accountName, shareOptions); err != nil {
-		return "", "", fmt.Errorf("failed to create share %s in account %s: %v", shareOptions.Name, accountName, err)
+		return "", "", fmt.Errorf("failed to create share %s in account %s: %w", shareOptions.Name, accountName, err)
 	}
 	klog.V(4).Infof("created share %s in account %s", shareOptions.Name, accountOptions.Name)
 	return accountName, accountKey, nil

--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -152,7 +152,7 @@ func (az *Cloud) EnsureStorageAccount(accountOptions *AccountOptions, genAccount
 			// find a storage account that matches accountType
 			accounts, err := az.getStorageAccounts(accountOptions)
 			if err != nil {
-				return "", "", fmt.Errorf("could not list storage accounts for account type %s: %v", accountType, err)
+				return "", "", fmt.Errorf("could not list storage accounts for account type %s: %w", accountType, err)
 			}
 
 			if len(accounts) > 0 {
@@ -220,7 +220,7 @@ func (az *Cloud) EnsureStorageAccount(accountOptions *AccountOptions, genAccount
 			defer cancel()
 			rerr := az.StorageAccountClient.Create(ctx, resourceGroup, accountName, cp)
 			if rerr != nil {
-				return "", "", fmt.Errorf(fmt.Sprintf("Failed to create storage account %s, error: %v", accountName, rerr))
+				return "", "", fmt.Errorf("failed to create storage account %s, error: %v", accountName, rerr)
 			}
 		}
 	}
@@ -228,7 +228,7 @@ func (az *Cloud) EnsureStorageAccount(accountOptions *AccountOptions, genAccount
 	// find the access key with this account
 	accountKey, err := az.GetStorageAccesskey(accountName, resourceGroup)
 	if err != nil {
-		return "", "", fmt.Errorf("could not get storage key for storage account %s: %v", accountName, err)
+		return "", "", fmt.Errorf("could not get storage key for storage account %s: %w", accountName, err)
 	}
 
 	return accountName, accountKey, nil

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -289,7 +290,7 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), "rg").Return(test.testResourceGroups, nil).AnyTimes()
 
 		accountsWithLocations, err := cloud.getStorageAccounts(test.testAccountOptions)
-		if err != test.expectedError {
+		if !errors.Is(err, test.expectedError) {
 			t.Errorf("unexpected error: %v", err)
 		}
 

--- a/pkg/provider/azure_zones.go
+++ b/pkg/provider/azure_zones.go
@@ -68,7 +68,7 @@ func (az *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 		if metadata.Compute.Zone != "" {
 			zoneID, err := strconv.Atoi(metadata.Compute.Zone)
 			if err != nil {
-				return cloudprovider.Zone{}, fmt.Errorf("failed to parse zone ID %q: %v", metadata.Compute.Zone, err)
+				return cloudprovider.Zone{}, fmt.Errorf("failed to parse zone ID %q: %w", metadata.Compute.Zone, err)
 			}
 			zone = az.makeZone(location, zoneID)
 		} else {

--- a/pkg/provider/azure_zones_test.go
+++ b/pkg/provider/azure_zones_test.go
@@ -175,7 +175,7 @@ func TestGetZone(t *testing.T) {
 			if test.expectedErr == nil {
 				t.Errorf("Test [%s] unexpected error: %v", test.name, err)
 			} else {
-				assert.Equal(t, test.expectedErr, err)
+				assert.EqualError(t, test.expectedErr, err.Error())
 			}
 		}
 		if zone.FailureDomain != test.expected {

--- a/pkg/retry/azure_error.go
+++ b/pkg/retry/azure_error.go
@@ -74,7 +74,7 @@ func (err *Error) Error() error {
 		retryAfterSeconds = int(err.RetryAfter.Sub(curTime) / time.Second)
 	}
 
-	return fmt.Errorf("Retriable: %v, RetryAfter: %ds, HTTPStatusCode: %d, RawError: %v",
+	return fmt.Errorf("Retriable: %v, RetryAfter: %ds, HTTPStatusCode: %d, RawError: %w",
 		err.Retriable, retryAfterSeconds, err.HTTPStatusCode, err.RawError)
 }
 
@@ -271,14 +271,14 @@ func GetStatusNotFoundAndForbiddenIgnoredError(resp *http.Response, err error) *
 
 	// Returns nil when it is StatusNotFound error.
 	if rerr.HTTPStatusCode == http.StatusNotFound {
-		klog.V(3).Infof("Ignoring StatusNotFound error: %v", rerr)
+		klog.V(3).Infof("Ignoring StatusNotFound error: %w", rerr)
 		return nil
 	}
 
 	// Returns nil if the status code is StatusForbidden.
 	// This happens when AuthorizationFailed is reported from Azure API.
 	if rerr.HTTPStatusCode == http.StatusForbidden {
-		klog.V(3).Infof("Ignoring StatusForbidden error: %v", rerr)
+		klog.V(3).Infof("Ignoring StatusForbidden error: %w", rerr)
 		return nil
 	}
 

--- a/pkg/util/controller/node/controller_utils.go
+++ b/pkg/util/controller/node/controller_utils.go
@@ -31,7 +31,7 @@ func CreateAddNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
 	return func(originalObj interface{}) {
 		node := originalObj.(*v1.Node).DeepCopy()
 		if err := f(node); err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add: %v", err))
+			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add: %w", err))
 		}
 	}
 }
@@ -43,7 +43,7 @@ func CreateUpdateNodeHandler(f func(oldNode, newNode *v1.Node) error) func(oldOb
 		prevNode := origOldObj.(*v1.Node).DeepCopy()
 
 		if err := f(prevNode, node); err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
+			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %w", err))
 		}
 	}
 }
@@ -68,7 +68,7 @@ func CreateDeleteNodeHandler(f func(node *v1.Node) error) func(obj interface{}) 
 		}
 		node := originalNode.DeepCopy()
 		if err := f(node); err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
+			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %w", err))
 		}
 	}
 }

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -55,11 +55,11 @@ func PatchNodeCIDR(c clientset.Interface, node types.NodeName, cidr string) erro
 	}
 	patchBytes, err := json.Marshal(&patch)
 	if err != nil {
-		return fmt.Errorf("failed to json.Marshal CIDR: %v", err)
+		return fmt.Errorf("failed to json.Marshal CIDR: %w", err)
 	}
 
 	if _, err := c.CoreV1().Nodes().Patch(context.TODO(), string(node), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("failed to patch node CIDR: %v", err)
+		return fmt.Errorf("failed to patch node CIDR: %w", err)
 	}
 	return nil
 }
@@ -76,11 +76,11 @@ func PatchNodeCIDRs(c clientset.Interface, node types.NodeName, cidrs []string) 
 
 	patchBytes, err := json.Marshal(&patch)
 	if err != nil {
-		return fmt.Errorf("failed to json.Marshal CIDR: %v", err)
+		return fmt.Errorf("failed to json.Marshal CIDR: %w", err)
 	}
 	klog.V(4).Infof("cidrs patch bytes are:%s", string(patchBytes))
 	if _, err := c.CoreV1().Nodes().Patch(context.TODO(), string(node), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("failed to patch node CIDR: %v", err)
+		return fmt.Errorf("failed to patch node CIDR: %w", err)
 	}
 	return nil
 }

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -43,13 +43,14 @@ func (v *versionValue) IsBoolFlag() bool {
 }
 
 func (v *versionValue) Get() interface{} {
-	return versionValue(*v)
+	return *v
 }
 
 func (v *versionValue) Set(s string) error {
 	if s == strRawVersion {
 		*v = VersionRaw
 		return nil
+
 	}
 	boolVal, err := strconv.ParseBool(s)
 	if boolVal {
@@ -64,7 +65,7 @@ func (v *versionValue) String() string {
 	if *v == VersionRaw {
 		return strRawVersion
 	}
-	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+	return fmt.Sprintf("%v", *v == VersionTrue)
 }
 
 // The type of the flag as required by the pflag.Value interface
@@ -79,7 +80,7 @@ func VersionVar(p *versionValue, name string, value versionValue, usage string) 
 	flag.Lookup(name).NoOptDefVal = "true"
 }
 
-func Version(name string, value versionValue, usage string) *versionValue {
+func newVersionValue(name string, value versionValue, usage string) *versionValue {
 	p := new(versionValue)
 	VersionVar(p, name, value, usage)
 	return p
@@ -88,7 +89,7 @@ func Version(name string, value versionValue, usage string) *versionValue {
 const versionFlagName = "version"
 
 var (
-	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
+	versionFlag = newVersionValue(versionFlagName, VersionFalse, "Print version information and quit")
 )
 
 // AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the

--- a/tests/e2e/auth/cred.go
+++ b/tests/e2e/auth/cred.go
@@ -62,7 +62,7 @@ var _ = Describe("Azure Credential Provider", func() {
 		defer func() {
 			err = tc.DeleteContainerRegistry(*registry.Name)
 			if err != nil {
-				utils.Logf("failed to cleanup registry with error: %v", err)
+				utils.Logf("failed to cleanup registry with error: %w", err)
 			}
 		}()
 

--- a/tests/e2e/utils/azure_auth.go
+++ b/tests/e2e/utils/azure_auth.go
@@ -60,7 +60,7 @@ type AzureAuthConfig struct {
 func getServicePrincipalToken(config *AzureAuthConfig) (*adal.ServicePrincipalToken, error) {
 	oauthConfig, err := adal.NewOAuthConfig(config.Environment.ActiveDirectoryEndpoint, config.TenantID)
 	if err != nil {
-		return nil, fmt.Errorf("creating the OAuth config: %v", err)
+		return nil, fmt.Errorf("creating the OAuth config: %w", err)
 	}
 
 	if len(config.AADClientSecret) > 0 {

--- a/tests/e2e/utils/container_registry_utils.go
+++ b/tests/e2e/utils/container_registry_utils.go
@@ -61,11 +61,11 @@ func (tc *AzureTestClient) DeleteContainerRegistry(registryName string) (err err
 	Logf("Deleting acr %s in resource group %s.", registryName, rgName)
 	future, err := acrClient.Delete(context.Background(), rgName, registryName)
 	if err != nil {
-		return fmt.Errorf("failed to delete acr %s in resource group %s with error: %v", registryName, rgName, err)
+		return fmt.Errorf("failed to delete acr %s in resource group %s with error: %w", registryName, rgName, err)
 	}
 	err = future.WaitForCompletionRef(context.Background(), acrClient.Client)
 	if err != nil {
-		return fmt.Errorf("failed to delete acr %s in resource group %s with error: %v", registryName, rgName, err)
+		return fmt.Errorf("failed to delete acr %s in resource group %s with error: %w", registryName, rgName, err)
 	}
 	return nil
 }
@@ -79,7 +79,7 @@ func DockerLogin(registryName string) (err error) {
 
 	cmd := exec.Command("docker", "-v")
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("failed to execute docker command with error: %v", err)
+		return fmt.Errorf("failed to execute docker command with error: %w", err)
 	}
 
 	Logf("Attempting Docker login with azure cred.")
@@ -89,7 +89,7 @@ func DockerLogin(registryName string) (err error) {
 		fmt.Sprintf("--password=%s", authConfig.AADClientSecret),
 		registryName+".azurecr.io")
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("docker failed to login with error: %v", err)
+		return fmt.Errorf("docker failed to login with error: %w", err)
 	}
 	Logf("Docker login success.")
 	return nil
@@ -108,20 +108,20 @@ func PushImageToACR(registryName, image string) (tag string, err error) {
 	Logf("Pulling %s from Docker Hub.", image)
 	cmd := exec.Command("docker", "pull", image)
 	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed pulling %s with error: %v", image, err)
+		return "", fmt.Errorf("failed pulling %s with error: %w", image, err)
 	}
 
 	Logf("Tagging image.")
 	tagSuffix := string(uuid.NewUUID())[0:4]
 	cmd = exec.Command("docker", "tag", image, fmt.Sprintf("%s.azurecr.io/%s:e2e-%s", registryName, image, tagSuffix))
 	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed tagging nginx image with error: %v", err)
+		return "", fmt.Errorf("failed tagging nginx image with error: %w", err)
 	}
 
 	Logf("Pushing image to ACR.")
 	cmd = exec.Command("docker", "push", fmt.Sprintf("%s.azurecr.io/%s:e2e-%s", registryName, image, tagSuffix))
 	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed pushing %s image to registry %s with error: %v", image, registryName, err)
+		return "", fmt.Errorf("failed pushing %s image to registry %s with error: %w", image, registryName, err)
 	}
 
 	Logf("Pushing image success.")

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -141,7 +141,7 @@ func (azureTestClient *AzureTestClient) getSecurityGroupList() (result aznetwork
 	err = wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
 		result, err = securityGroupsClient.List(context.Background(), azureTestClient.GetResourceGroup())
 		if err != nil {
-			Logf("error when listing sgs: %v", err)
+			Logf("error when listing sgs: %w", err)
 			if !IsRetryableAPIError(err) {
 				return false, err
 			}
@@ -216,7 +216,7 @@ func DeletePIPWithRetry(azureTestClient *AzureTestClient, ipName, rgName string)
 	err := wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
 		_, err := pipClient.Delete(context.Background(), rgName, ipName)
 		if err != nil {
-			Logf("error: %v, will retry soon", err)
+			Logf("error: %w, will retry soon", err)
 			return false, nil
 		}
 		return true, nil
@@ -253,7 +253,7 @@ func SelectAvailablePrivateIP(tc *AzureTestClient) (string, error) {
 	subnet := to.String((*vNet.Subnets)[0].AddressPrefix)
 	ip, _, err := net.ParseCIDR(subnet)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse subnet CIDR in vNet %s: %v", to.String(vNet.Name), err)
+		return "", fmt.Errorf("failed to parse subnet CIDR in vNet %s: %w", to.String(vNet.Name), err)
 	}
 	baseIP := ip.To4()
 	for i := 0; i <= 254; i++ {

--- a/tests/e2e/utils/pod_utils.go
+++ b/tests/e2e/utils/pod_utils.go
@@ -76,7 +76,7 @@ func WaitPodsToBeReady(cs clientset.Interface, ns string) error {
 	return wait.PollImmediate(pullInterval, pullTimeout, func() (done bool, err error) {
 		pendingPodCount, err := CountPendingPods(cs, ns)
 		if err != nil {
-			Logf("unexpected error: %v", err)
+			Logf("unexpected error: %w", err)
 			return false, err
 		}
 

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -143,7 +143,7 @@ func DeleteNamespace(cs clientset.Interface, namespace string) error {
 			if apierrs.IsNotFound(err) {
 				return true, nil
 			}
-			Logf("Error while waiting for namespace to be terminated: %v", err)
+			Logf("Error while waiting for namespace to be terminated: %w", err)
 			if !IsRetryableAPIError(err) {
 				return false, err
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,6 +195,7 @@ github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0 => github.com/opencontainers/go-digest v1.0.0-rc1
 github.com/opencontainers/go-digest
 # github.com/pkg/errors v0.9.1 => github.com/pkg/errors v0.8.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0 => github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -1024,8 +1025,6 @@ k8s.io/kubernetes/test/utils/image
 # k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.0.0-20201211092501-716c3daa6bc8
 ## explicit
 k8s.io/legacy-cloud-providers/gce
-# k8s.io/metrics v0.0.0 => k8s.io/metrics v0.0.0-20201114091333-d70c0e0c6aa5
-## explicit
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920 => k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
 ## explicit
 k8s.io/utils/buffer

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1024,6 +1024,8 @@ k8s.io/kubernetes/test/utils/image
 # k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.0.0-20201211092501-716c3daa6bc8
 ## explicit
 k8s.io/legacy-cloud-providers/gce
+# k8s.io/metrics v0.0.0 => k8s.io/metrics v0.0.0-20201114091333-d70c0e0c6aa5
+## explicit
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920 => k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19
 ## explicit
 k8s.io/utils/buffer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Fix code and enable more linter. PR is already pretty big so kept some commented out and will follow up with other PRs if there are no objections. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Kept the commits separate so it's easier to review. Some of the linters required no changes, some (errorlint, goimports) required a lot of changes across many files, but mostly repetitive. 

No logic / behavior changes.


**Release note**:
```
NONE
```
