### PR TITLE
chore: add make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,90 +59,95 @@ CCM_E2E_TEST_IMAGE=$(IMAGE_REGISTRY)/$(CCM_E2E_TEST_IMAGE_NAME):$(IMAGE_TAG)
 CCM_E2E_TEST_RELEASE_IMAGE=docker.pkg.github.com/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-e2e:$(IMAGE_TAG)
 
 
+##@ General
+
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[.a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
 ## --------------------------------------
-## Binaries
+##@ Binaries
 ## --------------------------------------
 
 .PHONY: all
-all: $(BIN_DIR)/azure-cloud-controller-manager $(BIN_DIR)/azure-cloud-node-manager $(BIN_DIR)/azure-cloud-node-manager.exe
+all: $(BIN_DIR)/azure-cloud-controller-manager $(BIN_DIR)/azure-cloud-node-manager $(BIN_DIR)/azure-cloud-node-manager.exe ## Build binaries for the project.
 
-$(BIN_DIR)/azure-cloud-node-manager: $(PKG_CONFIG) $(wildcard cmd/cloud-node-manager/*) $(wildcard cmd/cloud-node-manager/**/*) $(wildcard pkg/**/*)
-	CGO_ENABLED=0 GOOS=linux go build -a -o $@ $(PKG_CONFIG_CONTENT) ./cmd/cloud-node-manager
+$(BIN_DIR)/azure-cloud-node-manager: $(PKG_CONFIG) $(wildcard cmd/cloud-node-manager/*) $(wildcard cmd/cloud-node-manager/**/*) $(wildcard pkg/**/*) ## Build node-manager binary for Linux.
+	CGO_ENABLED=0 GOOS=linux go build -a -o $(BIN_DIR)/azure-cloud-node-manager $(PKG_CONFIG_CONTENT) ./cmd/cloud-node-manager
 
-$(BIN_DIR)/azure-cloud-node-manager.exe: $(PKG_CONFIG) $(wildcard cmd/cloud-node-manager/*) $(wildcard cmd/cloud-node-manager/**/*) $(wildcard pkg/**/*)
-	CGO_ENABLED=0 GOOS=windows go build -a -o $@ $(PKG_CONFIG_CONTENT) ./cmd/cloud-node-manager
+$(BIN_DIR)/azure-cloud-node-manager.exe: $(PKG_CONFIG) $(wildcard cmd/cloud-node-manager/*) $(wildcard cmd/cloud-node-manager/**/*) $(wildcard pkg/**/*) ## Build node-manager binary for Windows.
+	CGO_ENABLED=0 GOOS=windows go build -a -o $(BIN_DIR)/azure-cloud-node-manager.exe $(PKG_CONFIG_CONTENT) ./cmd/cloud-node-manager
 
-$(BIN_DIR)/azure-cloud-controller-manager: $(PKG_CONFIG) $(wildcard cmd/cloud-controller-manager/*) $(wildcard cmd/cloud-controller-manager/**/*) $(wildcard pkg/**/*)
-	CGO_ENABLED=0 GOOS=linux go build -a -o $@ $(PKG_CONFIG_CONTENT) ./cmd/cloud-controller-manager
+$(BIN_DIR)/azure-cloud-controller-manager: $(PKG_CONFIG) $(wildcard cmd/cloud-controller-manager/*) $(wildcard cmd/cloud-controller-manager/**/*) $(wildcard pkg/**/*) ## Build binary for controller-manager.
+	CGO_ENABLED=0 GOOS=linux go build -a -o $(BIN_DIR)/azure-cloud-controller-manager $(PKG_CONFIG_CONTENT) ./cmd/cloud-controller-manager
 
 ## --------------------------------------
-## Images
+##@ Images
 ## --------------------------------------
 
 .PHONY: docker-pull-prerequisites
-docker-pull-prerequisites:
+docker-pull-prerequisites: ## Pull prerequisite images.
 	docker pull docker/dockerfile:1.1-experimental
 	docker pull docker.io/library/golang:1.15.8-stretch
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: build-ccm-image
-build-ccm-image: docker-pull-prerequisites
+build-ccm-image: docker-pull-prerequisites ## Build controller-manager image.
 	DOCKER_BUILDKIT=1 docker build -t $(IMAGE) --build-arg ENABLE_GIT_COMMAND=$(ENABLE_GIT_COMMAND) .
 
 .PHONY: build-node-image
-build-node-image: docker-pull-prerequisites
+build-node-image: docker-pull-prerequisites ## Build node-manager image for Windows.
 	DOCKER_BUILDKIT=1 docker build -t $(NODE_MANAGER_IMAGE) -f cloud-node-manager.Dockerfile --build-arg ENABLE_GIT_COMMAND=$(ENABLE_GIT_COMMAND) .
 
 .PHONY: build-node-image-windows
-build-node-image-windows:
+build-node-image-windows: ## Build node-manager image for Windows.
 	go build -a -o $(BIN_DIR)/azure-cloud-node-manager.exe ./cmd/cloud-node-manager
 	docker build --platform windows/amd64 -t $(NODE_MANAGER_WINDOWS_IMAGE) -f cloud-node-manager-windows.Dockerfile .
 
 .PHONY: build-ccm-e2e-test-image
-build-ccm-e2e-test-image:
+build-ccm-e2e-test-image: ## Build e2e test image.
 	docker build -t $(CCM_E2E_TEST_IMAGE) -f ./e2e.Dockerfile .
 
 .PHONY: build-images
-build-images: build-ccm-image build-node-image
+build-images: build-ccm-image build-node-image ## Build all images.
 
 .PHONY: image
-image: build-ccm-image build-node-image
+image: build-ccm-image build-node-image ## Build all images.
 
 .PHONY: push-ccm-image
-push-ccm-image:
+push-ccm-image: ## Push controller-manager image.
 	docker push $(IMAGE)
 
 .PHONY: push-node-image
-push-node-image:
+push-node-image: ## Push node-manager image for Linux.
 	docker push $(NODE_MANAGER_IMAGE)
 
 .PHONY: push-node-image-windows
-push-node-image-windows:
+push-node-image-windows: ## Push node-manager image for Windows.
 	docker push $(NODE_MANAGER_WINDOWS_IMAGE)
 
 .PHONY: push
-push: push-ccm-image push-node-image
+push: push-ccm-image push-node-image ## Push all images.
 
 .PHONY: push-images
-push-images: push-ccm-image push-node-image
+push-images: push-ccm-image push-node-image ## Push all images.
 
 .PHONY: release-ccm-e2e-test-image
-release-ccm-e2e-test-image:
+release-ccm-e2e-test-image: ## Build and release e2e test image.
 	docker build -t $(CCM_E2E_TEST_RELEASE_IMAGE) -f ./e2e.Dockerfile .
 	docker push $(CCM_E2E_TEST_RELEASE_IMAGE)
 
-hyperkube:
+hyperkube:  ## Build hyperkube image.
 ifneq ($(K8S_BRANCH), )
 	$(eval K8S_VERSION=$(shell REGISTRY=$(IMAGE_REGISTRY) BRANCH=$(K8S_BRANCH) hack/build-hyperkube.sh))
 	$(eval HYPERKUBE_IMAGE=$(IMAGE_REGISTRY)/hyperkube-amd64:$(K8S_VERSION))
 endif
 
 ## --------------------------------------
-## Tests
+##@ Tests
 ## --------------------------------------
 
 .PHONY: test-unit
-test-unit: $(PKG_CONFIG)
+test-unit: $(PKG_CONFIG) ## Run unit tests.
 	mkdir -p $(TEST_RESULTS_DIR)
 	hack/test-unit.sh | tee -a $(TEST_RESULTS_DIR)/unittest.txt
 ifdef JUNIT
@@ -150,60 +155,60 @@ ifdef JUNIT
 endif
 
 .PHONY: test-check
-test-check: test-lint test-boilerplate test-spelling test-gofmt test-govet
+test-check: test-lint test-boilerplate test-spelling test-gofmt test-govet ## Run all static checks.
 
 .PHONY: test-gofmt
-test-gofmt:
+test-gofmt: ## Run gofmt test.
 	hack/verify-gofmt.sh
 
 .PHONY: test-govet
-test-govet:
+test-govet: ## Run govet test.
 	hack/verify-govet.sh
 
 .PHONY: test-lint
-test-lint:
+test-lint: ## Run golint test.
 	hack/verify-golint.sh
 
 .PHONY: test-boilerplate
-test-boilerplate:
+test-boilerplate: ## Run boilerplate test.
 	hack/verify-boilerplate.sh
 
 .PHONY: test-spelling
-test-spelling:
+test-spelling: ## Run spelling test.
 	hack/verify-spelling.sh
 
 .PHONY: update-dependencies
-update-dependencies:
+update-dependencies: ## Update dependencies and go modules.
 	hack/update-dependencies.sh
 
 .PHONY: update-gofmt
-update-gofmt:
+update-gofmt: ## Update go formats.
 	hack/update-gofmt.sh
 
 .PHONY: update
-update: update-dependencies update-gofmt
+update: update-dependencies update-gofmt ## Update go formats and dependencies.
 
-test-e2e:
+test-e2e: ## Run k8s e2e tests.
 	hack/test_k8s_e2e.sh $(TEST_E2E_ARGS)
 
-test-ccm-e2e:
+test-ccm-e2e: ## Run cloud provider e2e tests.
 	go test ./tests/e2e/ -timeout 0 -v -ginkgo.v $(CCM_E2E_ARGS)
 
 .PHONY: clean
-clean:
+clean: ## Cleanup local builds.
 	rm -rf $(BIN_DIR) $(PKG_CONFIG) $(TEST_RESULTS_DIR)
 
 $(PKG_CONFIG):
 	ENABLE_GIT_COMMANDS=$(ENABLE_GIT_COMMAND) hack/pkg-config.sh > $@
 
 ## --------------------------------------
-## Release
+##@ Release
 ## --------------------------------------
 
 .PHONY: deploy
-deploy: image push
+deploy: image push ## Build, push and deploy an aks-engine cluster.
 	IMAGE=$(IMAGE) HYPERKUBE_IMAGE=$(HYPERKUBE_IMAGE) hack/deploy-cluster.sh
 
 .PHONY: release-staging
-release-staging:
+release-staging: ## Release the cloud provider images.
 	ENABLE_GIT_COMMANDS=false IMAGE_REGISTRY=$(STAGING_REGISTRY) $(MAKE) build-images push-images


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
/kind cleanup

**What this PR does / why we need it**:

Add make help support. Here is a sample help message:

```
$  make help

Usage:
  make <target>

General
  help             Display this help.

Binaries
  all              Build binaries for the project.
  azure-cloud-node-manager  Build node-manager binary for Linux.
  azure-cloud-node-manager.exe  Build node-manager binary for Windows.
  azure-cloud-controller-manager  Build binary for controller-manager.

Images
  docker-pull-prerequisites  Pull prerequisite images.
  build-ccm-image  Build controller-manager image.
  build-node-image  Build node-manager image for Windows.
  build-node-image-windows  Build node-manager image for Windows.
  build-ccm-e2e-test-image  Build e2e test image.
  build-images     Build all images.
  image            Build all images.
  push-ccm-image   Push controller-manager image.
  push-node-image  Push node-manager image for Linux.
  push-node-image-windows  Push node-manager image for Windows.
  push             Push all images.
  push-images      Push all images.
  release-ccm-e2e-test-image  Build and release e2e test image.
  hyperkube        Build hyperkube image.

Tests
  test-unit        Run unit tests.
  test-check       Run all static checks.
  test-gofmt       Run gofmt test.
  test-govet       Run govet test.
  test-lint        Run golint test.
  test-boilerplate  Run boilerplate test.
  test-spelling    Run spelling test.
  update-dependencies  Update dependencies and go modules.
  update-gofmt     Update go formats.
  update           Update go formats and dependencies.
  test-e2e         Run k8s e2e tests.
  test-ccm-e2e     Run cloud provider e2e tests.
  clean            Cleanup local builds.

Release
  deploy           Build, push and deploy an aks-engine cluster.
  release-staging  Release the cloud provider images.
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```
