### PR TITLE
kubemark: replace deprecated --log-file parameter

### DIFF
--- a/tests/kubemark/templates/hollow-node.yaml
+++ b/tests/kubemark/templates/hollow-node.yaml
@@ -44,13 +44,13 @@ spec:
                   fieldPath: metadata.name
           command:
             [
+              "/go-runner",
+              "-log-file=/var/log/kubelet-$(NODE_NAME).log",
               "/kubemark",
               "--morph=kubelet",
               "--name=$(NODE_NAME)",
               "--kubeconfig=/kubeconfig/kubelet.kubeconfig",
               "$(CONTENT_TYPE)",
-              "--log-file=/var/log/kubelet-$(NODE_NAME).log",
-              "--logtostderr=false",
               "--v=2",
             ]
           volumeMounts:
@@ -82,14 +82,14 @@ spec:
                   fieldPath: metadata.name
           command:
             [
+              "/go-runner",
+              "-log-file=/var/log/kubeproxy-$(NODE_NAME).log",
               "/kubemark",
               "--morph=proxy",
               "--name=$(NODE_NAME)",
               "--use-real-proxier=false",
               "--kubeconfig=/kubeconfig/kubeproxy.kubeconfig",
               "$(CONTENT_TYPE)",
-              "--log-file=/var/log/kubeproxy-$(NODE_NAME).log",
-              "--logtostderr=false",
               "--v=10",
             ]
           volumeMounts:


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

The --log-file parameter will be deprecated as of Kubernetes 1.23 and should be
avoided. The replacement for distroless images is the image with go-runner, a
tool that handles output redirection.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/106103

#### Special notes for your reviewer:

This is the same change as in
https://github.com/kubernetes/kubernetes/pull/106150/files#diff-142166782be7d6e83af6f3179f9a5dfd8eb69ea6585f03da6a5260e466325f9c

The assumption is that these templates are going to be used with a recent kubemark image, one which has go-runner.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2845
```
