### PR TITLE
fix: use correct gitVersion in userAgent

### DIFF
--- a/pkg/azureclients/armclient/azure_armclient.go
+++ b/pkg/azureclients/armclient/azure_armclient.go
@@ -34,10 +34,9 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 
-	"k8s.io/client-go/pkg/version"
 	"k8s.io/klog/v2"
-
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
+	"sigs.k8s.io/cloud-provider-azure/pkg/version"
 )
 
 var _ Interface = &Client{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:

fix: use correct gitVersion in userAgent. `sigs.k8s.io/cloud-provider-azure/pkg/version` should be used to get correct version.

The userAgent would be changed from `Go/go1.16.6 (amd64-linux) go-autorest/v14.2.1; kubernetes-cloudprovider/v0.0.0-master+$Format:%H$` to `Go/go1.16.6 (amd64-linux) go-autorest/v14.2.1; kubernetes-cloudprovider/v1.1.0` for release tag and `Go/go1.16.6 (amd64-linux) go-autorest/v14.2.1; kubernetes-cloudprovider/v1.1.0-11-g55d8238ac` for commit after this fix.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #758 

**Special notes for your reviewer**:


**Release note**:
```
fix: use correct gitVersion in userAgent
```
