### PR TITLE
feat: allow nil getter in Timedcache

### DIFF
--- a/pkg/cache/azure_cache.go
+++ b/pkg/cache/azure_cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -70,10 +69,6 @@ type TimedCache struct {
 
 // NewTimedcache creates a new TimedCache.
 func NewTimedcache(ttl time.Duration, getter GetFunc) (*TimedCache, error) {
-	if getter == nil {
-		return nil, fmt.Errorf("getter is not provided")
-	}
-
 	return &TimedCache{
 		Getter: getter,
 		// switch to using NewStore instead of NewTTLStore so that we can
@@ -144,6 +139,10 @@ func (t *TimedCache) Get(key string, crt AzureCacheReadType) (interface{}, error
 	// Data is not cached yet, cache data is expired or requested force refresh
 	// cache it by getter. entry is locked before getting to ensure concurrent
 	// gets don't result in multiple ARM calls.
+	if t.Getter == nil {
+		return nil, nil
+	}
+
 	data, err := t.Getter(key)
 	if err != nil {
 		return nil, err

--- a/pkg/cache/azure_cache_test.go
+++ b/pkg/cache/azure_cache_test.go
@@ -116,6 +116,14 @@ func TestCacheGetError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, getError, err)
 	assert.Nil(t, val)
+
+	// test with getter = nil
+	getter = nil
+	cache, err = NewTimedcache(fakeCacheTTL, getter)
+	assert.NoError(t, err)
+	val, err = cache.Get("key", CacheReadTypeDefault)
+	assert.Nil(t, val)
+	assert.Nil(t, err)
 }
 
 func TestCacheDelete(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: allow nil getter in Timedcache
want to leverage this in azure file csi driver.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
feat: allow nil getter in Timedcache
```
