### PR TITLE
fix: ignore the NodeCIDRMaskSize in dualstack clusters

### DIFF
--- a/cmd/cloud-controller-manager/app/core.go
+++ b/cmd/cloud-controller-manager/app/core.go
@@ -274,20 +274,19 @@ func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration) (i
 // then it will return default IPv4 and IPv6 cidr mask sizes.
 func setNodeCIDRMaskSizesDualStack(cfg nodeipamconfig.NodeIPAMControllerConfiguration) (int, int, error) {
 	ipv4Mask, ipv6Mask := consts.DefaultNodeMaskCIDRIPv4, consts.DefaultNodeMaskCIDRIPv6
-	// NodeCIDRMaskSize can be used only for single stack clusters
-	if cfg.NodeCIDRMaskSize != 0 && (cfg.NodeCIDRMaskSizeIPv4 != 0 || cfg.NodeCIDRMaskSizeIPv6 != 0) {
-		return ipv4Mask, ipv6Mask, errors.New("usage of --node-cidr-mask-size is not allowed with dual-stack clusters")
+
+	if cfg.NodeCIDRMaskSize != 0 {
+		klog.Warningf("setNodeCIDRMaskSizesDualStack: --node-cidr-mask-size is set to %d, but it would be ignored because the dualstack is enabled", cfg.NodeCIDRMaskSize)
 	}
-	if cfg.NodeCIDRMaskSize != 0 && cfg.NodeCIDRMaskSizeIPv4 == 0 && cfg.NodeCIDRMaskSizeIPv6 == 0 {
-		ipv4Mask = int(cfg.NodeCIDRMaskSize)
-		ipv6Mask = int(cfg.NodeCIDRMaskSize)
-	}
+
 	if cfg.NodeCIDRMaskSizeIPv4 != 0 {
 		ipv4Mask = int(cfg.NodeCIDRMaskSizeIPv4)
 	}
+
 	if cfg.NodeCIDRMaskSizeIPv6 != 0 {
 		ipv6Mask = int(cfg.NodeCIDRMaskSizeIPv6)
 	}
+
 	return ipv4Mask, ipv6Mask, nil
 }
 

--- a/cmd/cloud-controller-manager/app/core_test.go
+++ b/cmd/cloud-controller-manager/app/core_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nodeipamconfig "sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/config"
+)
+
+func TestSetNodeCIDRMaskSizesDualStack(t *testing.T) {
+	for _, testCase := range []struct {
+		description                        string
+		mask, ipv4Mask, ipv6Mask           int32
+		expectedIPV4Mask, expectedIPV6Mask int
+	}{
+		{
+			description:      "setNodeCIDRMaskSizesDualStack should ignore the node cidr mask size",
+			mask:             17,
+			ipv6Mask:         65,
+			expectedIPV4Mask: 24,
+			expectedIPV6Mask: 65,
+		},
+		{
+			description:      "setNodeCIDRMaskSizesDualStack should set the ipv4 and ipv6 mask sizes as configured",
+			mask:             17,
+			ipv4Mask:         18,
+			ipv6Mask:         65,
+			expectedIPV4Mask: 18,
+			expectedIPV6Mask: 65,
+		},
+		{
+			description:      "setNodeCIDRMaskSizesDualStack should set the default ipv4 and ipv6 mask sizes",
+			mask:             17,
+			expectedIPV4Mask: 24,
+			expectedIPV6Mask: 64,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			cfg := nodeipamconfig.NodeIPAMControllerConfiguration{
+				NodeCIDRMaskSize:     testCase.mask,
+				NodeCIDRMaskSizeIPv4: testCase.ipv4Mask,
+				NodeCIDRMaskSizeIPv6: testCase.ipv6Mask,
+			}
+
+			ipv4Mask, ipv6Mask, err := setNodeCIDRMaskSizesDualStack(cfg)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedIPV4Mask, ipv4Mask)
+			assert.Equal(t, testCase.expectedIPV6Mask, ipv6Mask)
+		})
+	}
+}

--- a/site/content/en/topics/ipam.md
+++ b/site/content/en/topics/ipam.md
@@ -58,7 +58,7 @@ The following configurations from cloud-controller-manager would be used as defa
 | name | type | default | description |
 | ----- | -----| ----- | ----- |
 | allocate-node-cidrs | bool | true | Should CIDRs for Pods be allocated and set on the cloud provider. |
-| cluster-cidr | string | "10.244.0.0/16" | CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true. |
+| cluster-cidr | string | "10.244.0.0/16" | CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true. It will be ignored when enabling dualstack. |
 | service-cluster-ip-range | string | "" | CIDR Range for Services in cluster, this would get excluded from the allocatable range. Requires --allocate-node-cidrs to be true. |
 | node-cidr-mask-size | int | 24 | Mask size for node cidr in cluster. Default is 24 for IPv4 and 64 for IPv6. |
 | node-cidr-mask-size-ipv4 | int | 24 | Mask size for IPv4 node cidr in dual-stack cluster. Default is 24. |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:

The NodeCIDRMaskSize is set to 24 by default. This is bad when enabling dualstack and ipv4/ipv6 masks are not set explicitly. In this case the ipv4 and ipv6 masks will be set to 24, which may out of the range of the cluster cidr, especially for ipv6 cluster cidr whose default mask size is 64.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
fix: ignore the NodeCIDRMaskSize in dualstack clusters
```
