### PR TITLE
Not send availability zones as part of create for edge zones.

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1842,15 +1842,13 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			}
 
 			// only add zone information for new internal frontend IP configurations for standard load balancer not deployed to an edge zone.
-			if isInternal && az.useStandardLoadBalancer() && !az.HasExtendedLocation() {
-				location := az.Location
-				zones, err := az.getRegionZonesBackoff(location)
-				if err != nil {
-					return nil, false, err
-				}
-				if len(zones) > 0 {
-					newConfig.Zones = &zones
-				}
+			location := az.Location
+			zones, err := az.getRegionZonesBackoff(location)
+			if err != nil {
+				return nil, false, err
+			}
+			if isInternal && az.useStandardLoadBalancer() && len(zones) > 0 && !az.HasExtendedLocation() {
+				newConfig.Zones = &zones
 			}
 			newConfigs = append(newConfigs, newConfig)
 			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, defaultLBFrontendIPConfigName)

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -3502,8 +3502,10 @@ func TestEnsurePublicIPExistsWithExtendedLocation(t *testing.T) {
 	defer ctrl.Finish()
 
 	az := GetTestCloudWithExtendedLocation(ctrl)
+	az.LoadBalancerSku = consts.LoadBalancerSkuStandard
 	service := getTestService("test1", v1.ProtocolTCP, nil, false, 80)
 
+	exLocName := "microsoftlosangeles1"
 	expectedPIP := &network.PublicIPAddress{
 		Name:     to.StringPtr("pip1"),
 		Location: &az.location,
@@ -3527,9 +3529,18 @@ func TestEnsurePublicIPExistsWithExtendedLocation(t *testing.T) {
 	})
 	mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", "pip1", gomock.Any()).Return(*expectedPIP, nil).After(first)
 
-	mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "pip1", gomock.Any()).Return(nil).Times(1)
+	mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "pip1", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, resourceGroupName string, publicIPAddressName string, publicIPAddressParameters network.PublicIPAddress) *retry.Error {
+			assert.NotNil(t, publicIPAddressParameters)
+			assert.NotNil(t, publicIPAddressParameters.ExtendedLocation)
+			assert.Equal(t, *publicIPAddressParameters.ExtendedLocation.Name, exLocName)
+			assert.Equal(t, publicIPAddressParameters.ExtendedLocation.Type, network.ExtendedLocationTypesEdgeZone)
+			// Edge zones don't support availability zones.
+			assert.Nil(t, publicIPAddressParameters.Zones)
+			return nil
+		}).Times(1)
 	pip, err := az.ensurePublicIPExists(&service, "pip1", "", "", false, false)
-	assert.Equal(t, expectedPIP, pip, "ensurePublicIPExists shall create a new pip"+
+	assert.NotNil(t, pip, "ensurePublicIPExists shall create a new pip"+
 		"with extendedLocation if there is no existed pip")
 	assert.Nil(t, err, "ensurePublicIPExists should create a new pip without errors.")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Public IP creation for edge zones started failing recently because NRP doesn't allow `Availability Zones` to be provided as part of create request if it contains `extendedLocation`. This PR fixes that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**Release note**:
```
Not send availability zones as part of create for edge zones
```
