### PR TITLE
fix: remove --service-account-issuer from api model

### DIFF
--- a/tests/k8s-azure/manifest/linux-dual-stack-iptables-kubenet.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-iptables-kubenet.json
@@ -16,8 +16,7 @@
                 "kubeProxyMode": "iptables",
                 "networkPlugin": "kubenet",
                 "apiServerConfig": {
-                    "--feature-gates": "IPv6DualStack=true",
-                    "--service-account-issuer": "https://kubernetes.default.svc.cluster.local"
+                    "--feature-gates": "IPv6DualStack=true"
                 },
                 "kubeletConfig": {
                     "--feature-gates": "IPv6DualStack=true",

--- a/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet.json
@@ -16,8 +16,7 @@
                 "kubeProxyMode": "ipvs",
                 "networkPlugin": "kubenet",
                 "apiServerConfig": {
-                    "--feature-gates": "IPv6DualStack=true",
-                    "--service-account-issuer": "https://kubernetes.default.svc.cluster.local"
+                    "--feature-gates": "IPv6DualStack=true"
                 },
                 "kubeletConfig": {
                     "--feature-gates": "IPv6DualStack=true",

--- a/tests/k8s-azure/manifest/linux-ipv6.json
+++ b/tests/k8s-azure/manifest/linux-ipv6.json
@@ -12,8 +12,7 @@
                 "excludeMasterFromStandardLB": true,
                 "networkPlugin": "kubenet",
                 "apiServerConfig": {
-                    "--bind-address": "::",
-                    "--service-account-issuer": "https://kubernetes.default.svc.cluster.local"
+                    "--bind-address": "::"
                 },
                 "kubeletConfig": {
                     "--node-ip": "::",


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind failing-test

**What this PR does / why we need it**:
aks-engine sets the `--service-account-issuer` flag by default for 1.20+ (as it's mandatory). For 1.19 this isn't required and setting just the `--service-account-issuer` flag without the `--service-account-signing-key-file` for older k8s versions results in an error. Removing the explicit `--service-account-issuer` key from the api model to fallback on aks-engine defaulting.

```bash
Error: --service-account-signing-key-file, --service-account-issuer, and --api-audiences should be specified together
```

Fixes dual-stack 1.19 tests.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```
