### PR TITLE
chore: add resource param into GetServicePrincipalToken

### DIFF
--- a/pkg/auth/azure_auth.go
+++ b/pkg/auth/azure_auth.go
@@ -80,12 +80,16 @@ type AzureAuthConfig struct {
 // If NetworkResourceTenantID and NetworkResourceSubscriptionID are specified to have different values than TenantID and SubscriptionID, network resources are deployed in different AAD Tenant and Subscription than those for the cluster,
 // than only azure clients except VM/VMSS and network resource ones use this method to fetch Token.
 // For tokens for VM/VMSS and network resource ones, please check GetMultiTenantServicePrincipalToken and GetNetworkResourceServicePrincipalToken.
-func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (*adal.ServicePrincipalToken, error) {
+func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment, resource string) (*adal.ServicePrincipalToken, error) {
 	var tenantID string
 	if strings.EqualFold(config.IdentitySystem, consts.ADFSIdentitySystem) {
 		tenantID = consts.ADFSIdentitySystem
 	} else {
 		tenantID = config.TenantID
+	}
+
+	if resource == "" {
+		resource = env.ServiceManagementEndpoint
 	}
 
 	if config.UseManagedIdentityExtension {
@@ -97,13 +101,13 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (
 		if len(config.UserAssignedIdentityID) > 0 {
 			klog.V(4).Info("azure: using User Assigned MSI ID to retrieve access token")
 			return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint,
-				env.ServiceManagementEndpoint,
+				resource,
 				config.UserAssignedIdentityID)
 		}
 		klog.V(4).Info("azure: using System Assigned MSI to retrieve access token")
 		return adal.NewServicePrincipalTokenFromMSI(
 			msiEndpoint,
-			env.ServiceManagementEndpoint)
+			resource)
 	}
 
 	oauthConfig, err := adal.NewOAuthConfigWithAPIVersion(env.ActiveDirectoryEndpoint, tenantID, nil)
@@ -117,7 +121,7 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (
 			*oauthConfig,
 			config.AADClientID,
 			config.AADClientSecret,
-			env.ServiceManagementEndpoint)
+			resource)
 	}
 
 	if len(config.AADClientCertPath) > 0 && len(config.AADClientCertPassword) > 0 {
@@ -135,7 +139,7 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (
 			config.AADClientID,
 			certificate,
 			privateKey,
-			env.ServiceManagementEndpoint)
+			resource)
 	}
 
 	return nil, ErrorNoAuth

--- a/pkg/auth/azure_auth_test.go
+++ b/pkg/auth/azure_auth_test.go
@@ -71,7 +71,7 @@ func TestGetServicePrincipalTokenFromMSIWithUserAssignedID(t *testing.T) {
 	env := &azure.PublicCloud
 
 	for _, config := range configs {
-		token, err := GetServicePrincipalToken(config, env)
+		token, err := GetServicePrincipalToken(config, env, "")
 		assert.NoError(t, err)
 
 		msiEndpoint, err := adal.GetMSIVMEndpoint()
@@ -101,7 +101,7 @@ func TestGetServicePrincipalTokenFromMSI(t *testing.T) {
 	env := &azure.PublicCloud
 
 	for _, config := range configs {
-		token, err := GetServicePrincipalToken(config, env)
+		token, err := GetServicePrincipalToken(config, env, "")
 		assert.NoError(t, err)
 
 		msiEndpoint, err := adal.GetMSIVMEndpoint()
@@ -122,7 +122,7 @@ func TestGetServicePrincipalToken(t *testing.T) {
 	}
 	env := &azure.PublicCloud
 
-	token, err := GetServicePrincipalToken(config, env)
+	token, err := GetServicePrincipalToken(config, env, "")
 	assert.NoError(t, err)
 
 	oauthConfig, err := adal.NewOAuthConfigWithAPIVersion(env.ActiveDirectoryEndpoint, config.TenantID, nil)

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -483,7 +483,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret, syncZones
 		return err
 	}
 
-	servicePrincipalToken, err := auth.GetServicePrincipalToken(&config.AzureAuthConfig, env)
+	servicePrincipalToken, err := auth.GetServicePrincipalToken(&config.AzureAuthConfig, env, env.ServiceManagementEndpoint)
 	if errors.Is(err, auth.ErrorNoAuth) {
 		// Only controller-manager would lazy-initialize from secret, and credentials are required for such case.
 		if fromSecret {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
chore: add resource param into GetServicePrincipalToken

CSI driver needs to change `resource` parameter as keyvault endpoint to read from keyvault, make `GetServicePrincipalToken` more generic.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
related to https://github.com/kubernetes-sigs/blob-csi-driver/pull/460

**Release note**:
```
none
```
