### PR TITLE
chore: bump orchestrator release to 1.19 and remove enabled feature gates

### DIFF
--- a/examples/aks-engine.json
+++ b/examples/aks-engine.json
@@ -12,9 +12,6 @@
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
                 },
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-                },
                 "useCloudControllerManager": true,
                 "customCcmImage": "",
                 "addons": [

--- a/tests/k8s-azure/manifest/autoscaler-virtual-kubelet.json
+++ b/tests/k8s-azure/manifest/autoscaler-virtual-kubelet.json
@@ -4,16 +4,13 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
-                },
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
                 },
                 "kubeletConfig": {
                     "--feature-gates": "ExecProbeTimeout=true"

--- a/tests/k8s-azure/manifest/e2e-slow.json
+++ b/tests/k8s-azure/manifest/e2e-slow.json
@@ -4,14 +4,11 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-                },
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
                 },

--- a/tests/k8s-azure/manifest/linux-autoscaler-multi-nodepool.json
+++ b/tests/k8s-azure/manifest/linux-autoscaler-multi-nodepool.json
@@ -4,7 +4,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "useManagedIdentity": false,
                 "networkPolicy": "none",
@@ -12,9 +12,6 @@
                 "cloudProviderRateLimitBucket": 20,
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
-                },
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
                 },
                 "kubeletConfig": {
                     "--feature-gates": "ExecProbeTimeout=true"

--- a/tests/k8s-azure/manifest/linux-autoscaler.json
+++ b/tests/k8s-azure/manifest/linux-autoscaler.json
@@ -4,7 +4,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "useManagedIdentity": false,
                 "networkPolicy": "none",
@@ -12,9 +12,6 @@
                 "cloudProviderRateLimitBucket": 20,
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
-                },
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
                 },
                 "kubeletConfig": {
                     "--feature-gates": "ExecProbeTimeout=true"

--- a/tests/k8s-azure/manifest/linux-kcm.json
+++ b/tests/k8s-azure/manifest/linux-kcm.json
@@ -4,14 +4,11 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-                },
                 "kubeletConfig": {
                     "--feature-gates": "ExecProbeTimeout=true"
                 },

--- a/tests/k8s-azure/manifest/linux-vmss-basic-lb.json
+++ b/tests/k8s-azure/manifest/linux-vmss-basic-lb.json
@@ -4,15 +4,12 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.17",
+      "orchestratorRelease": "1.19",
       "kubernetesConfig": {
         "useManagedIdentity": false,
         "networkPolicy": "none",
         "cloudProviderRateLimitQPS": 6,
         "cloudProviderRateLimitBucket": 20,
-        "controllerManagerConfig": {
-          "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-        },
         "apiServerConfig": {
           "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
         },

--- a/tests/k8s-azure/manifest/linux-vmss-multi-zones.json
+++ b/tests/k8s-azure/manifest/linux-vmss-multi-zones.json
@@ -4,14 +4,11 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-                },
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
                 },

--- a/tests/k8s-azure/manifest/linux-vmss-serial.json
+++ b/tests/k8s-azure/manifest/linux-vmss-serial.json
@@ -4,14 +4,11 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-                },
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
                 },

--- a/tests/k8s-azure/manifest/linux-vmss.json
+++ b/tests/k8s-azure/manifest/linux-vmss.json
@@ -4,15 +4,12 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "useManagedIdentity": false,
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-                },
                 "kubeletConfig": {
                     "--feature-gates": "ExecProbeTimeout=true"
                 },

--- a/tests/k8s-azure/manifest/linux.json
+++ b/tests/k8s-azure/manifest/linux.json
@@ -4,15 +4,12 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.17",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "useManagedIdentity": false,
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
-                },
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
                 },

--- a/tests/kubemark/templates/external-cluster.json
+++ b/tests/kubemark/templates/external-cluster.json
@@ -4,16 +4,13 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.18",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
-                },
-                "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true"
                 },
                 "addons": [
                     {

--- a/tests/kubemark/templates/kubemark-cluster.json
+++ b/tests/kubemark/templates/kubemark-cluster.json
@@ -4,13 +4,12 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.18",
+            "orchestratorRelease": "1.19",
             "kubernetesConfig": {
                 "networkPolicy": "none",
                 "cloudProviderRateLimitQPS": 6,
                 "cloudProviderRateLimitBucket": 20,
                 "controllerManagerConfig": {
-                    "--feature-gates": "CSIInlineVolume=true,LocalStorageCapacityIsolation=true,ServiceNodeExclusion=true",
                     "--profiling": "true"
                 },
                 "apiServerConfig": {


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

- Bump orchestrator release to 1.19 since 1.18 has reach end-of-life
- Remove all feature gates that are enabled by default (CSIInlineVolume, LocalStorageCapacityIsolation, ServiceNodeExclusion)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
