### PR TITLE
feat: implement cloud cidr allocator for VMSS

### DIFF
--- a/cmd/cloud-controller-manager/app/core.go
+++ b/cmd/cloud-controller-manager/app/core.go
@@ -38,7 +38,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	cloudcontrollerconfig "sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app/config"
-	cloudcontrolleroptions "sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app/options"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	nodeipamcontroller "sigs.k8s.io/cloud-provider-azure/pkg/nodeipam"
 	nodeipamconfig "sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/config"
 	"sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/ipam"
@@ -257,7 +257,7 @@ func startNodeIpamController(ctx *cloudcontrollerconfig.CompletedConfig, cloud c
 // setNodeCIDRMaskSizes returns the IPv4 and IPv6 node cidr mask sizes.
 // If --node-cidr-mask-size not set, then it will return default IPv4 and IPv6 cidr mask sizes.
 func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration) (int, int, error) {
-	ipv4Mask, ipv6Mask := cloudcontrolleroptions.DefaultNodeMaskCIDRIPv4, cloudcontrolleroptions.DefaultNodeMaskCIDRIPv6
+	ipv4Mask, ipv6Mask := consts.DefaultNodeMaskCIDRIPv4, consts.DefaultNodeMaskCIDRIPv6
 	// NodeCIDRMaskSizeIPv4 and NodeCIDRMaskSizeIPv6 can be used only for dual-stack clusters
 	if cfg.NodeCIDRMaskSizeIPv4 != 0 || cfg.NodeCIDRMaskSizeIPv6 != 0 {
 		return ipv4Mask, ipv6Mask, errors.New("usage of --node-cidr-mask-size-ipv4 and --node-cidr-mask-size-ipv6 are not allowed with non dual-stack clusters")
@@ -273,7 +273,7 @@ func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration) (i
 // for --node-cidr-mask-size-ipv4 and --node-cidr-mask-size-ipv6 respectively. If value not provided,
 // then it will return default IPv4 and IPv6 cidr mask sizes.
 func setNodeCIDRMaskSizesDualStack(cfg nodeipamconfig.NodeIPAMControllerConfiguration) (int, int, error) {
-	ipv4Mask, ipv6Mask := cloudcontrolleroptions.DefaultNodeMaskCIDRIPv4, cloudcontrolleroptions.DefaultNodeMaskCIDRIPv6
+	ipv4Mask, ipv6Mask := consts.DefaultNodeMaskCIDRIPv4, consts.DefaultNodeMaskCIDRIPv6
 	// NodeCIDRMaskSize can be used only for single stack clusters
 	if cfg.NodeCIDRMaskSize != 0 {
 		return ipv4Mask, ipv6Mask, errors.New("usage of --node-cidr-mask-size is not allowed with dual-stack clusters")

--- a/cmd/cloud-controller-manager/app/options/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/app/options/nodeipamcontroller.go
@@ -22,16 +22,8 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	nodeipamconfig "sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/config"
-)
-
-const (
-	// DefaultNodeMaskCIDRIPv4 is default mask size for IPv4 node cidr
-	DefaultNodeMaskCIDRIPv4 = 24
-	// DefaultNodeMaskCIDRIPv6 is default mask size for IPv6 node cidr
-	DefaultNodeMaskCIDRIPv6 = 64
-	// DefaultNodeCIDRMaskSize is the default mask size for node cidr
-	DefaultNodeCIDRMaskSize = 24
 )
 
 // NodeIPAMControllerOptions holds the NodeIpamController options.
@@ -45,7 +37,7 @@ func (o *NodeIPAMControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 	fs.StringVar(&o.ServiceCIDR, "service-cluster-ip-range", "", "CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true")
-	fs.Int32Var(&o.NodeCIDRMaskSize, "node-cidr-mask-size", DefaultNodeCIDRMaskSize, "Mask size for node cidr in cluster. Default is 24 for IPv4 and 64 for IPv6.")
+	fs.Int32Var(&o.NodeCIDRMaskSize, "node-cidr-mask-size", consts.DefaultNodeCIDRMaskSize, "Mask size for node cidr in cluster. Default is 24 for IPv4 and 64 for IPv6.")
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv4, "node-cidr-mask-size-ipv4", 0, "Mask size for IPv4 node cidr in dual-stack cluster. Default is 24.")
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv6, "node-cidr-mask-size-ipv6", 0, "Mask size for IPv6 node cidr in dual-stack cluster. Default is 64.")
 }
@@ -91,7 +83,7 @@ func defaultNodeIPAMControllerOptions() *NodeIPAMControllerOptions {
 	return &NodeIPAMControllerOptions{
 		&nodeipamconfig.NodeIPAMControllerConfiguration{
 			ServiceCIDR:          "",
-			NodeCIDRMaskSize:     DefaultNodeCIDRMaskSize,
+			NodeCIDRMaskSize:     consts.DefaultNodeCIDRMaskSize,
 			NodeCIDRMaskSizeIPv4: 0,
 			NodeCIDRMaskSizeIPv6: 0,
 		},

--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -45,7 +45,7 @@ import (
 	"k8s.io/klog"
 
 	cloudcontrollerconfig "sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app/config"
-	azureprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 
 	// add the kubernetes feature gates
 	_ "k8s.io/kubernetes/pkg/features"
@@ -112,7 +112,7 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 	s.Authorization.AlwaysAllowPaths = []string{"/healthz"}
 
 	// Set cloud provider name to Azure.
-	s.KubeCloudShared.CloudProvider.Name = azureprovider.CloudProviderName
+	s.KubeCloudShared.CloudProvider.Name = consts.CloudProviderName
 
 	// Set the PairName but leave certificate directory blank to generate in-memory by default
 	s.SecureServing.ServerCert.CertDirectory = ""

--- a/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/cmd/cloud-controller-manager/app/options/options_test.go
@@ -34,6 +34,7 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	kubectrlmgrconfig "k8s.io/controller-manager/config"
 	cmoptions "k8s.io/controller-manager/options"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/config"
 )
 
@@ -94,7 +95,7 @@ func TestDefaultFlags(t *testing.T) {
 		},
 		NodeIPAMController: &NodeIPAMControllerOptions{
 			NodeIPAMControllerConfiguration: &config.NodeIPAMControllerConfiguration{
-				NodeCIDRMaskSize: DefaultNodeCIDRMaskSize,
+				NodeCIDRMaskSize: consts.DefaultNodeCIDRMaskSize,
 			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
@@ -237,7 +238,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		NodeIPAMController: &NodeIPAMControllerOptions{
 			NodeIPAMControllerConfiguration: &config.NodeIPAMControllerConfiguration{
-				NodeCIDRMaskSize: DefaultNodeCIDRMaskSize,
+				NodeCIDRMaskSize: consts.DefaultNodeCIDRMaskSize,
 			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{

--- a/pkg/auth/azure_auth.go
+++ b/pkg/auth/azure_auth.go
@@ -25,14 +25,12 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
+
 	"golang.org/x/crypto/pkcs12"
 
 	"k8s.io/klog/v2"
-)
 
-const (
-	// ADFSIdentitySystem is the override value for tenantID on Azure Stack clouds.
-	ADFSIdentitySystem = "adfs"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 var (
@@ -84,8 +82,8 @@ type AzureAuthConfig struct {
 // For tokens for VM/VMSS and network resource ones, please check GetMultiTenantServicePrincipalToken and GetNetworkResourceServicePrincipalToken.
 func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (*adal.ServicePrincipalToken, error) {
 	var tenantID string
-	if strings.EqualFold(config.IdentitySystem, ADFSIdentitySystem) {
-		tenantID = ADFSIdentitySystem
+	if strings.EqualFold(config.IdentitySystem, consts.ADFSIdentitySystem) {
+		tenantID = consts.ADFSIdentitySystem
 	} else {
 		tenantID = config.TenantID
 	}
@@ -266,7 +264,7 @@ func azureStackOverrides(env *azure.Environment, resourceManagerEndpoint, identi
 	env.ServiceManagementEndpoint = env.TokenAudience
 	env.ResourceManagerVMDNSSuffix = strings.Replace(resourceManagerEndpoint, "https://management.", "cloudapp.", -1)
 	env.ResourceManagerVMDNSSuffix = strings.TrimSuffix(env.ResourceManagerVMDNSSuffix, "/")
-	if strings.EqualFold(identitySystem, ADFSIdentitySystem) {
+	if strings.EqualFold(identitySystem, consts.ADFSIdentitySystem) {
 		env.ActiveDirectoryEndpoint = strings.TrimSuffix(env.ActiveDirectoryEndpoint, "/")
 		env.ActiveDirectoryEndpoint = strings.TrimSuffix(env.ActiveDirectoryEndpoint, "adfs")
 	}
@@ -278,7 +276,7 @@ func (config *AzureAuthConfig) checkConfigWhenNetworkResourceInDifferentTenant()
 		return fmt.Errorf("NetworkResourceTenantID and NetworkResourceSubscriptionID must be configured")
 	}
 
-	if strings.EqualFold(config.IdentitySystem, ADFSIdentitySystem) {
+	if strings.EqualFold(config.IdentitySystem, consts.ADFSIdentitySystem) {
 		return fmt.Errorf("ADFS identity system is not supported")
 	}
 

--- a/pkg/auth/azure_auth_test.go
+++ b/pkg/auth/azure_auth_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 var (
@@ -37,7 +39,7 @@ var (
 			AADClientSecret:               "AADClientSecret",
 			NetworkResourceTenantID:       "NetworkResourceTenantID",
 			NetworkResourceSubscriptionID: "NetworkResourceSubscriptionID",
-			IdentitySystem:                ADFSIdentitySystem,
+			IdentitySystem:                consts.ADFSIdentitySystem,
 		},
 		{
 			TenantID:                      "TenantID",

--- a/pkg/azureclients/armclient/azure_armclient_test.go
+++ b/pkg/azureclients/armclient/azure_armclient_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/stretchr/testify/assert"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -118,7 +119,7 @@ func TestSendFailure(t *testing.T) {
 func TestSendThrottled(t *testing.T) {
 	count := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(retry.RetryAfterHeaderKey, "30")
+		w.Header().Set(consts.RetryAfterHeaderKey, "30")
 		http.Error(w, "failed", http.StatusTooManyRequests)
 		count++
 	}))

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consts
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// VMTypeVMSS is the vmss vm type
+	VMTypeVMSS = "vmss"
+	// VMTypeStandard is the vmas vm type
+	VMTypeStandard = "standard"
+
+	// ExternalResourceGroupLabel is the label representing the node is in a different
+	// resource group from other cloud provider components
+	ExternalResourceGroupLabel = "kubernetes.azure.com/resource-group"
+	// ManagedByAzureLabel is the label representing the node is managed by cloud provider azure
+	ManagedByAzureLabel = "kubernetes.azure.com/managed"
+	// NotManagedByAzureLabelValue is the label value representing the node is not managed by cloud provider azure
+	NotManagedByAzureLabelValue = "false"
+
+	// LabelFailureDomainBetaZone refer to https://github.com/kubernetes/api/blob/8519c5ea46199d57724725d5b969c5e8e0533692/core/v1/well_known_labels.go#L22-L23
+	LabelFailureDomainBetaZone = "failure-domain.beta.kubernetes.io/zone"
+
+	// LabelFailureDomainBetaRegion failure-domain region label
+	LabelFailureDomainBetaRegion = "failure-domain.beta.kubernetes.io/region"
+
+	// ADFSIdentitySystem is the override value for tenantID on Azure Stack clouds.
+	ADFSIdentitySystem = "adfs"
+
+	// AzureMetricsNamespace is the namespace of the azure metrics
+	AzureMetricsNamespace = "cloudprovider_azure"
+
+	// VhdContainerName is the vhd container name
+	VhdContainerName = "vhds"
+	// UseHTTPSForBlobBasedDisk determines if we use the https for the blob based disk
+	UseHTTPSForBlobBasedDisk = true
+	// BlobServiceName is the name of the blob service
+	BlobServiceName = "blob"
+
+	// MetadataCacheTTL is the TTL of the metadata service
+	MetadataCacheTTL = time.Minute
+	// MetadataCacheKey is the metadata cache key
+	MetadataCacheKey = "InstanceMetadata"
+	// MetadataURL is the metadata service endpoint
+	MetadataURL = "http://169.254.169.254/metadata/instance"
+
+	// DefaultDiskIOPSReadWrite is the default IOPS Caps & Throughput Cap (MBps)
+	// per https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disks-ultra-ssd
+	DefaultDiskIOPSReadWrite = 500
+	// DefaultDiskMBpsReadWrite is the default disk MBps read write
+	DefaultDiskMBpsReadWrite = 100
+
+	DiskEncryptionSetIDFormat = "/subscriptions/{subs-id}/resourceGroups/{rg-name}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSet-name}"
+
+	// IPv6DualStack is here to avoid having to import features pkg
+	// and violate import rules
+	IPv6DualStack featuregate.Feature = "IPv6DualStack"
+
+	// MachineIDTemplate is the template of the virtual machine
+	MachineIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
+	// AvailabilitySetIDTemplate is the template of the availabilitySet ID
+	AvailabilitySetIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/%s"
+
+	// NodeLabelRole specifies the role of a node
+	NodeLabelRole = "kubernetes.io/role"
+
+	// NicFailedState is the failed state of a nic
+	NicFailedState = "Failed"
+
+	// StorageAccountNameMaxLength is the max length of a storage name
+	StorageAccountNameMaxLength = 24
+
+	// DefaultStorageAccountType is the default storage account type
+	DefaultStorageAccountType = string(storage.StandardLRS)
+	// DefaultStorageAccountKind is the default storage account kind
+	DefaultStorageAccountKind = storage.StorageV2
+	// FileShareAccountNamePrefix is the file share account name prefix
+	FileShareAccountNamePrefix = "f"
+	// SharedDiskAccountNamePrefix is the shared disk account name prefix
+	SharedDiskAccountNamePrefix = "ds"
+	// DedicatedDiskAccountNamePrefix is the dedicated disk account name prefix
+	DedicatedDiskAccountNamePrefix = "dd"
+
+	// RetryAfterHeaderKey is the retry-after header key in ARM responses.
+	RetryAfterHeaderKey = "Retry-After"
+
+	// StrRawVersion is the raw version string
+	StrRawVersion string = "raw"
+)
+
+// azure cloud config
+const (
+	// CloudProviderName is the value used for the --cloud-provider flag
+	CloudProviderName = "azure"
+	// AzureStackCloudName is the cloud name of Azure Stack
+	AzureStackCloudName = "AZURESTACKCLOUD"
+	// RateLimitQPSDefault is the default value of the rate limit qps
+	RateLimitQPSDefault = 1.0
+	// RateLimitBucketDefault is the default value of rate limit bucket
+	RateLimitBucketDefault = 5
+	// BackoffRetriesDefault is the default backoff retry count
+	BackoffRetriesDefault = 6
+	// BackoffExponentDefault is the default value of the backoff exponent
+	BackoffExponentDefault = 1.5
+	// BackoffDurationDefault is the default value of the backoff duration
+	BackoffDurationDefault = 5 // in seconds
+	// BackoffJitterDefault is the default value of the backoff jitter
+	BackoffJitterDefault = 1.0
+
+	// CloudConfigNamespace is the namespace of the cloud config secret
+	CloudConfigNamespace = "kube-system"
+	// CloudConfigKey is the name of the cloud config key
+	CloudConfigKey = "cloud-config"
+	// CloudConfigSecName is the name of the cloud config secret
+	CloudConfigSecName = "azure-cloud-provider"
+)
+
+// load balancer
+const (
+	// PreConfiguredBackendPoolLoadBalancerTypesNone means that the load balancers are not pre-configured
+	PreConfiguredBackendPoolLoadBalancerTypesNone = ""
+	// PreConfiguredBackendPoolLoadBalancerTypesInternal means that the `internal` load balancers are pre-configured
+	PreConfiguredBackendPoolLoadBalancerTypesInternal = "internal"
+	// PreConfiguredBackendPoolLoadBalancerTypesExternal means that the `external` load balancers are pre-configured
+	PreConfiguredBackendPoolLoadBalancerTypesExternal = "external"
+	// PreConfiguredBackendPoolLoadBalancerTypesAll means that all load balancers are pre-configured
+	PreConfiguredBackendPoolLoadBalancerTypesAll = "all"
+
+	// MaximumLoadBalancerRuleCount is the maximum number of load balancer rules
+	// ref: https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#load-balancer.
+	MaximumLoadBalancerRuleCount = 250
+
+	// LoadBalancerSkuBasic is the load balancer basic sku
+	LoadBalancerSkuBasic = "basic"
+	// LoadBalancerSkuStandard is the load balancer standard sku
+	LoadBalancerSkuStandard = "standard"
+
+	// ServiceAnnotationLoadBalancerInternal is the annotation used on the service
+	ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/azure-load-balancer-internal"
+
+	// ServiceAnnotationLoadBalancerInternalSubnet is the annotation used on the service
+	// to specify what subnet it is exposed on
+	ServiceAnnotationLoadBalancerInternalSubnet = "service.beta.kubernetes.io/azure-load-balancer-internal-subnet"
+
+	// ServiceAnnotationLoadBalancerMode is the annotation used on the service to specify
+	// which load balancer should be associated with the service. This is valid when using the basic
+	// load balancer or turn on the multiple standard load balancers mode, or it would be ignored.
+	// 1. Default mode - service has no annotation ("service.beta.kubernetes.io/azure-load-balancer-mode")
+	//	  In this case the Loadbalancer of the primary VMSS/VMAS is selected.
+	// 2. "__auto__" mode - service is annotated with __auto__ value, this when loadbalancer from any VMSS/VMAS
+	//    is selected which has the minimum rules associated with it.
+	// 3. "name" mode - this is when the load balancer from the specified VMSS/VMAS that has the
+	//    minimum rules associated with it is selected.
+	ServiceAnnotationLoadBalancerMode = "service.beta.kubernetes.io/azure-load-balancer-mode"
+
+	// ServiceAnnotationLoadBalancerAutoModeValue is the annotation used on the service to specify the
+	// Azure load balancer auto selection from the availability sets
+	ServiceAnnotationLoadBalancerAutoModeValue = "__auto__"
+
+	// ServiceAnnotationDNSLabelName is the annotation used on the service
+	// to specify the DNS label name for the service.
+	ServiceAnnotationDNSLabelName = "service.beta.kubernetes.io/azure-dns-label-name"
+
+	// ServiceAnnotationSharedSecurityRule is the annotation used on the service
+	// to specify that the service should be exposed using an Azure security rule
+	// that may be shared with other service, trading specificity of rules for an
+	// increase in the number of services that can be exposed. This relies on the
+	// Azure "augmented security rules" feature.
+	ServiceAnnotationSharedSecurityRule = "service.beta.kubernetes.io/azure-shared-securityrule"
+
+	// ServiceAnnotationLoadBalancerResourceGroup is the annotation used on the service
+	// to specify the resource group of load balancer objects that are not in the same resource group as the cluster.
+	ServiceAnnotationLoadBalancerResourceGroup = "service.beta.kubernetes.io/azure-load-balancer-resource-group"
+
+	// ServiceAnnotationPIPName specifies the pip that will be applied to load balancer
+	ServiceAnnotationPIPName = "service.beta.kubernetes.io/azure-pip-name"
+
+	// ServiceAnnotationIPTagsForPublicIP specifies the iptags used when dynamically creating a public ip
+	ServiceAnnotationIPTagsForPublicIP = "service.beta.kubernetes.io/azure-pip-ip-tags"
+
+	// ServiceAnnotationAllowedServiceTag is the annotation used on the service
+	// to specify a list of allowed service tags separated by comma
+	// Refer https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#service-tags for all supported service tags.
+	ServiceAnnotationAllowedServiceTag = "service.beta.kubernetes.io/azure-allowed-service-tags"
+
+	// ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges  denies all traffic to the load balancer except those
+	// within the service.Spec.LoadBalancerSourceRanges. Ref: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/374.
+	ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges = "service.beta.kubernetes.io/azure-deny-all-except-load-balancer-source-ranges"
+
+	// ServiceAnnotationLoadBalancerIdleTimeout is the annotation used on the service
+	// to specify the idle timeout for connections on the load balancer in minutes.
+	ServiceAnnotationLoadBalancerIdleTimeout = "service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout"
+
+	// ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts is the annotation used on the service
+	// to enable the high availability ports on the standard internal load balancer.
+	ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts = "service.beta.kubernetes.io/azure-load-balancer-enable-high-availability-ports"
+
+	// ServiceAnnotationLoadBalancerDisableTCPReset is the annotation used on the service
+	// to set enableTcpReset to false in load balancer rule. This only works for Azure standard load balancer backed service.
+	// TODO(feiskyer): disable-tcp-reset annotations has been deprecated since v1.18, it would removed on v1.20.
+	ServiceAnnotationLoadBalancerDisableTCPReset = "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset"
+
+	// ServiceAnnotationLoadBalancerHealthProbeProtocol determines the network protocol that the load balancer health probe use.
+	// If not set, the local service would use the HTTP and the cluster service would use the TCP by default.
+	ServiceAnnotationLoadBalancerHealthProbeProtocol = "service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"
+
+	// ServiceAnnotationLoadBalancerHealthProbeRequestPath determines the request path of the load balancer health probe.
+	// This is only useful for the HTTP and HTTPS, and would be ignored when using TCP. If not set,
+	// `/healthz` would be configured by default.
+	ServiceAnnotationLoadBalancerHealthProbeRequestPath = "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path"
+
+	// ServiceAnnotationAzurePIPTags determines what tags should be applied to the public IP of the service. The cluster name
+	// and service names tags (which is managed by controller manager itself) would keep unchanged. The supported format
+	// is `a=b,c=d,...`. After updated, the old user-assigned tags would not be replaced by the new ones.
+	ServiceAnnotationAzurePIPTags = "service.beta.kubernetes.io/azure-pip-tags"
+
+	// ServiceTagKey is the service key applied for public IP tags.
+	ServiceTagKey = "service"
+	// ClusterNameKey is the cluster name key applied for public IP tags.
+	ClusterNameKey = "kubernetes-cluster-name"
+	// ServiceUsingDNSKey is the service name consuming the DNS label on the public IP
+	ServiceUsingDNSKey = "kubernetes-dns-label-service"
+
+	// DefaultLoadBalancerSourceRanges is the default value of the load balancer source ranges
+	DefaultLoadBalancerSourceRanges = "0.0.0.0/0"
+
+	// TrueAnnotationValue is the true annotation value
+	TrueAnnotationValue = "true"
+
+	// LoadBalancerMinimumPriority is the minimum priority
+	LoadBalancerMinimumPriority = 500
+	// LoadBalancerMaximumPriority is the maximum priority
+	LoadBalancerMaximumPriority = 4096
+
+	// FrontendIPConfigIDTemplate is the template of the frontend IP configuration
+	FrontendIPConfigIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s"
+	// BackendPoolIDTemplate is the template of the backend pool
+	BackendPoolIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/backendAddressPools/%s"
+	// LoadBalancerProbeIDTemplate is the template of the load balancer probe
+	LoadBalancerProbeIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/probes/%s"
+
+	// InternalLoadBalancerNameSuffix is load balancer suffix
+	InternalLoadBalancerNameSuffix = "-internal"
+
+	// FrontendIPConfigNameMaxLength is the max length of the frontend IP configuration
+	FrontendIPConfigNameMaxLength = 80
+	// LoadBalancerRuleNameMaxLength is the max length of the load balancing rule
+	LoadBalancerRuleNameMaxLength = 80
+)
+
+// error messages
+const (
+	// VmssVMNotActiveErrorMessage not active means the instance is under deleting from Azure VMSS.
+	VmssVMNotActiveErrorMessage = "not an active Virtual Machine Scale Set VM instanceId"
+	// OperationCanceledErrorMessage means the operation is canceled by another new operation.
+	OperationCanceledErrorMessage = "canceledandsupersededduetoanotheroperation"
+	// CannotDeletePublicIPErrorMessageCode means the public IP cannot be deleted
+	CannotDeletePublicIPErrorMessageCode = "PublicIPAddressCannotBeDeleted"
+	// ReferencedResourceNotProvisionedMessageCode means the referenced resource has not been provisioned
+	ReferencedResourceNotProvisionedMessageCode = "ReferencedResourceNotProvisioned"
+)
+
+// node ipam controller
+const (
+	// DefaultNodeMaskCIDRIPv4 is default mask size for IPv4 node cidr
+	DefaultNodeMaskCIDRIPv4 = 24
+	// DefaultNodeMaskCIDRIPv6 is default mask size for IPv6 node cidr
+	DefaultNodeMaskCIDRIPv6 = 64
+	// DefaultNodeCIDRMaskSize is the default mask size for node cidr
+	DefaultNodeCIDRMaskSize = 24
+)
+
+// metadata service
+const (
+	// ImdsInstanceAPIVersion is the imds instance api version
+	ImdsInstanceAPIVersion = "2019-03-11"
+	// ImdsLoadBalancerAPIVersion is the imds load balancer api version
+	ImdsLoadBalancerAPIVersion = "2020-10-01"
+	// ImdsServer is the imds server endpoint
+	ImdsServer = "http://169.254.169.254"
+	// ImdsInstanceURI is the imds instance uri
+	ImdsInstanceURI = "/metadata/instance"
+	// ImdsLoadBalancerURI is the imds load balancer uri
+	ImdsLoadBalancerURI = "/metadata/loadbalancer"
+)

--- a/pkg/consts/doc.go
+++ b/pkg/consts/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package consts stages all the consts under pkg/.
+package consts

--- a/pkg/metrics/azure_metrics.go
+++ b/pkg/metrics/azure_metrics.go
@@ -22,10 +22,8 @@ import (
 
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-)
 
-const (
-	azureMetricsNamespace = "cloudprovider_azure"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 var (
@@ -110,7 +108,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 	metrics := &apiCallMetrics{
 		latency: metrics.NewHistogramVec(
 			&metrics.HistogramOpts{
-				Namespace:      azureMetricsNamespace,
+				Namespace:      consts.AzureMetricsNamespace,
 				Name:           "api_request_duration_seconds",
 				Help:           "Latency of an Azure API call",
 				Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 25, 50, 120, 300, 600, 1200},
@@ -120,7 +118,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 		),
 		errors: metrics.NewCounterVec(
 			&metrics.CounterOpts{
-				Namespace:      azureMetricsNamespace,
+				Namespace:      consts.AzureMetricsNamespace,
 				Name:           "api_request_errors",
 				Help:           "Number of errors for an Azure API call",
 				StabilityLevel: metrics.ALPHA,
@@ -129,7 +127,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 		),
 		rateLimitedCount: metrics.NewCounterVec(
 			&metrics.CounterOpts{
-				Namespace:      azureMetricsNamespace,
+				Namespace:      consts.AzureMetricsNamespace,
 				Name:           "api_request_ratelimited_count",
 				Help:           "Number of rate limited Azure API calls",
 				StabilityLevel: metrics.ALPHA,
@@ -138,7 +136,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 		),
 		throttledCount: metrics.NewCounterVec(
 			&metrics.CounterOpts{
-				Namespace:      azureMetricsNamespace,
+				Namespace:      consts.AzureMetricsNamespace,
 				Name:           "api_request_throttled_count",
 				Help:           "Number of throttled Azure API calls",
 				StabilityLevel: metrics.ALPHA,
@@ -160,7 +158,7 @@ func registerOperationMetrics(attributes ...string) *operationCallMetrics {
 	metrics := &operationCallMetrics{
 		operationLatency: metrics.NewHistogramVec(
 			&metrics.HistogramOpts{
-				Namespace:      azureMetricsNamespace,
+				Namespace:      consts.AzureMetricsNamespace,
 				Name:           "op_duration_seconds",
 				Help:           "Latency of an Azure service operation",
 				StabilityLevel: metrics.ALPHA,
@@ -170,7 +168,7 @@ func registerOperationMetrics(attributes ...string) *operationCallMetrics {
 		),
 		operationFailureCount: metrics.NewCounterVec(
 			&metrics.CounterOpts{
-				Namespace:      azureMetricsNamespace,
+				Namespace:      consts.AzureMetricsNamespace,
 				Name:           "op_failure_count",
 				Help:           "Number of failed Azure service operations",
 				StabilityLevel: metrics.ALPHA,

--- a/pkg/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/nodeipam/ipam/cidr_allocator.go
@@ -64,9 +64,6 @@ const (
 
 	// maxUpdateRetryTimeout is the maximum amount of time between timeouts.
 	maxUpdateRetryTimeout = 5 * time.Second
-
-	// updateMaxRetries is the max retries for a failed node
-	updateMaxRetries = 10
 )
 
 // CIDRAllocator is an interface implemented by things that know how
@@ -106,7 +103,7 @@ func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInfo
 	case RangeAllocatorType:
 		return NewCIDRRangeAllocator(kubeClient, nodeInformer, allocatorParams, nodeList)
 	case CloudAllocatorType:
-		return NewCloudCIDRAllocator(kubeClient, cloud, nodeInformer)
+		return NewCloudCIDRAllocator(kubeClient, cloud, nodeInformer, allocatorParams, nodeList)
 	default:
 		return nil, fmt.Errorf("invalid CIDR allocator type: %v", allocatorType)
 	}

--- a/pkg/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/nodeipam/ipam/cloud_cidr_allocator.go
@@ -23,38 +23,33 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	informers "k8s.io/client-go/informers/core/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
 	utiltaints "k8s.io/kubernetes/pkg/util/taints"
+	netutils "k8s.io/utils/net"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
+	"sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/ipam/cidrset"
 	providerazure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	nodeutil "sigs.k8s.io/cloud-provider-azure/pkg/util/controller/node"
 	utilnode "sigs.k8s.io/cloud-provider-azure/pkg/util/node"
 )
 
-// nodeProcessingInfo tracks information related to current nodes in processing
-type nodeProcessingInfo struct {
-	retries int
-}
-
-// cloudCIDRAllocator allocates node CIDRs according to IP address aliases
-// assigned by the cloud provider. In this case, the allocation and
-// deallocation is delegated to the external provider, and the controller
-// merely takes the assignment and updates the node spec.
+// cloudCIDRAllocator allocates node CIDRs according to the node subnet mask size
+// tagged on each VMSS/VMAS.
 type cloudCIDRAllocator struct {
 	client clientset.Interface
 	cloud  *providerazure.Cloud
@@ -69,18 +64,32 @@ type cloudCIDRAllocator struct {
 	// This increases the throughput of CIDR assignment by parallelization
 	// and not blocking on long operations (which shouldn't be done from
 	// event handlers anyway).
-	nodeUpdateChannel chan string
+	nodeUpdateChannel chan nodeReservedCIDRs
 	recorder          record.EventRecorder
 
-	// Keep a set of nodes that are currectly being processed to avoid races in CIDR allocation
+	// Keep a set of nodes that are correctly being processed to avoid races in CIDR allocation
 	lock              sync.Mutex
-	nodesInProcessing map[string]*nodeProcessingInfo
+	nodesInProcessing map[string]struct{}
+
+	// nodeName -> nodeSubnetMaskSizes for ipv4 and/or ipv6
+	nodeNameSubnetMaskSizesMap map[string][]int
+	maxSubnetMaskSizes         []int
+	cidrSets                   []*cidrset.CidrSet
+	clusterCIDRs               []*net.IPNet
+
+	nodeNamePodCIDRsMap map[string][]string
 }
 
 var _ CIDRAllocator = (*cloudCIDRAllocator)(nil)
 
 // NewCloudCIDRAllocator creates a new cloud CIDR allocator.
-func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Interface, nodeInformer informers.NodeInformer) (CIDRAllocator, error) {
+func NewCloudCIDRAllocator(
+	client clientset.Interface,
+	cloud cloudprovider.Interface,
+	nodeInformer informers.NodeInformer,
+	allocatorParams CIDRAllocatorParams,
+	nodeList *v1.NodeList,
+) (CIDRAllocator, error) {
 	if client == nil {
 		klog.Fatalf("kubeClient is nil when starting NodeController")
 	}
@@ -98,13 +107,76 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 	}
 
 	ca := &cloudCIDRAllocator{
-		client:            client,
-		cloud:             az,
-		nodeLister:        nodeInformer.Lister(),
-		nodesSynced:       nodeInformer.Informer().HasSynced,
-		nodeUpdateChannel: make(chan string, cidrUpdateQueueSize),
-		recorder:          recorder,
-		nodesInProcessing: map[string]*nodeProcessingInfo{},
+		client:                     client,
+		cloud:                      az,
+		nodeLister:                 nodeInformer.Lister(),
+		nodesSynced:                nodeInformer.Informer().HasSynced,
+		nodeUpdateChannel:          make(chan nodeReservedCIDRs, cidrUpdateQueueSize),
+		recorder:                   recorder,
+		nodesInProcessing:          map[string]struct{}{},
+		nodeNameSubnetMaskSizesMap: make(map[string][]int),
+		maxSubnetMaskSizes:         make([]int, len(allocatorParams.ClusterCIDRs)),
+		clusterCIDRs:               allocatorParams.ClusterCIDRs,
+		nodeNamePodCIDRsMap:        make(map[string][]string),
+	}
+
+	// update the node subnet mask size
+	if nodeList != nil {
+		for _, node := range nodeList.Items {
+			if node.Spec.ProviderID == "" {
+				klog.Warningf("NewCloudCIDRAllocator: failed when trying to read the node mask size on node %s: no provider ID", node.Name)
+				continue
+			}
+			err := ca.updateNodeSubnetMaskSizes(node.Name, node.Spec.ProviderID)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// find the max node subnet mask size and use them to create cidr sets
+	ca.updateMaxSubnetMaskSizes()
+
+	cidrSets := make([]*cidrset.CidrSet, len(allocatorParams.ClusterCIDRs))
+	for i, clusterCIDR := range allocatorParams.ClusterCIDRs {
+		clusterCIDR := clusterCIDR
+		cidrSet, err := cidrset.NewCIDRSet(clusterCIDR, ca.maxSubnetMaskSizes[i])
+		if err != nil {
+			return nil, err
+		}
+		cidrSets[i] = cidrSet
+	}
+	ca.cidrSets = cidrSets
+
+	if allocatorParams.ServiceCIDR != nil {
+		filterOutServiceRange(ca.clusterCIDRs, ca.cidrSets, allocatorParams.ServiceCIDR)
+	} else {
+		klog.V(0).Info("No Service CIDR provided. Skipping filtering out service addresses.")
+	}
+
+	if allocatorParams.SecondaryServiceCIDR != nil {
+		filterOutServiceRange(ca.clusterCIDRs, ca.cidrSets, allocatorParams.SecondaryServiceCIDR)
+	} else {
+		klog.V(0).Info("No Secondary Service CIDR provided. Skipping filtering out secondary service addresses.")
+	}
+
+	// mark the CIDRs on the existing nodes as used
+	if nodeList != nil {
+		for _, node := range nodeList.Items {
+			node := node
+			if len(node.Spec.PodCIDRs) == 0 {
+				klog.V(4).Infof("Node %v has no CIDR, ignoring", node.Name)
+				continue
+			}
+			klog.V(4).Infof("Node %v has CIDR %s, occupying it in CIDR map", node.Name, node.Spec.PodCIDR)
+			if err := ca.occupyCIDRs(&node); err != nil {
+				// This will happen if:
+				// 1. We find garbage in the podCIDRs field. Retrying is useless.
+				// 2. CIDR out of range: This means a node CIDR has changed.
+				// This error will keep crashing cloud controller manager.
+				return nil, err
+			}
+		}
 	}
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -129,6 +201,70 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 	return ca, nil
 }
 
+// updateMaxSubnetMaskSizes finds the max subnet size on all existing nodes
+func (ca *cloudCIDRAllocator) updateMaxSubnetMaskSizes() {
+	ca.lock.Lock()
+	defer ca.lock.Unlock()
+
+	maxNodeSubnetMaskSizes := make([]int, len(ca.clusterCIDRs))
+	for i := 0; i < len(ca.clusterCIDRs); i++ {
+		maxNodeSubnetMaskSizes[i] = 0
+	}
+
+	// find the max maks sizes on all existing nodes
+	for _, sizes := range ca.nodeNameSubnetMaskSizesMap {
+		for i := 0; i < len(ca.clusterCIDRs); i++ {
+			if sizes[i] > maxNodeSubnetMaskSizes[i] {
+				maxNodeSubnetMaskSizes[i] = sizes[i]
+			}
+		}
+	}
+
+	// update them to the cloud allocator
+	ca.maxSubnetMaskSizes = maxNodeSubnetMaskSizes
+}
+
+// updateNodeSubnetMaskSizes gets the node's VMSS/VMAS, reads the mask size tag on it and updates them into the map
+func (ca *cloudCIDRAllocator) updateNodeSubnetMaskSizes(nodeName, providerID string) error {
+	ca.lock.Lock()
+	defer ca.lock.Unlock()
+
+	if providerID == "" {
+		klog.Warningf("updateNodeSubnetMaskSizes(%s): empty providerID", providerID)
+	}
+
+	ipv4Mask, ipv6Mask, err := ca.cloud.VMSet.GetNodeCIDRMasksByProviderID(providerID)
+	if err != nil {
+		klog.Warningf("updateNodeSubnetMaskSizes(%s): cannot get node subnet mask size by providerID: %v", providerID, err)
+	}
+
+	if ipv4Mask == 0 {
+		ipv4Mask = consts.DefaultNodeMaskCIDRIPv4
+	}
+	if ipv6Mask == 0 {
+		ipv6Mask = consts.DefaultNodeMaskCIDRIPv6
+	}
+
+	maskSizes := make([]int, 0)
+	for _, clusterCIDR := range ca.clusterCIDRs {
+		clusterMaskSize, _ := clusterCIDR.Mask.Size()
+		if netutils.IsIPv6CIDR(clusterCIDR) {
+			if ipv6Mask < clusterMaskSize {
+				return fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv6 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", ipv6Mask, nodeName, clusterMaskSize)
+			}
+			maskSizes = append(maskSizes, ipv6Mask)
+		} else {
+			if ipv4Mask < clusterMaskSize {
+				return fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv4 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", ipv4Mask, nodeName, clusterMaskSize)
+			}
+			maskSizes = append(maskSizes, ipv4Mask)
+		}
+	}
+
+	ca.nodeNameSubnetMaskSizesMap[nodeName] = maskSizes
+	return nil
+}
+
 func (ca *cloudCIDRAllocator) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 
@@ -151,24 +287,13 @@ func (ca *cloudCIDRAllocator) worker(stopChan <-chan struct{}) {
 		select {
 		case workItem, ok := <-ca.nodeUpdateChannel:
 			if !ok {
-				klog.Warning("Channel nodeCIDRUpdateChannel was unexpectedly closed")
+				klog.Warning("Channel nodeUpdateChannel was unexpectedly closed")
 				return
 			}
-			if err := ca.updateCIDRAllocation(workItem); err == nil {
-				klog.V(3).Infof("Updated CIDR for %q", workItem)
-			} else {
-				klog.Errorf("Error updating CIDR for %q: %v", workItem, err)
-				if canRetry, timeout := ca.retryParams(workItem); canRetry {
-					klog.V(2).Infof("Retrying update for %q after %v", workItem, timeout)
-					time.AfterFunc(timeout, func() {
-						// Requeue the failed node for update again.
-						ca.nodeUpdateChannel <- workItem
-					})
-					continue
-				}
-				klog.Errorf("Exceeded retry count for %q, dropping from queue", workItem)
+			if err := ca.updateCIDRsAllocation(workItem); err != nil {
+				// Requeue the failed node for update again.
+				ca.nodeUpdateChannel <- workItem
 			}
-			ca.removeNodeFromProcessing(workItem)
 		case <-stopChan:
 			return
 		}
@@ -181,27 +306,8 @@ func (ca *cloudCIDRAllocator) insertNodeToProcessing(nodeName string) bool {
 	if _, found := ca.nodesInProcessing[nodeName]; found {
 		return false
 	}
-	ca.nodesInProcessing[nodeName] = &nodeProcessingInfo{}
+	ca.nodesInProcessing[nodeName] = struct{}{}
 	return true
-}
-
-func (ca *cloudCIDRAllocator) retryParams(nodeName string) (bool, time.Duration) {
-	ca.lock.Lock()
-	defer ca.lock.Unlock()
-
-	entry, ok := ca.nodesInProcessing[nodeName]
-	if !ok {
-		klog.Errorf("Cannot get retryParams for %q as entry does not exist", nodeName)
-		return false, 0
-	}
-
-	count := entry.retries + 1
-	if count > updateMaxRetries {
-		return false, 0
-	}
-	ca.nodesInProcessing[nodeName].retries = count
-
-	return true, nodeUpdateRetryTimeout(count)
 }
 
 func nodeUpdateRetryTimeout(count int) time.Duration {
@@ -221,11 +327,43 @@ func (ca *cloudCIDRAllocator) removeNodeFromProcessing(nodeName string) {
 	delete(ca.nodesInProcessing, nodeName)
 }
 
+// marks node.PodCIDRs[...] as used in allocator's tracked cidrSet
+func (ca *cloudCIDRAllocator) occupyCIDRs(node *v1.Node) error {
+	defer ca.removeNodeFromProcessing(node.Name)
+	if len(node.Spec.PodCIDRs) == 0 {
+		return nil
+	}
+	podCIDRs := make([]string, len(ca.clusterCIDRs))
+	for i, cidr := range node.Spec.PodCIDRs {
+		_, podCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to parse node %s, CIDR %s", node.Name, node.Spec.PodCIDR)
+		}
+		// If node has a pre allocate cidr that does not exist in our cidrs.
+		// This will happen if cluster went from dualstack(multi cidrs) to non-dualstack
+		// then we have now way of locking it
+		if i >= len(ca.cidrSets) {
+			return fmt.Errorf("node:%s has an allocated cidr: %v at index:%v that does not exist in cluster cidrs configuration", node.Name, cidr, i)
+		}
+
+		if err := ca.cidrSets[i].Occupy(podCIDR); err != nil {
+			return fmt.Errorf("failed to mark cidr[%v] at i [%v] as occupied for node %s: %w", podCIDR, i, node.Name, err)
+		}
+
+		podCIDRs[i] = cidr
+	}
+	ca.lock.Lock()
+	ca.nodeNamePodCIDRsMap[node.Name] = podCIDRs
+	ca.lock.Unlock()
+
+	return nil
+}
+
 // WARNING: If you're adding any return calls or defer any more work from this
 // function you have to make sure to update nodesInProcessing properly with the
 // disposition of the node when the work is done.
 func (ca *cloudCIDRAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
-	if node == nil {
+	if node == nil || node.Spec.ProviderID == "" {
 		return nil
 	}
 	if !ca.insertNodeToProcessing(node.Name) {
@@ -233,63 +371,112 @@ func (ca *cloudCIDRAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
 		return nil
 	}
 
+	err := ca.updateNodeSubnetMaskSizes(node.Name, node.Spec.ProviderID)
+	if err != nil {
+		klog.Errorf("AllocateOrOccupyCIDR(%s): failed to update node subnet mask sizes: %v", node.Name, err)
+		return err
+	}
+	ca.updateMaxSubnetMaskSizes()
+
+	// Keep the mask size in each cidr set the max one when new node added in.
+	// The mask size would not change unless the new node is from a new VMSS/VMAS
+	// and the mask value tagging on it is different from the existing ones.
+	for i, cidrSet := range ca.cidrSets {
+		cidrSet := cidrSet
+		err := cidrSet.UpdateSubnetMaskSize(ca.maxSubnetMaskSizes[i], ca.nodeNamePodCIDRsMap)
+		if err != nil {
+			ca.removeNodeFromProcessing(node.Name)
+			return err
+		}
+		ca.cidrSets[i] = cidrSet
+	}
+
+	if len(node.Spec.PodCIDRs) > 0 {
+		return ca.occupyCIDRs(node)
+	}
+
+	allocated := nodeReservedCIDRs{
+		nodeName:       node.Name,
+		allocatedCIDRs: make([]*net.IPNet, len(ca.cidrSets)),
+	}
+
+	for i := range ca.cidrSets {
+		podCIDR, err := ca.cidrSets[i].AllocateNextWithNodeMaskSize(ca.nodeNameSubnetMaskSizesMap[node.Name][i])
+		if err != nil {
+			ca.removeNodeFromProcessing(node.Name)
+			nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
+			return fmt.Errorf("failed to allocate cidr from cluster cidr at idx:%v: %w", i, err)
+		}
+		allocated.allocatedCIDRs[i] = podCIDR
+	}
+
 	klog.V(4).Infof("Putting node %s into the work queue", node.Name)
-	ca.nodeUpdateChannel <- node.Name
+	ca.nodeUpdateChannel <- allocated
 	return nil
 }
 
-// updateCIDRAllocation assigns CIDR to Node and sends an update to the API server.
-func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
-	node, err := ca.nodeLister.Get(nodeName)
+// updateCIDRsAllocation assigns CIDR to Node and sends an update to the API server.
+func (ca *cloudCIDRAllocator) updateCIDRsAllocation(data nodeReservedCIDRs) error {
+	var err error
+	var node *v1.Node
+	defer ca.removeNodeFromProcessing(data.nodeName)
+	cidrsString := cidrsAsString(data.allocatedCIDRs)
+	node, err = ca.nodeLister.Get(data.nodeName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil // node no longer available, skip processing
 		}
-		klog.Errorf("Failed while getting node %v for updating Node.Spec.PodCIDR: %v", nodeName, err)
+		klog.Errorf("Failed while getting node %v for updating Node.Spec.PodCIDR: %w", data.nodeName, err)
 		return err
 	}
-	if node.Spec.ProviderID == "" {
-		return fmt.Errorf("node %s doesn't have providerID", nodeName)
-	}
 
-	cidrs, err := ca.cloud.AliasRangesByProviderID(node.Spec.ProviderID)
-	if err != nil {
-		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
-		return fmt.Errorf("failed to allocate cidr: %w", err)
-	}
-	if len(cidrs) == 0 {
-		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
-		return fmt.Errorf("failed to allocate cidr: Node %v has no CIDRs", node.Name)
-	}
-	_, cidr, err := net.ParseCIDR(cidrs[0])
-	if err != nil {
-		return fmt.Errorf("failed to parse string '%s' as a CIDR: %w", cidrs[0], err)
-	}
-	podCIDR := cidr.String()
-
-	if node.Spec.PodCIDR == podCIDR {
-		klog.V(4).Infof("Node %v already has allocated CIDR %v. It matches the proposed one.", node.Name, podCIDR)
-		// We don't return here, in order to set the NetworkUnavailable condition later below.
-	} else {
-		if node.Spec.PodCIDR != "" {
-			klog.Errorf("PodCIDR being reassigned! Node %v spec has %v, but cloud provider has assigned %v", node.Name, node.Spec.PodCIDR, podCIDR)
-			// We fall through and set the CIDR despite this error. This
-			// implements the same logic as implemented in the
-			// rangeAllocator.
-			//
-			// See https://github.com/kubernetes/kubernetes/pull/42147#discussion_r103357248
-		}
-		for i := 0; i < cidrUpdateRetries; i++ {
-			if err = utilnode.PatchNodeCIDR(ca.client, types.NodeName(node.Name), podCIDR); err == nil {
-				klog.Infof("Set node %v PodCIDR to %v", node.Name, podCIDR)
+	// if cidr list matches the proposed.
+	// then we possibly updated this node
+	// and just failed to ack the success.
+	if len(node.Spec.PodCIDRs) == len(data.allocatedCIDRs) {
+		match := true
+		for idx, cidr := range cidrsString {
+			if node.Spec.PodCIDRs[idx] != cidr {
+				match = false
 				break
 			}
 		}
+		if match {
+			klog.V(4).Infof("Node %v already has allocated CIDR %v. It matches the proposed one.", node.Name, data.allocatedCIDRs)
+			return nil
+		}
 	}
-	if err != nil {
-		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRAssignmentFailed")
-		klog.Errorf("Failed to update node %v PodCIDR to %v after multiple attempts: %v", node.Name, podCIDR, err)
-		return err
+
+	// node has cidrs, release the reserved
+	if len(node.Spec.PodCIDRs) != 0 {
+		klog.Errorf("Node %v already has a CIDR allocated %v. Releasing the new one.", node.Name, node.Spec.PodCIDRs)
+		for idx, cidr := range data.allocatedCIDRs {
+			if releaseErr := ca.cidrSets[idx].Release(cidr); releaseErr != nil {
+				klog.Errorf("Error when releasing CIDR idx:%v value: %v err:%v", idx, cidr, releaseErr)
+			}
+		}
+		return nil
+	}
+
+	// If we reached here, it means that the node has no CIDR currently assigned. So we set it.
+	for i := 0; i < cidrUpdateRetries; i++ {
+		if err = utilnode.PatchNodeCIDRs(ca.client, types.NodeName(node.Name), cidrsString); err == nil {
+			return nil
+		}
+	}
+	// failed release back to the pool
+	klog.Errorf("Failed to update node %v PodCIDR to %v after multiple attempts: %v", node.Name, cidrsString, err)
+	nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRAssignmentFailed")
+	// We accept the fact that we may leak CIDRs here. This is safer than releasing
+	// them in case when we don't know if request went through.
+	// NodeController restart will return all falsely allocated CIDRs to the pool.
+	if !apierrors.IsServerTimeout(err) {
+		klog.Errorf("CIDR assignment for node %v failed: %v. Releasing allocated CIDR", node.Name, err)
+		for idx, cidr := range data.allocatedCIDRs {
+			if releaseErr := ca.cidrSets[idx].Release(cidr); releaseErr != nil {
+				klog.Errorf("Error releasing allocated CIDR for node %v: %v", node.Name, releaseErr)
+			}
+		}
 	}
 
 	err = utilnode.SetNodeCondition(ca.client, types.NodeName(node.Name), v1.NodeCondition{
@@ -302,11 +489,32 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 	if err != nil {
 		klog.Errorf("Error setting route status for node %v: %v", node.Name, err)
 	}
+
 	return err
 }
 
 func (ca *cloudCIDRAllocator) ReleaseCIDR(node *v1.Node) error {
-	klog.V(2).Infof("Node %v PodCIDR (%v) will be released by external cloud provider (not managed by controller)",
-		node.Name, node.Spec.PodCIDR)
+	if node == nil || len(node.Spec.PodCIDRs) == 0 {
+		return nil
+	}
+
+	for i, cidr := range node.Spec.PodCIDRs {
+		_, podCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to parse CIDR %s on Node %v: %w", cidr, node.Name, err)
+		}
+
+		if i >= len(ca.cidrSets) {
+			return fmt.Errorf("node:%s has an allocated cidr: %v at index:%v that does not exist in cluster cidrs configuration", node.Name, cidr, i)
+		}
+
+		klog.V(4).Infof("release CIDR %s for node:%v", cidr, node.Name)
+		if err = ca.cidrSets[i].Release(podCIDR); err != nil {
+			return fmt.Errorf("error when releasing CIDR %v: %w", cidr, err)
+		}
+
+	}
+	delete(ca.nodeNamePodCIDRsMap, node.Name)
+
 	return nil
 }

--- a/pkg/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -18,13 +18,23 @@ package ipam
 
 import (
 	"fmt"
+	"net"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
+	azureprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/util/controller/testutil"
 )
 
 func hasNodeInProcessing(ca *cloudCIDRAllocator, name string) bool {
@@ -37,7 +47,7 @@ func hasNodeInProcessing(ca *cloudCIDRAllocator, name string) bool {
 
 func TestBoundedRetries(t *testing.T) {
 	clientSet := fake.NewSimpleClientset()
-	updateChan := make(chan string, 1) // need to buffer as we are using only on go routine
+	updateChan := make(chan nodeReservedCIDRs, 1) // need to buffer as we are using only on go routine
 	stopChan := make(chan struct{})
 	sharedInfomer := informers.NewSharedInformerFactory(clientSet, 1*time.Hour)
 	ca := &cloudCIDRAllocator{
@@ -45,7 +55,7 @@ func TestBoundedRetries(t *testing.T) {
 		nodeUpdateChannel: updateChan,
 		nodeLister:        sharedInfomer.Core().V1().Nodes().Lister(),
 		nodesSynced:       sharedInfomer.Core().V1().Nodes().Informer().HasSynced,
-		nodesInProcessing: map[string]*nodeProcessingInfo{},
+		nodesInProcessing: map[string]struct{}{},
 	}
 	go ca.worker(stopChan)
 	nodeName := "testNode"
@@ -78,6 +88,169 @@ func TestNodeUpdateRetryTimeout(t *testing.T) {
 			if got := nodeUpdateRetryTimeout(tc.count); !withinExpectedRange(got, tc.want) {
 				t.Errorf("nodeUpdateRetryTimeout(tc.count) = %v; want %v", got, tc.want)
 			}
+		})
+	}
+}
+
+func TestNewCloudCIDRAllocator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	clientSet := fake.NewSimpleClientset()
+	fakeNodeHandler := &testutil.FakeNodeHandler{
+		Existing: []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node0",
+				},
+			},
+		},
+		Clientset: clientSet,
+	}
+	cloud := azureprovider.GetTestCloud(ctrl)
+	nodeInformer := getFakeNodeInformer(fakeNodeHandler)
+	allocatorParams := CIDRAllocatorParams{
+		ClusterCIDRs: func() []*net.IPNet {
+			_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/24")
+			return []*net.IPNet{clusterCIDRv4}
+		}(),
+		ServiceCIDR: func() *net.IPNet {
+			_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/25")
+			return clusterCIDRv4
+		}(),
+		SecondaryServiceCIDR: func() *net.IPNet {
+			_, clusterCIDRv4, _ := net.ParseCIDR("10.10.1.0/25")
+			return clusterCIDRv4
+		}(),
+	}
+
+	ca, err := NewCloudCIDRAllocator(clientSet, cloud, nodeInformer, allocatorParams, nil)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	_, ok := ca.(*cloudCIDRAllocator)
+	if !ok {
+		t.Fatalf("expected a cloud allocator")
+	}
+}
+
+func TestUpdateMaxSubnetSizes(t *testing.T) {
+	for _, tc := range []struct {
+		description                                    string
+		clusterCIDRs                                   []*net.IPNet
+		nodeNameSubnetMaskSizesMap                     map[string][]int
+		maxSubnetMaskSizes, expectedMaxSubnetMaskSizes []int
+	}{
+		{
+			description: "updateMaxSubnetSizes should calculate the correct max sizes",
+			clusterCIDRs: func() []*net.IPNet {
+				_, clusterCIDR, _ := net.ParseCIDR("10.240.0.0/16")
+				return []*net.IPNet{clusterCIDR}
+			}(),
+			nodeNameSubnetMaskSizesMap: map[string][]int{"node0": {24}, "node1": {26}},
+			maxSubnetMaskSizes:         []int{27},
+			expectedMaxSubnetMaskSizes: []int{26},
+		},
+		{
+			description: "updateMaxSubnetSizes should work with the dual stack cidrs",
+			clusterCIDRs: func() []*net.IPNet {
+				_, cidrIPV4, _ := net.ParseCIDR("10.240.0.0/16")
+				_, cidrIPV6, _ := net.ParseCIDR("beef::/48")
+				return []*net.IPNet{cidrIPV4, cidrIPV6}
+			}(),
+			nodeNameSubnetMaskSizesMap: map[string][]int{"node0": {26, 64}, "node1": {24, 66}},
+			maxSubnetMaskSizes:         []int{27, 67},
+			expectedMaxSubnetMaskSizes: []int{26, 66},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			ca := cloudCIDRAllocator{
+				clusterCIDRs:               tc.clusterCIDRs,
+				nodeNameSubnetMaskSizesMap: tc.nodeNameSubnetMaskSizesMap,
+				maxSubnetMaskSizes:         tc.maxSubnetMaskSizes,
+			}
+			ca.updateMaxSubnetMaskSizes()
+			assert.Equal(t, tc.expectedMaxSubnetMaskSizes, ca.maxSubnetMaskSizes)
+		})
+	}
+}
+
+func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range []struct {
+		description, providerID            string
+		tags                               map[string]*string
+		expectedNodeNameSubnetMaskSizesMap map[string][]int
+		expectedErr                        error
+	}{
+		{
+			description: "updateNodeSubnetMaskSizes should put the correct mask sizes on the map",
+			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+			tags: map[string]*string{
+				azureprovider.VMSetCIDRIPV4TagKey: to.StringPtr("25"),
+				azureprovider.VMSetCIDRIPV6TagKey: to.StringPtr("65"),
+			},
+			expectedNodeNameSubnetMaskSizesMap: map[string][]int{"vmss-0": {25, 65}},
+		},
+		{
+			description: "updateNodeSubnetMaskSizes should put the default mask sizes on the map if the providerID is invalid",
+			providerID:  "invalid",
+			tags: map[string]*string{
+				azureprovider.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
+				azureprovider.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+			},
+			expectedNodeNameSubnetMaskSizesMap: map[string][]int{"vmss-0": {24, 64}},
+		},
+		{
+			description: "updateNodeSubnetMaskSizes should report an error if the ipv4 mask is smaller than the cluster mask",
+			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+			tags: map[string]*string{
+				azureprovider.VMSetCIDRIPV4TagKey: to.StringPtr("15"),
+				azureprovider.VMSetCIDRIPV6TagKey: to.StringPtr("65"),
+			},
+			expectedNodeNameSubnetMaskSizesMap: map[string][]int{},
+			expectedErr:                        fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv4 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", 15, "vmss-0", 16),
+		},
+		{
+			description: "updateNodeSubnetMaskSizes should report an error if the ipv6 mask is smaller than the cluster mask",
+			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+			tags: map[string]*string{
+				azureprovider.VMSetCIDRIPV4TagKey: to.StringPtr("25"),
+				azureprovider.VMSetCIDRIPV6TagKey: to.StringPtr("45"),
+			},
+			expectedNodeNameSubnetMaskSizesMap: map[string][]int{},
+			expectedErr:                        fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv6 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", 45, "vmss-0", 48),
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			cloud := azureprovider.GetTestCloud(ctrl)
+			ss, err := azureprovider.NewTestScaleSet(ctrl)
+			assert.NoError(t, err)
+
+			expectedVMSS := compute.VirtualMachineScaleSet{
+				Name: to.StringPtr("vmss"),
+				Tags: tc.tags,
+			}
+			mockVMSSClient := ss.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), cloud.ResourceGroup).Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil).MaxTimes(1)
+			cloud.VMSet = ss
+
+			clusterCIDRs := func() []*net.IPNet {
+				_, cidrIPV4, _ := net.ParseCIDR("10.240.0.0/16")
+				_, cidrIPV6, _ := net.ParseCIDR("beef::/48")
+				return []*net.IPNet{cidrIPV4, cidrIPV6}
+			}()
+			ca := cloudCIDRAllocator{
+				cloud:                      cloud,
+				clusterCIDRs:               clusterCIDRs,
+				nodeNameSubnetMaskSizesMap: make(map[string][]int),
+			}
+
+			err = ca.updateNodeSubnetMaskSizes("vmss-0", tc.providerID)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedNodeNameSubnetMaskSizesMap, ca.nodeNameSubnetMaskSizesMap)
 		})
 	}
 }

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -61,6 +61,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 
 	// ensure the newly added package from azure-sdk-for-go is in vendor/
@@ -69,49 +70,6 @@ import (
 	_ "sigs.k8s.io/cloud-provider-azure/pkg/azureclients/deploymentclient"
 
 	"sigs.k8s.io/yaml"
-)
-
-const (
-	// CloudProviderName is the value used for the --cloud-provider flag
-	CloudProviderName = "azure"
-	// AzureStackCloudName is the cloud name of Azure Stack
-	AzureStackCloudName    = "AZURESTACKCLOUD"
-	rateLimitQPSDefault    = 1.0
-	rateLimitBucketDefault = 5
-	backoffRetriesDefault  = 6
-	backoffExponentDefault = 1.5
-	backoffDurationDefault = 5 // in seconds
-	backoffJitterDefault   = 1.0
-	// According to https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#load-balancer.
-	maximumLoadBalancerRuleCount = 250
-
-	vmTypeVMSS     = "vmss"
-	vmTypeStandard = "standard"
-
-	loadBalancerSkuBasic    = "basic"
-	loadBalancerSkuStandard = "standard"
-
-	externalResourceGroupLabel = "kubernetes.azure.com/resource-group"
-	managedByAzureLabel        = "kubernetes.azure.com/managed"
-
-	// LabelFailureDomainBetaZone refer to https://github.com/kubernetes/api/blob/8519c5ea46199d57724725d5b969c5e8e0533692/core/v1/well_known_labels.go#L22-L23
-	LabelFailureDomainBetaZone = "failure-domain.beta.kubernetes.io/zone"
-
-	// LabelFailureDomainBetaRegion failure-domain region label
-	LabelFailureDomainBetaRegion = "failure-domain.beta.kubernetes.io/region"
-
-	falseLabel = "false"
-)
-
-const (
-	// PreConfiguredBackendPoolLoadBalancerTypesNone means that the load balancers are not pre-configured
-	PreConfiguredBackendPoolLoadBalancerTypesNone = ""
-	// PreConfiguredBackendPoolLoadBalancerTypesInternal means that the `internal` load balancers are pre-configured
-	PreConfiguredBackendPoolLoadBalancerTypesInternal = "internal"
-	// PreConfiguredBackendPoolLoadBalancerTypesExternal means that the `external` load balancers are pre-configured
-	PreConfiguredBackendPoolLoadBalancerTypesExternal = "external"
-	// PreConfiguredBackendPoolLoadBalancerTypesAll means that all load balancers are pre-configured
-	PreConfiguredBackendPoolLoadBalancerTypesAll = "all"
 )
 
 var (
@@ -340,7 +298,7 @@ func init() {
 	}
 	autorest.StatusCodesForRetry = statusCodesForRetry
 
-	cloudprovider.RegisterCloudProvider(CloudProviderName, NewCloud)
+	cloudprovider.RegisterCloudProvider(consts.CloudProviderName, NewCloud)
 }
 
 // NewCloud returns a Cloud with initialized clients
@@ -349,7 +307,7 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	az.ipv6DualStackEnabled = utilfeature.DefaultFeatureGate.Enabled(IPv6DualStack)
+	az.ipv6DualStackEnabled = utilfeature.DefaultFeatureGate.Enabled(consts.IPv6DualStack)
 
 	return az, nil
 }
@@ -395,14 +353,14 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 
 	if config.VMType == "" {
 		// default to standard vmType if not set.
-		config.VMType = vmTypeStandard
+		config.VMType = consts.VMTypeStandard
 	}
 
 	if config.RouteUpdateWaitingInSeconds <= 0 {
 		config.RouteUpdateWaitingInSeconds = defaultRouteUpdateWaitingInSeconds
 	}
 
-	if config.DisableAvailabilitySetNodes && config.VMType != vmTypeVMSS {
+	if config.DisableAvailabilitySetNodes && config.VMType != consts.VMTypeVMSS {
 		return fmt.Errorf("disableAvailabilitySetNodes %v is only supported when vmType is 'vmss'", config.DisableAvailabilitySetNodes)
 	}
 
@@ -458,7 +416,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 	az.Config = *config
 	az.Environment = *env
 	az.ResourceRequestBackoff = resourceRequestBackoff
-	az.metadata, err = NewInstanceMetadataService(imdsServer)
+	az.metadata, err = NewInstanceMetadataService(consts.ImdsServer)
 	if err != nil {
 		return err
 	}
@@ -476,10 +434,10 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 	}
 
 	if az.MaximumLoadBalancerRuleCount == 0 {
-		az.MaximumLoadBalancerRuleCount = maximumLoadBalancerRuleCount
+		az.MaximumLoadBalancerRuleCount = consts.MaximumLoadBalancerRuleCount
 	}
 
-	if strings.EqualFold(vmTypeVMSS, az.Config.VMType) {
+	if strings.EqualFold(consts.VMTypeVMSS, az.Config.VMType) {
 		az.VMSet, err = newScaleSet(az)
 		if err != nil {
 			return err
@@ -520,7 +478,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 }
 
 func (az *Cloud) setLBDefaults(config *Config) error {
-	if strings.EqualFold(config.LoadBalancerSku, loadBalancerSkuStandard) {
+	if strings.EqualFold(config.LoadBalancerSku, consts.LoadBalancerSkuStandard) {
 		// Do not add master nodes to standard LB by default.
 		if config.ExcludeMasterFromStandardLB == nil {
 			config.ExcludeMasterFromStandardLB = &defaultExcludeMasterFromStandardLB
@@ -565,17 +523,17 @@ func (az *Cloud) setCloudProviderBackoffDefaults(config *Config) wait.Backoff {
 	if config.CloudProviderBackoff {
 		// Assign backoff defaults if no configuration was passed in
 		if config.CloudProviderBackoffRetries == 0 {
-			config.CloudProviderBackoffRetries = backoffRetriesDefault
+			config.CloudProviderBackoffRetries = consts.BackoffRetriesDefault
 		}
 		if config.CloudProviderBackoffDuration == 0 {
-			config.CloudProviderBackoffDuration = backoffDurationDefault
+			config.CloudProviderBackoffDuration = consts.BackoffDurationDefault
 		}
 		if config.CloudProviderBackoffExponent == 0 {
-			config.CloudProviderBackoffExponent = backoffExponentDefault
+			config.CloudProviderBackoffExponent = consts.BackoffExponentDefault
 		}
 
 		if config.CloudProviderBackoffJitter == 0 {
-			config.CloudProviderBackoffJitter = backoffJitterDefault
+			config.CloudProviderBackoffJitter = consts.BackoffJitterDefault
 		}
 
 		resourceRequestBackoff = wait.Backoff{
@@ -592,7 +550,7 @@ func (az *Cloud) setCloudProviderBackoffDefaults(config *Config) wait.Backoff {
 	} else {
 		// CloudProviderBackoffRetries will be set to 1 by default as the requirements of Azure SDK.
 		config.CloudProviderBackoffRetries = 1
-		config.CloudProviderBackoffDuration = backoffDurationDefault
+		config.CloudProviderBackoffDuration = consts.BackoffDurationDefault
 	}
 	return resourceRequestBackoff
 }
@@ -614,7 +572,7 @@ func (az *Cloud) configAzureClients(
 	// Error "not an active Virtual Machine Scale Set VM" is not retriable for VMSS VM.
 	// But http.StatusNotFound is retriable because of ARM replication latency.
 	vmssVMClientConfig := azClientConfig.WithRateLimiter(az.Config.VirtualMachineScaleSetRateLimit)
-	vmssVMClientConfig.Backoff = vmssVMClientConfig.Backoff.WithNonRetriableErrors([]string{vmssVMNotActiveErrorMessage}).WithRetriableHTTPStatusCodes([]int{http.StatusNotFound})
+	vmssVMClientConfig.Backoff = vmssVMClientConfig.Backoff.WithNonRetriableErrors([]string{consts.VmssVMNotActiveErrorMessage}).WithRetriableHTTPStatusCodes([]int{http.StatusNotFound})
 	routeClientConfig := azClientConfig.WithRateLimiter(az.Config.RouteRateLimit)
 	subnetClientConfig := azClientConfig.WithRateLimiter(az.Config.SubnetsRateLimit)
 	routeTableClientConfig := azClientConfig.WithRateLimiter(az.Config.RouteTableRateLimit)
@@ -760,7 +718,7 @@ func (az *Cloud) HasClusterID() bool {
 
 // ProviderName returns the cloud provider ID.
 func (az *Cloud) ProviderName() string {
-	return CloudProviderName
+	return consts.CloudProviderName
 }
 
 func initDiskControllers(az *Cloud) error {
@@ -795,8 +753,8 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 		UpdateFunc: func(prev, obj interface{}) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
-			if newNode.Labels[LabelFailureDomainBetaZone] ==
-				prevNode.Labels[LabelFailureDomainBetaZone] {
+			if newNode.Labels[consts.LabelFailureDomainBetaZone] ==
+				prevNode.Labels[consts.LabelFailureDomainBetaZone] {
 				return
 			}
 			az.updateNodeCaches(prevNode, newNode)
@@ -830,7 +788,7 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 
 	if prevNode != nil {
 		// Remove from nodeZones cache.
-		prevZone, ok := prevNode.ObjectMeta.Labels[LabelFailureDomainBetaZone]
+		prevZone, ok := prevNode.ObjectMeta.Labels[consts.LabelFailureDomainBetaZone]
 		if ok && az.isAvailabilityZone(prevZone) {
 			az.nodeZones[prevZone].Delete(prevNode.ObjectMeta.Name)
 			if az.nodeZones[prevZone].Len() == 0 {
@@ -839,21 +797,21 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		}
 
 		// Remove from nodeResourceGroups cache.
-		_, ok = prevNode.ObjectMeta.Labels[externalResourceGroupLabel]
+		_, ok = prevNode.ObjectMeta.Labels[consts.ExternalResourceGroupLabel]
 		if ok {
 			delete(az.nodeResourceGroups, prevNode.ObjectMeta.Name)
 		}
 
 		// Remove from unmanagedNodes cache.
-		managed, ok := prevNode.ObjectMeta.Labels[managedByAzureLabel]
-		if ok && managed == falseLabel {
+		managed, ok := prevNode.ObjectMeta.Labels[consts.ManagedByAzureLabel]
+		if ok && strings.EqualFold(managed, consts.NotManagedByAzureLabelValue) {
 			az.unmanagedNodes.Delete(prevNode.ObjectMeta.Name)
 		}
 	}
 
 	if newNode != nil {
 		// Add to nodeZones cache.
-		newZone, ok := newNode.ObjectMeta.Labels[LabelFailureDomainBetaZone]
+		newZone, ok := newNode.ObjectMeta.Labels[consts.LabelFailureDomainBetaZone]
 		if ok && az.isAvailabilityZone(newZone) {
 			if az.nodeZones[newZone] == nil {
 				az.nodeZones[newZone] = sets.NewString()
@@ -862,14 +820,14 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		}
 
 		// Add to nodeResourceGroups cache.
-		newRG, ok := newNode.ObjectMeta.Labels[externalResourceGroupLabel]
+		newRG, ok := newNode.ObjectMeta.Labels[consts.ExternalResourceGroupLabel]
 		if ok && len(newRG) > 0 {
 			az.nodeResourceGroups[newNode.ObjectMeta.Name] = strings.ToLower(newRG)
 		}
 
 		// Add to unmanagedNodes cache.
-		managed, ok := newNode.ObjectMeta.Labels[managedByAzureLabel]
-		if ok && managed == falseLabel {
+		managed, ok := newNode.ObjectMeta.Labels[consts.ManagedByAzureLabel]
+		if ok && strings.EqualFold(managed, consts.NotManagedByAzureLabelValue) {
 			az.unmanagedNodes.Insert(newNode.ObjectMeta.Name)
 		}
 	}
@@ -963,18 +921,13 @@ func (az *Cloud) GetUnmanagedNodes() (sets.String, error) {
 // ShouldNodeExcludedFromLoadBalancer returns true if node is unmanaged or in external resource group.
 func (az *Cloud) ShouldNodeExcludedFromLoadBalancer(node *v1.Node) bool {
 	labels := node.ObjectMeta.Labels
-	if rg, ok := labels[externalResourceGroupLabel]; ok && !strings.EqualFold(rg, az.ResourceGroup) {
+	if rg, ok := labels[consts.ExternalResourceGroupLabel]; ok && !strings.EqualFold(rg, az.ResourceGroup) {
 		return true
 	}
 
-	if managed, ok := labels[managedByAzureLabel]; ok && managed == falseLabel {
+	if managed, ok := labels[consts.ManagedByAzureLabel]; ok && strings.EqualFold(managed, consts.NotManagedByAzureLabelValue) {
 		return true
 	}
 
 	return false
-}
-
-// AliasRangesByProviderID to be implemented
-func (az *Cloud) AliasRangesByProviderID(id string) ([]string, error) {
-	return nil, nil
 }

--- a/pkg/provider/azure_backoff_test.go
+++ b/pkg/provider/azure_backoff_test.go
@@ -25,6 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
@@ -34,13 +40,8 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
-
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetVirtualMachineWithRetry(t *testing.T) {
@@ -224,7 +225,7 @@ func TestCreateOrUpdateSecurityGroupCanceled(t *testing.T) {
 
 	mockSGClient := az.SecurityGroupsClient.(*mocksecuritygroupclient.MockInterface)
 	mockSGClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(&retry.Error{
-		RawError: fmt.Errorf(operationCanceledErrorMessage),
+		RawError: fmt.Errorf(consts.OperationCanceledErrorMessage),
 	})
 	mockSGClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "sg", gomock.Any()).Return(network.SecurityGroup{}, nil)
 
@@ -252,7 +253,7 @@ func TestCreateOrUpdateLB(t *testing.T) {
 			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 412, RawError: %w", error(nil)),
 		},
 		{
-			clientErr:   &retry.Error{RawError: fmt.Errorf(operationCanceledErrorMessage)},
+			clientErr:   &retry.Error{RawError: fmt.Errorf(consts.OperationCanceledErrorMessage)},
 			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: %w", fmt.Errorf("canceledandsupersededduetoanotheroperation")),
 		},
 		{
@@ -378,7 +379,7 @@ func TestCreateOrUpdateRouteTable(t *testing.T) {
 			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 412, RawError: %w", error(nil)),
 		},
 		{
-			clientErr:   &retry.Error{RawError: fmt.Errorf(operationCanceledErrorMessage)},
+			clientErr:   &retry.Error{RawError: fmt.Errorf(consts.OperationCanceledErrorMessage)},
 			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: %w", fmt.Errorf("canceledandsupersededduetoanotheroperation")),
 		},
 	}
@@ -417,7 +418,7 @@ func TestCreateOrUpdateRoute(t *testing.T) {
 			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 412, RawError: %w", error(nil)),
 		},
 		{
-			clientErr:   &retry.Error{RawError: fmt.Errorf(operationCanceledErrorMessage)},
+			clientErr:   &retry.Error{RawError: fmt.Errorf(consts.OperationCanceledErrorMessage)},
 			expectedErr: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: %w", fmt.Errorf("canceledandsupersededduetoanotheroperation")),
 		},
 		{
@@ -505,7 +506,7 @@ func TestCreateOrUpdateVMSS(t *testing.T) {
 		{
 			vmss: compute.VirtualMachineScaleSet{
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-					ProvisioningState: &virtualMachineScaleSetsDeallocating,
+					ProvisioningState: to.StringPtr(virtualMachineScaleSetsDeallocating),
 				},
 			},
 		},

--- a/pkg/provider/azure_blobDiskController_test.go
+++ b/pkg/provider/azure_blobDiskController_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/storageaccountclient/mockstorageaccountclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -162,7 +163,7 @@ func TestCreateVHDBlobDisk(t *testing.T) {
 	assert.NoError(t, err)
 	blobClient := client.GetBlobService()
 
-	_, _, err = b.createVHDBlobDisk(blobClient, "testsa", "blob", vhdContainerName, int64(10))
+	_, _, err = b.createVHDBlobDisk(blobClient, "testsa", "blob", consts.VhdContainerName, int64(10))
 	expectedErr := "failed to put page blob blob.vhd in container vhds: storage: service returned error: StatusCode=403, ErrorCode=AccountIsDisabled, ErrorMessage=The specified account is disabled."
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), expectedErr))

--- a/pkg/provider/azure_config.go
+++ b/pkg/provider/azure_config.go
@@ -23,13 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/yaml"
-)
-
-const (
-	cloudConfigNamespace  = "kube-system"
-	cloudConfigKey        = "cloud-config"
-	cloudConfigSecretName = "azure-cloud-provider" // #nosec G101
 )
 
 // The config type for Azure cloud provider secret. Supported values are:
@@ -68,14 +63,14 @@ func (az *Cloud) getConfigFromSecret() (*Config, error) {
 		return nil, nil
 	}
 
-	secret, err := az.KubeClient.CoreV1().Secrets(cloudConfigNamespace).Get(context.TODO(), cloudConfigSecretName, metav1.GetOptions{})
+	secret, err := az.KubeClient.CoreV1().Secrets(consts.CloudConfigNamespace).Get(context.TODO(), consts.CloudConfigSecName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get secret %s: %w", cloudConfigSecretName, err)
+		return nil, fmt.Errorf("failed to get secret %s: %w", consts.CloudConfigSecName, err)
 	}
 
-	cloudConfigData, ok := secret.Data[cloudConfigKey]
+	cloudConfigData, ok := secret.Data[consts.CloudConfigKey]
 	if !ok {
-		return nil, fmt.Errorf("cloud-config is not set in the secret (%s)", cloudConfigSecretName)
+		return nil, fmt.Errorf("cloud-config is not set in the secret (%s)", consts.CloudConfigSecName)
 	}
 
 	config := Config{}

--- a/pkg/provider/azure_config_test.go
+++ b/pkg/provider/azure_config_test.go
@@ -28,6 +28,7 @@ import (
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/auth"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/yaml"
 )
 
@@ -163,7 +164,7 @@ func TestGetConfigFromSecret(t *testing.T) {
 				if test.secretConfig == badConfig {
 					secret.Data = map[string][]byte{"cloud-config": []byte(`unknown: "hello",unknown: "hello"`)}
 				}
-				_, err := az.KubeClient.CoreV1().Secrets(cloudConfigNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+				_, err := az.KubeClient.CoreV1().Secrets(consts.CloudConfigNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 				assert.NoError(t, err, test.name)
 			}
 
@@ -256,7 +257,7 @@ func TestInitializeCloudFromSecret(t *testing.T) {
 						"cloud-config": secretData,
 					}
 				}
-				_, err := az.KubeClient.CoreV1().Secrets(cloudConfigNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+				_, err := az.KubeClient.CoreV1().Secrets(consts.CloudConfigNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 				assert.NoError(t, err, test.name)
 			}
 

--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/klog/v2"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -109,14 +110,14 @@ type AttachDiskOptions struct {
 // getNodeVMSet gets the VMSet interface based on config.VMType and the real virtual machine type.
 func (c *controllerCommon) getNodeVMSet(nodeName types.NodeName, crt azcache.AzureCacheReadType) (VMSet, error) {
 	// 1. vmType is standard, return cloud.VMSet directly.
-	if c.cloud.VMType == vmTypeStandard {
+	if c.cloud.VMType == consts.VMTypeStandard {
 		return c.cloud.VMSet, nil
 	}
 
-	// 2. vmType is Virtual Machine Scale Set (vmss), convert vmSet to scaleSet.
-	ss, ok := c.cloud.VMSet.(*scaleSet)
+	// 2. vmType is Virtual Machine Scale Set (vmss), convert vmSet to ScaleSet.
+	ss, ok := c.cloud.VMSet.(*ScaleSet)
 	if !ok {
-		return nil, fmt.Errorf("error of converting vmSet (%q) to scaleSet with vmType %q", c.cloud.VMSet, c.cloud.VMType)
+		return nil, fmt.Errorf("error of converting vmSet (%q) to ScaleSet with vmType %q", c.cloud.VMSet, c.cloud.VMType)
 	}
 
 	// 3. If the node is managed by availability set, then return ss.availabilitySet.

--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -182,7 +183,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 		expectedLun     int32
 	}{
 		{
-			desc:          "an error shall be returned if convert vmSet to scaleSet failed",
+			desc:          "an error shall be returned if convert vmSet to ScaleSet failed",
 			vmList:        map[string]string{"vm1": "PowerState/Running"},
 			nodeName:      "vm1",
 			isVMSS:        false,
@@ -193,7 +194,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 			expectedErr:   true,
 		},
 		{
-			desc:          "an error shall be returned if convert vmSet to scaleSet success but node is not managed by availability set",
+			desc:          "an error shall be returned if convert vmSet to ScaleSet success but node is not managed by availability set",
 			vmssList:      []string{"vmss-vm-000001"},
 			nodeName:      "vmss1",
 			isVMSS:        true,
@@ -207,7 +208,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
-		testCloud.VMType = vmTypeVMSS
+		testCloud.VMType = consts.VMTypeVMSS
 		if test.isVMSS {
 			if test.isManagedBy {
 				testCloud.DisableAvailabilitySetNodes = false

--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // AttachDisk attaches a disk to vm
@@ -157,7 +158,7 @@ func (as *availabilitySet) DetachDisk(nodeName types.NodeName, diskMap map[strin
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-				if strings.EqualFold(as.cloud.Environment.Name, AzureStackCloudName) && !as.Config.DisableAzureStackCloud {
+				if strings.EqualFold(as.cloud.Environment.Name, consts.AzureStackCloudName) && !as.Config.DisableAzureStackCloud {
 					disks = append(disks[:i], disks[i+1:]...)
 				} else {
 					disks[i].ToBeDetached = to.BoolPtr(true)

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -27,10 +27,11 @@ import (
 	"k8s.io/klog/v2"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // AttachDisk attaches a disk to vm
-func (ss *scaleSet) AttachDisk(nodeName types.NodeName, diskMap map[string]*AttachDiskOptions) error {
+func (ss *ScaleSet) AttachDisk(nodeName types.NodeName, diskMap map[string]*AttachDiskOptions) error {
 	vmName := mapNodeNameToVMName(nodeName)
 	ssName, instanceID, vm, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 	if err != nil {
@@ -136,7 +137,7 @@ func (ss *scaleSet) AttachDisk(nodeName types.NodeName, diskMap map[string]*Atta
 }
 
 // DetachDisk detaches a disk from VM
-func (ss *scaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]string) error {
+func (ss *ScaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]string) error {
 	vmName := mapNodeNameToVMName(nodeName)
 	ssName, instanceID, vm, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 	if err != nil {
@@ -161,7 +162,7 @@ func (ss *scaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]strin
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-				if strings.EqualFold(ss.cloud.Environment.Name, AzureStackCloudName) && !ss.Config.DisableAzureStackCloud {
+				if strings.EqualFold(ss.cloud.Environment.Name, consts.AzureStackCloudName) && !ss.Config.DisableAzureStackCloud {
 					disks = append(disks[:i], disks[i+1:]...)
 				} else {
 					disks[i].ToBeDetached = to.BoolPtr(true)
@@ -212,7 +213,7 @@ func (ss *scaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]strin
 }
 
 // GetDataDisks gets a list of data disks attached to the node.
-func (ss *scaleSet) GetDataDisks(nodeName types.NodeName, crt azcache.AzureCacheReadType) ([]compute.DataDisk, error) {
+func (ss *ScaleSet) GetDataDisks(nodeName types.NodeName, crt azcache.AzureCacheReadType) ([]compute.DataDisk, error) {
 	_, _, vm, err := ss.getVmssVM(string(nodeName), crt)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/azure_controller_vmss_test.go
+++ b/pkg/provider/azure_controller_vmss_test.go
@@ -93,7 +93,7 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 
 	for i, test := range testCases {
 		scaleSetName := string(test.vmssName)
-		ss, err := newTestScaleSet(ctrl)
+		ss, err := NewTestScaleSet(ctrl)
 		assert.NoError(t, err, test.desc)
 		testCloud := ss.cloud
 		testCloud.PrimaryScaleSetName = scaleSetName
@@ -202,7 +202,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 
 	for i, test := range testCases {
 		scaleSetName := string(test.vmssName)
-		ss, err := newTestScaleSet(ctrl)
+		ss, err := NewTestScaleSet(ctrl)
 		assert.NoError(t, err, test.desc)
 		testCloud := ss.cloud
 		testCloud.PrimaryScaleSetName = scaleSetName
@@ -310,7 +310,7 @@ func TestGetDataDisksWithVMSS(t *testing.T) {
 	}
 	for i, test := range testCases {
 		scaleSetName := string(test.nodeName)
-		ss, err := newTestScaleSet(ctrl)
+		ss, err := NewTestScaleSet(ctrl)
 		assert.NoError(t, err, test.desc)
 		testCloud := ss.cloud
 		testCloud.PrimaryScaleSetName = scaleSetName

--- a/pkg/provider/azure_fakes.go
+++ b/pkg/provider/azure_fakes.go
@@ -36,11 +36,27 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 var (
 	errPreconditionFailedEtagMismatch = fmt.Errorf("PreconditionFailedEtagMismatch")
 )
+
+// NewTestScaleSet creates a fake ScaleSet for unit test
+func NewTestScaleSet(ctrl *gomock.Controller) (*ScaleSet, error) {
+	return newTestScaleSetWithState(ctrl)
+}
+
+func newTestScaleSetWithState(ctrl *gomock.Controller) (*ScaleSet, error) {
+	cloud := GetTestCloud(ctrl)
+	ss, err := newScaleSet(cloud)
+	if err != nil {
+		return nil, err
+	}
+
+	return ss.(*ScaleSet), nil
+}
 
 // GetTestCloud returns a fake azure cloud for unit tests in Azure related CSI drivers
 func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
@@ -62,7 +78,7 @@ func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 			PrimaryAvailabilitySetName:   "as",
 			PrimaryScaleSetName:          "vmss",
 			MaximumLoadBalancerRuleCount: 250,
-			VMType:                       vmTypeStandard,
+			VMType:                       consts.VMTypeStandard,
 		},
 		nodeZones:          map[string]sets.String{},
 		nodeInformerSynced: func() bool { return true },

--- a/pkg/provider/azure_instances.go
+++ b/pkg/provider/azure_instances.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 const (
@@ -148,7 +149,7 @@ func (az *Cloud) getLocalInstanceNodeAddresses(netInterfaces []NetworkInterface,
 
 	if len(addresses) == 1 {
 		// No IP addresses is got from instance metadata service, clean up cache and report errors.
-		_ = az.metadata.imsCache.Delete(metadataCacheKey)
+		_ = az.metadata.imsCache.Delete(consts.MetadataCacheKey)
 		return nil, fmt.Errorf("get empty IP addresses from instance metadata service")
 	}
 	return addresses, nil
@@ -282,7 +283,7 @@ func (az *Cloud) isCurrentInstance(name types.NodeName, metadataVMName string) (
 	nodeName := mapNodeNameToVMName(name)
 
 	// VMSS vmName is not same with hostname, use hostname instead.
-	if az.VMType == vmTypeVMSS {
+	if az.VMType == consts.VMTypeVMSS {
 		metadataVMName, err = os.Hostname()
 		if err != nil {
 			return false, err

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -118,7 +119,7 @@ func TestInstanceID(t *testing.T) {
 			vmList:              []string{"vm1"},
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
 		},
@@ -128,7 +129,7 @@ func TestInstanceID(t *testing.T) {
 			vmssName:            "vmss1",
 			nodeName:            "vmss1_0",
 			metadataName:        "vmss1_0",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0",
 		},
@@ -138,7 +139,7 @@ func TestInstanceID(t *testing.T) {
 			vmssName:            "vmss1",
 			nodeName:            "vmss1-0",
 			metadataName:        "vmss1-0",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vmss1-0",
 		},
@@ -147,7 +148,7 @@ func TestInstanceID(t *testing.T) {
 			vmList:              []string{"vm2"},
 			nodeName:            "vm2",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm2",
 		},
@@ -156,14 +157,14 @@ func TestInstanceID(t *testing.T) {
 			vmList:       []string{"vm2"},
 			nodeName:     "vm2",
 			metadataName: "vm2",
-			vmType:       vmTypeStandard,
+			vmType:       consts.VMTypeStandard,
 			expectedID:   "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm2",
 		},
 		{
 			name:                "InstanceID should report error if node doesn't exist",
 			vmList:              []string{"vm1"},
 			nodeName:            "vm3",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("instance not found"),
 		},
@@ -171,7 +172,7 @@ func TestInstanceID(t *testing.T) {
 			name:                "InstanceID should report error if metadata.Compute is nil",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			metadataTemplate:    `{"network":{"interface":[]}}`,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("failure of getting instance metadata"),
@@ -179,7 +180,7 @@ func TestInstanceID(t *testing.T) {
 		{
 			name:                "NodeAddresses should report error if cloud.VMSet is nil",
 			nodeName:            "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			nilVMSet:            true,
 			expectedErrMsg:      fmt.Errorf("no credentials provided for Azure cloud provider"),
@@ -188,7 +189,7 @@ func TestInstanceID(t *testing.T) {
 			name:                "NodeAddresses should report error if invoking GetMetadata returns error",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useCustomImsCache:   true,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("getError"),
@@ -226,7 +227,7 @@ func TestInstanceID(t *testing.T) {
 			t.Errorf("Test [%s] unexpected error: %v", test.name, err)
 		}
 		if test.useCustomImsCache {
-			cloud.metadata.imsCache, err = azcache.NewTimedcache(metadataCacheTTL, func(key string) (interface{}, error) {
+			cloud.metadata.imsCache, err = azcache.NewTimedcache(consts.MetadataCacheTTL, func(key string) (interface{}, error) {
 				return nil, fmt.Errorf("getError")
 			})
 			if err != nil {
@@ -435,7 +436,7 @@ func TestNodeAddresses(t *testing.T) {
 			name:                "NodeAddresses should report error if metadata.Network.Interface is nil",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			metadataTemplate:    `{"compute":{"name":"vm1"},"network":{}}`,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("no interface is found for the instance"),
@@ -444,7 +445,7 @@ func TestNodeAddresses(t *testing.T) {
 			name:                "NodeAddresses should report error when invoke GetMetadata",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useCustomImsCache:   true,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("getError"),
@@ -452,7 +453,7 @@ func TestNodeAddresses(t *testing.T) {
 		{
 			name:                "NodeAddresses should report error if cloud.VMSet is nil",
 			nodeName:            "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			nilVMSet:            true,
 			expectedErrMsg:      fmt.Errorf("no credentials provided for Azure cloud provider"),
@@ -461,7 +462,7 @@ func TestNodeAddresses(t *testing.T) {
 			name:                "NodeAddresses should report error when IPs are empty",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("get empty IP addresses from instance metadata service"),
 		},
@@ -469,28 +470,28 @@ func TestNodeAddresses(t *testing.T) {
 			name:                "NodeAddresses should report error if node don't exist",
 			nodeName:            "vm2",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedErrMsg:      fmt.Errorf("timed out waiting for the condition"),
 		},
 		{
 			name:                "NodeAddresses should get IP addresses from Azure API if node's name isn't equal to metadataName",
 			nodeName:            "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedAddress:     expectedNodeAddress,
 		},
 		{
 			name:            "NodeAddresses should get IP addresses from Azure API if useInstanceMetadata is false",
 			nodeName:        "vm1",
-			vmType:          vmTypeStandard,
+			vmType:          consts.VMTypeStandard,
 			expectedAddress: expectedNodeAddress,
 		},
 		{
 			name:                "NodeAddresses should get IP addresses from local IMDS if node's name is equal to metadataName",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			ipV4:                "10.240.0.1",
 			ipV4Public:          "192.168.1.12",
 			ipV6:                "1111:11111:00:00:1111:1111:000:111",
@@ -524,7 +525,7 @@ func TestNodeAddresses(t *testing.T) {
 			name:                "NodeAddresses should get IP addresses from local IMDS for standard LoadBalancer if node's name is equal to metadataName",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
-			vmType:              vmTypeStandard,
+			vmType:              consts.VMTypeStandard,
 			ipV4:                "10.240.0.1",
 			ipV4Public:          "192.168.1.12",
 			ipV6:                "1111:11111:00:00:1111:1111:000:111",
@@ -571,7 +572,7 @@ func TestNodeAddresses(t *testing.T) {
 
 		mux := http.NewServeMux()
 		mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.Contains(r.RequestURI, imdsLoadBalancerURI) {
+			if strings.Contains(r.RequestURI, consts.ImdsLoadBalancerURI) {
 				fmt.Fprintf(w, loadbalancerTemplate, test.ipV4Public, test.ipV4, test.ipV6Public, test.ipV6)
 				return
 			}
@@ -597,7 +598,7 @@ func TestNodeAddresses(t *testing.T) {
 		}
 
 		if test.useCustomImsCache {
-			cloud.metadata.imsCache, err = azcache.NewTimedcache(metadataCacheTTL, func(key string) (interface{}, error) {
+			cloud.metadata.imsCache, err = azcache.NewTimedcache(consts.MetadataCacheTTL, func(key string) (interface{}, error) {
 				return nil, fmt.Errorf("getError")
 			})
 			if err != nil {
@@ -713,7 +714,7 @@ func TestInstanceExistsByProviderID(t *testing.T) {
 	}
 
 	for _, test := range vmssTestCases {
-		ss, err := newTestScaleSet(ctrl)
+		ss, err := NewTestScaleSet(ctrl)
 		assert.NoError(t, err, test.name)
 		cloud.VMSet = ss
 

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -37,100 +37,9 @@ import (
 	utilnet "k8s.io/utils/net"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
-)
-
-const (
-	// ServiceAnnotationLoadBalancerInternal is the annotation used on the service
-	ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/azure-load-balancer-internal"
-
-	// ServiceAnnotationLoadBalancerInternalSubnet is the annotation used on the service
-	// to specify what subnet it is exposed on
-	ServiceAnnotationLoadBalancerInternalSubnet = "service.beta.kubernetes.io/azure-load-balancer-internal-subnet"
-
-	// ServiceAnnotationLoadBalancerMode is the annotation used on the service to specify
-	// which load balancer should be associated with the service. This is valid when using the basic
-	// load balancer or turn on the multiple standard load balancers mode, or it would be ignored.
-	// 1. Default mode - service has no annotation ("service.beta.kubernetes.io/azure-load-balancer-mode")
-	//	  In this case the Loadbalancer of the primary VMSS/VMAS is selected.
-	// 2. "__auto__" mode - service is annotated with __auto__ value, this when loadbalancer from any VMSS/VMAS
-	//    is selected which has the minimum rules associated with it.
-	// 3. "name" mode - this is when the load balancer from the specified VMSS/VMAS that has the
-	//    minimum rules associated with it is selected.
-	ServiceAnnotationLoadBalancerMode = "service.beta.kubernetes.io/azure-load-balancer-mode"
-
-	// ServiceAnnotationLoadBalancerAutoModeValue is the annotation used on the service to specify the
-	// Azure load balancer auto selection from the availability sets
-	ServiceAnnotationLoadBalancerAutoModeValue = "__auto__"
-
-	// ServiceAnnotationDNSLabelName is the annotation used on the service
-	// to specify the DNS label name for the service.
-	ServiceAnnotationDNSLabelName = "service.beta.kubernetes.io/azure-dns-label-name"
-
-	// ServiceAnnotationSharedSecurityRule is the annotation used on the service
-	// to specify that the service should be exposed using an Azure security rule
-	// that may be shared with other service, trading specificity of rules for an
-	// increase in the number of services that can be exposed. This relies on the
-	// Azure "augmented security rules" feature.
-	ServiceAnnotationSharedSecurityRule = "service.beta.kubernetes.io/azure-shared-securityrule"
-
-	// ServiceAnnotationLoadBalancerResourceGroup is the annotation used on the service
-	// to specify the resource group of load balancer objects that are not in the same resource group as the cluster.
-	ServiceAnnotationLoadBalancerResourceGroup = "service.beta.kubernetes.io/azure-load-balancer-resource-group"
-
-	// ServiceAnnotationPIPName specifies the pip that will be applied to load balancer
-	ServiceAnnotationPIPName = "service.beta.kubernetes.io/azure-pip-name"
-
-	// ServiceAnnotationIPTagsForPublicIP specifies the iptags used when dynamically creating a public ip
-	ServiceAnnotationIPTagsForPublicIP = "service.beta.kubernetes.io/azure-pip-ip-tags"
-
-	// ServiceAnnotationAllowedServiceTag is the annotation used on the service
-	// to specify a list of allowed service tags separated by comma
-	// Refer https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#service-tags for all supported service tags.
-	ServiceAnnotationAllowedServiceTag = "service.beta.kubernetes.io/azure-allowed-service-tags"
-
-	// ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges  denies all traffic to the load balancer except those
-	// within the service.Spec.LoadBalancerSourceRanges. Ref: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/374.
-	ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges = "service.beta.kubernetes.io/azure-deny-all-except-load-balancer-source-ranges"
-
-	// ServiceAnnotationLoadBalancerIdleTimeout is the annotation used on the service
-	// to specify the idle timeout for connections on the load balancer in minutes.
-	ServiceAnnotationLoadBalancerIdleTimeout = "service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout"
-
-	// ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts is the annotation used on the service
-	// to enable the high availability ports on the standard internal load balancer.
-	ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts = "service.beta.kubernetes.io/azure-load-balancer-enable-high-availability-ports"
-
-	// ServiceAnnotationLoadBalancerDisableTCPReset is the annotation used on the service
-	// to set enableTcpReset to false in load balancer rule. This only works for Azure standard load balancer backed service.
-	// TODO(feiskyer): disable-tcp-reset annotations has been depracated since v1.18, it would removed on v1.20.
-	ServiceAnnotationLoadBalancerDisableTCPReset = "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset"
-
-	// ServiceAnnotationLoadBalancerHealthProbeProtocol determines the network protocol that the load balancer health probe use.
-	// If not set, the local service would use the HTTP and the cluster service would use the TCP by default.
-	ServiceAnnotationLoadBalancerHealthProbeProtocol = "service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"
-
-	// ServiceAnnotationLoadBalancerHealthProbeRequestPath determines the request path of the load balancer health probe.
-	// This is only useful for the HTTP and HTTPS, and would be ignored when using TCP. If not set,
-	// `/healthz` would be configured by default.
-	ServiceAnnotationLoadBalancerHealthProbeRequestPath = "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path"
-
-	// ServiceAnnotationAzurePIPTags determines what tags should be applied to the public IP of the service. The cluster name
-	// and service names tags (which is managed by controller manager itself) would keep unchanged. The supported format
-	// is `a=b,c=d,...`. After updated, the old user-assigned tags would not be replaced by the new ones.
-	ServiceAnnotationAzurePIPTags = "service.beta.kubernetes.io/azure-pip-tags"
-
-	// serviceTagKey is the service key applied for public IP tags.
-	serviceTagKey = "service"
-	// clusterNameKey is the cluster name key applied for public IP tags.
-	clusterNameKey = "kubernetes-cluster-name"
-	// serviceUsingDNSKey is the service name consuming the DNS label on the public IP
-	serviceUsingDNSKey = "kubernetes-dns-label-service"
-
-	defaultLoadBalancerSourceRanges = "0.0.0.0/0"
-
-	trueAnnotationValue = "true"
 )
 
 // GetLoadBalancer returns whether the specified load balancer and its components exist, and
@@ -169,7 +78,7 @@ func (az *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, servic
 }
 
 func getPublicIPDomainNameLabel(service *v1.Service) (string, bool) {
-	if labelName, found := service.Annotations[ServiceAnnotationDNSLabelName]; found {
+	if labelName, found := service.Annotations[consts.ServiceAnnotationDNSLabelName]; found {
 		return labelName, found
 	}
 	return "", false
@@ -368,7 +277,7 @@ func (az *Cloud) shouldChangeLoadBalancer(service *v1.Service, currLBName, clust
 		return false
 	}
 	// if the current LB is what we want, keep it
-	lbName := strings.TrimSuffix(currLBName, InternalLoadBalancerNameSuffix)
+	lbName := strings.TrimSuffix(currLBName, consts.InternalLoadBalancerNameSuffix)
 	if strings.EqualFold(lbName, vmSetName) {
 		return false
 	}
@@ -691,7 +600,7 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 
 func (az *Cloud) determinePublicIPName(clusterName string, service *v1.Service) (string, bool, error) {
 	var shouldPIPExisted bool
-	if name, found := service.Annotations[ServiceAnnotationPIPName]; found && name != "" {
+	if name, found := service.Annotations[consts.ServiceAnnotationPIPName]; found && name != "" {
 		shouldPIPExisted = true
 		return name, shouldPIPExisted, nil
 	}
@@ -740,12 +649,12 @@ func flipServiceInternalAnnotation(service *v1.Service) *v1.Service {
 	if copyService.Annotations == nil {
 		copyService.Annotations = map[string]string{}
 	}
-	if v, ok := copyService.Annotations[ServiceAnnotationLoadBalancerInternal]; ok && v == trueAnnotationValue {
+	if v, ok := copyService.Annotations[consts.ServiceAnnotationLoadBalancerInternal]; ok && v == consts.TrueAnnotationValue {
 		// If it is internal now, we make it external by remove the annotation
-		delete(copyService.Annotations, ServiceAnnotationLoadBalancerInternal)
+		delete(copyService.Annotations, consts.ServiceAnnotationLoadBalancerInternal)
 	} else {
 		// If it is external now, we make it internal
-		copyService.Annotations[ServiceAnnotationLoadBalancerInternal] = trueAnnotationValue
+		copyService.Annotations[consts.ServiceAnnotationLoadBalancerInternal] = consts.TrueAnnotationValue
 	}
 	return copyService
 }
@@ -801,7 +710,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 
 		// return if pip exist and dns label is the same
 		if strings.EqualFold(getDomainNameLabel(&pip), domainNameLabel) {
-			if existingServiceName, ok := pip.Tags[serviceUsingDNSKey]; ok &&
+			if existingServiceName, ok := pip.Tags[consts.ServiceUsingDNSKey]; ok &&
 				strings.EqualFold(*existingServiceName, serviceName) {
 				klog.V(6).Infof("ensurePublicIPExists for service(%s): pip(%s) - "+
 					"the service is using the DNS label on the public IP", serviceName, pipName)
@@ -849,8 +758,8 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 			IPTags:                   getServiceIPTagRequestForPublicIP(service).IPTags,
 		}
 		pip.Tags = map[string]*string{
-			serviceTagKey:  to.StringPtr(""),
-			clusterNameKey: &clusterName,
+			consts.ServiceTagKey:  to.StringPtr(""),
+			consts.ClusterNameKey: &clusterName,
 		}
 		if _, err = bindServicesToPIP(&pip, []string{serviceName}, false); err != nil {
 			return nil, err
@@ -864,7 +773,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		klog.V(2).Infof("ensurePublicIPExists for service(%s): pip(%s) - creating", serviceName, *pip.Name)
 	}
 	if foundDNSLabelAnnotation {
-		if existingServiceName, ok := pip.Tags[serviceUsingDNSKey]; ok {
+		if existingServiceName, ok := pip.Tags[consts.ServiceUsingDNSKey]; ok {
 			if !strings.EqualFold(to.String(existingServiceName), serviceName) {
 				return nil, fmt.Errorf("ensurePublicIPExists for service(%s): pip(%s) - there is an existing service %s consuming the DNS label on the public IP, so the service cannot set the DNS label annotation with this value", serviceName, pipName, *existingServiceName)
 			}
@@ -885,7 +794,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 					return nil, fmt.Errorf("ensurePublicIPExists for service(%s): pip(%s) - there is an existing DNS label %s on the public IP", serviceName, pipName, *existingDNSLabel)
 				}
 			}
-			pip.Tags[serviceUsingDNSKey] = &serviceName
+			pip.Tags[consts.ServiceUsingDNSKey] = &serviceName
 		}
 	}
 
@@ -931,7 +840,7 @@ type serviceIPTagRequest struct {
 // Get the ip tag Request for the public ip from service annotations.
 func getServiceIPTagRequestForPublicIP(service *v1.Service) serviceIPTagRequest {
 	if service != nil {
-		if ipTagString, found := service.Annotations[ServiceAnnotationIPTagsForPublicIP]; found {
+		if ipTagString, found := service.Annotations[consts.ServiceAnnotationIPTagsForPublicIP]; found {
 			return serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags:                      convertIPTagMapToSlice(getIPTagMap(ipTagString)),
@@ -1023,7 +932,7 @@ func getIdleTimeout(s *v1.Service) (*int32, error) {
 		max = 30
 	)
 
-	val, ok := s.Annotations[ServiceAnnotationLoadBalancerIdleTimeout]
+	val, ok := s.Annotations[consts.ServiceAnnotationLoadBalancerIdleTimeout]
 	if !ok {
 		// Return a nil here as this will set the value to the azure default
 		return nil, nil
@@ -1569,7 +1478,7 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			newConfigs = append(newConfigs,
 				network.FrontendIPConfiguration{
 					Name:                                    to.StringPtr(defaultLBFrontendIPConfigName),
-					ID:                                      to.StringPtr(fmt.Sprintf(frontendIPConfigIDTemplate, az.SubscriptionID, az.ResourceGroup, *lb.Name, defaultLBFrontendIPConfigName)),
+					ID:                                      to.StringPtr(fmt.Sprintf(consts.FrontendIPConfigIDTemplate, az.SubscriptionID, az.ResourceGroup, *lb.Name, defaultLBFrontendIPConfigName)),
 					FrontendIPConfigurationPropertiesFormat: fipConfigurationProperties,
 				})
 			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, defaultLBFrontendIPConfigName)
@@ -1770,7 +1679,7 @@ func lbRuleConflictsWithPort(rule network.LoadBalancingRule, frontendIPConfigID 
 
 func parseHealthProbeProtocolAndPath(service *v1.Service) (string, string) {
 	var protocol, path string
-	if v, ok := service.Annotations[ServiceAnnotationLoadBalancerHealthProbeProtocol]; ok {
+	if v, ok := service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeProtocol]; ok {
 		protocol = v
 	} else {
 		return protocol, path
@@ -1778,7 +1687,7 @@ func parseHealthProbeProtocolAndPath(service *v1.Service) (string, string) {
 	// ignore the request path if using TCP
 	if strings.EqualFold(protocol, string(network.ProbeProtocolHTTP)) ||
 		strings.EqualFold(protocol, string(network.ProbeProtocolHTTPS)) {
-		if v, ok := service.Annotations[ServiceAnnotationLoadBalancerHealthProbeRequestPath]; ok {
+		if v, ok := service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath]; ok {
 			path = v
 		}
 	}
@@ -1803,7 +1712,7 @@ func (az *Cloud) getExpectedLBRules(
 	var enableTCPReset *bool
 	if az.useStandardLoadBalancer() {
 		enableTCPReset = to.BoolPtr(true)
-		if _, ok := service.Annotations[ServiceAnnotationLoadBalancerDisableTCPReset]; ok {
+		if _, ok := service.Annotations[consts.ServiceAnnotationLoadBalancerDisableTCPReset]; ok {
 			klog.Warning("annotation service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset has been removed as of Kubernetes 1.20. TCP Resets are always enabled on Standard SKU load balancers.")
 		}
 	}
@@ -1899,8 +1808,8 @@ func (az *Cloud) getExpectedLBRules(
 		}
 
 		if requiresInternalLoadBalancer(service) &&
-			strings.EqualFold(az.LoadBalancerSku, loadBalancerSkuStandard) &&
-			strings.EqualFold(service.Annotations[ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts], trueAnnotationValue) {
+			strings.EqualFold(az.LoadBalancerSku, consts.LoadBalancerSkuStandard) &&
+			strings.EqualFold(service.Annotations[consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts], consts.TrueAnnotationValue) {
 			expectedRule.FrontendPort = to.Int32Ptr(0)
 			expectedRule.BackendPort = to.Int32Ptr(0)
 			expectedRule.Protocol = network.TransportProtocolAll
@@ -1959,7 +1868,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	}
 	serviceTags := getServiceTags(service)
 	if len(serviceTags) != 0 {
-		delete(sourceRanges, defaultLoadBalancerSourceRanges)
+		delete(sourceRanges, consts.DefaultLoadBalancerSourceRanges)
 	}
 
 	var sourceAddressPrefixes []string
@@ -2142,7 +2051,7 @@ func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, s
 
 		shouldAddDenyRule := false
 		if len(sourceRanges) > 0 && !servicehelpers.IsAllowAll(sourceRanges) {
-			if v, ok := service.Annotations[ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges]; ok && strings.EqualFold(v, trueAnnotationValue) {
+			if v, ok := service.Annotations[consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges]; ok && strings.EqualFold(v, consts.TrueAnnotationValue) {
 				shouldAddDenyRule = true
 			}
 		}
@@ -2332,14 +2241,14 @@ func shouldReleaseExistingOwnedPublicIP(existingPip *network.PublicIPAddress, lb
 
 	// Check whether the public IP is being referenced by other service.
 	// The owned public IP can be released only when there is not other service using it.
-	if existingPip.Tags[serviceTagKey] != nil {
+	if existingPip.Tags[consts.ServiceTagKey] != nil {
 		// case 1: there is at least one reference when deleting the PIP
-		if !lbShouldExist && len(parsePIPServiceTag(existingPip.Tags[serviceTagKey])) > 0 {
+		if !lbShouldExist && len(parsePIPServiceTag(existingPip.Tags[consts.ServiceTagKey])) > 0 {
 			return false
 		}
 
 		// case 2: there is at least one reference from other service
-		if lbShouldExist && len(parsePIPServiceTag(existingPip.Tags[serviceTagKey])) > 1 {
+		if lbShouldExist && len(parsePIPServiceTag(existingPip.Tags[consts.ServiceTagKey])) > 1 {
 			return false
 		}
 	}
@@ -2360,25 +2269,25 @@ func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *network.PublicIPAddre
 	changed := false
 	configTags := parseTags(az.Tags)
 	annotationTags := make(map[string]*string)
-	if _, ok := service.Annotations[ServiceAnnotationAzurePIPTags]; ok {
-		annotationTags = parseTags(service.Annotations[ServiceAnnotationAzurePIPTags])
+	if _, ok := service.Annotations[consts.ServiceAnnotationAzurePIPTags]; ok {
+		annotationTags = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags])
 	}
 	for k, v := range annotationTags {
 		configTags[k] = v
 	}
 	// include the cluster name and service names tags when comparing
 	var clusterName, serviceNames *string
-	if v, ok := pip.Tags[clusterNameKey]; ok {
+	if v, ok := pip.Tags[consts.ClusterNameKey]; ok {
 		clusterName = v
 	}
-	if v, ok := pip.Tags[serviceTagKey]; ok {
+	if v, ok := pip.Tags[consts.ServiceTagKey]; ok {
 		serviceNames = v
 	}
 	if clusterName != nil {
-		configTags[clusterNameKey] = clusterName
+		configTags[consts.ClusterNameKey] = clusterName
 	}
 	if serviceNames != nil {
-		configTags[serviceTagKey] = serviceNames
+		configTags[consts.ServiceTagKey] = serviceNames
 	}
 	for k, v := range configTags {
 		if vv, ok := pip.Tags[k]; !ok || !strings.EqualFold(to.String(v), to.String(vv)) {
@@ -2685,7 +2594,7 @@ func findSecurityRule(rules []network.SecurityRule, rule network.SecurityRule) b
 }
 
 func (az *Cloud) getPublicIPAddressResourceGroup(service *v1.Service) string {
-	if resourceGroup, found := service.Annotations[ServiceAnnotationLoadBalancerResourceGroup]; found {
+	if resourceGroup, found := service.Annotations[consts.ServiceAnnotationLoadBalancerResourceGroup]; found {
 		resourceGroupName := strings.TrimSpace(resourceGroup)
 		if len(resourceGroupName) > 0 {
 			return resourceGroupName
@@ -2699,13 +2608,13 @@ func (az *Cloud) isBackendPoolPreConfigured(service *v1.Service) bool {
 	preConfigured := false
 	isInternal := requiresInternalLoadBalancer(service)
 
-	if az.PreConfiguredBackendPoolLoadBalancerTypes == PreConfiguredBackendPoolLoadBalancerTypesAll {
+	if az.PreConfiguredBackendPoolLoadBalancerTypes == consts.PreConfiguredBackendPoolLoadBalancerTypesAll {
 		preConfigured = true
 	}
-	if (az.PreConfiguredBackendPoolLoadBalancerTypes == PreConfiguredBackendPoolLoadBalancerTypesInternal) && isInternal {
+	if (az.PreConfiguredBackendPoolLoadBalancerTypes == consts.PreConfiguredBackendPoolLoadBalancerTypesInternal) && isInternal {
 		preConfigured = true
 	}
-	if (az.PreConfiguredBackendPoolLoadBalancerTypes == PreConfiguredBackendPoolLoadBalancerTypesExternal) && !isInternal {
+	if (az.PreConfiguredBackendPoolLoadBalancerTypes == consts.PreConfiguredBackendPoolLoadBalancerTypesExternal) && !isInternal {
 		preConfigured = true
 	}
 
@@ -2714,8 +2623,8 @@ func (az *Cloud) isBackendPoolPreConfigured(service *v1.Service) bool {
 
 // Check if service requires an internal load balancer.
 func requiresInternalLoadBalancer(service *v1.Service) bool {
-	if l, found := service.Annotations[ServiceAnnotationLoadBalancerInternal]; found {
-		return l == trueAnnotationValue
+	if l, found := service.Annotations[consts.ServiceAnnotationLoadBalancerInternal]; found {
+		return l == consts.TrueAnnotationValue
 	}
 
 	return false
@@ -2723,7 +2632,7 @@ func requiresInternalLoadBalancer(service *v1.Service) bool {
 
 func subnet(service *v1.Service) *string {
 	if requiresInternalLoadBalancer(service) {
-		if l, found := service.Annotations[ServiceAnnotationLoadBalancerInternalSubnet]; found && strings.TrimSpace(l) != "" {
+		if l, found := service.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet]; found && strings.TrimSpace(l) != "" {
 			return &l
 		}
 	}
@@ -2735,20 +2644,20 @@ func subnet(service *v1.Service) *string {
 // if the value is __auto__ it returns isAuto = TRUE.
 // if anything else it returns the unique VM set names after trimming spaces.
 func (az *Cloud) getServiceLoadBalancerMode(service *v1.Service) (bool, bool, string) {
-	mode, hasMode := service.Annotations[ServiceAnnotationLoadBalancerMode]
+	mode, hasMode := service.Annotations[consts.ServiceAnnotationLoadBalancerMode]
 	useSingleSLB := az.useStandardLoadBalancer() && !az.EnableMultipleStandardLoadBalancers
 	if useSingleSLB && hasMode {
-		klog.Warningf("single standard load balancer doesn't work with annotation %q, would ignore it", ServiceAnnotationLoadBalancerMode)
+		klog.Warningf("single standard load balancer doesn't work with annotation %q, would ignore it", consts.ServiceAnnotationLoadBalancerMode)
 	}
 	mode = strings.TrimSpace(mode)
-	isAuto := strings.EqualFold(mode, ServiceAnnotationLoadBalancerAutoModeValue)
+	isAuto := strings.EqualFold(mode, consts.ServiceAnnotationLoadBalancerAutoModeValue)
 
 	return hasMode, isAuto, mode
 }
 
 func useSharedSecurityRule(service *v1.Service) bool {
-	if l, ok := service.Annotations[ServiceAnnotationSharedSecurityRule]; ok {
-		return l == trueAnnotationValue
+	if l, ok := service.Annotations[consts.ServiceAnnotationSharedSecurityRule]; ok {
+		return l == consts.TrueAnnotationValue
 	}
 
 	return false
@@ -2759,7 +2668,7 @@ func getServiceTags(service *v1.Service) []string {
 		return nil
 	}
 
-	if serviceTags, found := service.Annotations[ServiceAnnotationAllowedServiceTag]; found {
+	if serviceTags, found := service.Annotations[consts.ServiceAnnotationAllowedServiceTag]; found {
 		result := []string{}
 		tags := strings.Split(strings.TrimSpace(serviceTags), ",")
 		for _, tag := range tags {
@@ -2777,8 +2686,8 @@ func getServiceTags(service *v1.Service) []string {
 
 func serviceOwnsPublicIP(pip *network.PublicIPAddress, clusterName, serviceName string) bool {
 	if pip != nil && pip.Tags != nil {
-		serviceTag := pip.Tags[serviceTagKey]
-		clusterTag := pip.Tags[clusterNameKey]
+		serviceTag := pip.Tags[consts.ServiceTagKey]
+		clusterTag := pip.Tags[consts.ClusterNameKey]
 
 		if serviceTag != nil && isSVCNameInPIPTag(*serviceTag, serviceName) {
 			// Backward compatible for clusters upgraded from old releases.
@@ -2837,10 +2746,10 @@ func bindServicesToPIP(pip *network.PublicIPAddress, incomingServiceNames []stri
 	}
 
 	if pip.Tags == nil {
-		pip.Tags = map[string]*string{serviceTagKey: to.StringPtr("")}
+		pip.Tags = map[string]*string{consts.ServiceTagKey: to.StringPtr("")}
 	}
 
-	serviceTagValue := pip.Tags[serviceTagKey]
+	serviceTagValue := pip.Tags[consts.ServiceTagKey]
 	serviceTagValueSet := make(map[string]struct{})
 	existingServiceNames := parsePIPServiceTag(serviceTagValue)
 	addedNew := false
@@ -2848,7 +2757,7 @@ func bindServicesToPIP(pip *network.PublicIPAddress, incomingServiceNames []stri
 	// replace is used when unbinding the service from PIP so addedNew remains false all the time
 	if replace {
 		serviceTagValue = to.StringPtr(strings.Join(incomingServiceNames, ","))
-		pip.Tags[serviceTagKey] = serviceTagValue
+		pip.Tags[consts.ServiceTagKey] = serviceTagValue
 
 		return false, nil
 	}
@@ -2873,7 +2782,7 @@ func bindServicesToPIP(pip *network.PublicIPAddress, incomingServiceNames []stri
 			}
 		}
 	}
-	pip.Tags[serviceTagKey] = serviceTagValue
+	pip.Tags[consts.ServiceTagKey] = serviceTagValue
 
 	return addedNew, nil
 }
@@ -2883,7 +2792,7 @@ func unbindServiceFromPIP(pip *network.PublicIPAddress, serviceName string) erro
 		return fmt.Errorf("nil public IP or tags")
 	}
 
-	serviceTagValue := pip.Tags[serviceTagKey]
+	serviceTagValue := pip.Tags[consts.ServiceTagKey]
 	existingServiceNames := parsePIPServiceTag(serviceTagValue)
 	var found bool
 	for i := len(existingServiceNames) - 1; i >= 0; i-- {
@@ -2901,9 +2810,9 @@ func unbindServiceFromPIP(pip *network.PublicIPAddress, serviceName string) erro
 		return err
 	}
 
-	if existingServiceName, ok := pip.Tags[serviceUsingDNSKey]; ok {
+	if existingServiceName, ok := pip.Tags[consts.ServiceUsingDNSKey]; ok {
 		if strings.EqualFold(*existingServiceName, serviceName) {
-			pip.Tags[serviceUsingDNSKey] = to.StringPtr("")
+			pip.Tags[consts.ServiceUsingDNSKey] = to.StringPtr("")
 		}
 	}
 

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/securitygroupclient/mocksecuritygroupclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -273,13 +274,13 @@ func TestGetIdleTimeout(t *testing.T) {
 		err         bool
 	}{
 		{desc: "no annotation"},
-		{desc: "annotation empty value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: ""}, err: true},
-		{desc: "annotation not a number", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "cookies"}, err: true},
-		{desc: "annotation negative value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "-6"}, err: true},
-		{desc: "annotation zero value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "0"}, err: true},
-		{desc: "annotation too low value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "3"}, err: true},
-		{desc: "annotation too high value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "31"}, err: true},
-		{desc: "annotation good value", annotations: map[string]string{ServiceAnnotationLoadBalancerIdleTimeout: "24"}, i: to.Int32Ptr(24)},
+		{desc: "annotation empty value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: ""}, err: true},
+		{desc: "annotation not a number", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "cookies"}, err: true},
+		{desc: "annotation negative value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "-6"}, err: true},
+		{desc: "annotation zero value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "0"}, err: true},
+		{desc: "annotation too low value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "3"}, err: true},
+		{desc: "annotation too high value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "31"}, err: true},
+		{desc: "annotation good value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "24"}, i: to.Int32Ptr(24)},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
 			s := &v1.Service{}
@@ -312,7 +313,7 @@ func TestSubnet(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
+						consts.ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
 					},
 				},
 			},
@@ -323,8 +324,8 @@ func TestSubnet(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
-						ServiceAnnotationLoadBalancerInternal:       "false",
+						consts.ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
+						consts.ServiceAnnotationLoadBalancerInternal:       "false",
 					},
 				},
 			},
@@ -335,8 +336,8 @@ func TestSubnet(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternalSubnet: "",
-						ServiceAnnotationLoadBalancerInternal:       "true",
+						consts.ServiceAnnotationLoadBalancerInternalSubnet: "",
+						consts.ServiceAnnotationLoadBalancerInternal:       "true",
 					},
 				},
 			},
@@ -347,8 +348,8 @@ func TestSubnet(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
-						ServiceAnnotationLoadBalancerInternal:       "true",
+						consts.ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
+						consts.ServiceAnnotationLoadBalancerInternal:       "true",
 					},
 				},
 			},
@@ -406,7 +407,7 @@ func TestEnsureLoadBalancerDeleted(t *testing.T) {
 
 	for i, c := range tests {
 
-		if c.service.Annotations[ServiceAnnotationLoadBalancerInternal] == "true" {
+		if c.service.Annotations[consts.ServiceAnnotationLoadBalancerInternal] == "true" {
 			validateTestSubnet(t, az, &c.service)
 		}
 
@@ -462,7 +463,7 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when service name tag doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey: to.StringPtr("nginx"),
+					consts.ServiceTagKey: to.StringPtr("nginx"),
 				},
 			},
 			serviceName: "web",
@@ -472,7 +473,7 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned when service name tag matches and cluster name tag is not set",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey: to.StringPtr("nginx"),
+					consts.ServiceTagKey: to.StringPtr("nginx"),
 				},
 			},
 			clusterName: "kubernetes",
@@ -483,8 +484,8 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when cluster name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("nginx"),
-					clusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  to.StringPtr("nginx"),
+					consts.ClusterNameKey: to.StringPtr("kubernetes"),
 				},
 			},
 			clusterName: "k8s",
@@ -495,8 +496,8 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when cluster name matches while service name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("web"),
-					clusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  to.StringPtr("web"),
+					consts.ClusterNameKey: to.StringPtr("kubernetes"),
 				},
 			},
 			clusterName: "kubernetes",
@@ -507,8 +508,8 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned when both service name tag and cluster name match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("nginx"),
-					clusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  to.StringPtr("nginx"),
+					consts.ClusterNameKey: to.StringPtr("kubernetes"),
 				},
 			},
 			clusterName: "kubernetes",
@@ -519,8 +520,8 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when the tag is empty",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr(""),
-					clusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  to.StringPtr(""),
+					consts.ClusterNameKey: to.StringPtr("kubernetes"),
 				},
 			},
 			clusterName: "kubernetes",
@@ -531,8 +532,8 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned if there is a match among a multi-service tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("nginx1,nginx2"),
-					clusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  to.StringPtr("nginx1,nginx2"),
+					consts.ClusterNameKey: to.StringPtr("kubernetes"),
 				},
 			},
 			clusterName: "kubernetes",
@@ -543,8 +544,8 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned if there is not a match among a multi-service tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					serviceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
-					clusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
+					consts.ClusterNameKey: to.StringPtr("kubernetes"),
 				},
 			},
 			clusterName: "kubernetes",
@@ -575,12 +576,12 @@ func TestGetPublicIPAddressResourceGroup(t *testing.T) {
 		},
 		{
 			desc:        "annotation with empty string resource group",
-			annotations: map[string]string{ServiceAnnotationLoadBalancerResourceGroup: ""},
+			annotations: map[string]string{consts.ServiceAnnotationLoadBalancerResourceGroup: ""},
 			expected:    "rg",
 		},
 		{
 			desc:        "annotation with non-empty resource group ",
-			annotations: map[string]string{ServiceAnnotationLoadBalancerResourceGroup: "rg2"},
+			annotations: map[string]string{consts.ServiceAnnotationLoadBalancerResourceGroup: "rg2"},
 			expected:    "rg2",
 		},
 	} {
@@ -898,7 +899,7 @@ func TestGetserviceIPTagRequestForPublicIP(t *testing.T) {
 			input: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationIPTagsForPublicIP: "",
+						consts.ServiceAnnotationIPTagsForPublicIP: "",
 					},
 				},
 			},
@@ -912,7 +913,7 @@ func TestGetserviceIPTagRequestForPublicIP(t *testing.T) {
 			input: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationIPTagsForPublicIP: "tag1=tag1value,tag2=tag2value,tag3malformed",
+						consts.ServiceAnnotationIPTagsForPublicIP: "tag1=tag1value,tag2=tag2value,tag3malformed",
 					},
 				},
 			},
@@ -1085,7 +1086,7 @@ func TestGetServiceTags(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationAllowedServiceTag: "tag1",
+						consts.ServiceAnnotationAllowedServiceTag: "tag1",
 					},
 				},
 			},
@@ -1096,7 +1097,7 @@ func TestGetServiceTags(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationAllowedServiceTag: "tag1, tag2",
+						consts.ServiceAnnotationAllowedServiceTag: "tag1, tag2",
 					},
 				},
 			},
@@ -1107,7 +1108,7 @@ func TestGetServiceTags(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationAllowedServiceTag: ", tag1, ",
+						consts.ServiceAnnotationAllowedServiceTag: ", tag1, ",
 					},
 				},
 			},
@@ -1203,7 +1204,7 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 				},
 			},
 			service:     getTestService("service1", v1.ProtocolTCP, nil, false, 80),
-			annotations: map[string]string{ServiceAnnotationLoadBalancerMode: "__auto__"},
+			annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "__auto__"},
 			wantLB:      true,
 			expectedLB: &network.LoadBalancer{
 				Name: to.StringPtr("testCluster"),
@@ -1522,7 +1523,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			}
 		}
 		test.service.Spec.LoadBalancerIP = test.loadBalancerIP
-		test.service.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = test.annotations
+		test.service.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet] = test.annotations
 		flag, rerr := az.isFrontendIPChanged("testCluster", test.config,
 			&test.service, test.lbFrontendIPConfigName)
 		if rerr != nil {
@@ -1675,10 +1676,10 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		az.Config.LoadBalancerSku = test.loadBalancerSku
 		service := test.service
 		if test.probeProtocol != "" {
-			service.Annotations[ServiceAnnotationLoadBalancerHealthProbeProtocol] = test.probeProtocol
+			service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeProtocol] = test.probeProtocol
 		}
 		if test.probePath != "" {
-			service.Annotations[ServiceAnnotationLoadBalancerHealthProbeRequestPath] = test.probePath
+			service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath] = test.probePath
 		}
 		probe, lbrule, err := az.getExpectedLBRules(&test.service, test.wantLb,
 			"frontendIPConfigID", "backendPoolID", "lbname", to.Int32Ptr(0))
@@ -2393,7 +2394,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			service: v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ServiceAnnotationSharedSecurityRule: "true",
+						consts.ServiceAnnotationSharedSecurityRule: "true",
 					},
 				},
 			},
@@ -2491,7 +2492,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 		},
 		{
 			desc:    "reconcileSecurityGroup shall not create unwanted security rules if there is service tags",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{ServiceAnnotationAllowedServiceTag: "tag"}, true, 80),
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAllowedServiceTag: "tag"}, true, 80),
 			wantLb:  true,
 			lbIP:    to.StringPtr("1.1.1.1"),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
@@ -2558,7 +2559,7 @@ func TestReconcileSecurityGroupLoadBalancerSourceRanges(t *testing.T) {
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	service := getTestService("test1", v1.ProtocolTCP, map[string]string{ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true"}, false, 80)
+	service := getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true"}, false, 80)
 	service.Spec.LoadBalancerSourceRanges = []string{"1.2.3.4/32"}
 	existingSg := network.SecurityGroup{
 		Name: to.StringPtr("nsg"),
@@ -2721,7 +2722,7 @@ func TestReconcilePublicIP(t *testing.T) {
 		{
 			desc:        "reconcilePublicIP shall report error if the given PIP name doesn't exist in the resource group",
 			wantLb:      true,
-			annotations: map[string]string{ServiceAnnotationPIPName: "testPIP"},
+			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
 					Name: to.StringPtr("pip1"),
@@ -2739,7 +2740,7 @@ func TestReconcilePublicIP(t *testing.T) {
 		{
 			desc:        "reconcilePublicIP shall delete unwanted PIP when given the name of desired PIP",
 			wantLb:      true,
-			annotations: map[string]string{ServiceAnnotationPIPName: "testPIP"},
+			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
 					Name: to.StringPtr("pip1"),
@@ -2769,7 +2770,7 @@ func TestReconcilePublicIP(t *testing.T) {
 		{
 			desc:        "reconcilePublicIP shall not delete unwanted PIP when there are other service references",
 			wantLb:      true,
-			annotations: map[string]string{ServiceAnnotationPIPName: "testPIP"},
+			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
 					Name: to.StringPtr("pip1"),
@@ -2800,8 +2801,8 @@ func TestReconcilePublicIP(t *testing.T) {
 			desc:   "reconcilePublicIP shall delete unwanted pips and existing pips, when the existing pips IP tags do not match",
 			wantLb: true,
 			annotations: map[string]string{
-				ServiceAnnotationPIPName:           "testPIP",
-				ServiceAnnotationIPTagsForPublicIP: "tag1=tag1value",
+				consts.ServiceAnnotationPIPName:           "testPIP",
+				consts.ServiceAnnotationIPTagsForPublicIP: "tag1=tag1value",
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
@@ -2839,8 +2840,8 @@ func TestReconcilePublicIP(t *testing.T) {
 			desc:   "reconcilePublicIP shall preserve existing pips, when the existing pips IP tags do match",
 			wantLb: true,
 			annotations: map[string]string{
-				ServiceAnnotationPIPName:           "testPIP",
-				ServiceAnnotationIPTagsForPublicIP: "tag1=tag1value",
+				consts.ServiceAnnotationPIPName:           "testPIP",
+				consts.ServiceAnnotationIPTagsForPublicIP: "tag1=tag1value",
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
@@ -2879,7 +2880,7 @@ func TestReconcilePublicIP(t *testing.T) {
 		{
 			desc:        "reconcilePublicIP shall find the PIP by given name and shall not delete the PIP which is not owned by service",
 			wantLb:      true,
-			annotations: map[string]string{ServiceAnnotationPIPName: "testPIP"},
+			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
 					Name: to.StringPtr("pip1"),
@@ -2909,7 +2910,7 @@ func TestReconcilePublicIP(t *testing.T) {
 			existingPIPs: []network.PublicIPAddress{
 				{
 					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{serviceTagKey: to.StringPtr("default/test1,default/test2")},
+					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1,default/test2")},
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -3134,7 +3135,7 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
 				Name: to.StringPtr("pip1"),
-				Tags: map[string]*string{serviceUsingDNSKey: to.StringPtr("test1")},
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
 						DomainNameLabel: to.StringPtr("previousdns"),
@@ -3412,17 +3413,17 @@ func TestBindServicesToPIP(t *testing.T) {
 	pips := []*network.PublicIPAddress{
 		{Tags: nil},
 		{Tags: map[string]*string{}},
-		{Tags: map[string]*string{serviceTagKey: to.StringPtr("ns1/svc1")}},
-		{Tags: map[string]*string{serviceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
-		{Tags: map[string]*string{serviceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")}},
 	}
 	serviceNames := []string{"ns2/svc2", "ns3/svc3"}
 	expectedTags := []map[string]*string{
-		{serviceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
-		{serviceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
-		{serviceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
-		{serviceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
-		{serviceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
 	}
 
 	flags := []bool{true, true, true, true, false}
@@ -3437,16 +3438,16 @@ func TestBindServicesToPIP(t *testing.T) {
 func TestUnbindServiceFromPIP(t *testing.T) {
 	pips := []*network.PublicIPAddress{
 		{Tags: nil},
-		{Tags: map[string]*string{serviceTagKey: to.StringPtr("")}},
-		{Tags: map[string]*string{serviceTagKey: to.StringPtr("ns1/svc1")}},
-		{Tags: map[string]*string{serviceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
 	}
 	serviceName := "ns2/svc2"
 	expectedTags := []map[string]*string{
 		nil,
-		{serviceTagKey: to.StringPtr("")},
-		{serviceTagKey: to.StringPtr("ns1/svc1")},
-		{serviceTagKey: to.StringPtr("ns1/svc1")},
+		{consts.ServiceTagKey: to.StringPtr("")},
+		{consts.ServiceTagKey: to.StringPtr("ns1/svc1")},
+		{consts.ServiceTagKey: to.StringPtr("ns1/svc1")},
 	}
 
 	for i, pip := range pips {
@@ -3693,7 +3694,7 @@ func TestCleanBackendpoolForPrimarySLB(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	cloud := GetTestCloud(ctrl)
-	cloud.LoadBalancerSku = loadBalancerSkuStandard
+	cloud.LoadBalancerSku = consts.LoadBalancerSkuStandard
 	cloud.EnableMultipleStandardLoadBalancers = true
 	cloud.PrimaryAvailabilitySetName = "agentpool1-availabilitySet-00000000"
 	clusterName := "testCluster"
@@ -3775,26 +3776,26 @@ func TestEnsurePIPTagged(t *testing.T) {
 		service := v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					ServiceAnnotationAzurePIPTags: "a=b,c=d,e=,=f,ghi",
+					consts.ServiceAnnotationAzurePIPTags: "a=b,c=d,e=,=f,ghi",
 				},
 			},
 		}
 		pip := network.PublicIPAddress{
 			Tags: map[string]*string{
-				clusterNameKey: to.StringPtr("testCluster"),
-				serviceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":          to.StringPtr("bar"),
-				"a":            to.StringPtr("j"),
+				consts.ClusterNameKey: to.StringPtr("testCluster"),
+				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
+				"foo":                 to.StringPtr("bar"),
+				"a":                   to.StringPtr("j"),
 			},
 		}
 		expectedPIP := network.PublicIPAddress{
 			Tags: map[string]*string{
-				clusterNameKey: to.StringPtr("testCluster"),
-				serviceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":          to.StringPtr("bar"),
-				"a":            to.StringPtr("b"),
-				"c":            to.StringPtr("d"),
-				"y":            to.StringPtr("z"),
+				consts.ClusterNameKey: to.StringPtr("testCluster"),
+				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
+				"foo":                 to.StringPtr("bar"),
+				"a":                   to.StringPtr("b"),
+				"c":                   to.StringPtr("d"),
+				"y":                   to.StringPtr("z"),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -3808,9 +3809,9 @@ func TestShouldChangeLoadBalancer(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		cloud := GetTestCloud(ctrl)
-		cloud.LoadBalancerSku = loadBalancerSkuBasic
+		cloud.LoadBalancerSku = consts.LoadBalancerSkuBasic
 		annotations := map[string]string{
-			ServiceAnnotationLoadBalancerMode: "as2",
+			consts.ServiceAnnotationLoadBalancerMode: "as2",
 		}
 		service := getTestService("service1", v1.ProtocolTCP, annotations, false, 80)
 		res := cloud.shouldChangeLoadBalancer(&service, "as1", "testCluster")

--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -32,14 +32,8 @@ import (
 	cloudvolume "k8s.io/cloud-provider/volume"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
 	"k8s.io/klog/v2"
-)
 
-const (
-	// default IOPS Caps & Throughput Cap (MBps) per https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disks-ultra-ssd
-	defaultDiskIOPSReadWrite = 500
-	defaultDiskMBpsReadWrite = 100
-
-	diskEncryptionSetIDFormat = "/subscriptions/{subs-id}/resourceGroups/{rg-name}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSet-name}"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 //ManagedDiskController : managed disk controller struct
@@ -118,7 +112,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	}
 
 	if diskSku == compute.UltraSSDLRS {
-		diskIOPSReadWrite := int64(defaultDiskIOPSReadWrite)
+		diskIOPSReadWrite := int64(consts.DefaultDiskIOPSReadWrite)
 		if options.DiskIOPSReadWrite != "" {
 			v, err := strconv.Atoi(options.DiskIOPSReadWrite)
 			if err != nil {
@@ -128,7 +122,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 		}
 		diskProperties.DiskIOPSReadWrite = to.Int64Ptr(diskIOPSReadWrite)
 
-		diskMBpsReadWrite := int64(defaultDiskMBpsReadWrite)
+		diskMBpsReadWrite := int64(consts.DefaultDiskMBpsReadWrite)
 		if options.DiskMBpsReadWrite != "" {
 			v, err := strconv.Atoi(options.DiskMBpsReadWrite)
 			if err != nil {
@@ -156,7 +150,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 
 	if options.DiskEncryptionSetID != "" {
 		if strings.Index(strings.ToLower(options.DiskEncryptionSetID), "/subscriptions/") != 0 {
-			return "", fmt.Errorf("AzureDisk - format of DiskEncryptionSetID(%s) is incorrect, correct format: %s", options.DiskEncryptionSetID, diskEncryptionSetIDFormat)
+			return "", fmt.Errorf("AzureDisk - format of DiskEncryptionSetID(%s) is incorrect, correct format: %s", options.DiskEncryptionSetID, consts.DiskEncryptionSetIDFormat)
 		}
 		diskProperties.Encryption = &compute.Encryption{
 			DiskEncryptionSetID: &options.DiskEncryptionSetID,
@@ -363,7 +357,7 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 	}
 
 	labels := map[string]string{
-		LabelFailureDomainBetaRegion: c.Location,
+		consts.LabelFailureDomainBetaRegion: c.Location,
 	}
 	// no azure credential is set, return nil
 	if c.DisksClient == nil {
@@ -392,6 +386,6 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 
 	zone := c.makeZone(c.Location, zoneID)
 	klog.V(4).Infof("Got zone %q for Azure disk %q", zone, diskName)
-	labels[LabelFailureDomainBetaZone] = zone
+	labels[consts.LabelFailureDomainBetaZone] = zone
 	return labels, nil
 }

--- a/pkg/provider/azure_managedDiskController_test.go
+++ b/pkg/provider/azure_managedDiskController_test.go
@@ -32,6 +32,7 @@ import (
 	cloudvolume "k8s.io/cloud-provider/volume"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/diskclient/mockdiskclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -122,7 +123,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			expectedDiskID:      "",
 			existedDisk:         compute.Disk{ID: to.StringPtr("diskid1"), Name: to.StringPtr("disk1"), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
-			expectedErrMsg:      fmt.Errorf("AzureDisk - format of DiskEncryptionSetID(%s) is incorrect, correct format: %s", badDiskEncryptionSetID, diskEncryptionSetIDFormat),
+			expectedErrMsg:      fmt.Errorf("AzureDisk - format of DiskEncryptionSetID(%s) is incorrect, correct format: %s", badDiskEncryptionSetID, consts.DiskEncryptionSetIDFormat),
 		},
 		{
 			desc:                "disk Id and no error shall be returned if everything is good with StandardLRS storage account with not empty diskIOPSReadWrite",
@@ -434,8 +435,8 @@ func TestGetLabelsForVolume(t *testing.T) {
 			},
 			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expected: map[string]string{
-				LabelFailureDomainBetaRegion: testCloud0.Location,
-				LabelFailureDomainBetaZone:   testCloud0.makeZone(testCloud0.Location, 1),
+				consts.LabelFailureDomainBetaRegion: testCloud0.Location,
+				consts.LabelFailureDomainBetaZone:   testCloud0.makeZone(testCloud0.Location, 1),
 			},
 			expectedErr: false,
 		},
@@ -471,7 +472,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 			},
 			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected: map[string]string{
-				LabelFailureDomainBetaRegion: testCloud0.Location,
+				consts.LabelFailureDomainBetaRegion: testCloud0.Location,
 			},
 			expectedErr:    false,
 			expectedErrMsg: nil,

--- a/pkg/provider/azure_mock_vmsets.go
+++ b/pkg/provider/azure_mock_vmsets.go
@@ -306,3 +306,19 @@ func (mr *MockVMSetMockRecorder) GetNodeNameByIPConfigurationID(ipConfigurationI
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeNameByIPConfigurationID", reflect.TypeOf((*MockVMSet)(nil).GetNodeNameByIPConfigurationID), ipConfigurationID)
 }
+
+// GetNodeCIDRMaskByProviderID mocks base method
+func (m *MockVMSet) GetNodeCIDRMasksByProviderID(providerID string) (int, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, " GetNodeCIDRMasksByProviderID", providerID)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetNodeCIDRMaskByProviderID indicates an expected call of GetNodeNameByIPConfigurationID
+func (mr *MockVMSetMockRecorder) GetNodeCIDRMaskByProviderID(providerID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeCIDRMasksByProviderID", reflect.TypeOf((*MockVMSet)(nil).GetNodeCIDRMasksByProviderID), providerID)
+}

--- a/pkg/provider/azure_ratelimit.go
+++ b/pkg/provider/azure_ratelimit.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // CloudProviderRateLimitConfig indicates the rate limit config for each clients.
@@ -49,10 +50,10 @@ func InitializeCloudProviderRateLimitConfig(config *CloudProviderRateLimitConfig
 
 	// Assign read rate limit defaults if no configuration was passed in.
 	if config.CloudProviderRateLimitQPS == 0 {
-		config.CloudProviderRateLimitQPS = rateLimitQPSDefault
+		config.CloudProviderRateLimitQPS = consts.RateLimitQPSDefault
 	}
 	if config.CloudProviderRateLimitBucket == 0 {
-		config.CloudProviderRateLimitBucket = rateLimitBucketDefault
+		config.CloudProviderRateLimitBucket = consts.RateLimitBucketDefault
 	}
 	// Assign write rate limit defaults if no configuration was passed in.
 	if config.CloudProviderRateLimitQPSWrite == 0 {

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -53,7 +54,7 @@ func TestIsMasterNode(t *testing.T) {
 	if isMasterNode(&v1.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Labels: map[string]string{
-				nodeLabelRole: "worker",
+				consts.NodeLabelRole: "worker",
 			},
 		},
 	}) {
@@ -62,7 +63,7 @@ func TestIsMasterNode(t *testing.T) {
 	if !isMasterNode(&v1.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Labels: map[string]string{
-				nodeLabelRole: "master",
+				consts.NodeLabelRole: "master",
 			},
 		},
 	}) {
@@ -142,8 +143,8 @@ func TestGenerateStorageAccountName(t *testing.T) {
 
 	for _, test := range tests {
 		accountName := generateStorageAccountName(test.prefix)
-		if len(accountName) > storageAccountNameMaxLength || len(accountName) < 3 {
-			t.Errorf("input prefix: %s, output account name: %s, length not in [3,%d]", test.prefix, accountName, storageAccountNameMaxLength)
+		if len(accountName) > consts.StorageAccountNameMaxLength || len(accountName) < 3 {
+			t.Errorf("input prefix: %s, output account name: %s, length not in [3,%d]", test.prefix, accountName, consts.StorageAccountNameMaxLength)
 		}
 
 		for _, char := range accountName {
@@ -196,9 +197,9 @@ func TestMapLoadBalancerNameToVMSet(t *testing.T) {
 
 	for _, c := range cases {
 		if c.useStandardLB {
-			az.Config.LoadBalancerSku = loadBalancerSkuStandard
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
 		} else {
-			az.Config.LoadBalancerSku = loadBalancerSkuBasic
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuBasic
 		}
 		vmset := az.mapLoadBalancerNameToVMSet(c.lbName, c.clusterName)
 		assert.Equal(t, c.expectedVMSet, vmset, c.description)
@@ -287,9 +288,9 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 
 	for _, c := range cases {
 		if c.useStandardLB {
-			az.Config.LoadBalancerSku = loadBalancerSkuStandard
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
 		} else {
-			az.Config.LoadBalancerSku = loadBalancerSkuBasic
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuBasic
 		}
 		az.Config.LoadBalancerName = c.lbName
 		loadbalancerName := az.getAzureLoadBalancerName(c.clusterName, c.vmSet, c.isInternal)
@@ -368,12 +369,12 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 
 	for _, c := range cases {
 		if c.useStandardLB {
-			az.Config.LoadBalancerSku = loadBalancerSkuStandard
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
 		} else {
-			az.Config.LoadBalancerSku = loadBalancerSkuBasic
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuBasic
 		}
-		svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
-		svc.Annotations[ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
+		svc.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
+		svc.Annotations[consts.ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
 
 		loadbalancerRuleName := az.getLoadBalancerRuleName(svc, c.protocol, c.port)
 		assert.Equal(t, c.expected, loadbalancerRuleName, c.description)
@@ -389,8 +390,8 @@ func TestGetFrontendIPConfigName(t *testing.T) {
 	svc := &v1.Service{
 		ObjectMeta: meta.ObjectMeta{
 			Annotations: map[string]string{
-				ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
-				ServiceAnnotationLoadBalancerInternal:       "true",
+				consts.ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
+				consts.ServiceAnnotationLoadBalancerInternal:       "true",
 			},
 			UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
 		},
@@ -442,12 +443,12 @@ func TestGetFrontendIPConfigName(t *testing.T) {
 
 	for _, c := range cases {
 		if c.useStandardLB {
-			az.Config.LoadBalancerSku = loadBalancerSkuStandard
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
 		} else {
-			az.Config.LoadBalancerSku = loadBalancerSkuBasic
+			az.Config.LoadBalancerSku = consts.LoadBalancerSkuBasic
 		}
-		svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
-		svc.Annotations[ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
+		svc.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
+		svc.Annotations[consts.ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
 
 		ipconfigName := az.getDefaultFrontendIPConfigName(svc)
 		assert.Equal(t, c.expected, ipconfigName, c.description)
@@ -459,7 +460,7 @@ func TestGetFrontendIPConfigID(t *testing.T) {
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	testGetLoadBalancerSubResourceID(t, az, az.getFrontendIPConfigID, frontendIPConfigIDTemplate)
+	testGetLoadBalancerSubResourceID(t, az, az.getFrontendIPConfigID, consts.FrontendIPConfigIDTemplate)
 }
 
 func TestGetBackendPoolID(t *testing.T) {
@@ -467,7 +468,7 @@ func TestGetBackendPoolID(t *testing.T) {
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	testGetLoadBalancerSubResourceID(t, az, az.getBackendPoolID, backendPoolIDTemplate)
+	testGetLoadBalancerSubResourceID(t, az, az.getBackendPoolID, consts.BackendPoolIDTemplate)
 }
 
 func TestGetLoadBalancerProbeID(t *testing.T) {
@@ -475,7 +476,7 @@ func TestGetLoadBalancerProbeID(t *testing.T) {
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	testGetLoadBalancerSubResourceID(t, az, az.getLoadBalancerProbeID, loadBalancerProbeIDTemplate)
+	testGetLoadBalancerSubResourceID(t, az, az.getLoadBalancerProbeID, consts.LoadBalancerProbeIDTemplate)
 }
 
 func testGetLoadBalancerSubResourceID(
@@ -1098,7 +1099,7 @@ func TestGetStandardVMSetNames(t *testing.T) {
 			name: "GetVMSetNames should return the primary vm set name when using the single SLB",
 			vm:   []compute.VirtualMachine{testVM},
 			service: &v1.Service{
-				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{ServiceAnnotationLoadBalancerMode: ServiceAnnotationLoadBalancerAutoModeValue}},
+				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: consts.ServiceAnnotationLoadBalancerAutoModeValue}},
 			},
 			usingSingleSLBS:    true,
 			expectedVMSetNames: &[]string{"as"},
@@ -1107,7 +1108,7 @@ func TestGetStandardVMSetNames(t *testing.T) {
 			name: "GetVMSetNames should return the correct as names if the service has auto mode annotation",
 			vm:   []compute.VirtualMachine{testVM},
 			service: &v1.Service{
-				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{ServiceAnnotationLoadBalancerMode: ServiceAnnotationLoadBalancerAutoModeValue}},
+				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: consts.ServiceAnnotationLoadBalancerAutoModeValue}},
 			},
 			nodes: []*v1.Node{
 				{
@@ -1122,7 +1123,7 @@ func TestGetStandardVMSetNames(t *testing.T) {
 			name: "GetVMSetNames should return the correct as names if node don't have availability set",
 			vm:   []compute.VirtualMachine{testVMWithoutAS},
 			service: &v1.Service{
-				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{ServiceAnnotationLoadBalancerMode: ServiceAnnotationLoadBalancerAutoModeValue}},
+				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: consts.ServiceAnnotationLoadBalancerAutoModeValue}},
 			},
 			nodes: []*v1.Node{
 				{
@@ -1137,7 +1138,7 @@ func TestGetStandardVMSetNames(t *testing.T) {
 			name: "GetVMSetNames should report the error if there's no such availability set",
 			vm:   []compute.VirtualMachine{testVM},
 			service: &v1.Service{
-				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{ServiceAnnotationLoadBalancerMode: "vm2"}},
+				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "vm2"}},
 			},
 			nodes: []*v1.Node{
 				{
@@ -1152,7 +1153,7 @@ func TestGetStandardVMSetNames(t *testing.T) {
 			name: "GetVMSetNames should return the correct node name",
 			vm:   []compute.VirtualMachine{testVM},
 			service: &v1.Service{
-				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{ServiceAnnotationLoadBalancerMode: "myAvailabilitySet"}},
+				ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "myAvailabilitySet"}},
 			},
 			nodes: []*v1.Node{
 				{
@@ -1169,7 +1170,7 @@ func TestGetStandardVMSetNames(t *testing.T) {
 		cloud := GetTestCloud(ctrl)
 		if test.usingSingleSLBS {
 			cloud.EnableMultipleStandardLoadBalancers = false
-			cloud.LoadBalancerSku = loadBalancerSkuStandard
+			cloud.LoadBalancerSku = consts.LoadBalancerSkuStandard
 		}
 		mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMClient.EXPECT().List(gomock.Any(), cloud.ResourceGroup).Return(test.vm, nil).AnyTimes()
@@ -1260,7 +1261,7 @@ func TestStandardEnsureHostInPool(t *testing.T) {
 			nodeName:          "vm3",
 			nicName:           "nic3",
 			nicID:             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic3",
-			nicProvisionState: nicFailedState,
+			nicProvisionState: consts.NicFailedState,
 			vmSetName:         "myAvailabilitySet",
 		},
 		{
@@ -1315,7 +1316,7 @@ func TestStandardEnsureHostInPool(t *testing.T) {
 
 	for _, test := range testCases {
 		if test.isStandardLB {
-			cloud.Config.LoadBalancerSku = loadBalancerSkuStandard
+			cloud.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
 		}
 
 		if test.useMultipleSLBs {
@@ -1386,7 +1387,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 				{
 					ObjectMeta: meta.ObjectMeta{
 						Name:   "vm2",
-						Labels: map[string]string{nodeLabelRole: "master"},
+						Labels: map[string]string{consts.NodeLabelRole: "master"},
 					},
 				},
 			},
@@ -1402,7 +1403,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 				{
 					ObjectMeta: meta.ObjectMeta{
 						Name:   "vm3",
-						Labels: map[string]string{externalResourceGroupLabel: "rg-external"},
+						Labels: map[string]string{consts.ExternalResourceGroupLabel: "rg-external"},
 					},
 				},
 			},
@@ -1418,7 +1419,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 				{
 					ObjectMeta: meta.ObjectMeta{
 						Name:   "vm4",
-						Labels: map[string]string{managedByAzureLabel: "false"},
+						Labels: map[string]string{consts.ManagedByAzureLabel: "false"},
 					},
 				},
 			},
@@ -1456,7 +1457,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		cloud.Config.LoadBalancerSku = loadBalancerSkuStandard
+		cloud.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
 		cloud.Config.ExcludeMasterFromStandardLB = to.BoolPtr(true)
 
 		testVM := buildDefaultTestVirtualMachine(availabilitySetID, []string{test.nicID})
@@ -1613,7 +1614,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
 					UID:         types.UID("secondary"),
-					Annotations: map[string]string{ServiceAnnotationLoadBalancerInternal: "true"},
+					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerInternal: "true"},
 				},
 				Spec: v1.ServiceSpec{
 					LoadBalancerIP: "4.3.2.1",

--- a/pkg/provider/azure_storage.go
+++ b/pkg/provider/azure_storage.go
@@ -24,14 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/fileclient"
-)
-
-const (
-	defaultStorageAccountType      = string(storage.StandardLRS)
-	defaultStorageAccountKind      = storage.StorageV2
-	fileShareAccountNamePrefix     = "f"
-	sharedDiskAccountNamePrefix    = "ds"
-	dedicatedDiskAccountNamePrefix = "dd"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // CreateFileShare creates a file share, using a matching storage account type, account kind, etc.
@@ -52,7 +45,7 @@ func (az *Cloud) CreateFileShare(accountOptions *AccountOptions, shareOptions *f
 		accountOptions.EnableHTTPSTrafficOnly = false
 	}
 
-	accountName, accountKey, err := az.EnsureStorageAccount(accountOptions, fileShareAccountNamePrefix)
+	accountName, accountKey, err := az.EnsureStorageAccount(accountOptions, consts.FileShareAccountNamePrefix)
 	if err != nil {
 		return "", "", fmt.Errorf("could not get storage key for storage account %s: %w", accountOptions.Name, err)
 	}

--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -22,9 +22,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest/to"
-	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 
 	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 // SkipMatchingTag skip account matching tag
@@ -186,11 +188,11 @@ func (az *Cloud) EnsureStorageAccount(accountOptions *AccountOptions, genAccount
 				location = az.Location
 			}
 			if accountType == "" {
-				accountType = defaultStorageAccountType
+				accountType = consts.DefaultStorageAccountType
 			}
 
 			// use StorageV2 by default per https://docs.microsoft.com/en-us/azure/storage/common/storage-account-options
-			kind := defaultStorageAccountKind
+			kind := consts.DefaultStorageAccountKind
 			if accountKind != "" {
 				kind = storage.Kind(accountKind)
 			}

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/securitygroupclient/mocksecuritygroupclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -164,8 +165,8 @@ func setMockPublicIPs(az *Cloud, ctrl *gomock.Controller, serviceCount int) {
 				IPAddress:                to.StringPtr("1.2.3.4"),
 			},
 			Tags: map[string]*string{
-				serviceTagKey:  to.StringPtr("default/servicea"),
-				clusterNameKey: to.StringPtr(testClusterName),
+				consts.ServiceTagKey:  to.StringPtr("default/servicea"),
+				consts.ClusterNameKey: to.StringPtr(testClusterName),
 			},
 			Sku: &network.PublicIPAddressSku{
 				Name: network.PublicIPAddressSkuNameStandard,
@@ -184,11 +185,11 @@ func setMockPublicIPs(az *Cloud, ctrl *gomock.Controller, serviceCount int) {
 	a := 'a'
 	for i := 1; i <= serviceCount; i++ {
 		expectedPIPs[0].Name = to.StringPtr(fmt.Sprintf("testCluster-aservice%d", i))
-		expectedPIPs[0].Tags[serviceTagKey] = to.StringPtr(fmt.Sprintf("default/service%d", i))
+		expectedPIPs[0].Tags[consts.ServiceTagKey] = to.StringPtr(fmt.Sprintf("default/service%d", i))
 		mockPIPsClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%d", i), gomock.Any()).Return(expectedPIPs[0], nil).AnyTimes()
 		mockPIPsClient.EXPECT().Delete(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%d", i)).Return(nil).AnyTimes()
 		expectedPIPs[0].Name = to.StringPtr(fmt.Sprintf("testCluster-aservice%c", a))
-		expectedPIPs[0].Tags[serviceTagKey] = to.StringPtr(fmt.Sprintf("default/service%c", a))
+		expectedPIPs[0].Tags[consts.ServiceTagKey] = to.StringPtr(fmt.Sprintf("default/service%c", a))
 		mockPIPsClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%c", a), gomock.Any()).Return(expectedPIPs[0], nil).AnyTimes()
 		mockPIPsClient.EXPECT().Delete(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%c", a)).Return(nil).AnyTimes()
 		a++
@@ -759,7 +760,7 @@ func TestReconcileLoadBalancerEditServiceSubnet(t *testing.T) {
 
 	validateLoadBalancer(t, lb, svc)
 
-	svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = "subnet"
+	svc.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet] = "subnet"
 	validateTestSubnet(t, az, &svc)
 
 	expectedLBs = make([]network.LoadBalancer, 0)
@@ -976,8 +977,8 @@ func TestServiceDefaultsToNoSessionPersistence(t *testing.T) {
 			PublicIPAddressVersion:   network.IPv4,
 		},
 		Tags: map[string]*string{
-			serviceTagKey:  to.StringPtr("aservicesaomitted1"),
-			clusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  to.StringPtr("aservicesaomitted1"),
+			consts.ClusterNameKey: to.StringPtr(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
@@ -1026,8 +1027,8 @@ func TestServiceRespectsNoSessionAffinity(t *testing.T) {
 			PublicIPAddressVersion:   network.IPv4,
 		},
 		Tags: map[string]*string{
-			serviceTagKey:  to.StringPtr("aservicesanone"),
-			clusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  to.StringPtr("aservicesanone"),
+			consts.ClusterNameKey: to.StringPtr(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
@@ -1078,8 +1079,8 @@ func TestServiceRespectsClientIPSessionAffinity(t *testing.T) {
 			PublicIPAddressVersion:   network.IPv4,
 		},
 		Tags: map[string]*string{
-			serviceTagKey:  to.StringPtr("aservicesaclientip"),
-			clusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  to.StringPtr("aservicesaclientip"),
+			consts.ClusterNameKey: to.StringPtr(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
@@ -1529,23 +1530,23 @@ func getTestService(identifier string, proto v1.Protocol, annotations map[string
 
 func getInternalTestService(identifier string, requestedPorts ...int32) v1.Service {
 	svc := getTestService(identifier, v1.ProtocolTCP, nil, false, requestedPorts...)
-	svc.Annotations[ServiceAnnotationLoadBalancerInternal] = trueAnnotationValue
+	svc.Annotations[consts.ServiceAnnotationLoadBalancerInternal] = consts.TrueAnnotationValue
 	return svc
 }
 
 func getResourceGroupTestService(identifier, resourceGroup, loadBalancerIP string, requestedPorts ...int32) v1.Service {
 	svc := getTestService(identifier, v1.ProtocolTCP, nil, false, requestedPorts...)
 	svc.Spec.LoadBalancerIP = loadBalancerIP
-	svc.Annotations[ServiceAnnotationLoadBalancerResourceGroup] = resourceGroup
+	svc.Annotations[consts.ServiceAnnotationLoadBalancerResourceGroup] = resourceGroup
 	return svc
 }
 
 func setLoadBalancerModeAnnotation(service *v1.Service, lbMode string) {
-	service.Annotations[ServiceAnnotationLoadBalancerMode] = lbMode
+	service.Annotations[consts.ServiceAnnotationLoadBalancerMode] = lbMode
 }
 
 func setLoadBalancerAutoModeAnnotation(service *v1.Service) {
-	setLoadBalancerModeAnnotation(service, ServiceAnnotationLoadBalancerAutoModeValue)
+	setLoadBalancerModeAnnotation(service, consts.ServiceAnnotationLoadBalancerAutoModeValue)
 }
 
 func getServiceSourceRanges(service *v1.Service) []string {
@@ -1602,7 +1603,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 			expectedFrontendIPCount++
 			expectedSubnetName := ""
 			if requiresInternalLoadBalancer(&services[i]) {
-				expectedSubnetName = svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet]
+				expectedSubnetName = svc.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet]
 				if expectedSubnetName == "" {
 					expectedSubnetName = az.SubnetName
 				}
@@ -1740,21 +1741,21 @@ func validatePublicIP(t *testing.T, publicIP *network.PublicIPAddress, service *
 		t.Fatal("Expected publicIP resource exists, when it is not an internal service")
 	}
 
-	if publicIP.Tags == nil || publicIP.Tags[serviceTagKey] == nil {
-		t.Fatalf("Expected publicIP resource does not have tags[%s]", serviceTagKey)
+	if publicIP.Tags == nil || publicIP.Tags[consts.ServiceTagKey] == nil {
+		t.Fatalf("Expected publicIP resource does not have tags[%s]", consts.ServiceTagKey)
 	}
 
 	serviceName := getServiceName(service)
-	if serviceName != *(publicIP.Tags[serviceTagKey]) {
-		t.Errorf("Expected publicIP resource has matching tags[%s]", serviceTagKey)
+	if serviceName != *(publicIP.Tags[consts.ServiceTagKey]) {
+		t.Errorf("Expected publicIP resource has matching tags[%s]", consts.ServiceTagKey)
 	}
 
-	if publicIP.Tags[clusterNameKey] == nil {
-		t.Fatalf("Expected publicIP resource does not have tags[%s]", clusterNameKey)
+	if publicIP.Tags[consts.ClusterNameKey] == nil {
+		t.Fatalf("Expected publicIP resource does not have tags[%s]", consts.ClusterNameKey)
 	}
 
-	if *(publicIP.Tags[clusterNameKey]) != testClusterName {
-		t.Errorf("Expected publicIP resource has matching tags[%s]", clusterNameKey)
+	if *(publicIP.Tags[consts.ClusterNameKey]) != testClusterName {
+		t.Errorf("Expected publicIP resource has matching tags[%s]", consts.ClusterNameKey)
 	}
 
 	// We cannot use service.Spec.LoadBalancerIP to compare with
@@ -1854,10 +1855,10 @@ func validateSecurityGroup(t *testing.T, securityGroup *network.SecurityGroup, s
 func TestSecurityRulePriorityPicksNextAvailablePriority(t *testing.T) {
 	rules := []network.SecurityRule{}
 
-	var expectedPriority int32 = loadBalancerMinimumPriority + 50
+	var expectedPriority int32 = consts.LoadBalancerMinimumPriority + 50
 
 	var i int32
-	for i = loadBalancerMinimumPriority; i < expectedPriority; i++ {
+	for i = consts.LoadBalancerMinimumPriority; i < expectedPriority; i++ {
 		rules = append(rules, network.SecurityRule{
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				Priority: to.Int32Ptr(i),
@@ -1879,7 +1880,7 @@ func TestSecurityRulePriorityFailsIfExhausted(t *testing.T) {
 	rules := []network.SecurityRule{}
 
 	var i int32
-	for i = loadBalancerMinimumPriority; i < loadBalancerMaximumPriority; i++ {
+	for i = consts.LoadBalancerMinimumPriority; i < consts.LoadBalancerMaximumPriority; i++ {
 		rules = append(rules, network.SecurityRule{
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				Priority: to.Int32Ptr(i),
@@ -2113,7 +2114,7 @@ func validateConfig(t *testing.T, config string) { //nolint
 	if azureCloud.RouteTableCacheTTLInSeconds != 100 {
 		t.Errorf("got incorrect value for routeTableCacheTTLInSeconds")
 	}
-	if azureCloud.VMType != vmTypeVMSS {
+	if azureCloud.VMType != consts.VMTypeVMSS {
 		t.Errorf("got incorrect value for vmType")
 	}
 	if !azureCloud.DisableAvailabilitySetNodes {
@@ -2156,7 +2157,7 @@ func TestGetNodeNameByProviderID(t *testing.T) {
 		fail bool
 	}{
 		{
-			providerID: CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			providerID: consts.CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
 			name:       "k8s-agent-AAAAAAAA-0",
 			fail:       false,
 		},
@@ -2166,12 +2167,12 @@ func TestGetNodeNameByProviderID(t *testing.T) {
 			fail:       false,
 		},
 		{
-			providerID: CloudProviderName + ":/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			providerID: consts.CloudProviderName + ":/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
 			name:       "k8s-agent-AAAAAAAA-0",
 			fail:       false,
 		},
 		{
-			providerID: CloudProviderName + "://",
+			providerID: consts.CloudProviderName + "://",
 			name:       "",
 			fail:       true,
 		},
@@ -2205,11 +2206,11 @@ func TestGetNodeNameByProviderID(t *testing.T) {
 }
 
 func validateTestSubnet(t *testing.T, az *Cloud, svc *v1.Service) {
-	if svc.Annotations[ServiceAnnotationLoadBalancerInternal] != trueAnnotationValue {
+	if svc.Annotations[consts.ServiceAnnotationLoadBalancerInternal] != consts.TrueAnnotationValue {
 		t.Error("Subnet added to non-internal service")
 	}
 
-	subName := svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet]
+	subName := svc.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet]
 	if subName == "" {
 		subName = az.SubnetName
 	}
@@ -2233,7 +2234,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T
 	az := GetTestCloud(ctrl)
 	svc := getTestService("servicea", v1.ProtocolTCP, nil, false, 80)
 	svc.Spec.LoadBalancerIP = testIP1
-	svc.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	sg := getTestSecurityGroup(az)
 	setMockSecurityGroup(az, ctrl, sg)
@@ -2276,7 +2277,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 	az := GetTestCloud(ctrl)
 	svc := getTestService("servicesr", v1.ProtocolTCP, nil, false, 80)
 	svc.Spec.LoadBalancerIP = testIP1
-	svc.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	expectedRuleName := testRuleName
 
@@ -2332,11 +2333,11 @@ func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated
 
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
 	svc1.Spec.LoadBalancerIP = testIP1
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
 	svc2.Spec.LoadBalancerIP = testIP2
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	sg := getTestSecurityGroup(az)
 	setMockSecurityGroup(az, ctrl, sg)
@@ -2401,11 +2402,11 @@ func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCre
 
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
 	svc1.Spec.LoadBalancerIP = testIP1
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolUDP, nil, false, 4444)
 	svc2.Spec.LoadBalancerIP = testIP1
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	testRuleName3 := "shared-UDP-4444-Internet"
 
@@ -2471,12 +2472,12 @@ func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRules
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 80)
 	svc1.Spec.LoadBalancerIP = testIP1
 	svc1.Spec.LoadBalancerSourceRanges = []string{"192.168.12.0/24"}
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 80)
 	svc2.Spec.LoadBalancerIP = testIP2
 	svc2.Spec.LoadBalancerSourceRanges = []string{"192.168.34.0/24"}
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	testRuleName2 := "shared-TCP-80-192.168.12.0_24"
 	testRuleName3 := "shared-TCP-80-192.168.34.0_24"
@@ -2544,15 +2545,15 @@ func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSepara
 
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
 	svc1.Spec.LoadBalancerIP = testIP1
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
 	svc2.Spec.LoadBalancerIP = testIP2
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
 	svc3.Spec.LoadBalancerIP = testIP3
-	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	testRuleName23 := testRuleName2
 	sg := getTestSecurityGroup(az)
@@ -2645,11 +2646,11 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 80)
 	svc1.Spec.LoadBalancerIP = testIP1
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 80)
 	svc2.Spec.LoadBalancerIP = testIP2
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	expectedRuleName := testRuleName
 
@@ -2703,15 +2704,15 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
 	svc1.Spec.LoadBalancerIP = testIP1
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
 	svc2.Spec.LoadBalancerIP = testIP2
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
 	svc3.Spec.LoadBalancerIP = testIP3
-	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	testRuleName23 := testRuleName2
 	sg := getTestSecurityGroup(az)
@@ -2811,15 +2812,15 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
 	svc1.Spec.LoadBalancerIP = testIP1
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
 	svc2.Spec.LoadBalancerIP = testIP2
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
 	svc3.Spec.LoadBalancerIP = testIP3
-	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	testRuleName23 := testRuleName2
 	sg := getTestSecurityGroup(az)
@@ -2893,23 +2894,23 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 
 	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
 	svc1.Spec.LoadBalancerIP = testIP1
-	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
 	svc2.Spec.LoadBalancerIP = testIP2
-	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
 	svc3.Spec.LoadBalancerIP = testIP3
-	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = trueAnnotationValue
+	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	svc4 := getTestService("servicesr4", v1.ProtocolTCP, nil, false, 4444)
 	svc4.Spec.LoadBalancerIP = "192.168.22.33"
-	svc4.Annotations[ServiceAnnotationSharedSecurityRule] = "false"
+	svc4.Annotations[consts.ServiceAnnotationSharedSecurityRule] = "false"
 
 	svc5 := getTestService("servicesr5", v1.ProtocolTCP, nil, false, 8888)
 	svc5.Spec.LoadBalancerIP = "192.168.22.33"
-	svc5.Annotations[ServiceAnnotationSharedSecurityRule] = "false"
+	svc5.Annotations[consts.ServiceAnnotationSharedSecurityRule] = "false"
 
 	testServices := []v1.Service{svc1, svc2, svc3, svc4, svc5}
 
@@ -3228,9 +3229,9 @@ func TestUpdateNodeCaches(t *testing.T) {
 	prevNode := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				LabelFailureDomainBetaZone: zone,
-				externalResourceGroupLabel: trueAnnotationValue,
-				managedByAzureLabel:        "false",
+				consts.LabelFailureDomainBetaZone: zone,
+				consts.ExternalResourceGroupLabel: consts.TrueAnnotationValue,
+				consts.ManagedByAzureLabel:        "false",
 			},
 			Name: "prevNode",
 		},
@@ -3244,9 +3245,9 @@ func TestUpdateNodeCaches(t *testing.T) {
 	newNode := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				LabelFailureDomainBetaZone: zone,
-				externalResourceGroupLabel: trueAnnotationValue,
-				managedByAzureLabel:        "false",
+				consts.LabelFailureDomainBetaZone: zone,
+				consts.ExternalResourceGroupLabel: consts.TrueAnnotationValue,
+				consts.ManagedByAzureLabel:        "false",
 			},
 			Name: "newNode",
 		},
@@ -3296,7 +3297,7 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 
 	config := Config{
 		DisableAvailabilitySetNodes: true,
-		VMType:                      vmTypeStandard,
+		VMType:                      consts.VMTypeStandard,
 	}
 	err = az.InitializeCloudFromConfig(&config, false)
 	expectedErr := fmt.Errorf("disableAvailabilitySetNodes true is only supported when vmType is 'vmss'")

--- a/pkg/provider/azure_vmsets.go
+++ b/pkg/provider/azure_vmsets.go
@@ -80,4 +80,7 @@ type VMSet interface {
 
 	// GetNodeNameByIPConfigurationID gets the nodeName and vmSetName by IP configuration ID.
 	GetNodeNameByIPConfigurationID(ipConfigurationID string) (string, string, error)
+
+	// GetNodeCIDRMaskByProviderID returns the node CIDR subnet mask by provider ID.
+	GetNodeCIDRMasksByProviderID(providerID string) (int, int, error)
 }

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -40,18 +40,26 @@ import (
 )
 
 var (
-	// virtualMachineScaleSetsDeallocating indicates VMSS instances are in Deallocating state.
-	virtualMachineScaleSetsDeallocating = "Deallocating"
-
 	// ErrorNotVmssInstance indicates an instance is not belonging to any vmss.
 	ErrorNotVmssInstance = errors.New("not a vmss instance")
 
 	scaleSetNameRE         = regexp.MustCompile(`.*/subscriptions/(?:.*)/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines(?:.*)`)
 	resourceGroupRE        = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?:.*)/virtualMachines(?:.*)`)
-	vmssMachineIDTemplate  = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s"
 	vmssIPConfigurationRE  = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(.+)/networkInterfaces(?:.*)`)
 	vmssPIPConfigurationRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(.+)/networkInterfaces/(.+)/ipConfigurations/(.+)/publicIPAddresses/(.+)`)
 	vmssVMProviderIDRE     = regexp.MustCompile(`azure:///subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(?:\d+)`)
+)
+
+const (
+	// virtualMachineScaleSetsDeallocating indicates VMSS instances are in Deallocating state.
+	virtualMachineScaleSetsDeallocating = "Deallocating"
+
+	vmssMachineIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s"
+
+	// VMSetCIDRIPV4TagKey specifies the node ipv4 CIDR mask of the instances on the VMSS or VMAS
+	VMSetCIDRIPV4TagKey = "kubernetesNodeCIDRMaskIPV4"
+	// VMSetCIDRIPV6TagKey specifies the node ipv6 CIDR mask of the instances on the VMSS or VMAS
+	VMSetCIDRIPV6TagKey = "kubernetesNodeCIDRMaskIPV6"
 )
 
 // vmssMetaInfo contains the metadata for a VMSS.
@@ -67,11 +75,11 @@ type nodeIdentity struct {
 	nodeName      string
 }
 
-// scaleSet implements VMSet interface for Azure scale set.
-type scaleSet struct {
+// ScaleSet implements VMSet interface for Azure scale set.
+type ScaleSet struct {
 	*Cloud
 
-	// availabilitySet is also required for scaleSet because some instances
+	// availabilitySet is also required for ScaleSet because some instances
 	// (e.g. master nodes) may not belong to any scale sets.
 	availabilitySet VMSet
 
@@ -80,12 +88,12 @@ type scaleSet struct {
 	availabilitySetNodesCache *azcache.TimedCache
 }
 
-// newScaleSet creates a new scaleSet.
+// newScaleSet creates a new ScaleSet.
 func newScaleSet(az *Cloud) (VMSet, error) {
 	if az.Config.VmssVirtualMachinesCacheTTLInSeconds == 0 {
 		az.Config.VmssVirtualMachinesCacheTTLInSeconds = vmssVirtualMachinesCacheTTLDefaultInSeconds
 	}
-	ss := &scaleSet{
+	ss := &ScaleSet{
 		Cloud:           az,
 		availabilitySet: newAvailabilitySet(az),
 		vmssVMCache:     &sync.Map{},
@@ -107,7 +115,7 @@ func newScaleSet(az *Cloud) (VMSet, error) {
 	return ss, nil
 }
 
-func (ss *scaleSet) getVMSS(vmssName string, crt azcache.AzureCacheReadType) (*compute.VirtualMachineScaleSet, error) {
+func (ss *ScaleSet) getVMSS(vmssName string, crt azcache.AzureCacheReadType) (*compute.VirtualMachineScaleSet, error) {
 	getter := func(vmssName string) (*compute.VirtualMachineScaleSet, error) {
 		cached, err := ss.vmssCache.Get(vmssKey, crt)
 		if err != nil {
@@ -146,7 +154,7 @@ func (ss *scaleSet) getVMSS(vmssName string, crt azcache.AzureCacheReadType) (*c
 
 // getVmssVMByNodeIdentity find virtualMachineScaleSetVM by nodeIdentity, using node's parent VMSS cache.
 // Returns cloudprovider.InstanceNotFound if the node does not belong to the scale set named in nodeIdentity.
-func (ss *scaleSet) getVmssVMByNodeIdentity(node *nodeIdentity, crt azcache.AzureCacheReadType) (string, string, *compute.VirtualMachineScaleSetVM, error) {
+func (ss *ScaleSet) getVmssVMByNodeIdentity(node *nodeIdentity, crt azcache.AzureCacheReadType) (string, string, *compute.VirtualMachineScaleSetVM, error) {
 	cacheKey, cache, err := ss.getVMSSVMCache(node.resourceGroup, node.vmssName)
 	if err != nil {
 		return "", "", nil, err
@@ -199,7 +207,7 @@ func (ss *scaleSet) getVmssVMByNodeIdentity(node *nodeIdentity, crt azcache.Azur
 
 // getVmssVM gets virtualMachineScaleSetVM by nodeName from cache.
 // Returns cloudprovider.InstanceNotFound if nodeName does not belong to any scale set.
-func (ss *scaleSet) getVmssVM(nodeName string, crt azcache.AzureCacheReadType) (string, string, *compute.VirtualMachineScaleSetVM, error) {
+func (ss *ScaleSet) getVmssVM(nodeName string, crt azcache.AzureCacheReadType) (string, string, *compute.VirtualMachineScaleSetVM, error) {
 	node, err := ss.getNodeIdentityByNodeName(nodeName, crt)
 	if err != nil {
 		return "", "", nil, err
@@ -209,7 +217,7 @@ func (ss *scaleSet) getVmssVM(nodeName string, crt azcache.AzureCacheReadType) (
 }
 
 // GetPowerStatusByNodeName returns the power state of the specified node.
-func (ss *scaleSet) GetPowerStatusByNodeName(name string) (powerState string, err error) {
+func (ss *ScaleSet) GetPowerStatusByNodeName(name string) (powerState string, err error) {
 	managedByAS, err := ss.isNodeManagedByAvailabilitySet(name, azcache.CacheReadTypeUnsafe)
 	if err != nil {
 		klog.Errorf("Failed to check isNodeManagedByAvailabilitySet: %v", err)
@@ -242,7 +250,7 @@ func (ss *scaleSet) GetPowerStatusByNodeName(name string) (powerState string, er
 
 // getCachedVirtualMachineByInstanceID gets scaleSetVMInfo from cache.
 // The node must belong to one of scale sets.
-func (ss *scaleSet) getVmssVMByInstanceID(resourceGroup, scaleSetName, instanceID string, crt azcache.AzureCacheReadType) (*compute.VirtualMachineScaleSetVM, error) {
+func (ss *ScaleSet) getVmssVMByInstanceID(resourceGroup, scaleSetName, instanceID string, crt azcache.AzureCacheReadType) (*compute.VirtualMachineScaleSetVM, error) {
 	cacheKey, cache, err := ss.getVMSSVMCache(resourceGroup, scaleSetName)
 	if err != nil {
 		return nil, err
@@ -302,7 +310,7 @@ func (ss *scaleSet) getVmssVMByInstanceID(resourceGroup, scaleSetName, instanceI
 // GetInstanceIDByNodeName gets the cloud provider ID by node name.
 // It must return ("", cloudprovider.InstanceNotFound) if the instance does
 // not exist or is no longer running.
-func (ss *scaleSet) GetInstanceIDByNodeName(name string) (string, error) {
+func (ss *ScaleSet) GetInstanceIDByNodeName(name string) (string, error) {
 	managedByAS, err := ss.isNodeManagedByAvailabilitySet(name, azcache.CacheReadTypeUnsafe)
 	if err != nil {
 		klog.Errorf("Failed to check isNodeManagedByAvailabilitySet: %v", err)
@@ -333,7 +341,7 @@ func (ss *scaleSet) GetInstanceIDByNodeName(name string) (string, error) {
 // 	 2. vmss providerID:
 //		azure:///subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/1
 //	    /subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/k8s-agentpool-36841236-vmss_1
-func (ss *scaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, error) {
+func (ss *ScaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, error) {
 	// NodeName is not part of providerID for vmss instances.
 	scaleSetName, err := extractScaleSetNameByProviderID(providerID)
 	if err != nil {
@@ -374,7 +382,7 @@ func (ss *scaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, 
 }
 
 // GetInstanceTypeByNodeName gets the instance type by node name.
-func (ss *scaleSet) GetInstanceTypeByNodeName(name string) (string, error) {
+func (ss *ScaleSet) GetInstanceTypeByNodeName(name string) (string, error) {
 	managedByAS, err := ss.isNodeManagedByAvailabilitySet(name, azcache.CacheReadTypeUnsafe)
 	if err != nil {
 		klog.Errorf("Failed to check isNodeManagedByAvailabilitySet: %v", err)
@@ -399,7 +407,7 @@ func (ss *scaleSet) GetInstanceTypeByNodeName(name string) (string, error) {
 
 // GetZoneByNodeName gets availability zone for the specified node. If the node is not running
 // with availability zone, then it returns fault domain.
-func (ss *scaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
+func (ss *ScaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
 	managedByAS, err := ss.isNodeManagedByAvailabilitySet(name, azcache.CacheReadTypeUnsafe)
 	if err != nil {
 		klog.Errorf("Failed to check isNodeManagedByAvailabilitySet: %v", err)
@@ -443,12 +451,12 @@ func (ss *scaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
 
 // GetPrimaryVMSetName returns the VM set name depending on the configured vmType.
 // It returns config.PrimaryScaleSetName for vmss and config.PrimaryAvailabilitySetName for standard vmType.
-func (ss *scaleSet) GetPrimaryVMSetName() string {
+func (ss *ScaleSet) GetPrimaryVMSetName() string {
 	return ss.Config.PrimaryScaleSetName
 }
 
 // GetIPByNodeName gets machine private IP and public IP by node name.
-func (ss *scaleSet) GetIPByNodeName(nodeName string) (string, string, error) {
+func (ss *ScaleSet) GetIPByNodeName(nodeName string) (string, string, error) {
 	nic, err := ss.GetPrimaryInterface(nodeName)
 	if err != nil {
 		klog.Errorf("error: ss.GetIPByNodeName(%s), GetPrimaryInterface(%q), err=%v", nodeName, nodeName, err)
@@ -489,7 +497,7 @@ func (ss *scaleSet) GetIPByNodeName(nodeName string) (string, string, error) {
 	return internalIP, publicIP, nil
 }
 
-func (ss *scaleSet) getVMSSPublicIPAddress(resourceGroupName string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string, IPConfigurationName string, publicIPAddressName string) (network.PublicIPAddress, bool, error) {
+func (ss *ScaleSet) getVMSSPublicIPAddress(resourceGroupName string, virtualMachineScaleSetName string, virtualMachineIndex string, networkInterfaceName string, IPConfigurationName string, publicIPAddressName string) (network.PublicIPAddress, bool, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
@@ -510,7 +518,7 @@ func (ss *scaleSet) getVMSSPublicIPAddress(resourceGroupName string, virtualMach
 // returns a list of private ips assigned to node
 // TODO (khenidak): This should read all nics, not just the primary
 // allowing users to split ipv4/v6 on multiple nics
-func (ss *scaleSet) GetPrivateIPsByNodeName(nodeName string) ([]string, error) {
+func (ss *ScaleSet) GetPrivateIPsByNodeName(nodeName string) ([]string, error) {
 	ips := make([]string, 0)
 	nic, err := ss.GetPrimaryInterface(nodeName)
 	if err != nil {
@@ -532,7 +540,7 @@ func (ss *scaleSet) GetPrivateIPsByNodeName(nodeName string) ([]string, error) {
 }
 
 // This returns the full identifier of the primary NIC for the given VM.
-func (ss *scaleSet) getPrimaryInterfaceID(machine compute.VirtualMachineScaleSetVM) (string, error) {
+func (ss *ScaleSet) getPrimaryInterfaceID(machine compute.VirtualMachineScaleSetVM) (string, error) {
 	if machine.NetworkProfile == nil || machine.NetworkProfile.NetworkInterfaces == nil {
 		return "", fmt.Errorf("failed to find the network interfaces for vm %s", to.String(machine.Name))
 	}
@@ -598,7 +606,7 @@ func extractResourceGroupByProviderID(providerID string) (string, error) {
 }
 
 // listScaleSets lists all scale sets with orchestrationMode ScaleSetVM.
-func (ss *scaleSet) listScaleSets(resourceGroup string) ([]string, error) {
+func (ss *ScaleSet) listScaleSets(resourceGroup string) ([]string, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
@@ -628,7 +636,7 @@ func (ss *scaleSet) listScaleSets(resourceGroup string) ([]string, error) {
 }
 
 // getNodeIdentityByNodeName use the VMSS cache to find a node's resourcegroup and vmss, returned in a nodeIdentity.
-func (ss *scaleSet) getNodeIdentityByNodeName(nodeName string, crt azcache.AzureCacheReadType) (*nodeIdentity, error) {
+func (ss *ScaleSet) getNodeIdentityByNodeName(nodeName string, crt azcache.AzureCacheReadType) (*nodeIdentity, error) {
 	getter := func(nodeName string, crt azcache.AzureCacheReadType) (*nodeIdentity, error) {
 		node := &nodeIdentity{
 			nodeName: nodeName,
@@ -688,7 +696,7 @@ func (ss *scaleSet) getNodeIdentityByNodeName(nodeName string, crt azcache.Azure
 }
 
 // listScaleSetVMs lists VMs belonging to the specified scale set.
-func (ss *scaleSet) listScaleSetVMs(scaleSetName, resourceGroup string) ([]compute.VirtualMachineScaleSetVM, error) {
+func (ss *ScaleSet) listScaleSetVMs(scaleSetName, resourceGroup string) ([]compute.VirtualMachineScaleSetVM, error) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
@@ -706,7 +714,7 @@ func (ss *scaleSet) listScaleSetVMs(scaleSetName, resourceGroup string) ([]compu
 
 // getAgentPoolScaleSets lists the virtual machines for the resource group and then builds
 // a list of scale sets that match the nodes available to k8s.
-func (ss *scaleSet) getAgentPoolScaleSets(nodes []*v1.Node) (*[]string, error) {
+func (ss *ScaleSet) getAgentPoolScaleSets(nodes []*v1.Node) (*[]string, error) {
 	agentPoolScaleSets := &[]string{}
 	for nx := range nodes {
 		if isMasterNode(nodes[nx]) {
@@ -737,7 +745,7 @@ func (ss *scaleSet) getAgentPoolScaleSets(nodes []*v1.Node) (*[]string, error) {
 // GetVMSetNames selects all possible scale sets for service load balancer. If the service has
 // no loadbalancer mode annotation returns the primary VMSet. If service annotation
 // for loadbalancer exists then return the eligible VMSet.
-func (ss *scaleSet) GetVMSetNames(service *v1.Service, nodes []*v1.Node) (*[]string, error) {
+func (ss *ScaleSet) GetVMSetNames(service *v1.Service, nodes []*v1.Node) (*[]string, error) {
 	hasMode, isAuto, serviceVMSetName := ss.getServiceLoadBalancerMode(service)
 	useSingleSLB := ss.useStandardLoadBalancer() && !ss.EnableMultipleStandardLoadBalancers
 	if !hasMode || useSingleSLB {
@@ -787,7 +795,7 @@ func extractResourceGroupByVMSSNicID(nicID string) (string, error) {
 }
 
 // GetPrimaryInterface gets machine primary network interface by node name and vmSet.
-func (ss *scaleSet) GetPrimaryInterface(nodeName string) (network.Interface, error) {
+func (ss *ScaleSet) GetPrimaryInterface(nodeName string) (network.Interface, error) {
 	managedByAS, err := ss.isNodeManagedByAvailabilitySet(nodeName, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("Failed to check isNodeManagedByAvailabilitySet: %v", err)
@@ -850,7 +858,7 @@ func (ss *scaleSet) GetPrimaryInterface(nodeName string) (network.Interface, err
 }
 
 // getPrimaryNetworkInterfaceConfiguration gets primary network interface configuration for scale set virtual machine.
-func (ss *scaleSet) getPrimaryNetworkInterfaceConfiguration(networkConfigurations []compute.VirtualMachineScaleSetNetworkConfiguration, nodeName string) (*compute.VirtualMachineScaleSetNetworkConfiguration, error) {
+func (ss *ScaleSet) getPrimaryNetworkInterfaceConfiguration(networkConfigurations []compute.VirtualMachineScaleSetNetworkConfiguration, nodeName string) (*compute.VirtualMachineScaleSetNetworkConfiguration, error) {
 	if len(networkConfigurations) == 1 {
 		return &networkConfigurations[0], nil
 	}
@@ -866,7 +874,7 @@ func (ss *scaleSet) getPrimaryNetworkInterfaceConfiguration(networkConfiguration
 }
 
 // getPrimaryNetworkInterfaceConfigurationForScaleSet gets primary network interface configuration for scale set.
-func (ss *scaleSet) getPrimaryNetworkInterfaceConfigurationForScaleSet(networkConfigurations []compute.VirtualMachineScaleSetNetworkConfiguration, vmssName string) (*compute.VirtualMachineScaleSetNetworkConfiguration, error) {
+func (ss *ScaleSet) getPrimaryNetworkInterfaceConfigurationForScaleSet(networkConfigurations []compute.VirtualMachineScaleSetNetworkConfiguration, vmssName string) (*compute.VirtualMachineScaleSetNetworkConfiguration, error) {
 	if len(networkConfigurations) == 1 {
 		return &networkConfigurations[0], nil
 	}
@@ -897,7 +905,7 @@ func getPrimaryIPConfigFromVMSSNetworkConfig(config *compute.VirtualMachineScale
 	return nil, fmt.Errorf("failed to find a primary IP configuration")
 }
 
-func (ss *scaleSet) getConfigForScaleSetByIPFamily(config *compute.VirtualMachineScaleSetNetworkConfiguration, nodeName string, IPv6 bool) (*compute.VirtualMachineScaleSetIPConfiguration, error) {
+func (ss *ScaleSet) getConfigForScaleSetByIPFamily(config *compute.VirtualMachineScaleSetNetworkConfiguration, nodeName string, IPv6 bool) (*compute.VirtualMachineScaleSetIPConfiguration, error) {
 	ipConfigurations := *config.IPConfigurations
 
 	var ipVersion compute.IPVersion
@@ -918,7 +926,7 @@ func (ss *scaleSet) getConfigForScaleSetByIPFamily(config *compute.VirtualMachin
 
 // EnsureHostInPool ensures the given VM's Primary NIC's Primary IP Configuration is
 // participating in the specified LoadBalancer Backend Pool, which returns (resourceGroup, vmssName, instanceID, vmssVM, error).
-func (ss *scaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID string, vmSetName string, isInternal bool) (string, string, string, *compute.VirtualMachineScaleSetVM, error) {
+func (ss *ScaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID string, vmSetName string, isInternal bool) (string, string, string, *compute.VirtualMachineScaleSetVM, error) {
 	klog.V(3).Infof("ensuring node %q of scaleset %q in LB backendpool %q", nodeName, vmSetName, backendPoolID)
 	vmName := mapNodeNameToVMName(nodeName)
 	ssName, instanceID, vm, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
@@ -940,7 +948,7 @@ func (ss *scaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeNam
 		needCheck = true
 	}
 	if vmSetName != "" && needCheck && !strings.EqualFold(vmSetName, ssName) {
-		klog.V(3).Infof("EnsureHostInPool skips node %s because it is not in the scaleSet %s", vmName, vmSetName)
+		klog.V(3).Infof("EnsureHostInPool skips node %s because it is not in the ScaleSet %s", vmName, vmSetName)
 		return "", "", "", nil, nil
 	}
 
@@ -1048,7 +1056,7 @@ func getVmssAndResourceGroupNameByVMProviderID(providerID string) (string, strin
 	return matches[1], matches[2], nil
 }
 
-func (ss *scaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetName string) error {
+func (ss *ScaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetName string) error {
 	klog.V(2).Infof("ensureVMSSInPool: ensuring VMSS with backendPoolID %s", backendPoolID)
 	vmssNamesMap := make(map[string]bool)
 
@@ -1186,7 +1194,7 @@ func (ss *scaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 
 // EnsureHostsInPool ensures the given Node's primary IP configurations are
 // participating in the specified LoadBalancer Backend Pool.
-func (ss *scaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetName string, isInternal bool) error {
+func (ss *ScaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetName string, isInternal bool) error {
 	mc := metrics.NewMetricContext("services", "vmss_ensure_hosts_in_pool", ss.ResourceGroup, ss.SubscriptionID, service.Name)
 	isOperationSucceeded := false
 	defer func() {
@@ -1299,7 +1307,7 @@ func (ss *scaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, bac
 
 // ensureBackendPoolDeletedFromNode ensures the loadBalancer backendAddressPools deleted
 // from the specified node, which returns (resourceGroup, vmssName, instanceID, vmssVM, error).
-func (ss *scaleSet) ensureBackendPoolDeletedFromNode(nodeName, backendPoolID string) (string, string, string, *compute.VirtualMachineScaleSetVM, error) {
+func (ss *ScaleSet) ensureBackendPoolDeletedFromNode(nodeName, backendPoolID string) (string, string, string, *compute.VirtualMachineScaleSetVM, error) {
 	ssName, instanceID, vm, err := ss.getVmssVM(nodeName, azcache.CacheReadTypeDefault)
 	if err != nil {
 		return "", "", "", nil, err
@@ -1366,7 +1374,7 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromNode(nodeName, backendPoolID str
 }
 
 // GetNodeNameByIPConfigurationID gets the node name and the VMSS name by IP configuration ID.
-func (ss *scaleSet) GetNodeNameByIPConfigurationID(ipConfigurationID string) (string, string, error) {
+func (ss *ScaleSet) GetNodeNameByIPConfigurationID(ipConfigurationID string) (string, string, error) {
 	matches := vmssIPConfigurationRE.FindStringSubmatch(ipConfigurationID)
 	if len(matches) != 4 {
 		klog.V(4).Infof("Can not extract scale set name from ipConfigurationID (%s), assuming it is managed by availability set", ipConfigurationID)
@@ -1400,7 +1408,7 @@ func getScaleSetAndResourceGroupNameByIPConfigurationID(ipConfigurationID string
 	return scaleSetName, resourceGroup, nil
 }
 
-func (ss *scaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backendPoolID, vmSetName string, ipConfigurationIDs []string) error {
+func (ss *ScaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backendPoolID, vmSetName string, ipConfigurationIDs []string) error {
 	vmssNamesMap := make(map[string]bool)
 
 	// the standard load balancer supports multiple vmss in its backend while the basic sku doesn't
@@ -1513,7 +1521,7 @@ func (ss *scaleSet) ensureBackendPoolDeletedFromVMSS(service *v1.Service, backen
 }
 
 // EnsureBackendPoolDeleted ensures the loadBalancer backendAddressPools deleted from the specified nodes.
-func (ss *scaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID, vmSetName string, backendAddressPools *[]network.BackendAddressPool) error {
+func (ss *ScaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID, vmSetName string, backendAddressPools *[]network.BackendAddressPool) error {
 	// Returns nil if backend address pools already deleted.
 	if backendAddressPools == nil {
 		return nil
@@ -1627,4 +1635,33 @@ func (ss *scaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID,
 
 	isOperationSucceeded = true
 	return nil
+}
+
+// GetNodeCIDRMaskByProviderID returns the node CIDR subnet mask by provider ID.
+func (ss *ScaleSet) GetNodeCIDRMasksByProviderID(providerID string) (int, int, error) {
+	_, vmssName, err := getVmssAndResourceGroupNameByVMProviderID(providerID)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	vmss, err := ss.getVMSS(vmssName, azcache.CacheReadTypeDefault)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var ipv4Mask, ipv6Mask int
+	if v4, ok := vmss.Tags[VMSetCIDRIPV4TagKey]; ok && v4 != nil {
+		ipv4Mask, err = strconv.Atoi(to.String(v4))
+		if err != nil {
+			klog.Errorf(" GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", to.String(v4), err)
+		}
+	}
+	if v6, ok := vmss.Tags[VMSetCIDRIPV6TagKey]; ok && v6 != nil {
+		ipv6Mask, err = strconv.Atoi(to.String(v6))
+		if err != nil {
+			klog.Errorf(" GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", to.String(v6), err)
+		}
+	}
+
+	return ipv4Mask, ipv6Mask, nil
 }

--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -57,7 +57,7 @@ type vmssEntry struct {
 	lastUpdate    time.Time
 }
 
-func (ss *scaleSet) newVMSSCache() (*azcache.TimedCache, error) {
+func (ss *ScaleSet) newVMSSCache() (*azcache.TimedCache, error) {
 	getter := func(key string) (interface{}, error) {
 		localCache := &sync.Map{} // [vmssName]*vmssEntry
 
@@ -111,7 +111,7 @@ func extractVmssVMName(name string) (string, string, error) {
 }
 
 // getVMSSVMCache returns an *azcache.TimedCache and cache key for a VMSS (creating that cache if new).
-func (ss *scaleSet) getVMSSVMCache(resourceGroup, vmssName string) (string, *azcache.TimedCache, error) {
+func (ss *ScaleSet) getVMSSVMCache(resourceGroup, vmssName string) (string, *azcache.TimedCache, error) {
 	cacheKey := strings.ToLower(fmt.Sprintf("%s/%s", resourceGroup, vmssName))
 	if entry, ok := ss.vmssVMCache.Load(cacheKey); ok {
 		cache := entry.(*azcache.TimedCache)
@@ -127,7 +127,7 @@ func (ss *scaleSet) getVMSSVMCache(resourceGroup, vmssName string) (string, *azc
 }
 
 // gcVMSSVMCache delete stale VMSS VMs caches from deleted VMSSes.
-func (ss *scaleSet) gcVMSSVMCache() error {
+func (ss *ScaleSet) gcVMSSVMCache() error {
 	cached, err := ss.vmssCache.Get(vmssKey, azcache.CacheReadTypeUnsafe)
 	if err != nil {
 		return err
@@ -152,7 +152,7 @@ func (ss *scaleSet) gcVMSSVMCache() error {
 }
 
 // newVMSSVirtualMachinesCache instantiates a new VMs cache for VMs belonging to the provided VMSS.
-func (ss *scaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cacheKey string) (*azcache.TimedCache, error) {
+func (ss *ScaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cacheKey string) (*azcache.TimedCache, error) {
 	vmssVirtualMachinesCacheTTL := time.Duration(ss.Config.VmssVirtualMachinesCacheTTLInSeconds) * time.Second
 
 	getter := func(key string) (interface{}, error) {
@@ -242,7 +242,7 @@ func (ss *scaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cac
 	return azcache.NewTimedcache(vmssVirtualMachinesCacheTTL, getter)
 }
 
-func (ss *scaleSet) deleteCacheForNode(nodeName string) error {
+func (ss *ScaleSet) deleteCacheForNode(nodeName string) error {
 	node, err := ss.getNodeIdentityByNodeName(nodeName, azcache.CacheReadTypeUnsafe)
 	if err != nil {
 		klog.Errorf("deleteCacheForNode(%s) failed with error: %v", nodeName, err)
@@ -270,7 +270,7 @@ func (ss *scaleSet) deleteCacheForNode(nodeName string) error {
 	return nil
 }
 
-func (ss *scaleSet) newAvailabilitySetNodesCache() (*azcache.TimedCache, error) {
+func (ss *ScaleSet) newAvailabilitySetNodesCache() (*azcache.TimedCache, error) {
 	getter := func(key string) (interface{}, error) {
 		localCache := sets.NewString()
 		resourceGroups, err := ss.GetResourceGroups()
@@ -300,7 +300,7 @@ func (ss *scaleSet) newAvailabilitySetNodesCache() (*azcache.TimedCache, error) 
 	return azcache.NewTimedcache(time.Duration(ss.Config.AvailabilitySetNodesCacheTTLInSeconds)*time.Second, getter)
 }
 
-func (ss *scaleSet) isNodeManagedByAvailabilitySet(nodeName string, crt azcache.AzureCacheReadType) (bool, error) {
+func (ss *ScaleSet) isNodeManagedByAvailabilitySet(nodeName string, crt azcache.AzureCacheReadType) (bool, error) {
 	// Assume all nodes are managed by VMSS when DisableAvailabilitySetNodes is enabled.
 	if ss.DisableAvailabilitySetNodes {
 		klog.V(2).Infof("Assuming node %q is managed by VMSS since DisableAvailabilitySetNodes is set to true", nodeName)

--- a/pkg/provider/azure_vmss_cache_test.go
+++ b/pkg/provider/azure_vmss_cache_test.go
@@ -51,13 +51,13 @@ func TestExtractVmssVMName(t *testing.T) {
 			expectError: true,
 		},
 		{
-			description:        "correct vmss VM name should return correct scaleSet and instanceID",
+			description:        "correct vmss VM name should return correct ScaleSet and instanceID",
 			vmName:             "vm_1234",
 			expectedScaleSet:   "vm",
 			expectedInstanceID: "1234",
 		},
 		{
-			description:        "correct vmss VM name with Extra Separator should return correct scaleSet and instanceID",
+			description:        "correct vmss VM name with Extra Separator should return correct ScaleSet and instanceID",
 			vmName:             "vm_test_1234",
 			expectedScaleSet:   "vm_test",
 			expectedInstanceID: "1234",
@@ -81,7 +81,7 @@ func TestVMSSVMCache(t *testing.T) {
 	defer ctrl.Finish()
 
 	vmList := []string{"vmssee6c2000000", "vmssee6c2000001", "vmssee6c2000002"}
-	ss, err := newTestScaleSet(ctrl)
+	ss, err := NewTestScaleSet(ctrl)
 	assert.NoError(t, err)
 
 	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)

--- a/pkg/provider/azure_wrap.go
+++ b/pkg/provider/azure_wrap.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -283,7 +284,7 @@ func (az *Cloud) newRouteTableCache() (*azcache.TimedCache, error) {
 }
 
 func (az *Cloud) useStandardLoadBalancer() bool {
-	return strings.EqualFold(az.LoadBalancerSku, loadBalancerSkuStandard)
+	return strings.EqualFold(az.LoadBalancerSku, consts.LoadBalancerSkuStandard)
 }
 
 func (az *Cloud) excludeMasterNodesFromStandardLB() bool {
@@ -337,7 +338,7 @@ func isBackendPoolOnSameLB(newBackendPoolID string, existingBackendPools []strin
 	}
 
 	newLBName := matches[1]
-	newLBNameTrimmed := strings.TrimSuffix(newLBName, InternalLoadBalancerNameSuffix)
+	newLBNameTrimmed := strings.TrimSuffix(newLBName, consts.InternalLoadBalancerNameSuffix)
 	for _, backendPool := range existingBackendPools {
 		matches := backendPoolIDRE.FindStringSubmatch(backendPool)
 		if len(matches) != 2 {
@@ -345,7 +346,7 @@ func isBackendPoolOnSameLB(newBackendPoolID string, existingBackendPools []strin
 		}
 
 		lbName := matches[1]
-		if !strings.EqualFold(strings.TrimSuffix(lbName, InternalLoadBalancerNameSuffix), newLBNameTrimmed) {
+		if !strings.EqualFold(strings.TrimSuffix(lbName, consts.InternalLoadBalancerNameSuffix), newLBNameTrimmed) {
 			return false, lbName, nil
 		}
 	}

--- a/pkg/provider/azure_wrap_test.go
+++ b/pkg/provider/azure_wrap_test.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -123,11 +124,11 @@ func TestIsNodeUnmanagedByProviderID(t *testing.T) {
 		name       string
 	}{
 		{
-			providerID: CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			providerID: consts.CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
 			expected:   false,
 		},
 		{
-			providerID: CloudProviderName + "://",
+			providerID: consts.CloudProviderName + "://",
 			expected:   true,
 		},
 		{
@@ -175,8 +176,8 @@ func TestConvertResourceGroupNameToLower(t *testing.T) {
 		},
 		{
 			desc:       "resource group name in VM providerID should be converted",
-			resourceID: CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
-			expected:   CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroupname/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			resourceID: consts.CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			expected:   consts.CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroupname/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
 		},
 		{
 			desc:       "resource group name in VM resourceID should be converted",
@@ -185,8 +186,8 @@ func TestConvertResourceGroupNameToLower(t *testing.T) {
 		},
 		{
 			desc:       "resource group name in VMSS providerID should be converted",
-			resourceID: CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSetName/virtualMachines/156",
-			expected:   CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroupname/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSetName/virtualMachines/156",
+			resourceID: consts.CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSetName/virtualMachines/156",
+			expected:   consts.CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroupname/providers/Microsoft.Compute/virtualMachineScaleSets/myScaleSetName/virtualMachines/156",
 		},
 		{
 			desc:       "resource group name in VMSS resourceID should be converted",

--- a/pkg/provider/azure_zones.go
+++ b/pkg/provider/azure_zones.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // makeZone returns the zone value in format of <region>-<zone-id>.
@@ -59,7 +60,7 @@ func (az *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 		}
 
 		if metadata.Compute == nil {
-			_ = az.metadata.imsCache.Delete(metadataCacheKey)
+			_ = az.metadata.imsCache.Delete(consts.MetadataCacheKey)
 			return cloudprovider.Zone{}, fmt.Errorf("failure of getting compute information from instance metadata")
 		}
 

--- a/pkg/retry/azure_error.go
+++ b/pkg/retry/azure_error.go
@@ -26,11 +26,8 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
-)
 
-const (
-	// RetryAfterHeaderKey is the retry-after header key in ARM responses.
-	RetryAfterHeaderKey = "Retry-After"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 var (
@@ -229,7 +226,7 @@ func getRetryAfter(resp *http.Response) time.Duration {
 		return 0
 	}
 
-	ra := resp.Header.Get(RetryAfterHeaderKey)
+	ra := resp.Header.Get(consts.RetryAfterHeaderKey)
 	if ra == "" {
 		return 0
 	}

--- a/pkg/util/controller/testutil/test_utils.go
+++ b/pkg/util/controller/testutil/test_utils.go
@@ -463,11 +463,8 @@ func contains(node *v1.Node, nodes []*v1.Node) bool {
 	return false
 }
 
-// GroupName is the group name use in this package
-const GroupName = ""
-
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+var SchemeGroupVersion = schema.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func Resource(resource string) schema.GroupResource {

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"strconv"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
+
 	flag "github.com/spf13/pflag"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/version"
@@ -36,8 +38,6 @@ const (
 	VersionRaw   versionValue = 2
 )
 
-const strRawVersion string = "raw"
-
 func (v *versionValue) IsBoolFlag() bool {
 	return true
 }
@@ -47,7 +47,7 @@ func (v *versionValue) Get() interface{} {
 }
 
 func (v *versionValue) Set(s string) error {
-	if s == strRawVersion {
+	if s == consts.StrRawVersion {
 		*v = VersionRaw
 		return nil
 
@@ -63,7 +63,7 @@ func (v *versionValue) Set(s string) error {
 
 func (v *versionValue) String() string {
 	if *v == VersionRaw {
-		return strRawVersion
+		return consts.StrRawVersion
 	}
 	return fmt.Sprintf("%v", *v == VersionTrue)
 }

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
 
-	azureprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -139,7 +139,7 @@ var _ = Describe("Network security group", func() {
 	It("can set source IP prefixes automatically according to corresponding service tag", func() {
 		By("Creating service and wait it to expose")
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationAllowedServiceTag: "AzureCloud",
+			consts.ServiceAnnotationAllowedServiceTag: "AzureCloud",
 		}
 		_ = createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
 
@@ -162,8 +162,8 @@ var _ = Describe("Network security group", func() {
 	It("should support service annotation `service.beta.kubernetes.io/azure-deny-all-except-load-balancer-source-ranges`", func() {
 		By("Creating a test service with the deny rule annotation but without `service.Spec.LoadBalancerSourceRanges`")
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true",
-			azureprovider.ServiceAnnotationLoadBalancerInternal:                  "true",
+			consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true",
+			consts.ServiceAnnotationLoadBalancerInternal:                  "true",
 		}
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
 		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 
-	azureprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -111,7 +111,7 @@ var _ = Describe("Service with annotation", func() {
 		serviceDomainNamePrefix := serviceName + string(uuid.NewUUID())
 
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationDNSLabelName: serviceDomainNamePrefix,
+			consts.ServiceAnnotationDNSLabelName: serviceDomainNamePrefix,
 		}
 
 		// create service with given annotation and wait it to expose
@@ -152,7 +152,7 @@ var _ = Describe("Service with annotation", func() {
 
 	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-internal'", func() {
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationLoadBalancerInternal: "true",
+			consts.ServiceAnnotationLoadBalancerInternal: "true",
 		}
 
 		// create service with given annotation and wait it to expose
@@ -199,8 +199,8 @@ var _ = Describe("Service with annotation", func() {
 		}
 
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationLoadBalancerInternal:       "true",
-			azureprovider.ServiceAnnotationLoadBalancerInternalSubnet: subnetName,
+			consts.ServiceAnnotationLoadBalancerInternal:       "true",
+			consts.ServiceAnnotationLoadBalancerInternalSubnet: subnetName,
 		}
 
 		// create service with given annotation and wait it to expose
@@ -220,7 +220,7 @@ var _ = Describe("Service with annotation", func() {
 
 	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout'", func() {
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationLoadBalancerIdleTimeout: "5",
+			consts.ServiceAnnotationLoadBalancerIdleTimeout: "5",
 		}
 
 		// create service with given annotation and wait it to expose
@@ -276,7 +276,7 @@ var _ = Describe("Service with annotation", func() {
 		}()
 
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationLoadBalancerResourceGroup: to.String(rg.Name),
+			consts.ServiceAnnotationLoadBalancerResourceGroup: to.String(rg.Name),
 		}
 		By("Creating service " + serviceName + " in namespace " + ns.Name)
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
@@ -297,7 +297,7 @@ var _ = Describe("Service with annotation", func() {
 	It("should support service annotation `service.beta.kubernetes.io/azure-shared-securityrule`", func() {
 		By("Exposing two services with shared security rule")
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationSharedSecurityRule: "true",
+			consts.ServiceAnnotationSharedSecurityRule: "true",
 		}
 		ip1 := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
 
@@ -326,7 +326,7 @@ var _ = Describe("Service with annotation", func() {
 	It("should support service annotation `service.beta.kubernetes.io/azure-pip-tags`", func() {
 		By("Creating a service with custom tags")
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationAzurePIPTags: "a=b,c= d,e =, =f",
+			consts.ServiceAnnotationAzurePIPTags: "a=b,c= d,e =, =f",
 		}
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
 		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
@@ -363,7 +363,7 @@ var _ = Describe("Service with annotation", func() {
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		service.Annotations = map[string]string{
-			azureprovider.ServiceAnnotationAzurePIPTags: "a=c,x=y",
+			consts.ServiceAnnotationAzurePIPTags: "a=c,x=y",
 		}
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -393,7 +393,7 @@ var _ = Describe("Service with annotation", func() {
 
 		By("Creating a service referring to the first pip")
 		annotation := map[string]string{
-			azureprovider.ServiceAnnotationPIPName: "pip1",
+			consts.ServiceAnnotationPIPName: "pip1",
 		}
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
 		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
@@ -407,7 +407,7 @@ var _ = Describe("Service with annotation", func() {
 		By("Updating the service to refer to the second service")
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		service.Annotations[azureprovider.ServiceAnnotationPIPName] = "pip2"
+		service.Annotations[consts.ServiceAnnotationPIPName] = "pip2"
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -680,7 +680,7 @@ func validateLoadBalancerBackendPools(tc *utils.AzureTestClient, vmssName string
 	// create annotation for LoadBalancer service
 	By("Creating service " + serviceName + " in namespace " + ns)
 	annotation := map[string]string{
-		azureprovider.ServiceAnnotationLoadBalancerMode: vmssName,
+		consts.ServiceAnnotationLoadBalancerMode: vmssName,
 	}
 	service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns, ports)
 	_, err := cs.CoreV1().Services(ns).Create(context.TODO(), service, metav1.CreateOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
/kind feature

**What this PR does / why we need it**:
Implement cloud cidr allocator. The cloud cidr allocator reads the mask size of each node from the VMSS label `kubernetesNodeCIDRMaskSizeIPV4` and `kubernetesNodeCIDRMaskSizeIPV6`. If not set the default value would be `24` and `64`. Compared to the range allocator that doesn't support mask size per VMSS, it is possible for the cloud allocator that the total cidr space is not fully used. The logic of VMAS has not yet been implemented because there is no availability set arm client. I would do it in a separated or in the future if necessary.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #462

**Special notes for your reviewer**:


**Release note**:
```
feat: implement cloud cidr allocator for VMSS
```
