### PR TITLE
Route updates wait a while for new routes to take effect

### DIFF
--- a/cmd/cloud-node-manager/app/config/config.go
+++ b/cmd/cloud-node-manager/app/config/config.go
@@ -69,4 +69,8 @@ type Config struct {
 	// ClientConnection specifies the kubeconfig file and client connection
 	// settings for the proxy server to use when communicating with the apiserver.
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration
+
+	// WaitForRoutes indicates whether the node should wait for routes to be created on Azure.
+	// If true, the node condition "NodeNetworkUnavailable" would be set to true on initialization.
+	WaitForRoutes bool
 }

--- a/cmd/cloud-node-manager/app/nodemanager.go
+++ b/cmd/cloud-node-manager/app/nodemanager.go
@@ -136,7 +136,8 @@ func startControllers(c *cloudnodeconfig.Config, stopCh <-chan struct{}) error {
 		// cloud node controller uses existing cluster role from node-controller
 		c.ClientBuilder.ClientOrDie("node-controller"),
 		nodeprovider.NewIMDSNodeProvider(),
-		c.NodeStatusUpdateFrequency.Duration)
+		c.NodeStatusUpdateFrequency.Duration,
+		c.WaitForRoutes)
 
 	go nodeController.Run(stopCh)
 

--- a/cmd/cloud-node-manager/app/options/options.go
+++ b/cmd/cloud-node-manager/app/options/options.go
@@ -78,6 +78,9 @@ type CloudNodeManagerOptions struct {
 	// ClientConnection specifies the kubeconfig file and client connection
 	// settings for the proxy server to use when communicating with the apiserver.
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration
+	// WaitForRoutes indicates whether the node should wait for routes to be created on Azure.
+	// If true, the node condition "NodeNetworkUnavailable" would be set to true on initialization.
+	WaitForRoutes bool
 }
 
 // NewCloudNodeManagerOptions creates a new CloudNodeManagerOptions with a default config.
@@ -124,6 +127,7 @@ func (o *CloudNodeManagerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.ClientConnection.ContentType, "kube-api-content-type", o.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
 	fs.Float32Var(&o.ClientConnection.QPS, "kube-api-qps", 20, "QPS to use while talking with kubernetes apiserver.")
 	fs.Int32Var(&o.ClientConnection.Burst, "kube-api-burst", 30, "Burst to use while talking with kubernetes apiserver.")
+	fs.BoolVar(&o.WaitForRoutes, "wait-routes", false, "Whether the nodes should wait for routes created on Azure route table. It should be set to true when using kubenet plugin.")
 	return fss
 }
 
@@ -156,6 +160,7 @@ func (o *CloudNodeManagerOptions) ApplyTo(c *cloudnodeconfig.Config, userAgent s
 	c.Kubeconfig.ContentConfig.ContentType = o.ClientConnection.ContentType
 	c.Kubeconfig.QPS = o.ClientConnection.QPS
 	c.Kubeconfig.Burst = int(o.ClientConnection.Burst)
+	c.WaitForRoutes = o.WaitForRoutes
 
 	c.Client, err = clientset.NewForConfig(restclient.AddUserAgent(c.Kubeconfig, userAgent))
 	if err != nil {

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -119,6 +119,8 @@ var (
 	defaultExcludeMasterFromStandardLB = true
 	// Outbound SNAT is enabled by default.
 	defaultDisableOutboundSNAT = false
+	// RouteUpdateWaitingInSeconds is 30 seconds by default.
+	defaultRouteUpdateWaitingInSeconds = 30
 )
 
 // Config holds the configuration parsed from the --cloud-config flag
@@ -243,6 +245,10 @@ type Config struct {
 	// when setting AzureAuthConfig.Cloud with "AZURESTACKCLOUD" to customize ARM endpoints
 	// while the cluster is not running on AzureStack.
 	DisableAzureStackCloud bool `json:"disableAzureStackCloud,omitempty" yaml:"disableAzureStackCloud,omitempty"`
+
+	// RouteUpdateWaitingInSeconds is the delay time for waiting route updates to take effect. This waiting delay is added
+	// because the routes are not taken effect when the async route updating operation returns success. Default is 30 seconds.
+	RouteUpdateWaitingInSeconds int `json:"routeUpdateWaitingInSeconds,omitempty" yaml:"routeUpdateWaitingInSeconds,omitempty"`
 
 	// Tags determines what tags shall be applied to the shared resources managed by controller manager, which
 	// includes load balancer, security group and route table. The supported format is `a=b,c=d,...`. After updated
@@ -394,6 +400,10 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 	if config.VMType == "" {
 		// default to standard vmType if not set.
 		config.VMType = vmTypeStandard
+	}
+
+	if config.RouteUpdateWaitingInSeconds <= 0 {
+		config.RouteUpdateWaitingInSeconds = defaultRouteUpdateWaitingInSeconds
 	}
 
 	if config.DisableAvailabilitySetNodes && config.VMType != vmTypeVMSS {

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -200,6 +200,9 @@ func (d *delayedRouteUpdater) updateRoutes() {
 			klog.Errorf("CreateOrUpdateRouteTable() failed with error: %v", err)
 			return
 		}
+
+		// wait a while for route updates to take effect.
+		time.Sleep(time.Duration(d.az.Config.RouteUpdateWaitingInSeconds) * time.Second)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When using kubenet network plugin together with cluster-autoscaler, new Pods scheduled to newly created node would get DNS resolution failure.

After talking with Azure Networking team, we confirmed this is because the route updates haven't take effect yet when the async updating returns success.

Since there's no API exposed to check whether routes take effect or not, this PR adds a delay after route updating requests (defautl is 30s). It also adds a new configuration option, so the delay could be tuned in the future.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #527

**Special notes for your reviewer**:


**Release note**:
```
Fixed routes not created issues before Pod scheduling. When using kubenet, 1) cloud-node-manager supports "--wait-routes=true" to indicate a node would wait for route updates before accepting Pod scheduling and  2) route controller would wait a while for new routes to take effect (default is 30s). 
```
