### PR TITLE
fix: no sleep when GetDisk is throttled

### DIFF
--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -37,8 +36,6 @@ import (
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
-
-const expectedDiskProvisionSeconds = 3 // seconds
 
 //ManagedDiskController : managed disk controller struct
 type ManagedDiskController struct {
@@ -203,8 +200,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	diskID := fmt.Sprintf(managedDiskPath, cloud.subscriptionID, options.ResourceGroup, options.DiskName)
 
 	if options.SkipGetDiskOperation {
-		klog.Warningf("azureDisk - GetDisk(%s, StorageAccountType:%s) is throttled, wait 3s for disk provisioning complete", options.DiskName, options.StorageAccountType)
-		time.Sleep(expectedDiskProvisionSeconds * time.Second)
+		klog.Warningf("azureDisk - GetDisk(%s, StorageAccountType:%s) is throttled, unable to confirm provisioningState in poll process", options.DiskName, options.StorageAccountType)
 	} else {
 		err = kwait.ExponentialBackoff(defaultBackOff, func() (bool, error) {
 			provisionState, id, err := c.GetDisk(options.ResourceGroup, options.DiskName)
@@ -225,8 +221,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 		})
 
 		if err != nil {
-			klog.Warningf("azureDisk - created new MD Name:%s StorageAccountType:%s Size:%v but was unable to confirm provisioningState in poll process, wait 3s for disk provisioning complete", options.DiskName, options.StorageAccountType, options.SizeGB)
-			time.Sleep(expectedDiskProvisionSeconds * time.Second)
+			klog.Warningf("azureDisk - created new MD Name:%s StorageAccountType:%s Size:%v but was unable to confirm provisioningState in poll process", options.DiskName, options.StorageAccountType, options.SizeGB)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
fix: no sleep when GetDisk is throttled
it's not necessary to sleep 3s when GetDisk is throttled since `DisksClient.CreateOrUpdate` already returned, which means disk is actually created.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
fix: no sleep when GetDisk is throttled
```
