### PR TITLE
chore: Call initDiskControllers() in GetTestCloud()

### DIFF
--- a/pkg/provider/azure_fakes.go
+++ b/pkg/provider/azure_fakes.go
@@ -104,9 +104,8 @@ func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 	az.nsgCache, _ = az.newNSGCache()
 	az.rtCache, _ = az.newRouteTableCache()
 
-	common := &controllerCommon{cloud: az, resourceGroup: "rg", location: "westus"}
-	az.controllerCommon = common
-	az.ManagedDiskController = &ManagedDiskController{common: common}
+	_ = initDiskControllers(az)
+
 	az.regionZonesMap = map[string][]string{az.Location: {"1", "2", "3"}}
 
 	return az


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind cleanup

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR changes the `GetTestCloud` function to call `initDiskControllers` instead of (incompletely) initializing the disk controllers directly. This way, the disk controller methods like `AttachDisk` and `DetachDisk` can be used in unit tests and mocked.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:


**Release note**:
```
`GetTestCloud` properly initializes the disk controller fields enabling them to be used in unit tests and mocked.
```
