### PR TITLE
fix: convert backend pool id to lower case before using it

### DIFF
--- a/tests/e2e/network/standard_lb.go
+++ b/tests/e2e/network/standard_lb.go
@@ -97,7 +97,7 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 
 		lbBackendAddressPoolsIDMap := make(map[string]bool)
 		for _, backendAddressPool := range *lb.BackendAddressPools {
-			backendAddressPoolID := to.String(backendAddressPool.ID)
+			backendAddressPoolID := strings.ToLower(to.String(backendAddressPool.ID))
 			lbBackendAddressPoolsIDMap[backendAddressPoolID] = true
 			utils.Logf("found backend pool %s", backendAddressPoolID)
 		}
@@ -117,15 +117,9 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 				}
 				utils.Logf("found ip config %s", to.String(ipConfig.Name))
 				for _, backendAddressPool := range *ipConfig.LoadBalancerBackendAddressPools {
-					backendAddressPoolID := to.String(backendAddressPool.ID)
+					backendAddressPoolID := strings.ToLower(to.String(backendAddressPool.ID))
 					utils.Logf("found backend pool on nic %s", backendAddressPoolID)
-					if v, ok := lbBackendAddressPoolsIDMap[backendAddressPoolID]; ok {
-						utils.Logf("value: %v", v)
-					} else {
-						utils.Logf("not found")
-					}
 					if lbBackendAddressPoolsIDMap[backendAddressPoolID] {
-						utils.Logf("setting found = true")
 						found = true
 						break
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
 /kind failing-test

**What this PR does / why we need it**:
fix: convert backend pool id to lower case before using it

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
fix: convert backend pool id to lower case before using it
```
