### PR TITLE
Add ability to reconcile Nodes from a single CNM replica

### DIFF
--- a/cmd/cloud-node-manager/app/options/options.go
+++ b/cmd/cloud-node-manager/app/options/options.go
@@ -57,6 +57,8 @@ const (
 	CloudControllerManagerPort = 10263
 	// defaultNodeStatusUpdateFrequencyInMinute is the default frequency at which the manager updates nodes' status.
 	defaultNodeStatusUpdateFrequencyInMinute = 5
+	// defaultNodeName is the default option for --node-name flag, which will result in usage of os.Hostname() output value
+	defaultNodeName = "hostname"
 )
 
 // CloudNodeManagerOptions is the main context object for the controller manager.
@@ -123,7 +125,7 @@ func (o *CloudNodeManagerOptions) Flags() cliflag.NamedFlagSets {
 	fs := fss.FlagSet("misc")
 	fs.StringVar(&o.Master, "master", o.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-	fs.StringVar(&o.NodeName, "node-name", o.NodeName, "Name of the Node (default is hostname).")
+	fs.StringVar(&o.NodeName, "node-name", defaultNodeName, "Name of the Node. If omitted, defaults to VM hostname. Setting it to emply value disables requirement for running it from inside VM.")
 	fs.DurationVar(&o.NodeStatusUpdateFrequency.Duration, "node-status-update-frequency", o.NodeStatusUpdateFrequency.Duration, "Specifies how often the controller updates nodes' status.")
 	fs.DurationVar(&o.MinResyncPeriod.Duration, "min-resync-period", o.MinResyncPeriod.Duration, "The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod.")
 	fs.StringVar(&o.ClientConnection.ContentType, "kube-api-content-type", o.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
@@ -184,7 +186,7 @@ func (o *CloudNodeManagerOptions) ApplyTo(c *cloudnodeconfig.Config, userAgent s
 
 	// Default NodeName is hostname.
 	c.NodeName = strings.ToLower(o.NodeName)
-	if c.NodeName == "" {
+	if c.NodeName == defaultNodeName {
 		hostname, err := os.Hostname()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind api-change


**What this PR does / why we need it**:

This PR allows to serve multiple `Node` initialization from single `CNM` replica running outside of Nodes VM network. This is required to match the pattern in-tree CCM for Azure are doing, and simplifies migration process.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
Change of the --node-name behavior. If omitted, defaults to VM hostname. Setting it to emply value disables requirement for running it from inside the VM. Example Azure out-of-tree CCM is populating the value from "spec.nodeName" of the Pod.
```
