### PR TITLE
Disable blobfuse-flexvolume addon in tests

### DIFF
--- a/tests/k8s-azure/manifest/linux-autoscaler-multi-nodepool.json
+++ b/tests/k8s-azure/manifest/linux-autoscaler-multi-nodepool.json
@@ -1,86 +1,90 @@
 {
-  "apiVersion": "vlabs",
-  "location": "",
-  "properties": {
-    "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.17",
-      "kubernetesConfig": {
-        "useManagedIdentity": false,
-        "networkPolicy": "none",
-        "cloudProviderRateLimitQPS": 6,
-        "cloudProviderRateLimitBucket": 20,
-        "apiServerConfig": {
-          "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
-        },
-        "controllerManagerConfig": {
-          "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-        },
-        "kubeletConfig": {
-          "--feature-gates": "ExecProbeTimeout=true"
-        },
-        "addons": [
-          {
-            "name": "cluster-autoscaler",
-            "enabled": true,
-            "pools": [
-              {
-                "name": "agentpool1",
-                "config": {
-                  "min-nodes": "1",
-                  "max-nodes": "1000"
-                }
-              },
-              {
-                "name": "agentpool2",
-                "config": {
-                  "min-nodes": "1",
-                  "max-nodes": "1000"
-                }
-              }
-            ],
-            "config": {
-              "scale-down-delay-after-add": "5m",
-              "scale-down-unneeded-time": "5m"
+    "apiVersion": "vlabs",
+    "location": "",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "1.17",
+            "kubernetesConfig": {
+                "useManagedIdentity": false,
+                "networkPolicy": "none",
+                "cloudProviderRateLimitQPS": 6,
+                "cloudProviderRateLimitBucket": 20,
+                "apiServerConfig": {
+                    "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
+                },
+                "controllerManagerConfig": {
+                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
+                },
+                "kubeletConfig": {
+                    "--feature-gates": "ExecProbeTimeout=true"
+                },
+                "addons": [
+                    {
+                        "name": "cluster-autoscaler",
+                        "enabled": true,
+                        "pools": [
+                            {
+                                "name": "agentpool1",
+                                "config": {
+                                    "min-nodes": "1",
+                                    "max-nodes": "1000"
+                                }
+                            },
+                            {
+                                "name": "agentpool2",
+                                "config": {
+                                    "min-nodes": "1",
+                                    "max-nodes": "1000"
+                                }
+                            }
+                        ],
+                        "config": {
+                            "scale-down-delay-after-add": "5m",
+                            "scale-down-unneeded-time": "5m"
+                        }
+                    },
+                    {
+                        "name": "blobfuse-flexvolume",
+                        "enabled": false
+                    }
+                ]
             }
-          }
-        ]
-      }
-    },
-    "masterProfile": {
-      "count": 1,
-      "dnsPrefix": "{dnsPrefix}",
-      "vmSize": "Standard_F2"
-    },
-    "agentPoolProfiles": [
-      {
-        "name": "agentpool1",
-        "count": 2,
-        "vmSize": "Standard_F2",
-        "availabilityProfile": "VirtualMachineScaleSets",
-        "storageProfile": "ManagedDisks"
-      },
-      {
-        "name": "agentpool2",
-        "count": 2,
-        "vmSize": "Standard_F2",
-        "availabilityProfile": "VirtualMachineScaleSets",
-        "storageProfile": "ManagedDisks"
-      }
-    ],
-    "linuxProfile": {
-      "adminUsername": "k8s-ci",
-      "ssh": {
-        "publicKeys": [
-          {
-            "keyData": "{keyData}"
-          }
-        ]
-      }
-    },
-    "servicePrincipalProfile": {
-      "clientID": "{servicePrincipalClientID}",
-      "secret": "{servicePrincipalClientSecret}"
+        },
+        "masterProfile": {
+            "count": 1,
+            "dnsPrefix": "{dnsPrefix}",
+            "vmSize": "Standard_F2"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "agentpool1",
+                "count": 2,
+                "vmSize": "Standard_F2",
+                "availabilityProfile": "VirtualMachineScaleSets",
+                "storageProfile": "ManagedDisks"
+            },
+            {
+                "name": "agentpool2",
+                "count": 2,
+                "vmSize": "Standard_F2",
+                "availabilityProfile": "VirtualMachineScaleSets",
+                "storageProfile": "ManagedDisks"
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "k8s-ci",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": "{keyData}"
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientID": "{servicePrincipalClientID}",
+            "secret": "{servicePrincipalClientSecret}"
+        }
     }
-  }
 }

--- a/tests/k8s-azure/manifest/linux-autoscaler.json
+++ b/tests/k8s-azure/manifest/linux-autoscaler.json
@@ -36,6 +36,10 @@
                             "scale-down-delay-after-add": "5m",
                             "scale-down-unneeded-time": "5m"
                         }
+                    },
+                    {
+                        "name": "blobfuse-flexvolume",
+                        "enabled": false
                     }
                 ]
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Disable blobfuse-flexvolume addon in tests.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-sigs/cloud-provider-azure/issues/581. Let's check whether this could help.

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
