### PR TITLE
chore: reduce node LIST APIs in cloud-node-manager

### DIFF
--- a/cmd/cloud-node-manager/app/options/options.go
+++ b/cmd/cloud-node-manager/app/options/options.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -178,17 +179,6 @@ func (o *CloudNodeManagerOptions) ApplyTo(c *cloudnodeconfig.Config, userAgent s
 		return err
 	}
 
-	c.EventRecorder = createRecorder(c.Client, userAgent)
-	c.ClientBuilder = clientbuilder.SimpleControllerClientBuilder{
-		ClientConfig: c.Kubeconfig,
-	}
-	c.VersionedClient = c.ClientBuilder.ClientOrDie("shared-informers")
-	// TODO(feiskyer): filter watch by node name whenever it's supported.
-	c.SharedInformers = informers.NewSharedInformerFactory(c.VersionedClient, resyncPeriod(c)())
-	c.NodeStatusUpdateFrequency = o.NodeStatusUpdateFrequency
-	c.UseInstanceMetadata = o.UseInstanceMetadata
-	c.CloudConfigFilePath = o.CloudConfigFilePath
-
 	// Default NodeName is hostname.
 	c.NodeName = strings.ToLower(o.NodeName)
 	if c.NodeName == "" {
@@ -199,6 +189,19 @@ func (o *CloudNodeManagerOptions) ApplyTo(c *cloudnodeconfig.Config, userAgent s
 
 		c.NodeName = strings.ToLower(hostname)
 	}
+
+	c.EventRecorder = createRecorder(c.Client, userAgent)
+	c.ClientBuilder = clientbuilder.SimpleControllerClientBuilder{
+		ClientConfig: c.Kubeconfig,
+	}
+	c.VersionedClient = c.ClientBuilder.ClientOrDie("shared-informers")
+	// Only need to watch the node itself. There is no need to set up a watch on the nodes in the cluster.
+	c.SharedInformers = informers.NewSharedInformerFactoryWithOptions(c.VersionedClient, resyncPeriod(c)(), informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermEqualSelector("metadata.name", c.NodeName).String()
+	}))
+	c.NodeStatusUpdateFrequency = o.NodeStatusUpdateFrequency
+	c.UseInstanceMetadata = o.UseInstanceMetadata
+	c.CloudConfigFilePath = o.CloudConfigFilePath
 
 	c.WindowsService = o.WindowsService
 

--- a/pkg/nodemanager/nodemanager.go
+++ b/pkg/nodemanager/nodemanager.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -176,39 +175,30 @@ func (cnc *CloudNodeController) Run(stopCh <-chan struct{}) {
 
 // UpdateNodeStatus updates the node status, such as node addresses
 func (cnc *CloudNodeController) UpdateNodeStatus(ctx context.Context) {
-	nodes, err := cnc.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		ResourceVersion: "0",
-		FieldSelector:   fields.OneTermEqualSelector("metadata.name", cnc.nodeName).String(),
-	})
+	node, err := cnc.nodeInformer.Lister().Get(cnc.nodeName)
 	if err != nil {
-		klog.Errorf("Error monitoring node status: %v", err)
+		// If node not found, just ignore it.
+		if apierrors.IsNotFound(err) {
+			return
+		}
+
+		klog.Errorf("Error getting node %q from informer, err: %v", cnc.nodeName, err)
 		return
 	}
 
-	for i := range nodes.Items {
-		cnc.updateNodeAddress(ctx, &nodes.Items[i])
+	err = cnc.updateNodeAddress(ctx, node)
+	if err != nil {
+		klog.Errorf("Error reconciling node address for node %q, err: %v", node.Name, err)
 	}
 
-	for _, node := range nodes.Items {
-		err = cnc.reconcileNodeLabels(node.Name)
-		if err != nil {
-			klog.Errorf("Error reconciling node labels for node %q, err: %v", node.Name, err)
-		}
+	err = cnc.reconcileNodeLabels(node)
+	if err != nil {
+		klog.Errorf("Error reconciling node labels for node %q, err: %v", node.Name, err)
 	}
 }
 
 // reconcileNodeLabels reconciles node labels transitioning from beta to GA
-func (cnc *CloudNodeController) reconcileNodeLabels(nodeName string) error {
-	node, err := cnc.nodeInformer.Lister().Get(nodeName)
-	if err != nil {
-		// If node not found, just ignore it.
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-
-		return err
-	}
-
+func (cnc *CloudNodeController) reconcileNodeLabels(node *v1.Node) error {
 	if node.Labels == nil {
 		// Nothing to reconcile.
 		return nil
@@ -248,33 +238,32 @@ func (cnc *CloudNodeController) reconcileNodeLabels(nodeName string) error {
 }
 
 // UpdateNodeAddress updates the nodeAddress of a single node
-func (cnc *CloudNodeController) updateNodeAddress(ctx context.Context, node *v1.Node) {
+func (cnc *CloudNodeController) updateNodeAddress(ctx context.Context, node *v1.Node) error {
 	// Do not process nodes that are still tainted
 	cloudTaint := getCloudTaint(node.Spec.Taints)
 	if cloudTaint != nil {
 		klog.V(5).Infof("This node %s is still tainted. Will not process.", node.Name)
-		return
+		return nil
 	}
 
 	// Node that isn't present according to the cloud provider shouldn't have its address updated
 	exists, err := cnc.ensureNodeExistsByProviderID(ctx, node)
 	if err != nil {
 		// Continue to update node address when not sure the node is not exists
-		klog.Error(err)
+		klog.Warningf("ensureNodeExistsByProviderID (node %s) reported an error (%v), continue to update its address", node.Name, err)
 	} else if !exists {
 		klog.V(4).Infof("The node %s is no longer present according to the cloud provider, do not process.", node.Name)
-		return
+		return nil
 	}
 
 	nodeAddresses, err := cnc.getNodeAddressesByName(ctx, node)
 	if err != nil {
-		klog.Errorf("Error getting node addresses for node %q: %v", node.Name, err)
-		return
+		return fmt.Errorf("Error getting node addresses for node %q: %v", node.Name, err)
 	}
 
 	if len(nodeAddresses) == 0 {
 		klog.V(5).Infof("Skipping node address update for node %q since cloud provider did not return any", node.Name)
-		return
+		return nil
 	}
 
 	// Check if a hostname address exists in the cloud provided addresses
@@ -298,19 +287,21 @@ func (cnc *CloudNodeController) updateNodeAddress(ctx context.Context, node *v1.
 	// it can be found in the cloud as well (consistent with the behaviour in kubelet)
 	if nodeIP, ok := ensureNodeProvidedIPExists(node, nodeAddresses); ok {
 		if nodeIP == nil {
-			klog.Errorf("Specified Node IP not found in cloudprovider for node %q", node.Name)
-			return
+			return fmt.Errorf("specified Node IP %s not found in cloudprovider for node %q", nodeAddresses, node.Name)
 		}
 	}
 	if !nodeAddressesChangeDetected(node.Status.Addresses, nodeAddresses) {
-		return
+		return nil
 	}
+
 	newNode := node.DeepCopy()
 	newNode.Status.Addresses = nodeAddresses
 	_, _, err = PatchNodeStatus(cnc.kubeClient.CoreV1(), types.NodeName(node.Name), node, newNode)
 	if err != nil {
-		klog.Errorf("Error patching node with cloud ip addresses = [%v]", err)
+		return fmt.Errorf("Error patching node with cloud ip addresses = [%v]", err)
 	}
+
+	return nil
 }
 
 // nodeModifier is used to carry changes to node objects across multiple attempts to update them
@@ -360,7 +351,7 @@ func (cnc *CloudNodeController) AddCloudNode(ctx context.Context, obj interface{
 // This processes nodes that were added into the cluster, and cloud initialize them if appropriate
 func (cnc *CloudNodeController) initializeNode(ctx context.Context, node *v1.Node) {
 	klog.Infof("Initializing node %s with cloud provider", node.Name)
-	curNode, err := cnc.kubeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	curNode, err := cnc.kubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("failed to get node %s: %w", node.Name, err))
 		return
@@ -394,7 +385,7 @@ func (cnc *CloudNodeController) initializeNode(ctx context.Context, node *v1.Nod
 	})
 
 	err = clientretry.RetryOnConflict(UpdateNodeSpecBackoff, func() error {
-		curNode, err := cnc.kubeClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		curNode, err := cnc.kubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -403,14 +394,17 @@ func (cnc *CloudNodeController) initializeNode(ctx context.Context, node *v1.Nod
 			modify(curNode)
 		}
 
-		_, err = cnc.kubeClient.CoreV1().Nodes().Update(context.TODO(), curNode, metav1.UpdateOptions{})
+		_, err = cnc.kubeClient.CoreV1().Nodes().Update(ctx, curNode, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
 
 		// After adding, call UpdateNodeAddress to set the CloudProvider provided IPAddresses
 		// So that users do not see any significant delay in IP addresses being filled into the node
-		cnc.updateNodeAddress(ctx, curNode)
+		err = cnc.updateNodeAddress(ctx, curNode)
+		if err != nil {
+			return err
+		}
 
 		klog.Infof("Successfully initialized node %s with cloud provider", node.Name)
 		return nil

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -17,7 +17,6 @@ limitations under the License.
 package provider
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -33,7 +32,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -1099,15 +1097,6 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 			az.nodePrivateIPs[newNode.Name].Insert(address)
 		}
 	}
-}
-
-func (az *Cloud) ListNodes(ctx context.Context) ([]v1.Node, error) {
-	nodes, err := az.KubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return []v1.Node{}, fmt.Errorf("ListAllNodes: failed to list nodes: %w", err)
-	}
-
-	return nodes.Items, nil
 }
 
 // GetActiveZones returns all the zones in which k8s nodes are currently running.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Refer the codes below, cloud-node-manager is querying the node every 5 minutes to reconcile its addresses, but this API call is not actually required as there's already informers:

 https://github.com/kubernetes-sigs/cloud-provider-azure/blob/0e8ef48b6c170202b697428f94b94a57b19ff791/pkg/nodemanager/nodemanager.go#L178-L181

Hence, this PR replaces the node LIST with informer LIST, which would reduce the API calls to apiserver.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
chore: reduce node LIST APIs in cloud-node-manager
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
