### PR TITLE
fix: ignore GetDisk throttling in DeleteDisk

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -352,3 +352,6 @@ const (
 	DefaultCloudProviderConfigSecNamespace = "kube-system"
 	DefaultCloudProviderConfigSecKey       = "cloud-config"
 )
+
+// RateLimited error string
+const RateLimited = "rate limited"

--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -251,35 +251,33 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 }
 
 //DeleteManagedDisk : delete managed disk
-func (c *ManagedDiskController) DeleteManagedDisk(diskURI string) error {
-	diskName := path.Base(diskURI)
+func (c *ManagedDiskController) DeleteManagedDisk(ctx context.Context, diskURI string) error {
 	resourceGroup, err := getResourceGroupFromDiskURI(diskURI)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := getContextWithCancel()
-	defer cancel()
-
 	if _, ok := c.common.diskStateMap.Load(strings.ToLower(diskURI)); ok {
 		return fmt.Errorf("failed to delete disk(%s) since it's in attaching or detaching state", diskURI)
 	}
 
+	diskName := path.Base(diskURI)
 	disk, rerr := c.common.cloud.DisksClient.Get(ctx, resourceGroup, diskName)
 	if rerr != nil {
 		if rerr.HTTPStatusCode == http.StatusNotFound {
 			klog.V(2).Infof("azureDisk - disk(%s) is already deleted", diskURI)
 			return nil
 		}
-		return rerr.Error()
+		// ignore GetDisk throttling
+		if !rerr.IsThrottled() && !strings.Contains(rerr.RawError.Error(), consts.RateLimited) {
+			return rerr.Error()
+		}
 	}
-
 	if disk.ManagedBy != nil {
 		return fmt.Errorf("disk(%s) already attached to node(%s), could not be deleted", diskURI, *disk.ManagedBy)
 	}
 
-	rerr = c.common.cloud.DisksClient.Delete(ctx, resourceGroup, diskName)
-	if rerr != nil {
+	if rerr := c.common.cloud.DisksClient.Delete(ctx, resourceGroup, diskName); rerr != nil {
 		return rerr.Error()
 	}
 	// We don't need poll here, k8s will immediately stop referencing the disk

--- a/pkg/provider/azure_managedDiskController_test.go
+++ b/pkg/provider/azure_managedDiskController_test.go
@@ -314,6 +314,8 @@ func TestDeleteManagedDisk(t *testing.T) {
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
 		},
 	}
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
 
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
@@ -332,7 +334,7 @@ func TestDeleteManagedDisk(t *testing.T) {
 		}
 		mockDisksClient.EXPECT().Delete(gomock.Any(), testCloud.ResourceGroup, test.diskName).Return(nil).AnyTimes()
 
-		err := managedDiskController.DeleteManagedDisk(diskURI)
+		err := managedDiskController.DeleteManagedDisk(ctx, diskURI)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
 		if test.expectedErr {
 			assert.EqualError(t, test.expectedErrMsg, err.Error(), "TestCase[%d]: %s, expected: %v, return: %v", i, test.desc, test.expectedErrMsg, err)

--- a/pkg/retry/azure_error.go
+++ b/pkg/retry/azure_error.go
@@ -34,6 +34,9 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
+// RateLimited error string
+const RateLimited = "rate limited"
+
 var (
 	// The function to get current time.
 	now = time.Now
@@ -134,7 +137,7 @@ func GetRateLimitError(isWrite bool, opName string) *Error {
 	if isWrite {
 		opType = "write"
 	}
-	return GetRetriableError(fmt.Errorf("azure cloud provider rate limited(%s) for operation %q", opType, opName))
+	return GetRetriableError(fmt.Errorf("azure cloud provider %s(%s) for operation %q", RateLimited, opType, opName))
 }
 
 // GetThrottlingError creates a new error for throttling.

--- a/pkg/retry/azure_error_test.go
+++ b/pkg/retry/azure_error_test.go
@@ -342,6 +342,12 @@ func TestIsThrottled(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			err: &Error{
+				RetryAfter: time.Now().Add(0),
+			},
+			expected: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: ignore GetDisk throttling in DeleteDisk

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
 1 controllerserver.go:378] delete azure disk(/subscriptions/xxx/resourceGroups/aks55h93-nodegroup/providers/Microsoft.Compute/disks/pvc-ecfefbb9-102c-4f40-944f-d5d4b6183568) returned with Retriable: true, RetryAfter: 0s, HTTPStatusCode: 0, RawError: azure cloud provider rate limited(read) for operation "GetDisk"
 1 utils.go:100] GRPC error: Retriable: true, RetryAfter: 0s, HTTPStatusCode: 0, RawError: azure cloud provider rate limited(read) for operation "GetDisk"
```

**Release note**:
```
fix: ignore GetDisk throttling in DeleteDisk
```
