### PR TITLE
fix: get vmss instance error for standalone vm

### DIFF
--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -142,6 +142,13 @@ func (c *controllerCommon) getNodeVMSet(nodeName types.NodeName, crt azcache.Azu
 	}
 
 	// 4. Node is managed by vmss
+	if _, err := ss.GetInstanceIDByNodeName(mapNodeNameToVMName(nodeName)); err != nil {
+		if strings.Contains(err.Error(), ErrorNotVmssInstanceErrorMsg) {
+			klog.Errorf("GetInstanceIDByNodeName(%s) failed with %v, fall back to standard VMType", nodeName, err)
+			return c.cloud.VMSet, nil
+		}
+		klog.Errorf("GetInstanceIDByNodeName(%s) failed with %v", err)
+	}
 	return ss, nil
 }
 

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -40,9 +40,12 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
 )
 
+// ErrorNotVmssInstanceErrorMsg indicates an instance is not belonging to any vmss.
+const ErrorNotVmssInstanceErrorMsg = "not a vmss instance"
+
 var (
 	// ErrorNotVmssInstance indicates an instance is not belonging to any vmss.
-	ErrorNotVmssInstance = errors.New("not a vmss instance")
+	ErrorNotVmssInstance = errors.New(ErrorNotVmssInstanceErrorMsg)
 
 	scaleSetNameRE         = regexp.MustCompile(`.*/subscriptions/(?:.*)/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines(?:.*)`)
 	resourceGroupRE        = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?:.*)/virtualMachines(?:.*)`)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: get vmss instance error for standalone vm

This PR fixed the issue when agent node is either not vmss nor in availability set, in such case, should return `standard` vmType when attach/detach disk. Original error is like following on capz cluster:
```
AttachVolume.Attach failed for volume "pvc-84f57545-0f8c-4087-b9ab-a04f500e6218" : failed to get azure instance id for node "capz-target-cluster-md-0-xs8cn" (not a vmss instance)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #338, #576

#### Special notes for your reviewer:
/hold

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: get vmss instance error for standalone vm
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
