### PR TITLE
fix: delete non existing disk issue

### DIFF
--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -19,9 +19,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -35,6 +37,8 @@ import (
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
+
+const expectedDiskProvisionSeconds = 3 // seconds
 
 //ManagedDiskController : managed disk controller struct
 type ManagedDiskController struct {
@@ -71,6 +75,8 @@ type ManagedDiskOptions struct {
 	MaxShares int32
 	// Logical sector size in bytes for Ultra disks
 	LogicalSectorSize int32
+	// SkipGetDiskOperation indicates whether skip GetDisk operation(mainly due to throttling)
+	SkipGetDiskOperation bool
 }
 
 //CreateManagedDisk : create managed disk
@@ -186,36 +192,45 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 		options.ResourceGroup = c.common.resourceGroup
 	}
 
+	cloud := c.common.cloud
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
-	rerr := c.common.cloud.DisksClient.CreateOrUpdate(ctx, options.ResourceGroup, options.DiskName, model)
+	rerr := cloud.DisksClient.CreateOrUpdate(ctx, options.ResourceGroup, options.DiskName, model)
 	if rerr != nil {
 		return "", rerr.Error()
 	}
 
-	diskID := ""
+	diskID := fmt.Sprintf(managedDiskPath, cloud.subscriptionID, options.ResourceGroup, options.DiskName)
 
-	err = kwait.ExponentialBackoff(defaultBackOff, func() (bool, error) {
-		provisionState, id, err := c.GetDisk(options.ResourceGroup, options.DiskName)
-		diskID = id
-		// We are waiting for provisioningState==Succeeded
-		// We don't want to hand-off managed disks to k8s while they are
-		//still being provisioned, this is to avoid some race conditions
-		if err != nil {
-			return false, err
-		}
-		if strings.ToLower(provisionState) == "succeeded" {
-			return true, nil
-		}
-		return false, nil
-	})
-
-	if err != nil {
-		klog.V(2).Infof("azureDisk - created new MD Name:%s StorageAccountType:%s Size:%v but was unable to confirm provisioningState in poll process", options.DiskName, options.StorageAccountType, options.SizeGB)
+	if options.SkipGetDiskOperation {
+		klog.Warningf("azureDisk - GetDisk(%s, StorageAccountType:%s) is throttled, wait 3s for disk provisioning complete", options.DiskName, options.StorageAccountType)
+		time.Sleep(expectedDiskProvisionSeconds * time.Second)
 	} else {
-		klog.V(2).Infof("azureDisk - created new MD Name:%s StorageAccountType:%s Size:%v", options.DiskName, options.StorageAccountType, options.SizeGB)
+		err = kwait.ExponentialBackoff(defaultBackOff, func() (bool, error) {
+			provisionState, id, err := c.GetDisk(options.ResourceGroup, options.DiskName)
+			if err == nil {
+				if id != "" {
+					diskID = id
+				}
+			} else {
+				// We are waiting for provisioningState==Succeeded
+				// We don't want to hand-off managed disks to k8s while they are
+				//still being provisioned, this is to avoid some race conditions
+				return false, err
+			}
+			if strings.ToLower(provisionState) == "succeeded" {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err != nil {
+			klog.Warningf("azureDisk - created new MD Name:%s StorageAccountType:%s Size:%v but was unable to confirm provisioningState in poll process, wait 3s for disk provisioning complete", options.DiskName, options.StorageAccountType, options.SizeGB)
+			time.Sleep(expectedDiskProvisionSeconds * time.Second)
+		}
 	}
 
+	klog.V(2).Infof("azureDisk - created new MD Name:%s StorageAccountType:%s Size:%v", options.DiskName, options.StorageAccountType, options.SizeGB)
 	return diskID, nil
 }
 
@@ -236,6 +251,10 @@ func (c *ManagedDiskController) DeleteManagedDisk(diskURI string) error {
 
 	disk, rerr := c.common.cloud.DisksClient.Get(ctx, resourceGroup, diskName)
 	if rerr != nil {
+		if rerr.HTTPStatusCode == http.StatusNotFound {
+			klog.V(2).Infof("azureDisk - disk(%s) is already deleted", diskURI)
+			return nil
+		}
 		return rerr.Error()
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: delete non existing disk issue
 - delete non existing disk should return success
 - if `GetDisk` is throttled, should  wait 3s for disk creation complete(3s is the common time cost of creating a disk)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
I0510 01:40:12.833561       1 utils.go:95] GRPC call: /csi.v1.Controller/DeleteVolume
I0510 01:40:12.833580       1 utils.go:96] GRPC request: {"volume_id":"/subscriptions/xxx/resourceGroups/aks55h93-nodegroup/providers/Microsoft.Compute/disks/pvc-66e17d3e-efc2-4758-9582-1b0728dfe3c1"}
I0510 01:40:12.833646       1 controllerserver.go:376] deleting azure disk(/subscriptions/xxx/resourceGroups/aks55h93-nodegroup/providers/Microsoft.Compute/disks/pvc-66e17d3e-efc2-4758-9582-1b0728dfe3c1)
I0510 01:40:12.871068       1 azure_diskclient.go:135] Received error in disk.get.request: resourceID: /subscriptions/xxx/resourceGroups/aks55h93-nodegroup/providers/Microsoft.Compute/disks/pvc-66e17d3e-efc2-4758-9582-1b0728dfe3c1, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: {"error":{"code":"ResourceNotFound","message":"The Resource 'Microsoft.Compute/disks/pvc-66e17d3e-efc2-4758-9582-1b0728dfe3c1' under resource group 'aks55h93-nodegroup' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}}
```

**Release note**:
```
fix: delete non existing disk issue
```
