### PR TITLE
Not send availability zones as part of create for edge zones.

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1027,6 +1027,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		pip.Name = to.StringPtr(pipName)
 		pip.Location = to.StringPtr(az.Location)
 		if az.HasExtendedLocation() {
+			klog.V(2).Infof("Using extended location with name %s, and type %s for PIP", az.ExtendedLocationName, az.ExtendedLocationType)
 			pip.ExtendedLocation = &network.ExtendedLocation{
 				Name: &az.ExtendedLocationName,
 				Type: &az.ExtendedLocationType,
@@ -1049,13 +1050,16 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 				Name: network.PublicIPAddressSkuNameStandard,
 			}
 
-			// only add zone information for the new standard pips
-			zones, err := az.getRegionZonesBackoff(to.String(pip.Location))
-			if err != nil {
-				return nil, err
-			}
-			if len(zones) > 0 {
-				pip.Zones = &zones
+			// skip adding zone info since edge zones doesn't support multiple availability zones.
+			if !az.HasExtendedLocation() {
+				// only add zone information for the new standard pips
+				zones, err := az.getRegionZonesBackoff(to.String(pip.Location))
+				if err != nil {
+					return nil, err
+				}
+				if len(zones) > 0 {
+					pip.Zones = &zones
+				}
 			}
 		}
 		klog.V(2).Infof("ensurePublicIPExists for service(%s): pip(%s) - creating", serviceName, *pip.Name)
@@ -1789,13 +1793,13 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 				FrontendIPConfigurationPropertiesFormat: fipConfigurationProperties,
 			}
 
-			// only add zone information for new internal frontend IP configurations
+			// only add zone information for new internal frontend IP configurations for standard load balancer not deployed to an edge zone.
 			location := az.Location
 			zones, err := az.getRegionZonesBackoff(location)
 			if err != nil {
 				return nil, false, err
 			}
-			if isInternal && az.useStandardLoadBalancer() && len(zones) > 0 {
+			if isInternal && az.useStandardLoadBalancer() && len(zones) > 0 && !az.HasExtendedLocation() {
 				newConfig.Zones = &zones
 			}
 			newConfigs = append(newConfigs, newConfig)


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cherry pick for #702 : Not send availability zones as part of create for edge zones.


**Release note**:
```
Not send availability zones as part of create for edge zones.
```
