### PR TITLE
chore: use aks-ubuntu-16.04 distro for dual-stack and ipv6

### DIFF
--- a/tests/k8s-azure/manifest/linux-dual-stack-iptables-kubenet.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-iptables-kubenet.json
@@ -38,14 +38,14 @@
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
             "vmSize": "Standard_DS3_v2",
-            "distro": "ubuntu"
+            "distro": "aks-ubuntu-16.04"
         },
         "agentPoolProfiles": [
             {
                 "name": "agentpool1",
                 "count": 2,
                 "vmSize": "Standard_DS3_v2",
-                "distro": "ubuntu"
+                "distro": "aks-ubuntu-16.04"
             }
         ],
         "linuxProfile": {

--- a/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet.json
@@ -39,14 +39,14 @@
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
             "vmSize": "Standard_DS3_v2",
-            "distro": "ubuntu"
+            "distro": "aks-ubuntu-16.04"
         },
         "agentPoolProfiles": [
             {
                 "name": "agentpool1",
                 "count": 2,
                 "vmSize": "Standard_DS3_v2",
-                "distro": "ubuntu"
+                "distro": "aks-ubuntu-16.04"
             }
         ],
         "linuxProfile": {

--- a/tests/k8s-azure/manifest/linux-ipv6.json
+++ b/tests/k8s-azure/manifest/linux-ipv6.json
@@ -37,7 +37,7 @@
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
             "vmSize": "Standard_DS3_v2",
-            "distro": "ubuntu"
+            "distro": "aks-ubuntu-16.04"
         },
         "agentPoolProfiles": [
             {
@@ -45,7 +45,7 @@
                 "count": 2,
                 "vmSize": "Standard_DS3_v2",
                 "availabilityProfile": "AvailabilitySet",
-                "distro": "ubuntu"
+                "distro": "aks-ubuntu-16.04"
             }
         ],
         "linuxProfile": {


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind failing-test

**What this PR does / why we need it**:
Using `ubuntu` distro doesn't honor `runUnattendedUpgradesOnBootstrap: false` and the nodes get rebooted. This causes the API server reachability tests to fail for dual-stack. Switching to use `aks-ubuntu-16.04` instead.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
