### PR TITLE
fix: detach disk panic on Azure Stack

### DIFF
--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -68,7 +68,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			nodeName:    "vm1",
 			diskName:    "disk-name",
 			existedDisk: nil,
-			expectedLun: 1,
+			expectedLun: 3,
 			expectedErr: false,
 		},
 		{
@@ -101,7 +101,7 @@ func TestCommonAttachDisk(t *testing.T) {
 					DiskState:  compute.Unattached,
 				},
 				Tags: testTags},
-			expectedLun: 1,
+			expectedLun: 3,
 			expectedErr: false,
 		},
 		{
@@ -372,7 +372,7 @@ func TestCommonUpdateVM(t *testing.T) {
 			desc:        "no error shall be returned if there's no matching disk according to given diskName",
 			vmList:      map[string]string{"vm1": "PowerState/Running"},
 			nodeName:    "vm1",
-			diskName:    "disk2",
+			diskName:    "diskx",
 			expectedErr: false,
 		},
 		{
@@ -428,7 +428,7 @@ func TestGetDiskLun(t *testing.T) {
 	}{
 		{
 			desc:        "LUN -1 and error shall be returned if diskName != disk.Name or diskURI != disk.Vhd.URI",
-			diskName:    "disk2",
+			diskName:    "diskx",
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -480,7 +480,7 @@ func TestSetDiskLun(t *testing.T) {
 			nodeName:    "nodeName",
 			diskURI:     "diskURI",
 			diskMap:     map[string]*AttachDiskOptions{"diskURI": {}},
-			expectedLun: 1,
+			expectedLun: 3,
 			expectedErr: false,
 		},
 		{
@@ -544,9 +544,9 @@ func TestDisksAreAttached(t *testing.T) {
 		},
 		{
 			desc:             "proper attach map shall be returned if everything is good",
-			diskNames:        []string{"disk1", "disk2"},
+			diskNames:        []string{"disk1", "diskx"},
 			nodeName:         "vm1",
-			expectedAttached: map[string]bool{"disk1": true, "disk2": false},
+			expectedAttached: map[string]bool{"disk1": true, "diskx": false},
 			expectedErr:      false,
 		},
 	}

--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -158,11 +158,7 @@ func (as *availabilitySet) DetachDisk(nodeName types.NodeName, diskMap map[strin
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-				if strings.EqualFold(as.cloud.Environment.Name, consts.AzureStackCloudName) && !as.Config.DisableAzureStackCloud {
-					disks = append(disks[:i], disks[i+1:]...)
-				} else {
-					disks[i].ToBeDetached = to.BoolPtr(true)
-				}
+				disks[i].ToBeDetached = to.BoolPtr(true)
 				bFoundDisk = true
 			}
 		}
@@ -171,6 +167,17 @@ func (as *availabilitySet) DetachDisk(nodeName types.NodeName, diskMap map[strin
 	if !bFoundDisk {
 		// only log here, next action is to update VM status with original meta data
 		klog.Errorf("detach azure disk on node(%s): disk list(%s) not found", nodeName, diskMap)
+	} else {
+		if strings.EqualFold(as.cloud.Environment.Name, consts.AzureStackCloudName) && !as.Config.DisableAzureStackCloud {
+			// Azure stack does not support ToBeDetached flag, use original way to detach disk
+			newDisks := []compute.DataDisk{}
+			for _, disk := range disks {
+				if !to.Bool(disk.ToBeDetached) {
+					newDisks = append(newDisks, disk)
+				}
+			}
+			disks = newDisks
+		}
 	}
 
 	newVM := compute.VirtualMachineUpdate{

--- a/pkg/provider/azure_controller_standard_test.go
+++ b/pkg/provider/azure_controller_standard_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -126,7 +127,7 @@ func TestStandardDetachDisk(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		nodeName      types.NodeName
-		diskName      string
+		disks         []string
 		isDetachFail  bool
 		expectedError bool
 	}{
@@ -138,13 +139,19 @@ func TestStandardDetachDisk(t *testing.T) {
 		{
 			desc:          "no error shall be returned if there's no corresponding disk",
 			nodeName:      "vm1",
-			diskName:      "disk2",
+			disks:         []string{"diskx"},
 			expectedError: false,
 		},
 		{
 			desc:          "no error shall be returned if there's a corresponding disk",
 			nodeName:      "vm1",
-			diskName:      "disk1",
+			disks:         []string{"disk1"},
+			expectedError: false,
+		},
+		{
+			desc:          "no error shall be returned if there's 2 corresponding disks",
+			nodeName:      "vm1",
+			disks:         []string{"disk1", "disk2"},
 			expectedError: false,
 		},
 		{
@@ -167,17 +174,20 @@ func TestStandardDetachDisk(t *testing.T) {
 		if test.isDetachFail {
 			mockVMsClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(&retry.Error{HTTPStatusCode: http.StatusNotFound, RawError: cloudprovider.InstanceNotFound}).AnyTimes()
 		} else {
-			mockVMsClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockVMsClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, "vm1", gomock.Any(), "detach_disk").Return(nil).AnyTimes()
 		}
 
-		diskMap := map[string]string{
-			"uri": test.diskName,
+		diskMap := map[string]string{}
+		for _, diskName := range test.disks {
+			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
+				testCloud.SubscriptionID, testCloud.ResourceGroup, diskName)
+			diskMap[diskURI] = diskName
 		}
 		err := vmSet.DetachDisk(test.nodeName, diskMap)
 		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
-		if !test.expectedError && test.diskName != "" {
+		if !test.expectedError && len(test.disks) > 0 {
 			dataDisks, _, err := vmSet.GetDataDisks(test.nodeName, azcache.CacheReadTypeDefault)
-			assert.Equal(t, true, len(dataDisks) == 1, "TestCase[%d]: %s, err: %v", i, test.desc, err)
+			assert.Equal(t, true, len(dataDisks) == 3, "TestCase[%d]: %s, err: %v", i, test.desc, err)
 		}
 	}
 }
@@ -237,7 +247,7 @@ func TestStandardUpdateVM(t *testing.T) {
 		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
 		if !test.expectedError && test.diskName != "" {
 			dataDisks, _, err := vmSet.GetDataDisks(test.nodeName, azcache.CacheReadTypeDefault)
-			assert.Equal(t, true, len(dataDisks) == 1, "TestCase[%d]: %s, err: %v", i, test.desc, err)
+			assert.Equal(t, true, len(dataDisks) == 3, "TestCase[%d]: %s, err: %v", i, test.desc, err)
 		}
 	}
 }

--- a/pkg/provider/azure_controller_standard_test.go
+++ b/pkg/provider/azure_controller_standard_test.go
@@ -279,6 +279,14 @@ func TestGetDataDisks(t *testing.T) {
 					Lun:  to.Int32Ptr(0),
 					Name: to.StringPtr("disk1"),
 				},
+				{
+					Lun:  to.Int32Ptr(1),
+					Name: to.StringPtr("disk2"),
+				},
+				{
+					Lun:  to.Int32Ptr(2),
+					Name: to.StringPtr("disk3"),
+				},
 			},
 			expectedError: false,
 			crt:           azcache.CacheReadTypeDefault,
@@ -290,6 +298,14 @@ func TestGetDataDisks(t *testing.T) {
 				{
 					Lun:  to.Int32Ptr(0),
 					Name: to.StringPtr("disk1"),
+				},
+				{
+					Lun:  to.Int32Ptr(1),
+					Name: to.StringPtr("disk2"),
+				},
+				{
+					Lun:  to.Int32Ptr(2),
+					Name: to.StringPtr("disk3"),
 				},
 			},
 			expectedError: false,

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -162,11 +162,7 @@ func (ss *ScaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]strin
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-				if strings.EqualFold(ss.cloud.Environment.Name, consts.AzureStackCloudName) && !ss.Config.DisableAzureStackCloud {
-					disks = append(disks[:i], disks[i+1:]...)
-				} else {
-					disks[i].ToBeDetached = to.BoolPtr(true)
-				}
+				disks[i].ToBeDetached = to.BoolPtr(true)
 				bFoundDisk = true
 			}
 		}
@@ -175,6 +171,17 @@ func (ss *ScaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]strin
 	if !bFoundDisk {
 		// only log here, next action is to update VM status with original meta data
 		klog.Errorf("detach azure disk on node(%s): disk list(%s) not found", nodeName, diskMap)
+	} else {
+		if strings.EqualFold(ss.cloud.Environment.Name, consts.AzureStackCloudName) && !ss.Config.DisableAzureStackCloud {
+			// Azure stack does not support ToBeDetached flag, use original way to detach disk
+			newDisks := []compute.DataDisk{}
+			for _, disk := range disks {
+				if !to.Bool(disk.ToBeDetached) {
+					newDisks = append(newDisks, disk)
+				}
+			}
+			disks = newDisks
+		}
 	}
 
 	newVM := compute.VirtualMachineScaleSetVM{

--- a/pkg/provider/azure_controller_vmss_test.go
+++ b/pkg/provider/azure_controller_vmss_test.go
@@ -383,7 +383,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 
 		if !test.expectedErr {
 			dataDisks, _, err := ss.GetDataDisks(test.vmssvmName, azcache.CacheReadTypeDefault)
-			assert.Equal(t, true, len(dataDisks) == 3, "TestCase[%d]: %s, actual data disk num: %d, err: %v", i, test.desc, len(dataDisks), err)
+			assert.Equal(t, true, len(dataDisks) == 1, "TestCase[%d]: %s, actual data disk num: %d, err: %v", i, test.desc, len(dataDisks), err)
 		}
 	}
 }

--- a/pkg/provider/azure_controller_vmss_test.go
+++ b/pkg/provider/azure_controller_vmss_test.go
@@ -44,7 +44,7 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 		desc           string
 		vmssName       types.NodeName
 		vmssvmName     types.NodeName
-		existedDisk    compute.Disk
+		disks          []string
 		vmList         map[string]string
 		vmssVMList     []string
 		isManagedDisk  bool
@@ -57,17 +57,26 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 			vmssName:       "vm1",
 			vmssvmName:     "vm1",
 			isManagedDisk:  false,
-			existedDisk:    compute.Disk{Name: to.StringPtr("disk-name")},
+			disks:          []string{"disk-name"},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("not a vmss instance"),
 		},
 		{
-			desc:          "no error shall be returned if everything is good with managed disk",
+			desc:          "no error shall be returned if everything is good with one managed disk",
 			vmssVMList:    []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:      "vmss00",
 			vmssvmName:    "vmss00-vm-000000",
 			isManagedDisk: true,
-			existedDisk:   compute.Disk{Name: to.StringPtr("disk-name")},
+			disks:         []string{"disk-name"},
+			expectedErr:   false,
+		},
+		{
+			desc:          "no error shall be returned if everything is good with 2 managed disks",
+			vmssVMList:    []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
+			vmssName:      "vmss00",
+			vmssvmName:    "vmss00-vm-000000",
+			isManagedDisk: true,
+			disks:         []string{"disk-name", "disk-name2"},
 			expectedErr:   false,
 		},
 		{
@@ -76,7 +85,7 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 			vmssName:      "vmss00",
 			vmssvmName:    "vmss00-vm-000000",
 			isManagedDisk: false,
-			existedDisk:   compute.Disk{Name: to.StringPtr("disk-name")},
+			disks:         []string{"disk-name"},
 			expectedErr:   false,
 		},
 		{
@@ -85,7 +94,7 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 			vmssName:       fakeStatusNotFoundVMSSName,
 			vmssvmName:     "vmss00-vm-000000",
 			isManagedDisk:  false,
-			existedDisk:    compute.Disk{Name: to.StringPtr("disk-name")},
+			disks:          []string{"disk-name"},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: %w", fmt.Errorf("instance not found")),
 		},
@@ -126,19 +135,20 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 			mockVMSSVMClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, scaleSetName, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		}
 
-		diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
-			testCloud.SubscriptionID, testCloud.ResourceGroup, *test.existedDisk.Name)
+		diskMap := map[string]*AttachDiskOptions{}
+		for i, diskName := range test.disks {
+			options := AttachDiskOptions{
+				lun:                     int32(i),
+				isManagedDisk:           test.isManagedDisk,
+				diskName:                diskName,
+				cachingMode:             compute.CachingTypesReadWrite,
+				diskEncryptionSetID:     "",
+				writeAcceleratorEnabled: true,
+			}
 
-		options := AttachDiskOptions{
-			lun:                     0,
-			isManagedDisk:           test.isManagedDisk,
-			diskName:                "disk-name",
-			cachingMode:             compute.CachingTypesReadWrite,
-			diskEncryptionSetID:     "",
-			writeAcceleratorEnabled: true,
-		}
-		diskMap := map[string]*AttachDiskOptions{
-			diskURI: &options,
+			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
+				testCloud.SubscriptionID, testCloud.ResourceGroup, diskName)
+			diskMap[diskURI] = &options
 		}
 		err = ss.AttachDisk(test.vmssvmName, diskMap)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
@@ -160,7 +170,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 		vmssVMList     []string
 		vmssName       types.NodeName
 		vmssvmName     types.NodeName
-		existedDisk    compute.Disk
+		disks          []string
 		expectedErr    bool
 		expectedErrMsg error
 	}{
@@ -169,7 +179,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 			vmssVMList:     []string{"vmss-vm-000001"},
 			vmssName:       "vm1",
 			vmssvmName:     "vm1",
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
+			disks:          []string{diskName},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("not a vmss instance"),
 		},
@@ -178,7 +188,15 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 			vmssVMList:  []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:    "vmss00",
 			vmssvmName:  "vmss00-vm-000000",
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName)},
+			disks:       []string{diskName},
+			expectedErr: false,
+		},
+		{
+			desc:        "no error shall be returned if everything is good",
+			vmssVMList:  []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
+			vmssName:    "vmss00",
+			vmssvmName:  "vmss00-vm-000000",
+			disks:       []string{diskName, "disk2"},
 			expectedErr: false,
 		},
 		{
@@ -186,7 +204,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 			vmssVMList:     []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:       fakeStatusNotFoundVMSSName,
 			vmssvmName:     "vmss00-vm-000000",
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
+			disks:          []string{diskName},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: %w", fmt.Errorf("instance not found")),
 		},
@@ -195,7 +213,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 			vmssVMList:  []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:    "vmss00",
 			vmssvmName:  "vmss00-vm-000000",
-			existedDisk: compute.Disk{Name: to.StringPtr("disk-name-err")},
+			disks:       []string{"disk-name-err"},
 			expectedErr: false,
 		},
 	}
@@ -224,10 +242,20 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 						},
 					},
 				},
-				DataDisks: &[]compute.DataDisk{{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr(diskName),
-				}},
+				DataDisks: &[]compute.DataDisk{
+					{
+						Lun:  to.Int32Ptr(0),
+						Name: to.StringPtr(diskName),
+					},
+					{
+						Lun:  to.Int32Ptr(1),
+						Name: to.StringPtr("disk2"),
+					},
+					{
+						Lun:  to.Int32Ptr(2),
+						Name: to.StringPtr("disk3"),
+					},
+				},
 			}
 		}
 		mockVMSSVMClient := testCloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
@@ -238,8 +266,11 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 			mockVMSSVMClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, scaleSetName, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		}
 
-		diskMap := map[string]string{
-			diskName: *test.existedDisk.Name,
+		diskMap := map[string]string{}
+		for _, diskName := range test.disks {
+			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
+				testCloud.SubscriptionID, testCloud.ResourceGroup, diskName)
+			diskMap[diskURI] = diskName
 		}
 		err = ss.DetachDisk(test.vmssvmName, diskMap)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, err: %v", i, test.desc, err)
@@ -249,7 +280,7 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 
 		if !test.expectedErr {
 			dataDisks, _, err := ss.GetDataDisks(test.vmssvmName, azcache.CacheReadTypeDefault)
-			assert.Equal(t, true, len(dataDisks) == 1, "TestCase[%d]: %s, actual data disk num: %d, err: %v", i, test.desc, len(dataDisks), err)
+			assert.Equal(t, true, len(dataDisks) == 3, "TestCase[%d]: %s, actual data disk num: %d, err: %v", i, test.desc, len(dataDisks), err)
 		}
 	}
 }
@@ -352,7 +383,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 
 		if !test.expectedErr {
 			dataDisks, _, err := ss.GetDataDisks(test.vmssvmName, azcache.CacheReadTypeDefault)
-			assert.Equal(t, true, len(dataDisks) == 1, "TestCase[%d]: %s, actual data disk num: %d, err: %v", i, test.desc, len(dataDisks), err)
+			assert.Equal(t, true, len(dataDisks) == 3, "TestCase[%d]: %s, actual data disk num: %d, err: %v", i, test.desc, len(dataDisks), err)
 		}
 	}
 }

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -76,10 +76,20 @@ func setTestVirtualMachines(c *Cloud, vmList map[string]string, isDataDisksFull 
 			},
 		}
 		if !isDataDisksFull {
-			vm.StorageProfile.DataDisks = &[]compute.DataDisk{{
-				Lun:  to.Int32Ptr(0),
-				Name: to.StringPtr("disk1"),
-			}}
+			vm.StorageProfile.DataDisks = &[]compute.DataDisk{
+				{
+					Lun:  to.Int32Ptr(0),
+					Name: to.StringPtr("disk1"),
+				},
+				{
+					Lun:  to.Int32Ptr(1),
+					Name: to.StringPtr("disk2"),
+				},
+				{
+					Lun:  to.Int32Ptr(2),
+					Name: to.StringPtr("disk3"),
+				},
+			}
 		} else {
 			dataDisks := make([]compute.DataDisk, maxLUN)
 			for i := 0; i < maxLUN; i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: detach disk panic on Azure Stack

e2e tests already passes on https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/909

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #684

**Special notes for your reviewer**:


**Release note**:
```
fix: detach disk panic on Azure Stack
```
