### PR TITLE
fix: reduce crp throttling in attach disk scenario

### DIFF
--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -440,7 +440,7 @@ func (c *controllerCommon) GetDiskLun(diskName, diskURI string, nodeName types.N
 // SetDiskLun find unused luns and allocate lun for every disk in diskMap.
 // Return lun of diskURI, -1 if all luns are used.
 func (c *controllerCommon) SetDiskLun(nodeName types.NodeName, diskURI string, diskMap map[string]*AttachDiskOptions) (int32, error) {
-	disks, _, err := c.getNodeDataDisks(nodeName, azcache.CacheReadTypeForceRefresh)
+	disks, _, err := c.getNodeDataDisks(nodeName, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("error of getting data disks for node %q: %v", nodeName, err)
 		return -1, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: reduce crp throttling in attach disk scenario
original `CacheReadTypeForceRefresh` is not necessary since once attach/detach completed, cache is already cleaned, this operation could clean cache for every disk attach, finally cause crp throttling, e.g.
```
I0508 05:26:08.763336       1 utils.go:95] GRPC call: /csi.v1.Controller/ControllerPublishVolume
I0508 05:26:08.763360       1 utils.go:96] GRPC request: {"node_id":"aks-agentpool-15002531-vmss000000","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}},"volume_context":{"skuname":"StandardSSD_LRS","storage.kubernetes.io/csiProvisionerIdentity":"1620324123891-8081-disk.csi.azure.com"},"volume_id":"/subscriptions/xxx/resourceGroups/aks55h93-nodegroup/providers/Microsoft.Compute/disks/pvc-f0dfbac9-6737-4462-98ff-1d8d793a0021"}
E0508 05:26:08.782792       1 azure_vmss.go:700] VirtualMachineScaleSetVMsClient.List failed: &{true 0 2021-05-08 05:29:59.777620028 +0000 UTC m=+1787.759114644 azure cloud provider throttled for operation VMSSVMList with reason "client throttled"}
E0508 05:26:08.782826       1 azure_controller_common.go:445] error of getting data disks for node "aks-agentpool-15002531-vmss00000n": Retriable: true, RetryAfter: 230s, HTTPStatusCode: 0, RawError: azure cloud provider throttled for operation VMSSVMList with reason "client throttled"
E0508 05:26:08.782842       1 controllerserver.go:463] Attach volume "/subscriptions/xxx/resourceGroups/aks55h93-nodegroup/providers/Microsoft.Compute/disks/pvc-d48cabdc-9985-411a-a31d-769d19fd7595" to instance "aks-agentpool-15002531-vmss00000n" failed with Retriable: true, RetryAfter: 230s, HTTPStatusCode: 0, RawError: azure cloud provider throttled for operation VMSSVMList with reason "client throttled"
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
fix: reduce crp throttling in attach disk scenario
```
