### PR TITLE
feat: support reloading cloud controller manager from secret dynamically

### DIFF
--- a/cmd/cloud-controller-manager/app/config/config.go
+++ b/cmd/cloud-controller-manager/app/config/config.go
@@ -60,6 +60,15 @@ type Config struct {
 
 	// SharedInformers gives access to informers for the controller.
 	SharedInformers informers.SharedInformerFactory
+
+	DynamicReloadingConfig DynamicReloadingConfig
+}
+
+type DynamicReloadingConfig struct {
+	EnableDynamicReloading     bool
+	CloudConfigSecretName      string
+	CloudConfigSecretNamespace string
+	CloudConfigKey             string
 }
 
 type completedConfig struct {

--- a/cmd/cloud-controller-manager/app/dynamic/watch_secret.go
+++ b/cmd/cloud-controller-manager/app/dynamic/watch_secret.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	cloudcontrollerconfig "sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app/config"
+	"sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app/options"
+)
+
+type SecretWatcher struct {
+	informerFactory informers.SharedInformerFactory
+	secretInformer  coreinformers.SecretInformer
+}
+
+// Run starts shared informers and waits for the shared informer cache to
+// synchronize.
+func (c *SecretWatcher) Run(stopCh <-chan struct{}) error {
+	c.informerFactory.Start(stopCh)
+
+	if !cache.WaitForCacheSync(stopCh, c.secretInformer.Informer().HasSynced) {
+		return fmt.Errorf("failed to operation the initial list of secrets")
+	}
+
+	return nil
+}
+
+func RunSecretWatcherOrDie(c *cloudcontrollerconfig.Config) chan struct{} {
+	factory := informers.NewSharedInformerFactory(c.VersionedClient, options.ResyncPeriod(c)())
+	secretWatcher, updateCh := NewSecretWatcher(factory, c.DynamicReloadingConfig.CloudConfigSecretName, c.DynamicReloadingConfig.CloudConfigSecretNamespace)
+	err := secretWatcher.Run(wait.NeverStop)
+	if err != nil {
+		klog.Errorf("Run: failed to initialize secret watcher: %v", err)
+		os.Exit(1)
+	}
+
+	return updateCh
+}
+
+// NewSecretWatcher creates a SecretWatcher and a signal channel to indicate
+// the specific secret has been updated
+func NewSecretWatcher(informerFactory informers.SharedInformerFactory, secretName, secretNamespace string) (*SecretWatcher, chan struct{}) {
+	secretInformer := informerFactory.Core().V1().Secrets()
+	updateSignal := make(chan struct{})
+
+	secretWatcher := &SecretWatcher{
+		informerFactory: informerFactory,
+		secretInformer:  secretInformer,
+	}
+	secretInformer.Informer().AddEventHandler(
+		// Your custom resource event handlers.
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				newSecret := newObj.(*v1.Secret)
+
+				if strings.EqualFold(newSecret.Name, secretName) &&
+					strings.EqualFold(newSecret.Namespace, secretNamespace) {
+					klog.V(1).Infof("secret %s updated, sending the signal", newSecret.Name)
+					updateSignal <- struct{}{}
+				}
+			},
+		},
+	)
+
+	return secretWatcher, updateSignal
+}

--- a/cmd/cloud-controller-manager/app/options/dynamic.go
+++ b/cmd/cloud-controller-manager/app/options/dynamic.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+
+	app "sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app/config"
+)
+
+// DynamicReloadingOptions holds the configurations of the dynamic reloading logics
+type DynamicReloadingOptions struct {
+	EnableDynamicReloading     bool
+	CloudConfigSecretName      string
+	CloudConfigSecretNamespace string
+	CloudConfigKey             string
+}
+
+// AddFlags adds flags releated to dynamic reloading for controller manager to the specified FlagSet
+func (o *DynamicReloadingOptions) AddFlags(fs *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
+	fs.BoolVar(&o.EnableDynamicReloading, "enable-dynamic-reloading", false, "Enable re-configuring cloud controller manager from secret without restarting")
+	fs.StringVar(&o.CloudConfigSecretName, "cloud-config-secret-name", "cloud-provider-config", "The name of the cloud config secret, default to 'cloud-provider-config'")
+	fs.StringVar(&o.CloudConfigSecretNamespace, "cloud-config-secret-namespace", "kube-system", "The k8s namespace of the cloud config secret, default to 'kube-system'")
+	fs.StringVar(&o.CloudConfigKey, "cloud-config-key", "cloud-config", "The key of the config data in the cloud config secret, default to 'cloud-config'")
+}
+
+// ApplyTo fills up dynamic reloading config with options
+func (o *DynamicReloadingOptions) ApplyTo(cfg *app.DynamicReloadingConfig) error {
+	if o == nil {
+		return nil
+	}
+
+	cfg.EnableDynamicReloading = o.EnableDynamicReloading
+	cfg.CloudConfigSecretName = o.CloudConfigSecretName
+	cfg.CloudConfigSecretNamespace = o.CloudConfigSecretNamespace
+	cfg.CloudConfigKey = o.CloudConfigKey
+
+	return nil
+}
+
+// Validate checks validation of DynamicReloadingOptions
+func (o *DynamicReloadingOptions) Validate() []error {
+	return nil
+}
+
+func defaultDynamicReloadingOptions() *DynamicReloadingOptions {
+	return &DynamicReloadingOptions{
+		EnableDynamicReloading:     false,
+		CloudConfigSecretName:      "",
+		CloudConfigSecretNamespace: "",
+		CloudConfigKey:             "",
+	}
+}

--- a/cmd/cloud-controller-manager/app/testing/testserver.go
+++ b/cmd/cloud-controller-manager/app/testing/testserver.go
@@ -120,7 +120,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 
 	errCh := make(chan error)
 	go func(stopCh <-chan struct{}) {
-		if err := app.Run(config.Complete(), stopCh); err != nil {
+		if err := app.Run(context.TODO(), config.Complete()); err != nil {
 			errCh <- err
 		}
 	}(stopCh)

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -165,13 +165,6 @@ const (
 	BackoffDurationDefault = 5 // in seconds
 	// BackoffJitterDefault is the default value of the backoff jitter
 	BackoffJitterDefault = 1.0
-
-	// CloudConfigNamespace is the namespace of the cloud config secret
-	CloudConfigNamespace = "kube-system"
-	// CloudConfigKey is the name of the cloud config key
-	CloudConfigKey = "cloud-config"
-	// CloudConfigSecName is the name of the cloud config secret
-	CloudConfigSecName = "azure-cloud-provider"
 )
 
 // load balancer

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1430,7 +1430,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 
 	existingLBs, err := az.reconcileSharedLoadBalancer(service, clusterName, nodes)
 	if err != nil {
-		klog.Errorf("reconcileLoadBalancer: failed to reconcile shared load balancer: %w", err)
+		klog.Errorf("reconcileLoadBalancer: failed to reconcile shared load balancer: %v", err)
 		return nil, err
 	}
 

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -3296,7 +3296,7 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 	az := GetTestCloud(ctrl)
 
 	err := az.InitializeCloudFromConfig(nil, false)
-	assert.NoError(t, err)
+	assert.Equal(t, fmt.Errorf("InitializeCloudFromConfig: cannot initialize from nil config"), err)
 
 	config := Config{
 		DisableAvailabilitySetNodes: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind feature

**What this PR does / why we need it**:

This PR enables reloading ccm from secret dynamically.
There are two ways to build a ccm: statically build from cloud-config file or dynamically build from secret.
To use the cloud-config file, set `--enable-dynamic-reloading=false` and `--cloud-config` to an non-empty value. To use the secret, set `--enable-dynamic-reloading=true`, `--cloud-config-secret-name`, `--cloud-config-secret-namespace` and `--cloud-config-key`. In this way, the ccm would be restarted every time a change is made to the secret.

Works to do:
- [ ] update the doc

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #604

**Special notes for your reviewer**:


**Release note**:
```
feat: support reloading cloud controller manager from secret dynamically
```
