### PR TITLE
Add a "code" dimension to the Azure API error metric

### DIFF
--- a/pkg/azureclients/containerserviceclient/azure_containerserviceclient.go
+++ b/pkg/azureclients/containerserviceclient/azure_containerserviceclient.go
@@ -96,7 +96,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, managedClust
 	}
 
 	result, rerr := c.getManagedCluster(ctx, resourceGroupName, managedClusterName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -157,7 +157,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]containe
 	}
 
 	result, rerr := c.listManagedCluster(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -318,7 +318,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, m
 	}
 
 	rerr := c.createOrUpdateManagedCluster(ctx, resourceGroupName, managedClusterName, parameters, etag)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -393,7 +393,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, managedCl
 	}
 
 	rerr := c.deleteManagedCluster(ctx, resourceGroupName, managedClusterName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/deploymentclient/azure_deploymentclient.go
+++ b/pkg/azureclients/deploymentclient/azure_deploymentclient.go
@@ -96,7 +96,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, deploymentNa
 	}
 
 	result, rerr := c.getDeployment(ctx, resourceGroupName, deploymentName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -157,7 +157,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]resource
 	}
 
 	result, rerr := c.listDeployment(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -318,7 +318,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, d
 	}
 
 	rerr := c.createOrUpdateDeployment(ctx, resourceGroupName, deploymentName, parameters, etag)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -392,7 +392,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, deploymen
 	}
 
 	rerr := c.deleteDeployment(ctx, resourceGroupName, deploymentName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/diskclient/azure_diskclient.go
+++ b/pkg/azureclients/diskclient/azure_diskclient.go
@@ -106,7 +106,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, diskName str
 	}
 
 	result, rerr := c.getDisk(ctx, resourceGroupName, diskName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -167,7 +167,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, d
 	}
 
 	rerr := c.createOrUpdateDisk(ctx, resourceGroupName, diskName, diskParameter)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -235,7 +235,7 @@ func (c *Client) Update(ctx context.Context, resourceGroupName string, diskName 
 	}
 
 	rerr := c.updateDisk(ctx, resourceGroupName, diskName, diskParameter)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -303,7 +303,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, diskName 
 	}
 
 	rerr := c.deleteDisk(ctx, resourceGroupName, diskName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/interfaceclient/azure_interfaceclient.go
+++ b/pkg/azureclients/interfaceclient/azure_interfaceclient.go
@@ -105,7 +105,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, networkInter
 	}
 
 	result, rerr := c.getNetworkInterface(ctx, resourceGroupName, networkInterfaceName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -166,7 +166,7 @@ func (c *Client) GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, 
 	}
 
 	result, rerr := c.getVMSSNetworkInterface(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -241,7 +241,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, n
 	}
 
 	rerr := c.createOrUpdateInterface(ctx, resourceGroupName, networkInterfaceName, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -316,7 +316,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, networkIn
 	}
 
 	rerr := c.deleteInterface(ctx, resourceGroupName, networkInterfaceName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient.go
+++ b/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient.go
@@ -103,7 +103,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, loadBalancer
 	}
 
 	result, rerr := c.getLB(ctx, resourceGroupName, loadBalancerName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -164,7 +164,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]network.
 	}
 
 	result, rerr := c.listLB(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -235,7 +235,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, l
 	}
 
 	rerr := c.createOrUpdateLB(ctx, resourceGroupName, loadBalancerName, parameters, etag)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -310,7 +310,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, loadBalan
 	}
 
 	rerr := c.deleteLB(ctx, resourceGroupName, loadBalancerName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -443,7 +443,7 @@ func (c *Client) CreateOrUpdateBackendPools(ctx context.Context, resourceGroupNa
 	}
 
 	rerr := c.createOrUpdateLBBackendPool(ctx, resourceGroupName, loadBalancerName, backendPoolName, parameters, etag)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/publicipclient/azure_publicipclient.go
+++ b/pkg/azureclients/publicipclient/azure_publicipclient.go
@@ -105,7 +105,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, publicIPAddr
 	}
 
 	result, rerr := c.getPublicIPAddress(ctx, resourceGroupName, publicIPAddressName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -166,7 +166,7 @@ func (c *Client) GetVirtualMachineScaleSetPublicIPAddress(ctx context.Context, r
 	}
 
 	result, rerr := c.getVMSSPublicIPAddress(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, IPConfigurationName, publicIPAddressName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -243,7 +243,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]network.
 	}
 
 	result, rerr := c.listPublicIPAddress(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -314,7 +314,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, p
 	}
 
 	rerr := c.createOrUpdatePublicIP(ctx, resourceGroupName, publicIPAddressName, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -382,7 +382,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, publicIPA
 	}
 
 	rerr := c.deletePublicIP(ctx, resourceGroupName, publicIPAddressName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/routeclient/azure_routeclient.go
+++ b/pkg/azureclients/routeclient/azure_routeclient.go
@@ -101,7 +101,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, r
 	}
 
 	rerr := c.createOrUpdateRoute(ctx, resourceGroupName, routeTableName, routeName, routeParameters, etag)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -178,7 +178,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, routeTabl
 	}
 
 	rerr := c.deleteRoute(ctx, resourceGroupName, routeTableName, routeName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/routetableclient/azure_routetableclient.go
+++ b/pkg/azureclients/routetableclient/azure_routetableclient.go
@@ -101,7 +101,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, routeTableNa
 	}
 
 	result, rerr := c.getRouteTable(ctx, resourceGroupName, routeTableName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -162,7 +162,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, r
 	}
 
 	rerr := c.createOrUpdateRouteTable(ctx, resourceGroupName, routeTableName, parameters, etag)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/securitygroupclient/azure_securitygroupclient.go
+++ b/pkg/azureclients/securitygroupclient/azure_securitygroupclient.go
@@ -103,7 +103,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, networkSecur
 	}
 
 	result, rerr := c.getSecurityGroup(ctx, resourceGroupName, networkSecurityGroupName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -164,7 +164,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]network.
 	}
 
 	result, rerr := c.listSecurityGroup(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -235,7 +235,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, n
 	}
 
 	rerr := c.createOrUpdateNSG(ctx, resourceGroupName, networkSecurityGroupName, parameters, etag)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -310,7 +310,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, networkSe
 	}
 
 	rerr := c.deleteNSG(ctx, resourceGroupName, networkSecurityGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/snapshotclient/azure_snapshotclient.go
+++ b/pkg/azureclients/snapshotclient/azure_snapshotclient.go
@@ -103,7 +103,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, snapshotName
 	}
 
 	result, rerr := c.getSnapshot(ctx, resourceGroupName, snapshotName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -164,7 +164,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, snapshotN
 	}
 
 	rerr := c.deleteSnapshot(ctx, resourceGroupName, snapshotName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -207,7 +207,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, s
 	}
 
 	rerr := c.createOrUpdateSnapshot(ctx, resourceGroupName, snapshotName, snapshot)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -275,7 +275,7 @@ func (c *Client) ListByResourceGroup(ctx context.Context, resourceGroupName stri
 	}
 
 	result, rerr := c.listSnapshotsByResourceGroup(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
+++ b/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
@@ -103,7 +103,7 @@ func (c *Client) GetProperties(ctx context.Context, resourceGroupName string, ac
 	}
 
 	result, rerr := c.getStorageAccount(ctx, resourceGroupName, accountName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -164,7 +164,7 @@ func (c *Client) ListKeys(ctx context.Context, resourceGroupName string, account
 	}
 
 	result, rerr := c.listStorageAccountKeys(ctx, resourceGroupName, accountName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -225,7 +225,7 @@ func (c *Client) Create(ctx context.Context, resourceGroupName string, accountNa
 	}
 
 	rerr := c.createStorageAccount(ctx, resourceGroupName, accountName, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -293,7 +293,7 @@ func (c *Client) Update(ctx context.Context, resourceGroupName string, accountNa
 	}
 
 	rerr := c.updateStorageAccount(ctx, resourceGroupName, accountName, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -359,7 +359,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, accountNa
 	}
 
 	rerr := c.deleteStorageAccount(ctx, resourceGroupName, accountName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -402,7 +402,7 @@ func (c *Client) ListByResourceGroup(ctx context.Context, resourceGroupName stri
 	}
 
 	result, rerr := c.ListStorageAccountByResourceGroup(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/subnetclient/azure_subnetclient.go
+++ b/pkg/azureclients/subnetclient/azure_subnetclient.go
@@ -102,7 +102,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, virtualNetwo
 	}
 
 	result, rerr := c.getSubnet(ctx, resourceGroupName, virtualNetworkName, subnetName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -165,7 +165,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string, virtualNetw
 	}
 
 	result, rerr := c.listSubnet(ctx, resourceGroupName, virtualNetworkName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -240,7 +240,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, v
 	}
 
 	rerr := c.createOrUpdateSubnet(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -309,7 +309,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, virtualNe
 	}
 
 	rerr := c.deleteSubnet(ctx, resourceGroupName, virtualNetworkName, subnetName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/vmasclient/azure_vmasclient.go
+++ b/pkg/azureclients/vmasclient/azure_vmasclient.go
@@ -103,7 +103,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, vmasName str
 	}
 
 	result, rerr := c.getVMAS(ctx, resourceGroupName, vmasName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -164,7 +164,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]compute.
 	}
 
 	result, rerr := c.listVMAS(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/vmclient/azure_vmclient.go
+++ b/pkg/azureclients/vmclient/azure_vmclient.go
@@ -103,7 +103,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, VMName strin
 	}
 
 	result, rerr := c.getVM(ctx, resourceGroupName, VMName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -164,7 +164,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]compute.
 	}
 
 	result, rerr := c.listVM(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -237,7 +237,7 @@ func (c *Client) Update(ctx context.Context, resourceGroupName string, VMName st
 	}
 
 	rerr := c.updateVM(ctx, resourceGroupName, VMName, parameters, source)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -275,7 +275,7 @@ func (c *Client) UpdateAsync(ctx context.Context, resourceGroupName string, VMNa
 	)
 
 	future, rerr := c.armClient.PatchResourceAsync(ctx, resourceID, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -292,7 +292,7 @@ func (c *Client) UpdateAsync(ctx context.Context, resourceGroupName string, VMNa
 func (c *Client) WaitForUpdateResult(ctx context.Context, future *azure.Future, resourceGroupName, source string) *retry.Error {
 	mc := metrics.NewMetricContext("vm", "wait_for_update_result", resourceGroupName, c.subscriptionID, source)
 	response, err := c.armClient.WaitForAsyncOperationResult(ctx, future, "VMWaitForUpdateResult")
-	_ = mc.Observe(err)
+	mc.Observe(retry.NewErrorOrNil(false, err))
 
 	if response != nil && response.StatusCode != http.StatusNoContent {
 		_, rerr := c.updateResponder(response)
@@ -452,7 +452,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, V
 	}
 
 	rerr := c.createOrUpdateVM(ctx, resourceGroupName, VMName, parameters, source)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -521,7 +521,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, VMName st
 	}
 
 	rerr := c.deleteVM(ctx, resourceGroupName, VMName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/vmsizeclient/azure_vmsizeclient.go
+++ b/pkg/azureclients/vmsizeclient/azure_vmsizeclient.go
@@ -102,7 +102,7 @@ func (c *Client) List(ctx context.Context, location string) (compute.VirtualMach
 	}
 
 	result, rerr := c.listVirtualMachineSizes(ctx, location)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/azureclients/vmssclient/azure_vmssclient.go
+++ b/pkg/azureclients/vmssclient/azure_vmssclient.go
@@ -103,7 +103,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, VMScaleSetNa
 	}
 
 	result, rerr := c.getVMSS(ctx, resourceGroupName, VMScaleSetName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -164,7 +164,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string) ([]compute.
 	}
 
 	result, rerr := c.listVMSS(ctx, resourceGroupName)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -235,7 +235,7 @@ func (c *Client) CreateOrUpdate(ctx context.Context, resourceGroupName string, V
 	}
 
 	rerr := c.createOrUpdateVMSS(ctx, resourceGroupName, VMScaleSetName, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -273,7 +273,7 @@ func (c *Client) CreateOrUpdateAsync(ctx context.Context, resourceGroupName stri
 	)
 
 	future, rerr := c.armClient.PutResourceAsync(ctx, resourceID, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -288,39 +288,30 @@ func (c *Client) CreateOrUpdateAsync(ctx context.Context, resourceGroupName stri
 
 // WaitForCreateOrUpdateResult waits for the response of the create or update request
 func (c *Client) WaitForCreateOrUpdateResult(ctx context.Context, future *azure.Future, resourceGroupName string) (*http.Response, error) {
-	mc := metrics.NewMetricContext("vmss", "wait_for_create_or_update_result", resourceGroupName, c.subscriptionID, "")
-	res, err := c.armClient.WaitForAsyncOperationResult(ctx, future, "VMSSWaitForCreateOrUpdateResult")
-	_ = mc.Observe(err)
-	return res, err
+	return c.WaitForAsyncOperationResult(ctx, future, resourceGroupName, "wait_for_create_or_update_result", "VMSSWaitForCreateOrUpdateResult")
 }
 
 // WaitForDeleteInstancesResult waits for the response of the delete instance request
 func (c *Client) WaitForDeleteInstancesResult(ctx context.Context, future *azure.Future, resourceGroupName string) (*http.Response, error) {
-	mc := metrics.NewMetricContext("vmss", "wait_for_delete_instances_result", resourceGroupName, c.subscriptionID, "")
-	res, err := c.armClient.WaitForAsyncOperationResult(ctx, future, "VMSSWaitForDeleteInstancesResult")
-	_ = mc.Observe(err)
-	return res, err
+	return c.WaitForAsyncOperationResult(ctx, future, resourceGroupName, "wait_for_delete_instances_result", "VMSSWaitForDeleteInstancesResult")
 }
 
 // WaitForDeallocateInstancesResult waits for the response of the delete instance request
 func (c *Client) WaitForDeallocateInstancesResult(ctx context.Context, future *azure.Future, resourceGroupName string) (*http.Response, error) {
-	mc := metrics.NewMetricContext("vmss", "wait_for_deallocate_instances_result", resourceGroupName, c.subscriptionID, "")
-	res, err := c.armClient.WaitForAsyncOperationResult(ctx, future, "VMSSWaitForDeallocateInstancesResult")
-	_ = mc.Observe(err)
-	return res, err
+	return c.WaitForAsyncOperationResult(ctx, future, resourceGroupName, "wait_for_deallocate_instances_result", "VMSSWaitForDeallocateInstancesResult")
 }
 
 // WaitForStartInstancesResult waits for the response of the delete instance request
 func (c *Client) WaitForStartInstancesResult(ctx context.Context, future *azure.Future, resourceGroupName string) (*http.Response, error) {
-	mc := metrics.NewMetricContext("vmss", "wait_for_start_instances_result", resourceGroupName, c.subscriptionID, "")
-	res, err := c.armClient.WaitForAsyncOperationResult(ctx, future, "VMSSWaitForStartInstancesResult")
-	_ = mc.Observe(err)
-	return res, err
+	return c.WaitForAsyncOperationResult(ctx, future, resourceGroupName, "wait_for_start_instances_result", "VMSSWaitForStartInstancesResult")
 }
 
 // WaitForAsyncOperationResult waits for the response of the request
-func (c *Client) WaitForAsyncOperationResult(ctx context.Context, future *azure.Future) (*http.Response, error) {
-	return c.armClient.WaitForAsyncOperationResult(ctx, future, "VMSSWaitForAsyncOperationResult")
+func (c *Client) WaitForAsyncOperationResult(ctx context.Context, future *azure.Future, resourceGroupName, request, asycOpName string) (*http.Response, error) {
+	mc := metrics.NewMetricContext("vmss", request, resourceGroupName, c.subscriptionID, "")
+	res, err := c.armClient.WaitForAsyncOperationResult(ctx, future, asycOpName)
+	mc.Observe(retry.NewErrorOrNil(false, err))
+	return res, err
 }
 
 // createOrUpdateVMSS creates or updates a VirtualMachineScaleSet.
@@ -467,7 +458,7 @@ func (c *Client) DeleteInstances(ctx context.Context, resourceGroupName string, 
 	}
 
 	rerr := c.deleteVMSSInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -514,15 +505,16 @@ func (c *Client) DeleteInstancesAsync(ctx context.Context, resourceGroupName str
 
 	err := autorest.Respond(response, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
 	if err != nil {
-		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deletevms.respond", resourceID, rerr.Error())
+		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deletevms.respond", resourceID, err)
 		return nil, retry.GetError(response, err)
 	}
 
 	future, err := azure.NewFutureFromResponse(response)
-	_ = mc.Observe(err)
+	rerr = retry.NewErrorOrNil(false, err)
+	mc.Observe(rerr)
 	if err != nil {
-		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deletevms.future", resourceID, rerr.Error())
-		return nil, retry.NewError(false, err)
+		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deletevms.future", resourceID, err)
+		return nil, rerr
 	}
 
 	return &future, nil
@@ -562,15 +554,16 @@ func (c *Client) DeallocateInstancesAsync(ctx context.Context, resourceGroupName
 
 	err := autorest.Respond(response, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
 	if err != nil {
-		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deallocatevms.respond", resourceID, rerr.Error())
+		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deallocatevms.respond", resourceID, err)
 		return nil, retry.GetError(response, err)
 	}
 
 	future, err := azure.NewFutureFromResponse(response)
-	_ = mc.Observe(err)
+	rerr = retry.NewErrorOrNil(false, err)
+	mc.Observe(rerr)
 	if err != nil {
-		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deallocatevms.future", resourceID, rerr.Error())
-		return nil, retry.NewError(false, err)
+		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.deallocatevms.future", resourceID, err)
+		return nil, rerr
 	}
 
 	return &future, nil
@@ -610,15 +603,16 @@ func (c *Client) StartInstancesAsync(ctx context.Context, resourceGroupName stri
 
 	err := autorest.Respond(response, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted))
 	if err != nil {
-		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.startvms.respond", resourceID, rerr.Error())
+		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.startvms.respond", resourceID, err)
 		return nil, retry.GetError(response, err)
 	}
 
 	future, err := azure.NewFutureFromResponse(response)
-	_ = mc.Observe(err)
+	rerr = retry.NewErrorOrNil(false, err)
+	mc.Observe(rerr)
 	if err != nil {
-		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.startvms.future", resourceID, rerr.Error())
-		return nil, retry.NewError(false, err)
+		klog.V(5).Infof("Received error in %s: resourceID: %s, error: %s", "vmss.startvms.future", resourceID, err)
+		return nil, rerr
 	}
 
 	return &future, nil

--- a/pkg/azureclients/vmssclient/azure_vmssclient_test.go
+++ b/pkg/azureclients/vmssclient/azure_vmssclient_test.go
@@ -678,7 +678,7 @@ func TestWaitForAsyncOperationResult(t *testing.T) {
 
 	armClient.EXPECT().WaitForAsyncOperationResult(gomock.Any(), &azure.Future{}, "VMSSWaitForAsyncOperationResult").Return(response, nil)
 	vmssClient := getTestVMSSClient(armClient)
-	_, err := vmssClient.WaitForAsyncOperationResult(context.TODO(), &azure.Future{})
+	_, err := vmssClient.WaitForAsyncOperationResult(context.TODO(), &azure.Future{}, "rgName", "req", "VMSSWaitForAsyncOperationResult")
 	assert.NoError(t, err)
 }
 

--- a/pkg/azureclients/vmssclient/interface.go
+++ b/pkg/azureclients/vmssclient/interface.go
@@ -52,7 +52,7 @@ type Interface interface {
 	CreateOrUpdateAsync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (*azure.Future, *retry.Error)
 
 	// WaitForAsyncOperationResult waits for the response of the request
-	WaitForAsyncOperationResult(ctx context.Context, future *azure.Future) (*http.Response, error)
+	WaitForAsyncOperationResult(ctx context.Context, future *azure.Future, resourceGroupName, request, asyncOpName string) (*http.Response, error)
 
 	// DeleteInstances deletes the instances for a VirtualMachineScaleSet.
 	DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) *retry.Error

--- a/pkg/azureclients/vmssclient/mockvmssclient/interface.go
+++ b/pkg/azureclients/vmssclient/mockvmssclient/interface.go
@@ -110,18 +110,18 @@ func (mr *MockInterfaceMockRecorder) CreateOrUpdateAsync(ctx, resourceGroupName,
 }
 
 // WaitForAsyncOperationResult mocks base method
-func (m *MockInterface) WaitForAsyncOperationResult(ctx context.Context, future *azure.Future) (*http.Response, error) {
+func (m *MockInterface) WaitForAsyncOperationResult(ctx context.Context, future *azure.Future, resourceGroupName string, request string, asycOpName string) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForAsyncOperationResult", ctx, future)
+	ret := m.ctrl.Call(m, "WaitForAsyncOperationResult", ctx, future, resourceGroupName, request, asycOpName)
 	ret0, _ := ret[0].(*http.Response)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WaitForAsyncOperationResult indicates an expected call of WaitForAsyncOperationResult
-func (mr *MockInterfaceMockRecorder) WaitForAsyncOperationResult(ctx, future interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) WaitForAsyncOperationResult(ctx, future interface{}, resourceGroupName string, request string, asycOpName string) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForAsyncOperationResult", reflect.TypeOf((*MockInterface)(nil).WaitForAsyncOperationResult), ctx, future)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForAsyncOperationResult", reflect.TypeOf((*MockInterface)(nil).WaitForAsyncOperationResult), ctx, future, resourceGroupName, request, asycOpName)
 }
 
 // WaitForCreateOrUpdateResult mocks base method

--- a/pkg/azureclients/vmssvmclient/azure_vmssvmclient.go
+++ b/pkg/azureclients/vmssvmclient/azure_vmssvmclient.go
@@ -104,7 +104,7 @@ func (c *Client) Get(ctx context.Context, resourceGroupName string, VMScaleSetNa
 	}
 
 	result, rerr := c.getVMSSVM(ctx, resourceGroupName, VMScaleSetName, instanceID, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -167,7 +167,7 @@ func (c *Client) List(ctx context.Context, resourceGroupName string, virtualMach
 	}
 
 	result, rerr := c.listVMSSVM(ctx, resourceGroupName, virtualMachineScaleSetName, expand)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -241,7 +241,7 @@ func (c *Client) Update(ctx context.Context, resourceGroupName string, VMScaleSe
 	}
 
 	rerr := c.updateVMSSVM(ctx, resourceGroupName, VMScaleSetName, instanceID, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -281,7 +281,7 @@ func (c *Client) UpdateAsync(ctx context.Context, resourceGroupName string, VMSc
 	)
 
 	future, rerr := c.armClient.PutResourceAsync(ctx, resourceID, parameters)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
@@ -298,7 +298,7 @@ func (c *Client) UpdateAsync(ctx context.Context, resourceGroupName string, VMSc
 func (c *Client) WaitForUpdateResult(ctx context.Context, future *azure.Future, resourceGroupName, source string) *retry.Error {
 	mc := metrics.NewMetricContext("vmss", "wait_for_update_result", resourceGroupName, c.subscriptionID, source)
 	response, err := c.armClient.WaitForAsyncOperationResult(ctx, future, "VMSSWaitForUpdateResult")
-	_ = mc.Observe(err)
+	mc.Observe(retry.NewErrorOrNil(false, err))
 	if response != nil && response.StatusCode != http.StatusNoContent {
 		_, rerr := c.updateResponder(response)
 		if rerr != nil {
@@ -456,7 +456,7 @@ func (c *Client) UpdateVMs(ctx context.Context, resourceGroupName string, VMScal
 	}
 
 	rerr := c.updateVMSSVMs(ctx, resourceGroupName, VMScaleSetName, instances)
-	_ = mc.Observe(rerr.Error())
+	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.

--- a/pkg/provider/azure_backoff.go
+++ b/pkg/provider/azure_backoff.go
@@ -384,7 +384,7 @@ func (az *Cloud) DeletePublicIP(service *v1.Service, pipResourceGroup string, pi
 }
 
 // DeleteLB invokes az.LoadBalancerClient.Delete with exponential backoff retry
-func (az *Cloud) DeleteLB(service *v1.Service, lbName string) error {
+func (az *Cloud) DeleteLB(service *v1.Service, lbName string) *retry.Error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
@@ -398,7 +398,7 @@ func (az *Cloud) DeleteLB(service *v1.Service, lbName string) error {
 
 	klog.Errorf("LoadBalancerClient.Delete(%s) failed: %s", lbName, rerr.Error().Error())
 	az.Event(service, v1.EventTypeWarning, "DeleteLoadBalancer", rerr.Error().Error())
-	return rerr.Error()
+	return rerr
 }
 
 // CreateOrUpdateRouteTable invokes az.RouteTablesClient.CreateOrUpdate with exponential backoff retry

--- a/pkg/provider/azure_backoff_test.go
+++ b/pkg/provider/azure_backoff_test.go
@@ -417,7 +417,7 @@ func TestDeleteLB(t *testing.T) {
 	mockLBClient.EXPECT().Delete(gomock.Any(), az.ResourceGroup, "lb").Return(&retry.Error{HTTPStatusCode: http.StatusInternalServerError})
 
 	err := az.DeleteLB(&v1.Service{}, "lb")
-	assert.EqualError(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: %w", error(nil)), err.Error())
+	assert.EqualError(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: %w", error(nil)), fmt.Sprintf("%s", err.Error()))
 }
 
 func TestCreateOrUpdateRouteTable(t *testing.T) {

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -49,6 +49,15 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
+// LBInUseRawError is the LoadBalancerInUseByVirtualMachineScaleSet raw error
+const LBInUseRawError = `{
+	"error": {
+    	"code": "LoadBalancerInUseByVirtualMachineScaleSet",
+    	"message": "Cannot delete load balancer /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb since its child resources lb are in use by virtual machine scale set /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss.",
+    	"details": []
+  	}
+}`
+
 func TestFindProbe(t *testing.T) {
 	tests := []struct {
 		msg           string
@@ -4273,7 +4282,7 @@ func TestCleanOrphanedLoadBalancerLBInUseByVMSS(t *testing.T) {
 		cloud.LoadBalancerSku = consts.LoadBalancerSkuStandard
 
 		mockLBClient := cloud.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
-		mockLBClient.EXPECT().Delete(gomock.Any(), "rg", "test").Return(&retry.Error{RawError: errors.New(retry.LBInUseRawError)})
+		mockLBClient.EXPECT().Delete(gomock.Any(), "rg", "test").Return(&retry.Error{RawError: errors.New(LBInUseRawError)})
 		mockLBClient.EXPECT().Delete(gomock.Any(), "rg", "test").Return(nil)
 
 		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)

--- a/pkg/retry/azure_error.go
+++ b/pkg/retry/azure_error.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/go-autorest/autorest/azure"
 	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Azure/go-autorest/autorest/azure"
 
 	"k8s.io/klog/v2"
 
@@ -109,6 +110,14 @@ func NewError(retriable bool, err error) *Error {
 		Retriable: retriable,
 		RawError:  err,
 	}
+}
+
+// NewError creates a new Error. Returns nil if err is nil
+func NewErrorOrNil(retriable bool, err error) *Error {
+	if err == nil {
+		return nil
+	}
+	return NewError(retriable, err)
 }
 
 // GetRetriableError gets new retriable Error.

--- a/pkg/retry/azure_error_test.go
+++ b/pkg/retry/azure_error_test.go
@@ -27,6 +27,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// LBInUseRawError is the LoadBalancerInUseByVirtualMachineScaleSet raw error
+const LBInUseRawError = `{
+	"error": {
+    	"code": "LoadBalancerInUseByVirtualMachineScaleSet",
+    	"message": "Cannot delete load balancer /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb since its child resources lb are in use by virtual machine scale set /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss.",
+    	"details": []
+  	}
+}`
+
 func TestNewError(t *testing.T) {
 	rawErr := fmt.Errorf("HTTP status code (404)")
 	newErr := NewError(true, rawErr)
@@ -365,26 +374,8 @@ func TestHasErrorCode(t *testing.T) {
 	assert.True(t, result)
 }
 
-func TestParseRawError(t *testing.T) {
-	rawError := LBInUseRawError
-	errStruct, err := ParseRawError(rawError)
-	fmt.Println(err)
-	if errStruct != nil {
-		fmt.Println(*errStruct)
-	}
-	assert.NoError(t, err)
-
-	expectedErrStruct := &RawErrorContainer{
-		Code:    "LoadBalancerInUseByVirtualMachineScaleSet",
-		Message: "Cannot delete load balancer /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb since its child resources lb are in use by virtual machine scale set /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss.",
-		Details: []string{},
-	}
-	assert.Equal(t, expectedErrStruct, errStruct)
-}
-
 func TestGetVMSSNameByRawError(t *testing.T) {
-	rawError := LBInUseRawError
-	rgName, vmssName, err := GetVMSSMetadataByRawError(rawError)
+	rgName, vmssName, err := GetVMSSMetadataByRawError(&Error{RawError: fmt.Errorf(LBInUseRawError)})
 	assert.NoError(t, err)
 	assert.Equal(t, "rg", rgName)
 	assert.Equal(t, "vmss", vmssName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
This adds a more detailed "Code" label to the azure API errors metrics which is useful to classify the reason behind failed calls. For example, Quota, SubnetExhaustion, etc.
 
This can help unlock certain auto-healing scenarios.

The PR also changes some existing parsing of an LB error to be more robust and build on the same pattern using `autorest.ServiceError` instead of duplicating the fields.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
azure_api_request_errors metric now has an added "code" label which provides more details on the errors encountered.
```
