### PR TITLE
fix: panic due to nil pointer

### DIFF
--- a/pkg/provider/azure_instances.go
+++ b/pkg/provider/azure_instances.go
@@ -170,6 +170,11 @@ func (az *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID strin
 		return nil, nil
 	}
 
+	if az.VMSet == nil {
+		// vmSet == nil indicates credentials are not provided.
+		return nil, fmt.Errorf("no credentials provided for Azure cloud provider")
+	}
+
 	name, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		return nil, err
@@ -189,6 +194,11 @@ func (az *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID stri
 	if az.IsNodeUnmanagedByProviderID(providerID) {
 		klog.V(4).Infof("InstanceExistsByProviderID: assuming unmanaged node %q exists", providerID)
 		return true, nil
+	}
+
+	if az.VMSet == nil {
+		// vmSet == nil indicates credentials are not provided.
+		return false, fmt.Errorf("no credentials provided for Azure cloud provider")
 	}
 
 	name, err := az.VMSet.GetNodeNameByProviderID(providerID)
@@ -233,6 +243,10 @@ func (az *Cloud) InstanceExists(ctx context.Context, node *v1.Node) (bool, error
 func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	if providerID == "" {
 		return false, nil
+	}
+	if az.VMSet == nil {
+		// vmSet == nil indicates credentials are not provided.
+		return false, fmt.Errorf("no credentials provided for Azure cloud provider")
 	}
 
 	nodeName, err := az.VMSet.GetNodeNameByProviderID(providerID)
@@ -399,6 +413,11 @@ func (az *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string
 		return "", nil
 	}
 
+	if az.VMSet == nil {
+		// vmSet == nil indicates credentials are not provided.
+		return "", fmt.Errorf("no credentials provided for Azure cloud provider")
+	}
+
 	name, err := az.VMSet.GetNodeNameByProviderID(providerID)
 	if err != nil {
 		return "", err
@@ -448,6 +467,11 @@ func (az *Cloud) InstanceType(ctx context.Context, name types.NodeName) (string,
 		if metadata.Compute.VMSize != "" {
 			return metadata.Compute.VMSize, nil
 		}
+	}
+
+	if az.VMSet == nil {
+		// vmSet == nil indicates credentials are not provided.
+		return "", fmt.Errorf("no credentials provided for Azure cloud provider")
 	}
 
 	return az.VMSet.GetInstanceTypeByNodeName(string(name))

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -581,6 +581,9 @@ func (as *availabilitySet) GetInstanceTypeByNodeName(name string) (string, error
 		return "", err
 	}
 
+	if machine.HardwareProfile == nil {
+		return "", fmt.Errorf("HardwareProfile of node(%s) is nil", name)
+	}
 	return string(machine.HardwareProfile.VMSize), nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: panic due to nil pointer
This PR fixes panic in two places: 1) `VMSet` when initialize cloud config failed 2) `HardwareProfile` on standard VM

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: panic due to nil pointer
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: panic due to nil pointer
```
