### PR TITLE
fix: avoid wrapping RawError twice

### DIFF
--- a/pkg/retry/azure_retry_test.go
+++ b/pkg/retry/azure_retry_test.go
@@ -167,7 +167,7 @@ func TestDoBackoffRetry(t *testing.T) {
 	resp, err := doBackoffRetry(client, fakeRequest, &Backoff{Factor: 1.0, Steps: 3})
 	assert.NotNil(t, resp)
 	assert.Equal(t, 500, resp.StatusCode)
-	assert.Equal(t, expectedErr.Error(), err)
+	assert.Equal(t, expectedErr.RawError, err)
 	assert.Equal(t, 3, client.Attempts())
 
 	// retries with 0 steps
@@ -218,7 +218,7 @@ func TestDoBackoffRetry(t *testing.T) {
 		RawError:       fmt.Errorf("HTTP status code (429)"),
 	}
 	resp, err = doBackoffRetry(client, fakeRequest, &Backoff{Factor: 1.0, Steps: 3})
-	assert.Equal(t, expectedErr.Error(), err)
+	assert.Equal(t, expectedErr.RawError, err)
 	assert.Equal(t, 1, client.Attempts())
 	assert.NotNil(t, resp)
 	assert.Equal(t, 429, resp.StatusCode)
@@ -235,7 +235,7 @@ func TestDoBackoffRetry(t *testing.T) {
 	resp, err = doBackoffRetry(client, fakeRequest, &Backoff{Factor: 1.0, Steps: 3})
 	assert.NotNil(t, resp)
 	assert.Equal(t, 404, resp.StatusCode)
-	assert.Equal(t, expectedErr.Error(), err)
+	assert.Equal(t, expectedErr.RawError, err)
 	assert.Equal(t, 1, client.Attempts())
 
 	// retry on RetriableHTTPStatusCodes
@@ -254,6 +254,6 @@ func TestDoBackoffRetry(t *testing.T) {
 	})
 	assert.NotNil(t, resp)
 	assert.Equal(t, 102, resp.StatusCode)
-	assert.Equal(t, expectedErr.Error(), err)
+	assert.Equal(t, expectedErr.RawError, err)
 	assert.Equal(t, 3, client.Attempts())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The sender decorator builds a local `Error` type that embeds the RawError returned from the Azure service. However, in the client's `sendRequest` method it wraps this error again under the `Error` type.

```
retry.GetError(response, err)
```
This would return a double-wrapped error the consumers:
```
Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: {"error":{"code":"ReadOnlyDisabledSubscription","message":"The subscription 'xxx' is disabled and therefore marked as read only. You cannot perform any write actions on this subscription until it is re-enabled."}}
 
```

Initially was thinking of safe guarding the behaviour but because `Error` doesn't implement the error interface, it seemed to be a bit of hassle.

With the fix in place, the top-level consumers will get the expected error body:

```
Retriable: false, RetryAfter: 0s, HTTPStatusCode: 409, RawError: {​​​​​​​"error":{​​​​​​​"code":"ReadOnlyDisabledSubscription","message":"The subscription 'xxx' is disabled and therefore marked as read only. You cannot perform any write actions on this subscription until it is re-enabled."}​​​​​​​}​​​​​​​
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
N/A
```
