### PR TITLE
enable gocyclo linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
     - errcheck
     - errorlint
     - goconst
-#    - gocyclo
+    - gocyclo
     - gofmt
     - goimports
     - golint

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1242,223 +1242,36 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 	lbName := *lb.Name
 	lbResourceGroup := az.getLoadBalancerResourceGroup()
+	lbBackendPoolID := az.getBackendPoolID(lbName, az.getLoadBalancerResourceGroup(), getBackendPoolName(clusterName, service))
 	klog.V(2).Infof("reconcileLoadBalancer for service(%s): lb(%s/%s) wantLb(%t) resolved load balancer name", serviceName, lbResourceGroup, lbName, wantLb)
 	defaultLBFrontendIPConfigName := az.getDefaultFrontendIPConfigName(service)
 	defaultLBFrontendIPConfigID := az.getFrontendIPConfigID(lbName, lbResourceGroup, defaultLBFrontendIPConfigName)
-	lbBackendPoolName := getBackendPoolName(clusterName, service)
-	lbBackendPoolID := az.getBackendPoolID(lbName, lbResourceGroup, lbBackendPoolName)
+	dirtyLb := false
 
 	lbIdleTimeout, err := getIdleTimeout(service)
 	if wantLb && err != nil {
 		return nil, err
 	}
 
-	dirtyLb := false
-
-	// Ensure LoadBalancer's Backend Pool Configuration
+	// reconcile the load balancer's backend pool configuration.
 	if wantLb {
-		newBackendPools := []network.BackendAddressPool{}
-		if lb.BackendAddressPools != nil {
-			newBackendPools = *lb.BackendAddressPools
-		}
-
-		foundBackendPool := false
-		for _, bp := range newBackendPools {
-			if strings.EqualFold(*bp.Name, lbBackendPoolName) {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found wanted backendpool. not adding anything", serviceName, wantLb)
-				foundBackendPool = true
-
-				var backendIPConfigurationsToBeDeleted []network.InterfaceIPConfiguration
-				if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
-					for _, ipConf := range *bp.BackendIPConfigurations {
-						ipConfID := to.String(ipConf.ID)
-						nodeName, _, err := az.VMSet.GetNodeNameByIPConfigurationID(ipConfID)
-						if err != nil {
-							return nil, err
-						}
-						if nodeName == "" {
-							// VM may under deletion
-							continue
-						}
-						// If a node is not supposed to be included in the LB, it
-						// would not be in the `nodes` slice. We need to check the nodes that
-						// have been added to the LB's backendpool, find the unwanted ones and
-						// delete them from the pool.
-						if !nodeNameInNodes(nodeName, nodes) {
-							klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found unwanted node %s, decouple it from the LB", serviceName, wantLb, nodeName)
-							// construct a backendPool that only contains the IP config of the node to be deleted
-							backendIPConfigurationsToBeDeleted = append(backendIPConfigurationsToBeDeleted, network.InterfaceIPConfiguration{ID: to.StringPtr(ipConfID)})
-						}
-					}
-					if len(backendIPConfigurationsToBeDeleted) > 0 {
-						backendpoolToBeDeleted := &[]network.BackendAddressPool{
-							{
-								ID: to.StringPtr(lbBackendPoolID),
-								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
-									BackendIPConfigurations: &backendIPConfigurationsToBeDeleted,
-								},
-							},
-						}
-						vmSetName := az.mapLoadBalancerNameToVMSet(lbName, clusterName)
-						// decouple the backendPool from the node
-						err = az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, backendpoolToBeDeleted)
-						if err != nil {
-							return nil, err
-						}
-					}
-				}
-				break
-			} else {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found other backendpool %s", serviceName, wantLb, *bp.Name)
-			}
-		}
-		if !foundBackendPool {
-			if isBackendPoolPreConfigured {
-				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - PreConfiguredBackendPoolLoadBalancerTypes %s has been set but can not find corresponding backend pool, ignoring it",
-					serviceName,
-					wantLb,
-					az.PreConfiguredBackendPoolLoadBalancerTypes)
-				isBackendPoolPreConfigured = false
-			}
-
-			newBackendPools = append(newBackendPools, network.BackendAddressPool{
-				Name: to.StringPtr(lbBackendPoolName),
-			})
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - adding backendpool", serviceName, wantLb)
-
-			dirtyLb = true
-			lb.BackendAddressPools = &newBackendPools
-		}
-	}
-
-	// Ensure LoadBalancer's Frontend IP Configurations
-	dirtyConfigs := false
-	newConfigs := []network.FrontendIPConfiguration{}
-	if lb.FrontendIPConfigurations != nil {
-		newConfigs = *lb.FrontendIPConfigurations
-	}
-
-	var ownedFIPConfig *network.FrontendIPConfiguration
-	if !wantLb {
-		for i := len(newConfigs) - 1; i >= 0; i-- {
-			config := newConfigs[i]
-			isServiceOwnsFrontendIP, _, err := az.serviceOwnsFrontendIP(config, service)
-			if err != nil {
-				return nil, err
-			}
-			if isServiceOwnsFrontendIP {
-				unsafe, err := az.isFrontendIPConfigUnsafeToDelete(lb, service, config.ID)
-				if err != nil {
-					return nil, err
-				}
-
-				// If the frontend IP configuration is not being referenced by:
-				// 1. loadBalancing rules of other services with different ports;
-				// 2. outbound rules;
-				// 3. inbound NAT rules;
-				// 4. inbound NAT pools,
-				// do the deletion, or skip it.
-				if !unsafe {
-					var configNameToBeDeleted string
-					if newConfigs[i].Name != nil {
-						configNameToBeDeleted = *newConfigs[i].Name
-						klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - dropping", serviceName, wantLb, configNameToBeDeleted)
-					} else {
-						klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): nil name of lb frontendconfig", serviceName, wantLb)
-					}
-
-					newConfigs = append(newConfigs[:i], newConfigs[i+1:]...)
-					dirtyConfigs = true
-				}
-			}
-		}
-	} else {
-		for i := len(newConfigs) - 1; i >= 0; i-- {
-			config := newConfigs[i]
-			isFipChanged, err := az.isFrontendIPChanged(clusterName, config, service, defaultLBFrontendIPConfigName)
-			if err != nil {
-				return nil, err
-			}
-			if isFipChanged {
-				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - dropping", serviceName, wantLb, *config.Name)
-				newConfigs = append(newConfigs[:i], newConfigs[i+1:]...)
-				dirtyConfigs = true
-			}
-		}
-
-		ownedFIPConfig, _, err = az.findFrontendIPConfigOfService(&newConfigs, service)
+		preConfig, changed, err := az.reconcileBackendPools(clusterName, service, nodes, lb, isBackendPoolPreConfigured)
 		if err != nil {
-			return nil, err
+			return lb, err
 		}
-
-		if ownedFIPConfig == nil {
-			klog.V(4).Infof("ensure(%s): lb(%s) - creating a new frontend IP config", serviceName, lbName)
-
-			// construct FrontendIPConfigurationPropertiesFormat
-			var fipConfigurationProperties *network.FrontendIPConfigurationPropertiesFormat
-			if isInternal {
-				// azure does not support ILB for IPv6 yet.
-				// TODO: remove this check when ILB supports IPv6 *and* the SDK
-				// have been rev'ed to 2019* version
-				if utilnet.IsIPv6String(service.Spec.ClusterIP) {
-					return nil, fmt.Errorf("ensure(%s): lb(%s) - internal load balancers does not support IPv6", serviceName, lbName)
-				}
-
-				subnetName := subnet(service)
-				if subnetName == nil {
-					subnetName = &az.SubnetName
-				}
-				subnet, existsSubnet, err := az.getSubnet(az.VnetName, *subnetName)
-				if err != nil {
-					return nil, err
-				}
-
-				if !existsSubnet {
-					return nil, fmt.Errorf("ensure(%s): lb(%s) - failed to get subnet: %s/%s", serviceName, lbName, az.VnetName, az.SubnetName)
-				}
-
-				configProperties := network.FrontendIPConfigurationPropertiesFormat{
-					Subnet: &subnet,
-				}
-
-				loadBalancerIP := service.Spec.LoadBalancerIP
-				if loadBalancerIP != "" {
-					configProperties.PrivateIPAllocationMethod = network.Static
-					configProperties.PrivateIPAddress = &loadBalancerIP
-				} else {
-					// We'll need to call GetLoadBalancer later to retrieve allocated IP.
-					configProperties.PrivateIPAllocationMethod = network.Dynamic
-				}
-
-				fipConfigurationProperties = &configProperties
-			} else {
-				pipName, shouldPIPExisted, err := az.determinePublicIPName(clusterName, service)
-				if err != nil {
-					return nil, err
-				}
-				domainNameLabel, found := getPublicIPDomainNameLabel(service)
-				pip, err := az.ensurePublicIPExists(service, pipName, domainNameLabel, clusterName, shouldPIPExisted, found)
-				if err != nil {
-					return nil, err
-				}
-				fipConfigurationProperties = &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: pip.ID},
-				}
-			}
-
-			newConfigs = append(newConfigs,
-				network.FrontendIPConfiguration{
-					Name:                                    to.StringPtr(defaultLBFrontendIPConfigName),
-					ID:                                      to.StringPtr(fmt.Sprintf(frontendIPConfigIDTemplate, az.SubscriptionID, az.ResourceGroup, *lb.Name, defaultLBFrontendIPConfigName)),
-					FrontendIPConfigurationPropertiesFormat: fipConfigurationProperties,
-				})
-			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, defaultLBFrontendIPConfigName)
-			dirtyConfigs = true
+		if changed {
+			dirtyLb = true
 		}
+		isBackendPoolPreConfigured = preConfig
 	}
-	if dirtyConfigs {
+
+	// reconcile the load balancer's frontend IP configurations.
+	ownedFIPConfig, changed, err := az.reconcileFrontendIPConfigs(clusterName, service, lb, wantLb, defaultLBFrontendIPConfigName)
+	if err != nil {
+		return lb, err
+	}
+	if changed {
 		dirtyLb = true
-		lb.FrontendIPConfigurations = &newConfigs
 	}
 
 	// update probes/rules
@@ -1471,100 +1284,28 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 
 	if wantLb {
-		err = az.checkLoadBalancerResourcesConflicted(lb, defaultLBFrontendIPConfigID, service)
+		err = az.checkLoadBalancerResourcesConflicts(lb, defaultLBFrontendIPConfigID, service)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	expectedProbes, expectedRules, err := az.reconcileLoadBalancerRule(service, wantLb, defaultLBFrontendIPConfigID, lbBackendPoolID, lbName, lbIdleTimeout)
+	expectedProbes, expectedRules, err := az.getExpectedLBRules(service, wantLb, defaultLBFrontendIPConfigID, lbBackendPoolID, lbName, lbIdleTimeout)
 	if err != nil {
 		return nil, err
 	}
 
-	// remove unwanted probes
-	dirtyProbes := false
-	var updatedProbes []network.Probe
-	if lb.Probes != nil {
-		updatedProbes = *lb.Probes
-	}
-	for i := len(updatedProbes) - 1; i >= 0; i-- {
-		existingProbe := updatedProbes[i]
-		if az.serviceOwnsRule(service, *existingProbe.Name) {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - considering evicting", serviceName, wantLb, *existingProbe.Name)
-			keepProbe := false
-			if findProbe(expectedProbes, existingProbe) {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - keeping", serviceName, wantLb, *existingProbe.Name)
-				keepProbe = true
-			}
-			if !keepProbe {
-				updatedProbes = append(updatedProbes[:i], updatedProbes[i+1:]...)
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - dropping", serviceName, wantLb, *existingProbe.Name)
-				dirtyProbes = true
-			}
-		}
-	}
-	// add missing, wanted probes
-	for _, expectedProbe := range expectedProbes {
-		foundProbe := false
-		if findProbe(updatedProbes, expectedProbe) {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - already exists", serviceName, wantLb, *expectedProbe.Name)
-			foundProbe = true
-		}
-		if !foundProbe {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - adding", serviceName, wantLb, *expectedProbe.Name)
-			updatedProbes = append(updatedProbes, expectedProbe)
-			dirtyProbes = true
-		}
-	}
-	if dirtyProbes {
+	changed = az.reconcileLBProbes(lb, service, serviceName, wantLb, expectedProbes)
+	if changed {
 		dirtyLb = true
-		lb.Probes = &updatedProbes
 	}
 
-	// update rules
-	dirtyRules := false
-	var updatedRules []network.LoadBalancingRule
-	if lb.LoadBalancingRules != nil {
-		updatedRules = *lb.LoadBalancingRules
-	}
-
-	// update rules: remove unwanted
-	for i := len(updatedRules) - 1; i >= 0; i-- {
-		existingRule := updatedRules[i]
-		if az.serviceOwnsRule(service, *existingRule.Name) {
-			keepRule := false
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
-			if findRule(expectedRules, existingRule, wantLb) {
-				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
-				keepRule = true
-			}
-			if !keepRule {
-				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - dropping", serviceName, wantLb, *existingRule.Name)
-				updatedRules = append(updatedRules[:i], updatedRules[i+1:]...)
-				dirtyRules = true
-			}
-		}
-	}
-	// update rules: add needed
-	for _, expectedRule := range expectedRules {
-		foundRule := false
-		if findRule(updatedRules, expectedRule, wantLb) {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
-			foundRule = true
-		}
-		if !foundRule {
-			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) adding", serviceName, wantLb, *expectedRule.Name)
-			updatedRules = append(updatedRules, expectedRule)
-			dirtyRules = true
-		}
-	}
-	if dirtyRules {
+	changed = az.reconcileLBRules(lb, service, serviceName, wantLb, expectedRules)
+	if changed {
 		dirtyLb = true
-		lb.LoadBalancingRules = &updatedRules
 	}
 
-	changed := az.ensureLoadBalancerTagged(lb)
+	changed = az.ensureLoadBalancerTagged(lb)
 	if changed {
 		dirtyLb = true
 	}
@@ -1619,10 +1360,316 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	return lb, nil
 }
 
-// checkLoadBalancerResourcesConflicted checks if the service is consuming
-// ports which are conflicted with the existing loadBalancer resources,
+func (az *Cloud) reconcileLBProbes(lb *network.LoadBalancer, service *v1.Service, serviceName string, wantLb bool, expectedProbes []network.Probe) bool {
+	// remove unwanted probes
+	dirtyProbes := false
+	var updatedProbes []network.Probe
+	if lb.Probes != nil {
+		updatedProbes = *lb.Probes
+	}
+	for i := len(updatedProbes) - 1; i >= 0; i-- {
+		existingProbe := updatedProbes[i]
+		if az.serviceOwnsRule(service, *existingProbe.Name) {
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - considering evicting", serviceName, wantLb, *existingProbe.Name)
+			keepProbe := false
+			if findProbe(expectedProbes, existingProbe) {
+				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - keeping", serviceName, wantLb, *existingProbe.Name)
+				keepProbe = true
+			}
+			if !keepProbe {
+				updatedProbes = append(updatedProbes[:i], updatedProbes[i+1:]...)
+				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - dropping", serviceName, wantLb, *existingProbe.Name)
+				dirtyProbes = true
+			}
+		}
+	}
+	// add missing, wanted probes
+	for _, expectedProbe := range expectedProbes {
+		foundProbe := false
+		if findProbe(updatedProbes, expectedProbe) {
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - already exists", serviceName, wantLb, *expectedProbe.Name)
+			foundProbe = true
+		}
+		if !foundProbe {
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb probe(%s) - adding", serviceName, wantLb, *expectedProbe.Name)
+			updatedProbes = append(updatedProbes, expectedProbe)
+			dirtyProbes = true
+		}
+	}
+	if dirtyProbes {
+		lb.Probes = &updatedProbes
+	}
+	return dirtyProbes
+}
+
+func (az *Cloud) reconcileLBRules(lb *network.LoadBalancer, service *v1.Service, serviceName string, wantLb bool, expectedRules []network.LoadBalancingRule) bool {
+	// update rules
+	dirtyRules := false
+	var updatedRules []network.LoadBalancingRule
+	if lb.LoadBalancingRules != nil {
+		updatedRules = *lb.LoadBalancingRules
+	}
+
+	// update rules: remove unwanted
+	for i := len(updatedRules) - 1; i >= 0; i-- {
+		existingRule := updatedRules[i]
+		if az.serviceOwnsRule(service, *existingRule.Name) {
+			keepRule := false
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
+			if findRule(expectedRules, existingRule, wantLb) {
+				klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
+				keepRule = true
+			}
+			if !keepRule {
+				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - dropping", serviceName, wantLb, *existingRule.Name)
+				updatedRules = append(updatedRules[:i], updatedRules[i+1:]...)
+				dirtyRules = true
+			}
+		}
+	}
+	// update rules: add needed
+	for _, expectedRule := range expectedRules {
+		foundRule := false
+		if findRule(updatedRules, expectedRule, wantLb) {
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
+			foundRule = true
+		}
+		if !foundRule {
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb rule(%s) adding", serviceName, wantLb, *expectedRule.Name)
+			updatedRules = append(updatedRules, expectedRule)
+			dirtyRules = true
+		}
+	}
+	if dirtyRules {
+		lb.LoadBalancingRules = &updatedRules
+	}
+	return dirtyRules
+}
+
+func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Service, lb *network.LoadBalancer, wantLb bool, defaultLBFrontendIPConfigName string) (*network.FrontendIPConfiguration, bool, error) {
+	var err error
+	lbName := *lb.Name
+	serviceName := getServiceName(service)
+	isInternal := requiresInternalLoadBalancer(service)
+	dirtyConfigs := false
+	var newConfigs []network.FrontendIPConfiguration
+	if lb.FrontendIPConfigurations != nil {
+		newConfigs = *lb.FrontendIPConfigurations
+	}
+
+	var ownedFIPConfig *network.FrontendIPConfiguration
+	if !wantLb {
+		for i := len(newConfigs) - 1; i >= 0; i-- {
+			config := newConfigs[i]
+			isServiceOwnsFrontendIP, _, err := az.serviceOwnsFrontendIP(config, service)
+			if err != nil {
+				return nil, false, err
+			}
+			if isServiceOwnsFrontendIP {
+				unsafe, err := az.isFrontendIPConfigUnsafeToDelete(lb, service, config.ID)
+				if err != nil {
+					return nil, false, err
+				}
+
+				// If the frontend IP configuration is not being referenced by:
+				// 1. loadBalancing rules of other services with different ports;
+				// 2. outbound rules;
+				// 3. inbound NAT rules;
+				// 4. inbound NAT pools,
+				// do the deletion, or skip it.
+				if !unsafe {
+					var configNameToBeDeleted string
+					if newConfigs[i].Name != nil {
+						configNameToBeDeleted = *newConfigs[i].Name
+						klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - dropping", serviceName, wantLb, configNameToBeDeleted)
+					} else {
+						klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): nil name of lb frontendconfig", serviceName, wantLb)
+					}
+
+					newConfigs = append(newConfigs[:i], newConfigs[i+1:]...)
+					dirtyConfigs = true
+				}
+			}
+		}
+	} else {
+		for i := len(newConfigs) - 1; i >= 0; i-- {
+			config := newConfigs[i]
+			isFipChanged, err := az.isFrontendIPChanged(clusterName, config, service, defaultLBFrontendIPConfigName)
+			if err != nil {
+				return nil, false, err
+			}
+			if isFipChanged {
+				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - dropping", serviceName, wantLb, *config.Name)
+				newConfigs = append(newConfigs[:i], newConfigs[i+1:]...)
+				dirtyConfigs = true
+			}
+		}
+
+		ownedFIPConfig, _, err = az.findFrontendIPConfigOfService(&newConfigs, service)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if ownedFIPConfig == nil {
+			klog.V(4).Infof("ensure(%s): lb(%s) - creating a new frontend IP config", serviceName, lbName)
+
+			// construct FrontendIPConfigurationPropertiesFormat
+			var fipConfigurationProperties *network.FrontendIPConfigurationPropertiesFormat
+			if isInternal {
+				// azure does not support ILB for IPv6 yet.
+				// TODO: remove this check when ILB supports IPv6 *and* the SDK
+				// have been rev'ed to 2019* version
+				if utilnet.IsIPv6String(service.Spec.ClusterIP) {
+					return nil, false, fmt.Errorf("ensure(%s): lb(%s) - internal load balancers does not support IPv6", serviceName, lbName)
+				}
+
+				subnetName := subnet(service)
+				if subnetName == nil {
+					subnetName = &az.SubnetName
+				}
+				subnet, existsSubnet, err := az.getSubnet(az.VnetName, *subnetName)
+				if err != nil {
+					return nil, false, err
+				}
+
+				if !existsSubnet {
+					return nil, false, fmt.Errorf("ensure(%s): lb(%s) - failed to get subnet: %s/%s", serviceName, lbName, az.VnetName, az.SubnetName)
+				}
+
+				configProperties := network.FrontendIPConfigurationPropertiesFormat{
+					Subnet: &subnet,
+				}
+
+				loadBalancerIP := service.Spec.LoadBalancerIP
+				if loadBalancerIP != "" {
+					configProperties.PrivateIPAllocationMethod = network.Static
+					configProperties.PrivateIPAddress = &loadBalancerIP
+				} else {
+					// We'll need to call GetLoadBalancer later to retrieve allocated IP.
+					configProperties.PrivateIPAllocationMethod = network.Dynamic
+				}
+
+				fipConfigurationProperties = &configProperties
+			} else {
+				pipName, shouldPIPExisted, err := az.determinePublicIPName(clusterName, service)
+				if err != nil {
+					return nil, false, err
+				}
+				domainNameLabel, found := getPublicIPDomainNameLabel(service)
+				pip, err := az.ensurePublicIPExists(service, pipName, domainNameLabel, clusterName, shouldPIPExisted, found)
+				if err != nil {
+					return nil, false, err
+				}
+				fipConfigurationProperties = &network.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &network.PublicIPAddress{ID: pip.ID},
+				}
+			}
+
+			newConfigs = append(newConfigs,
+				network.FrontendIPConfiguration{
+					Name:                                    to.StringPtr(defaultLBFrontendIPConfigName),
+					ID:                                      to.StringPtr(fmt.Sprintf(frontendIPConfigIDTemplate, az.SubscriptionID, az.ResourceGroup, *lb.Name, defaultLBFrontendIPConfigName)),
+					FrontendIPConfigurationPropertiesFormat: fipConfigurationProperties,
+				})
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, defaultLBFrontendIPConfigName)
+			dirtyConfigs = true
+		}
+	}
+	if dirtyConfigs {
+		lb.FrontendIPConfigurations = &newConfigs
+	}
+	return ownedFIPConfig, dirtyConfigs, err
+}
+
+func (az *Cloud) reconcileBackendPools(clusterName string, service *v1.Service, nodes []*v1.Node, lb *network.LoadBalancer, isBackendPoolPreConfigured bool) (bool, bool, error) {
+	var newBackendPools []network.BackendAddressPool
+	var err error
+	if lb.BackendAddressPools != nil {
+		newBackendPools = *lb.BackendAddressPools
+	}
+
+	foundBackendPool := false
+	dirtyLb := false
+	wantLb := true
+	lbName := *lb.Name
+
+	serviceName := getServiceName(service)
+	lbBackendPoolName := getBackendPoolName(clusterName, service)
+	lbBackendPoolID := az.getBackendPoolID(lbName, az.getLoadBalancerResourceGroup(), lbBackendPoolName)
+	vmSetName := az.mapLoadBalancerNameToVMSet(lbName, clusterName)
+
+	for _, bp := range newBackendPools {
+		if strings.EqualFold(*bp.Name, lbBackendPoolName) {
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found wanted backendpool. not adding anything", serviceName, wantLb)
+			foundBackendPool = true
+
+			var backendIPConfigurationsToBeDeleted []network.InterfaceIPConfiguration
+			if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
+				for _, ipConf := range *bp.BackendIPConfigurations {
+					ipConfID := to.String(ipConf.ID)
+					nodeName, _, err := az.VMSet.GetNodeNameByIPConfigurationID(ipConfID)
+					if err != nil {
+						return false, false, err
+					}
+					if nodeName == "" {
+						// VM may under deletion
+						continue
+					}
+					// If a node is not supposed to be included in the LB, it
+					// would not be in the `nodes` slice. We need to check the nodes that
+					// have been added to the LB's backendpool, find the unwanted ones and
+					// delete them from the pool.
+					if !nodeNameInNodes(nodeName, nodes) {
+						klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found unwanted node %s, decouple it from the LB", serviceName, wantLb, nodeName)
+						// construct a backendPool that only contains the IP config of the node to be deleted
+						backendIPConfigurationsToBeDeleted = append(backendIPConfigurationsToBeDeleted, network.InterfaceIPConfiguration{ID: to.StringPtr(ipConfID)})
+					}
+				}
+				if len(backendIPConfigurationsToBeDeleted) > 0 {
+					backendpoolToBeDeleted := &[]network.BackendAddressPool{
+						{
+							ID: to.StringPtr(lbBackendPoolID),
+							BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
+								BackendIPConfigurations: &backendIPConfigurationsToBeDeleted,
+							},
+						},
+					}
+					// decouple the backendPool from the node
+					err = az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, backendpoolToBeDeleted)
+					if err != nil {
+						return false, false, err
+					}
+				}
+			}
+			break
+		} else {
+			klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - found other backendpool %s", serviceName, wantLb, *bp.Name)
+		}
+	}
+	if !foundBackendPool {
+		if isBackendPoolPreConfigured {
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - PreConfiguredBackendPoolLoadBalancerTypes %s has been set but can not find corresponding backend pool, ignoring it",
+				serviceName,
+				wantLb,
+				az.PreConfiguredBackendPoolLoadBalancerTypes)
+			isBackendPoolPreConfigured = false
+		}
+
+		newBackendPools = append(newBackendPools, network.BackendAddressPool{
+			Name: to.StringPtr(lbBackendPoolName),
+		})
+		klog.V(10).Infof("reconcileLoadBalancer for service (%s)(%t): lb backendpool - adding backendpool", serviceName, wantLb)
+
+		dirtyLb = true
+		lb.BackendAddressPools = &newBackendPools
+	}
+	return isBackendPoolPreConfigured, dirtyLb, err
+}
+
+// checkLoadBalancerResourcesConflicts checks if the service is consuming
+// ports which conflict with the existing loadBalancer resources,
 // including inbound NAT rule, inbound NAT pools and loadBalancing rules
-func (az *Cloud) checkLoadBalancerResourcesConflicted(
+func (az *Cloud) checkLoadBalancerResourcesConflicts(
 	lb *network.LoadBalancer,
 	frontendIPConfigID string,
 	service *v1.Service,
@@ -1635,18 +1682,12 @@ func (az *Cloud) checkLoadBalancerResourcesConflicted(
 	for _, port := range ports {
 		if lb.LoadBalancingRules != nil {
 			for _, rule := range *lb.LoadBalancingRules {
-				if rule.LoadBalancingRulePropertiesFormat != nil &&
-					rule.FrontendIPConfiguration != nil &&
-					rule.FrontendIPConfiguration.ID != nil &&
-					strings.EqualFold(*rule.FrontendIPConfiguration.ID, frontendIPConfigID) &&
-					strings.EqualFold(string(rule.Protocol), string(port.Protocol)) &&
-					rule.FrontendPort != nil &&
-					*rule.FrontendPort == port.Port {
+				if lbRuleConflictsWithPort(rule, frontendIPConfigID, port) {
 					// ignore self-owned rules for unit test
 					if rule.Name != nil && az.serviceOwnsRule(service, *rule.Name) {
 						continue
 					}
-					return fmt.Errorf("checkLoadBalancerResourcesConflicted: service port %s is trying to "+
+					return fmt.Errorf("checkLoadBalancerResourcesConflicts: service port %s is trying to "+
 						"consume the port %d which is being referenced by an existing loadBalancing rule %s with "+
 						"the same protocol %s and frontend IP config with ID %s",
 						port.Name,
@@ -1660,14 +1701,8 @@ func (az *Cloud) checkLoadBalancerResourcesConflicted(
 
 		if lb.InboundNatRules != nil {
 			for _, inboundNatRule := range *lb.InboundNatRules {
-				if inboundNatRule.InboundNatRulePropertiesFormat != nil &&
-					inboundNatRule.FrontendIPConfiguration != nil &&
-					inboundNatRule.FrontendIPConfiguration.ID != nil &&
-					strings.EqualFold(*inboundNatRule.FrontendIPConfiguration.ID, frontendIPConfigID) &&
-					strings.EqualFold(string(inboundNatRule.Protocol), string(port.Protocol)) &&
-					inboundNatRule.FrontendPort != nil &&
-					*inboundNatRule.FrontendPort == port.Port {
-					return fmt.Errorf("checkLoadBalancerResourcesConflicted: service port %s is trying to "+
+				if inboundNatRuleConflictsWithPort(inboundNatRule, frontendIPConfigID, port) {
+					return fmt.Errorf("checkLoadBalancerResourcesConflicts: service port %s is trying to "+
 						"consume the port %d which is being referenced by an existing inbound NAT rule %s with "+
 						"the same protocol %s and frontend IP config with ID %s",
 						port.Name,
@@ -1681,16 +1716,8 @@ func (az *Cloud) checkLoadBalancerResourcesConflicted(
 
 		if lb.InboundNatPools != nil {
 			for _, pool := range *lb.InboundNatPools {
-				if pool.InboundNatPoolPropertiesFormat != nil &&
-					pool.FrontendIPConfiguration != nil &&
-					pool.FrontendIPConfiguration.ID != nil &&
-					strings.EqualFold(*pool.FrontendIPConfiguration.ID, frontendIPConfigID) &&
-					strings.EqualFold(string(pool.Protocol), string(port.Protocol)) &&
-					pool.FrontendPortRangeStart != nil &&
-					pool.FrontendPortRangeEnd != nil &&
-					*pool.FrontendPortRangeStart <= port.Port &&
-					*pool.FrontendPortRangeEnd >= port.Port {
-					return fmt.Errorf("checkLoadBalancerResourcesConflicted: service port %s is trying to "+
+				if inboundNatPoolConflictsWithPort(pool, frontendIPConfigID, port) {
+					return fmt.Errorf("checkLoadBalancerResourcesConflicts: service port %s is trying to "+
 						"consume the port %d which is being in the range (%d-%d) of an existing "+
 						"inbound NAT pool %s with the same protocol %s and frontend IP config with ID %s",
 						port.Name,
@@ -1706,6 +1733,38 @@ func (az *Cloud) checkLoadBalancerResourcesConflicted(
 	}
 
 	return nil
+}
+
+func inboundNatPoolConflictsWithPort(pool network.InboundNatPool, frontendIPConfigID string, port v1.ServicePort) bool {
+	return pool.InboundNatPoolPropertiesFormat != nil &&
+		pool.FrontendIPConfiguration != nil &&
+		pool.FrontendIPConfiguration.ID != nil &&
+		strings.EqualFold(*pool.FrontendIPConfiguration.ID, frontendIPConfigID) &&
+		strings.EqualFold(string(pool.Protocol), string(port.Protocol)) &&
+		pool.FrontendPortRangeStart != nil &&
+		pool.FrontendPortRangeEnd != nil &&
+		*pool.FrontendPortRangeStart <= port.Port &&
+		*pool.FrontendPortRangeEnd >= port.Port
+}
+
+func inboundNatRuleConflictsWithPort(inboundNatRule network.InboundNatRule, frontendIPConfigID string, port v1.ServicePort) bool {
+	return inboundNatRule.InboundNatRulePropertiesFormat != nil &&
+		inboundNatRule.FrontendIPConfiguration != nil &&
+		inboundNatRule.FrontendIPConfiguration.ID != nil &&
+		strings.EqualFold(*inboundNatRule.FrontendIPConfiguration.ID, frontendIPConfigID) &&
+		strings.EqualFold(string(inboundNatRule.Protocol), string(port.Protocol)) &&
+		inboundNatRule.FrontendPort != nil &&
+		*inboundNatRule.FrontendPort == port.Port
+}
+
+func lbRuleConflictsWithPort(rule network.LoadBalancingRule, frontendIPConfigID string, port v1.ServicePort) bool {
+	return rule.LoadBalancingRulePropertiesFormat != nil &&
+		rule.FrontendIPConfiguration != nil &&
+		rule.FrontendIPConfiguration.ID != nil &&
+		strings.EqualFold(*rule.FrontendIPConfiguration.ID, frontendIPConfigID) &&
+		strings.EqualFold(string(rule.Protocol), string(port.Protocol)) &&
+		rule.FrontendPort != nil &&
+		*rule.FrontendPort == port.Port
 }
 
 func parseHealthProbeProtocolAndPath(service *v1.Service) (string, string) {
@@ -1725,7 +1784,7 @@ func parseHealthProbeProtocolAndPath(service *v1.Service) (string, string) {
 	return protocol, path
 }
 
-func (az *Cloud) reconcileLoadBalancerRule(
+func (az *Cloud) getExpectedLBRules(
 	service *v1.Service,
 	wantLb bool,
 	lbFrontendIPConfigID string,
@@ -1752,7 +1811,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 	var expectedRules []network.LoadBalancingRule
 	for _, port := range ports {
 		lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port)
-		klog.V(2).Infof("reconcileLoadBalancerRule lb name (%s) rule name (%s)", lbName, lbRuleName)
+		klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
 
 		transportProto, _, probeProto, err := getProtocolsFromKubernetesProtocol(port.Protocol)
 		if err != nil {
@@ -1906,6 +1965,145 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		}
 		sourceAddressPrefixes = append(sourceAddressPrefixes, serviceTags...)
 	}
+
+	expectedSecurityRules, err := az.getExpectedSecurityRules(wantLb, ports, sourceAddressPrefixes, service, destinationIPAddress, sourceRanges)
+	if err != nil {
+		return nil, err
+	}
+
+	// update security rules
+	dirtySg, updatedRules, err := az.reconcileSecurityRules(sg, service, serviceName, wantLb, expectedSecurityRules, ports, sourceAddressPrefixes, destinationIPAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	changed := az.ensureSecurityGroupTagged(&sg)
+	if changed {
+		dirtySg = true
+	}
+
+	if dirtySg {
+		sg.SecurityRules = &updatedRules
+		klog.V(2).Infof("reconcileSecurityGroup for service(%s): sg(%s) - updating", serviceName, *sg.Name)
+		klog.V(10).Infof("CreateOrUpdateSecurityGroup(%q): start", *sg.Name)
+		err := az.CreateOrUpdateSecurityGroup(sg)
+		if err != nil {
+			klog.V(2).Infof("ensure(%s) abort backoff: sg(%s) - updating", serviceName, *sg.Name)
+			return nil, err
+		}
+		klog.V(10).Infof("CreateOrUpdateSecurityGroup(%q): end", *sg.Name)
+		_ = az.nsgCache.Delete(to.String(sg.Name))
+	}
+	return &sg, nil
+}
+
+func (az *Cloud) reconcileSecurityRules(sg network.SecurityGroup, service *v1.Service, serviceName string, wantLb bool, expectedSecurityRules []network.SecurityRule, ports []v1.ServicePort, sourceAddressPrefixes []string, destinationIPAddress string) (bool, []network.SecurityRule, error) {
+	dirtySg := false
+	var updatedRules []network.SecurityRule
+	if sg.SecurityGroupPropertiesFormat != nil && sg.SecurityGroupPropertiesFormat.SecurityRules != nil {
+		updatedRules = *sg.SecurityGroupPropertiesFormat.SecurityRules
+	}
+
+	for _, r := range updatedRules {
+		klog.V(10).Infof("Existing security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
+	}
+
+	// update security rules: remove unwanted rules that belong privately
+	// to this service
+	for i := len(updatedRules) - 1; i >= 0; i-- {
+		existingRule := updatedRules[i]
+		if az.serviceOwnsRule(service, *existingRule.Name) {
+			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
+			keepRule := false
+			if findSecurityRule(expectedSecurityRules, existingRule) {
+				klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
+				keepRule = true
+			}
+			if !keepRule {
+				klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - dropping", serviceName, wantLb, *existingRule.Name)
+				updatedRules = append(updatedRules[:i], updatedRules[i+1:]...)
+				dirtySg = true
+			}
+		}
+	}
+
+	// update security rules: if the service uses a shared rule and is being deleted,
+	// then remove it from the shared rule
+	if useSharedSecurityRule(service) && !wantLb {
+		for _, port := range ports {
+			for _, sourceAddressPrefix := range sourceAddressPrefixes {
+				sharedRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefix)
+				sharedIndex, sharedRule, sharedRuleFound := findSecurityRuleByName(updatedRules, sharedRuleName)
+				if !sharedRuleFound {
+					klog.V(4).Infof("Expected to find shared rule %s for service %s being deleted, but did not", sharedRuleName, service.Name)
+					return false, nil, fmt.Errorf("expected to find shared rule %s for service %s being deleted, but did not", sharedRuleName, service.Name)
+				}
+				if sharedRule.DestinationAddressPrefixes == nil {
+					klog.V(4).Infof("Expected to have array of destinations in shared rule for service %s being deleted, but did not", service.Name)
+					return false, nil, fmt.Errorf("expected to have array of destinations in shared rule for service %s being deleted, but did not", service.Name)
+				}
+				existingPrefixes := *sharedRule.DestinationAddressPrefixes
+				addressIndex, found := findIndex(existingPrefixes, destinationIPAddress)
+				if !found {
+					klog.V(4).Infof("Expected to find destination address %s in shared rule %s for service %s being deleted, but did not", destinationIPAddress, sharedRuleName, service.Name)
+					return false, nil, fmt.Errorf("expected to find destination address %s in shared rule %s for service %s being deleted, but did not", destinationIPAddress, sharedRuleName, service.Name)
+				}
+				if len(existingPrefixes) == 1 {
+					updatedRules = append(updatedRules[:sharedIndex], updatedRules[sharedIndex+1:]...)
+				} else {
+					newDestinations := append(existingPrefixes[:addressIndex], existingPrefixes[addressIndex+1:]...)
+					sharedRule.DestinationAddressPrefixes = &newDestinations
+					updatedRules[sharedIndex] = sharedRule
+				}
+				dirtySg = true
+			}
+		}
+	}
+
+	// update security rules: prepare rules for consolidation
+	for index, rule := range updatedRules {
+		if allowsConsolidation(rule) {
+			updatedRules[index] = makeConsolidatable(rule)
+		}
+	}
+	for index, rule := range expectedSecurityRules {
+		if allowsConsolidation(rule) {
+			expectedSecurityRules[index] = makeConsolidatable(rule)
+		}
+	}
+	// update security rules: add needed
+	for _, expectedRule := range expectedSecurityRules {
+		foundRule := false
+		if findSecurityRule(updatedRules, expectedRule) {
+			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
+			foundRule = true
+		}
+		if foundRule && allowsConsolidation(expectedRule) {
+			index, _ := findConsolidationCandidate(updatedRules, expectedRule)
+			updatedRules[index] = consolidate(updatedRules[index], expectedRule)
+			dirtySg = true
+		}
+		if !foundRule {
+			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - adding", serviceName, wantLb, *expectedRule.Name)
+
+			nextAvailablePriority, err := getNextAvailablePriority(updatedRules)
+			if err != nil {
+				return false, nil, err
+			}
+
+			expectedRule.Priority = to.Int32Ptr(nextAvailablePriority)
+			updatedRules = append(updatedRules, expectedRule)
+			dirtySg = true
+		}
+	}
+
+	for _, r := range updatedRules {
+		klog.V(10).Infof("Updated security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
+	}
+	return dirtySg, updatedRules, nil
+}
+
+func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, sourceAddressPrefixes []string, service *v1.Service, destinationIPAddress string, sourceRanges utilnet.IPNetSet) ([]network.SecurityRule, error) {
 	expectedSecurityRules := []network.SecurityRule{}
 
 	if wantLb {
@@ -1966,128 +2164,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	for _, r := range expectedSecurityRules {
 		klog.V(10).Infof("Expecting security rule for %s: %s:%s -> %s:%s", service.Name, *r.SourceAddressPrefix, *r.SourcePortRange, *r.DestinationAddressPrefix, *r.DestinationPortRange)
 	}
-
-	// update security rules
-	dirtySg := false
-	var updatedRules []network.SecurityRule
-	if sg.SecurityGroupPropertiesFormat != nil && sg.SecurityGroupPropertiesFormat.SecurityRules != nil {
-		updatedRules = *sg.SecurityGroupPropertiesFormat.SecurityRules
-	}
-
-	for _, r := range updatedRules {
-		klog.V(10).Infof("Existing security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
-	}
-
-	// update security rules: remove unwanted rules that belong privately
-	// to this service
-	for i := len(updatedRules) - 1; i >= 0; i-- {
-		existingRule := updatedRules[i]
-		if az.serviceOwnsRule(service, *existingRule.Name) {
-			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - considering evicting", serviceName, wantLb, *existingRule.Name)
-			keepRule := false
-			if findSecurityRule(expectedSecurityRules, existingRule) {
-				klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - keeping", serviceName, wantLb, *existingRule.Name)
-				keepRule = true
-			}
-			if !keepRule {
-				klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - dropping", serviceName, wantLb, *existingRule.Name)
-				updatedRules = append(updatedRules[:i], updatedRules[i+1:]...)
-				dirtySg = true
-			}
-		}
-	}
-	// update security rules: if the service uses a shared rule and is being deleted,
-	// then remove it from the shared rule
-	if useSharedSecurityRule(service) && !wantLb {
-		for _, port := range ports {
-			for _, sourceAddressPrefix := range sourceAddressPrefixes {
-				sharedRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefix)
-				sharedIndex, sharedRule, sharedRuleFound := findSecurityRuleByName(updatedRules, sharedRuleName)
-				if !sharedRuleFound {
-					klog.V(4).Infof("Expected to find shared rule %s for service %s being deleted, but did not", sharedRuleName, service.Name)
-					return nil, fmt.Errorf("expected to find shared rule %s for service %s being deleted, but did not", sharedRuleName, service.Name)
-				}
-				if sharedRule.DestinationAddressPrefixes == nil {
-					klog.V(4).Infof("Expected to have array of destinations in shared rule for service %s being deleted, but did not", service.Name)
-					return nil, fmt.Errorf("expected to have array of destinations in shared rule for service %s being deleted, but did not", service.Name)
-				}
-				existingPrefixes := *sharedRule.DestinationAddressPrefixes
-				addressIndex, found := findIndex(existingPrefixes, destinationIPAddress)
-				if !found {
-					klog.V(4).Infof("Expected to find destination address %s in shared rule %s for service %s being deleted, but did not", destinationIPAddress, sharedRuleName, service.Name)
-					return nil, fmt.Errorf("expected to find destination address %s in shared rule %s for service %s being deleted, but did not", destinationIPAddress, sharedRuleName, service.Name)
-				}
-				if len(existingPrefixes) == 1 {
-					updatedRules = append(updatedRules[:sharedIndex], updatedRules[sharedIndex+1:]...)
-				} else {
-					newDestinations := append(existingPrefixes[:addressIndex], existingPrefixes[addressIndex+1:]...)
-					sharedRule.DestinationAddressPrefixes = &newDestinations
-					updatedRules[sharedIndex] = sharedRule
-				}
-				dirtySg = true
-			}
-		}
-	}
-
-	// update security rules: prepare rules for consolidation
-	for index, rule := range updatedRules {
-		if allowsConsolidation(rule) {
-			updatedRules[index] = makeConsolidatable(rule)
-		}
-	}
-	for index, rule := range expectedSecurityRules {
-		if allowsConsolidation(rule) {
-			expectedSecurityRules[index] = makeConsolidatable(rule)
-		}
-	}
-	// update security rules: add needed
-	for _, expectedRule := range expectedSecurityRules {
-		foundRule := false
-		if findSecurityRule(updatedRules, expectedRule) {
-			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - already exists", serviceName, wantLb, *expectedRule.Name)
-			foundRule = true
-		}
-		if foundRule && allowsConsolidation(expectedRule) {
-			index, _ := findConsolidationCandidate(updatedRules, expectedRule)
-			updatedRules[index] = consolidate(updatedRules[index], expectedRule)
-			dirtySg = true
-		}
-		if !foundRule {
-			klog.V(10).Infof("reconcile(%s)(%t): sg rule(%s) - adding", serviceName, wantLb, *expectedRule.Name)
-
-			nextAvailablePriority, err := getNextAvailablePriority(updatedRules)
-			if err != nil {
-				return nil, err
-			}
-
-			expectedRule.Priority = to.Int32Ptr(nextAvailablePriority)
-			updatedRules = append(updatedRules, expectedRule)
-			dirtySg = true
-		}
-	}
-
-	for _, r := range updatedRules {
-		klog.V(10).Infof("Updated security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
-	}
-
-	changed := az.ensureSecurityGroupTagged(&sg)
-	if changed {
-		dirtySg = true
-	}
-
-	if dirtySg {
-		sg.SecurityRules = &updatedRules
-		klog.V(2).Infof("reconcileSecurityGroup for service(%s): sg(%s) - updating", serviceName, *sg.Name)
-		klog.V(10).Infof("CreateOrUpdateSecurityGroup(%q): start", *sg.Name)
-		err := az.CreateOrUpdateSecurityGroup(sg)
-		if err != nil {
-			klog.V(2).Infof("ensure(%s) abort backoff: sg(%s) - updating", serviceName, *sg.Name)
-			return nil, err
-		}
-		klog.V(10).Infof("CreateOrUpdateSecurityGroup(%q): end", *sg.Name)
-		_ = az.nsgCache.Delete(to.String(sg.Name))
-	}
-	return &sg, nil
+	return expectedSecurityRules, nil
 }
 
 func (az *Cloud) shouldUpdateLoadBalancer(clusterName string, service *v1.Service) bool {
@@ -2339,62 +2416,9 @@ func (az *Cloud) reconcilePublicIP(clusterName string, service *v1.Service, lbNa
 		return nil, err
 	}
 
-	var (
-		serviceAnnotationRequestsNamedPublicIP = shouldPIPExisted
-		discoveredDesiredPublicIP              bool
-		deletedDesiredPublicIP                 bool
-		pipsToBeDeleted                        []*network.PublicIPAddress
-		pipsToBeUpdated                        []*network.PublicIPAddress
-	)
-
-	for i := range pips {
-		pip := pips[i]
-		pipName := *pip.Name
-
-		// If we've been told to use a specific public ip by the client, let's track whether or not it actually existed
-		// when we inspect the set in Azure.
-		discoveredDesiredPublicIP = discoveredDesiredPublicIP || wantLb && !isInternal && pipName == desiredPipName
-
-		// Now, let's perform additional analysis to determine if we should release the public ips we have found.
-		// We can only let them go if (a) they are owned by this service and (b) they meet the criteria for deletion.
-		if serviceOwnsPublicIP(&pip, clusterName, serviceName) {
-			var dirtyPIP, toBeDeleted bool
-			if !wantLb {
-				klog.V(2).Infof("reconcilePublicIP for service(%s): unbinding the service from pip %s", serviceName, *pip.Name)
-				err = unbindServiceFromPIP(&pip, serviceName)
-				if err != nil {
-					return nil, err
-				}
-				dirtyPIP = true
-			}
-			changed := az.ensurePIPTagged(service, &pip)
-			if changed {
-				dirtyPIP = true
-			}
-			if shouldReleaseExistingOwnedPublicIP(&pip, wantLb, isInternal, desiredPipName, serviceName, serviceIPTagRequest) {
-				// Then, release the public ip
-				pipsToBeDeleted = append(pipsToBeDeleted, &pip)
-
-				// Flag if we deleted the desired public ip
-				deletedDesiredPublicIP = deletedDesiredPublicIP || pipName == desiredPipName
-
-				// An aside: It would be unusual, but possible, for us to delete a public ip referred to explicitly by name
-				// in Service annotations (which is usually reserved for non-service-owned externals), if that IP is tagged as
-				// having been owned by a particular Kubernetes cluster.
-
-				// If the pip is going to be deleted, we do not need to update it
-				toBeDeleted = true
-			}
-
-			// Update tags of PIP only instead of deleting it.
-			if !toBeDeleted && dirtyPIP {
-				pipsToBeUpdated = append(pipsToBeUpdated, &pip)
-			}
-		}
-	}
-
-	if !isInternal && serviceAnnotationRequestsNamedPublicIP && !discoveredDesiredPublicIP && wantLb {
-		return nil, fmt.Errorf("reconcilePublicIP for service(%s): pip(%s) not found", serviceName, desiredPipName)
+	discoveredDesiredPublicIP, pipsToBeDeleted, deletedDesiredPublicIP, pipsToBeUpdated, err := az.getPublicIPUpdates(clusterName, service, pips, wantLb, isInternal, desiredPipName, serviceName, serviceIPTagRequest, shouldPIPExisted)
+	if err != nil {
+		return nil, err
 	}
 
 	var deleteFuncs, updateFuncs []func() error
@@ -2426,13 +2450,73 @@ func (az *Cloud) reconcilePublicIP(clusterName string, service *v1.Service, lbNa
 		// Confirm desired public ip resource exists
 		var pip *network.PublicIPAddress
 		domainNameLabel, found := getPublicIPDomainNameLabel(service)
-		errorIfPublicIPDoesNotExist := serviceAnnotationRequestsNamedPublicIP && discoveredDesiredPublicIP && !deletedDesiredPublicIP
+		errorIfPublicIPDoesNotExist := shouldPIPExisted && discoveredDesiredPublicIP && !deletedDesiredPublicIP
 		if pip, err = az.ensurePublicIPExists(service, desiredPipName, domainNameLabel, clusterName, errorIfPublicIPDoesNotExist, found); err != nil {
 			return nil, err
 		}
 		return pip, nil
 	}
 	return nil, nil
+}
+
+func (az *Cloud) getPublicIPUpdates(clusterName string, service *v1.Service, pips []network.PublicIPAddress, wantLb bool, isInternal bool, desiredPipName string, serviceName string, serviceIPTagRequest serviceIPTagRequest, serviceAnnotationRequestsNamedPublicIP bool) (bool, []*network.PublicIPAddress, bool, []*network.PublicIPAddress, error) {
+	var (
+		err                       error
+		discoveredDesiredPublicIP bool
+		deletedDesiredPublicIP    bool
+		pipsToBeDeleted           []*network.PublicIPAddress
+		pipsToBeUpdated           []*network.PublicIPAddress
+	)
+	for i := range pips {
+		pip := pips[i]
+		pipName := *pip.Name
+
+		// If we've been told to use a specific public ip by the client, let's track whether or not it actually existed
+		// when we inspect the set in Azure.
+		discoveredDesiredPublicIP = discoveredDesiredPublicIP || wantLb && !isInternal && pipName == desiredPipName
+
+		// Now, let's perform additional analysis to determine if we should release the public ips we have found.
+		// We can only let them go if (a) they are owned by this service and (b) they meet the criteria for deletion.
+		if serviceOwnsPublicIP(&pip, clusterName, serviceName) {
+			var dirtyPIP, toBeDeleted bool
+			if !wantLb {
+				klog.V(2).Infof("reconcilePublicIP for service(%s): unbinding the service from pip %s", serviceName, *pip.Name)
+				err = unbindServiceFromPIP(&pip, serviceName)
+				if err != nil {
+					return false, nil, false, nil, err
+				}
+				dirtyPIP = true
+			}
+			changed := az.ensurePIPTagged(service, &pip)
+			if changed {
+				dirtyPIP = true
+			}
+			if shouldReleaseExistingOwnedPublicIP(&pip, wantLb, isInternal, desiredPipName, serviceName, serviceIPTagRequest) {
+				// Then, release the public ip
+				pipsToBeDeleted = append(pipsToBeDeleted, &pip)
+
+				// Flag if we deleted the desired public ip
+				deletedDesiredPublicIP = deletedDesiredPublicIP || pipName == desiredPipName
+
+				// An aside: It would be unusual, but possible, for us to delete a public ip referred to explicitly by name
+				// in Service annotations (which is usually reserved for non-service-owned externals), if that IP is tagged as
+				// having been owned by a particular Kubernetes cluster.
+
+				// If the pip is going to be deleted, we do not need to update it
+				toBeDeleted = true
+			}
+
+			// Update tags of PIP only instead of deleting it.
+			if !toBeDeleted && dirtyPIP {
+				pipsToBeUpdated = append(pipsToBeUpdated, &pip)
+			}
+		}
+	}
+
+	if !isInternal && serviceAnnotationRequestsNamedPublicIP && !discoveredDesiredPublicIP && wantLb {
+		return false, nil, false, nil, fmt.Errorf("reconcilePublicIP for service(%s): pip(%s) not found", serviceName, desiredPipName)
+	}
+	return discoveredDesiredPublicIP, pipsToBeDeleted, deletedDesiredPublicIP, pipsToBeUpdated, err
 }
 
 // safeDeletePublicIP deletes public IP by removing its reference first.

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1609,12 +1609,12 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		expectedErr     error
 	}{
 		{
-			desc:    "reconcileLoadBalancerRule shall return nil if wantLb is false",
+			desc:    "getExpectedLBRules shall return nil if wantLb is false",
 			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			wantLb:  false,
 		},
 		{
-			desc:            "reconcileLoadBalancerRule shall return corresponding probe and lbRule(blb)",
+			desc:            "getExpectedLBRules shall return corresponding probe and lbRule(blb)",
 			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "true"}, false, 80),
 			loadBalancerSku: "basic",
 			wantLb:          true,
@@ -1622,7 +1622,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			expectedRules:   getDefaultTestRules(false),
 		},
 		{
-			desc:            "reconcileLoadBalancerRule shall return corresponding probe and lbRule (slb without tcp reset)",
+			desc:            "getExpectedLBRules shall return corresponding probe and lbRule (slb without tcp reset)",
 			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "True"}, false, 80),
 			loadBalancerSku: "standard",
 			wantLb:          true,
@@ -1630,7 +1630,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
-			desc:            "reconcileLoadBalancerRule shall return corresponding probe and lbRule(slb with tcp reset)",
+			desc:            "getExpectedLBRules shall return corresponding probe and lbRule(slb with tcp reset)",
 			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			loadBalancerSku: "standard",
 			wantLb:          true,
@@ -1638,7 +1638,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
-			desc:            "reconcileLoadBalancerRule shall respect the probe protocol and path configuration in the config file",
+			desc:            "getExpectedLBRules shall respect the probe protocol and path configuration in the config file",
 			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			loadBalancerSku: "standard",
 			wantLb:          true,
@@ -1658,7 +1658,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		if test.probePath != "" {
 			service.Annotations[ServiceAnnotationLoadBalancerHealthProbeRequestPath] = test.probePath
 		}
-		probe, lbrule, err := az.reconcileLoadBalancerRule(&test.service, test.wantLb,
+		probe, lbrule, err := az.getExpectedLBRules(&test.service, test.wantLb,
 			"frontendIPConfigID", "backendPoolID", "lbname", to.Int32Ptr(0))
 
 		if test.expectedErr != nil {
@@ -3528,7 +3528,7 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 		expectedErr bool
 	}{
 		{
-			desc: "checkLoadBalancerResourcesConflicted should report the conflict error if " +
+			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted loadBalancing rule",
 			existingLB: &network.LoadBalancer{
 				Name: to.StringPtr("lb"),
@@ -3548,7 +3548,7 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			desc: "checkLoadBalancerResourcesConflicted should report the conflict error if " +
+			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted inbound NAT rule",
 			existingLB: &network.LoadBalancer{
 				Name: to.StringPtr("lb"),
@@ -3568,7 +3568,7 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			desc: "checkLoadBalancerResourcesConflicted should report the conflict error if " +
+			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted inbound NAT pool",
 			existingLB: &network.LoadBalancer{
 				Name: to.StringPtr("lb"),
@@ -3589,7 +3589,7 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			desc: "checkLoadBalancerResourcesConflicted should not report the conflict error if there " +
+			desc: "checkLoadBalancerResourcesConflicts should not report the conflict error if there " +
 				"is no conflicted loadBalancer resources",
 			existingLB: &network.LoadBalancer{
 				Name: to.StringPtr("lb"),
@@ -3631,7 +3631,7 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := az.checkLoadBalancerResourcesConflicted(testCase.existingLB, fipID, &service)
+		err := az.checkLoadBalancerResourcesConflicts(testCase.existingLB, fipID, &service)
 		assert.Equal(t, testCase.expectedErr, err != nil, testCase.desc)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup


**What this PR does / why we need it**: Fix code and enable gocyclo linter. Follow up from #518.

**Which issue(s) this PR fixes**:

```
pkg/provider/azure_loadbalancer.go:1231:1: cyclomatic complexity 76 of func `(*Cloud).reconcileLoadBalancer` is high (> 30) (gocyclo)
func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node, wantLb bool) (*network.LoadBalancer, error) {
^
pkg/provider/azure_loadbalancer.go:1857:1: cyclomatic complexity 56 of func `(*Cloud).reconcileSecurityGroup` is high (> 30) (gocyclo)
func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service, lbIP *string, wantLb bool) (*network.SecurityGroup, error) {
^
pkg/provider/azure.go:372:1: cyclomatic complexity 38 of func `(*Cloud).InitializeCloudFromConfig` is high (> 30) (gocyclo)
func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) error {
^
pkg/provider/azure_loadbalancer.go:1623:1: cyclomatic complexity 34 of func `(*Cloud).checkLoadBalancerResourcesConflicted` is high (> 30) (gocyclo)
func (az *Cloud) checkLoadBalancerResourcesConflicted(
^
pkg/provider/azure_test.go:2015:1: cyclomatic complexity 33 of func `validateConfig` is high (> 30) (gocyclo)
func validateConfig(t *testing.T, config string) {
^
pkg/provider/azure_loadbalancer.go:2306:1: cyclomatic complexity 32 of func `(*Cloud).reconcilePublicIP` is high (> 30) (gocyclo)
func (az *Cloud) reconcilePublicIP(clusterName string, service *v1.Service, lbName string, wantLb bool) (*network.PublicIPAddress, error) {
^
pkg/provider/azure_test.go:2890:1: cyclomatic complexity 31 of func `TestCanCombineSharedAndPrivateRulesInSameGroup` is high (> 30) (gocyclo)
func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
^
```

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
