### PR TITLE
Do not set cached Sku when updating VMSS and VMSS instances

### DIFF
--- a/hack/deploy-cluster.sh
+++ b/hack/deploy-cluster.sh
@@ -17,28 +17,19 @@
 set -e
 
 REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
-RESOURCE_GROUP_NAME=${RESOURCE_GROUP_NAME:-""}
-LOCATION=${K8S_AZURE_LOCATION-""}
 
-#Check for variables is initialized or not
-SUBSCRIPTION_ID=${K8S_AZURE_SUBSID:-""}
-CLIENT_ID=${K8S_AZURE_SPID:-""}
-CLIENT_SECRET=${K8S_AZURE_SPSEC:-""}
-TENANT_ID=${K8S_AZURE_TENANTID:-""}
-USE_CSI_DEFAULT_STORAGECLASS=${USE_CSI_DEFAULT_STORAGECLASS:-""}
-ENABLE_AVAILABILITY_ZONE=${ENABLE_AVAILABILITY_ZONE:-""}
-
-# Check for variables is initialized or not
-if [ -z "${LOCATION}" ] || [ -z "${SUBSCRIPTION_ID}" ] || [ -z "${CLIENT_ID}" ] || [ -z "${CLIENT_SECRET}" ] || [ -z "${TENANT_ID}" ] || [ -z "${USE_CSI_DEFAULT_STORAGECLASS}" ] || [ -z "${K8S_RELEASE_VERSION}" ] || [ -z "${CCM_IMAGE}" ] || [ -z "${CNM_IMAGE}" ]; then
-  echo "SUBSCRIPTION_ID, CLIENT_ID, TENANT_ID, CLIENT_SECRET ,LOCATION, USE_CSI_DEFAULT_STORAGECLASS, K8S_RELEASE_VERSION, CCM_IMAGE and CNM_IMAGE must be specified"
-  exit 1
-fi
-
-if [ "${RESOURCE_GROUP_NAME}" = "" ]
-then
-echo "RESOURCE GROUP NAME must be specified"
-exit 1
-fi
+# Verify the required Environment Variables are present.
+: "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
+: "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
+: "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
+: "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+: "${AZURE_LOCATION:?Environment variable empty or not defined.}"
+: "${USE_CSI_DEFAULT_STORAGECLASS:?Environment variable empty or not defined.}"
+: "${K8S_RELEASE_VERSION:?Environment variable empty or not defined.}"
+: "${AZURE_LOCATION:?Environment variable empty or not defined.}"
+: "${CCM_IMAGE:?Environment variable empty or not defined.}"
+: "${CNM_IMAGE:?Environment variable empty or not defined.}"
+: "${RESOURCE_GROUP_NAME:?Environment variable empty or not defined.}"
 
 # Check for commands which would be used in following steps.
 if ! [ -x "$(command -v jq)" ]; then
@@ -64,7 +55,7 @@ function cleanup() {
 trap cleanup EXIT
 
 base_manifest=${REPO_ROOT}/examples/aks-engine.json
-if [ ! -z "${ENABLE_AVAILABILITY_ZONE}" ]; then
+if [ ! -z "${ENABLE_AVAILABILITY_ZONE:-}" ]; then
     base_manifest=${REPO_ROOT}/examples/az.json
 fi
 

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1026,7 +1026,6 @@ func (ss *ScaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeNam
 		})
 	primaryIPConfiguration.LoadBalancerBackendAddressPools = &newBackendPools
 	newVM := &compute.VirtualMachineScaleSetVM{
-		Sku:      vm.Sku,
 		Location: vm.Location,
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 			HardwareProfile: vm.HardwareProfile,
@@ -1168,7 +1167,6 @@ func (ss *ScaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 			})
 		primaryIPConfig.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
 		newVMSS := compute.VirtualMachineScaleSet{
-			Sku:      vmss.Sku,
 			Location: vmss.Location,
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
@@ -1351,7 +1349,6 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromNode(nodeName, backendPoolID str
 	// Compose a new vmssVM with added backendPoolID.
 	primaryIPConfiguration.LoadBalancerBackendAddressPools = &newBackendPools
 	newVM := &compute.VirtualMachineScaleSetVM{
-		Sku:      vm.Sku,
 		Location: vm.Location,
 		VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 			HardwareProfile: vm.HardwareProfile,
@@ -1638,7 +1635,6 @@ func (ss *ScaleSet) EnsureBackendPoolDeletedFromVMSets(vmssNamesMap map[string]b
 			// Compose a new vmss with added backendPoolID.
 			primaryIPConfig.LoadBalancerBackendAddressPools = &newBackendPools
 			newVMSS := compute.VirtualMachineScaleSet{
-				Sku:      vmss.Sku,
 				Location: vmss.Location,
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 					VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -1769,7 +1769,6 @@ func TestEnsureHostInPool(t *testing.T) {
 			expectedVMSSName:          testVMSSName,
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &compute.VirtualMachineScaleSetVM{
-				Sku:      &compute.Sku{Name: to.StringPtr("sku")},
 				Location: to.StringPtr("westus"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
@@ -2166,7 +2165,6 @@ func TestEnsureBackendPoolDeletedFromNode(t *testing.T) {
 			expectedVMSSName:          testVMSSName,
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &compute.VirtualMachineScaleSetVM{
-				Sku:      &compute.Sku{Name: to.StringPtr("sku")},
 				Location: to.StringPtr("westus"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{

--- a/site/content/en/development/e2e/e2e-tests-azure.md
+++ b/site/content/en/development/e2e/e2e-tests-azure.md
@@ -19,13 +19,13 @@ Refer step 1-3 in [e2e-tests](../e2e-tests) for deploying the Kubernetes cluster
 ### Setup Azure credentials
 
 ```sh
-export K8S_AZURE_TENANTID=<tenant-id>               # the tenant ID
-export K8S_AZURE_SUBSID=<subscription-id>           # the subscription ID
-export K8S_AZURE_SPID=<service-principal-id>        # the service principal ID
-export K8S_AZURE_SPSEC=<service-principal-secret>   # the service principal secret
-export K8S_AZURE_ENVIRONMENT=<AzurePublicCloud>     # the cloud environment (optional, default is AzurePublicCloud)
-export K8S_AZURE_LOCATION=<location>                # the location
-export K8S_AZURE_LOADBALANCE_SKU=<loadbalancer-sku> # the sku of load balancer (optional, default is basic)
+export AZURE_TENANT_ID=<tenant-id>               # the tenant ID
+export AZURE_SUBSCRIPTION_ID=<subscription-id>           # the subscription ID
+export AZURE_CLIENT_ID=<service-principal-id>        # the service principal ID
+export AZURE_CLIENT_SECRET=<service-principal-secret>   # the service principal secret
+export AZURE_ENVIRONMENT=<AzurePublicCloud>     # the cloud environment (optional, default is AzurePublicCloud)
+export AZURE_LOCATION=<location>                # the location
+export AZURE_LOADBALANCER_SKU=<loadbalancer-sku> # the sku of load balancer (optional, default is basic)
 ```
 
 ### Setup KUBECONFIG

--- a/site/content/en/development/e2e/e2e-tests.md
+++ b/site/content/en/development/e2e/e2e-tests.md
@@ -73,11 +73,11 @@ description: >
 
     ```sh
     export RESOURCE_GROUP_NAME=<resource group name>
-    export K8S_AZURE_LOCATION=<location>
-    export K8S_AZURE_SUBSID=<subscription ID>
-    export K8S_AZURE_SPID=<client id>
-    export K8S_AZURE_SPSEC=<client secret>
-    export K8S_AZURE_TENANTID=<tenant id>
+    export AZURE_LOCATION=<location>
+    export AZURE_SUBSCRIPTION_ID=<subscription ID>
+    export AZURE_CLIENT_ID=<client id>
+    export AZURE_CLIENT_SECRET=<client secret>
+    export AZURE_TENANT_ID=<tenant id>
     export USE_CSI_DEFAULT_STORAGECLASS=<true/false>
     export K8S_RELEASE_VERSION=<k8s release version>
     export CCM_IMAGE=<image of the cloud controller manager>

--- a/tests/e2e/job/test_in_cluster_job.yaml
+++ b/tests/e2e/job/test_in_cluster_job.yaml
@@ -13,27 +13,27 @@ spec:
           image: docker.pkg.github.com/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-e2e:latest
           command: ["/bin/bash", "tests/e2e/job/run.sh"]
           env:
-            - name: K8S_AZURE_TENANTID
+            - name: AZURE_TENANT_ID
               valueFrom:
                 secretKeyRef:
                   name: envs
                   key: tenantID
-            - name: K8S_AZURE_SUBSID
+            - name: AZURE_SUBSCRIPTION_ID
               valueFrom:
                 secretKeyRef:
                   name: envs
                   key: subscription
-            - name: K8S_AZURE_SPID
+            - name: AZURE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: envs
                   key: clientID
-            - name: K8S_AZURE_SPSEC
+            - name: AZURE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: envs
                   key: clientSecret
-            - name: K8S_AZURE_LOCATION
+            - name: AZURE_LOCATION
               valueFrom:
                 secretKeyRef:
                   name: envs

--- a/tests/e2e/utils/azure_auth.go
+++ b/tests/e2e/utils/azure_auth.go
@@ -32,13 +32,13 @@ import (
 
 // Environmental variables for validating Azure resource status.
 const (
-	TenantIDEnv               = "K8S_AZURE_TENANTID"
-	SubscriptionEnv           = "K8S_AZURE_SUBSID"
-	ServicePrincipleIDEnv     = "K8S_AZURE_SPID"
-	ServicePrincipleSecretEnv = "K8S_AZURE_SPSEC" // #nosec G101
-	ClusterLocationEnv        = "K8S_AZURE_LOCATION"
-	ClusterEnvironment        = "K8S_AZURE_ENVIRONMENT"
-	LoadBalancerSkuEnv        = "K8S_AZURE_LOADBALANCE_SKU"
+	TenantIDEnv               = "AZURE_TENANT_ID"
+	SubscriptionEnv           = "AZURE_SUBSCRIPTION_ID"
+	ServicePrincipleIDEnv     = "AZURE_CLIENT_ID"
+	ServicePrincipleSecretEnv = "AZURE_CLIENT_SECRET" // #nosec G101
+	ClusterLocationEnv        = "AZURE_LOCATION"
+	ClusterEnvironment        = "AZURE_ENVIRONMENT"
+	LoadBalancerSkuEnv        = "AZURE_LOADBALANCER_SKU"
 )
 
 // AzureAuthConfig holds auth related part of cloud config

--- a/tests/kubemark/build-kubemark.sh
+++ b/tests/kubemark/build-kubemark.sh
@@ -116,9 +116,9 @@ fi
 
 # read azure credentials
 echo "reading azure credentials from environment variables"
-ClientID="${K8S_AZURE_SPID}"
-ClientSecret="${K8S_AZURE_SPSEC}"
-TenantID="${K8S_AZURE_TENANTID}"
+ClientID="${AZURE_CLIENT_ID}"
+ClientSecret="${AZURE_CLIENT_SECRET}"
+TenantID="${AZURE_TENANT_ID}"
 
 echo "logging in to azure"
 az login --service-principal --username "${ClientID}" --password "${ClientSecret}" --tenant "${TenantID}" > /dev/null


### PR DESCRIPTION
cherry-pick https://github.com/kubernetes-sigs/cloud-provider-azure/pull/630 to release-0.7.


**Release note**:
```
Do not set cached Sku when updating VMSS and VMSS instances
```
