### PR TITLE
Override subscription and tenant configs when network resources is in different tenant or subscriptions

### DIFF
--- a/pkg/auth/azure_auth.go
+++ b/pkg/auth/azure_auth.go
@@ -237,14 +237,12 @@ func ParseAzureEnvironment(cloudName, resourceManagerEndpoint, identitySystem st
 	return &env, err
 }
 
-// UsesNetworkResourceInDifferentTenant determines whether the AzureAuthConfig indicates to use network resources in different AAD Tenant and Subscription than those for the cluster
-// Return true only when both NetworkResourceTenantID and NetworkResourceSubscriptionID are specified
-// and they are not equals to TenantID and SubscriptionID
-func (config *AzureAuthConfig) UsesNetworkResourceInDifferentTenant() bool {
-	return len(config.NetworkResourceTenantID) > 0 &&
-		len(config.NetworkResourceSubscriptionID) > 0 &&
-		!strings.EqualFold(config.NetworkResourceTenantID, config.TenantID) &&
-		!strings.EqualFold(config.NetworkResourceSubscriptionID, config.SubscriptionID)
+// UsesNetworkResourceInDifferentTenantOrSubscription determines whether the AzureAuthConfig indicates to use network resources in different AAD Tenant and Subscription than those for the cluster
+// Return true when one of NetworkResourceTenantID and NetworkResourceSubscriptionID are specified
+// and equal to one defined in global configs
+func (config *AzureAuthConfig) UsesNetworkResourceInDifferentTenantOrSubscription() bool {
+	return (len(config.NetworkResourceTenantID) > 0 && !strings.EqualFold(config.NetworkResourceTenantID, config.TenantID)) ||
+		(len(config.NetworkResourceSubscriptionID) > 0 && !strings.EqualFold(config.NetworkResourceSubscriptionID, config.SubscriptionID))
 }
 
 // decodePkcs12 decodes a PKCS#12 client certificate by extracting the public certificate and
@@ -276,7 +274,7 @@ func azureStackOverrides(env *azure.Environment, resourceManagerEndpoint, identi
 
 // checkConfigWhenNetworkResourceInDifferentTenant checks configuration for the scenario of using network resource in different tenant
 func (config *AzureAuthConfig) checkConfigWhenNetworkResourceInDifferentTenant() error {
-	if !config.UsesNetworkResourceInDifferentTenant() {
+	if !config.UsesNetworkResourceInDifferentTenantOrSubscription() {
 		return fmt.Errorf("NetworkResourceTenantID and NetworkResourceSubscriptionID must be configured")
 	}
 

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -692,7 +692,7 @@ func (az *Cloud) configureMultiTenantClients(servicePrincipalToken *adal.Service
 	var err error
 	var multiTenantServicePrincipalToken *adal.MultiTenantServicePrincipalToken
 	var networkResourceServicePrincipalToken *adal.ServicePrincipalToken
-	if az.Config.UsesNetworkResourceInDifferentTenant() {
+	if az.Config.UsesNetworkResourceInDifferentTenantOrSubscription() {
 		multiTenantServicePrincipalToken, err = auth.GetMultiTenantServicePrincipalToken(&az.Config.AzureAuthConfig, &az.Environment)
 		if err != nil {
 			return err

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -105,7 +105,7 @@ func (az *Cloud) getLoadBalancerProbeID(lbName, rgName, lbRuleName string) strin
 
 // getNetworkResourceSubscriptionID returns the subscription id which hosts network resources
 func (az *Cloud) getNetworkResourceSubscriptionID() string {
-	if az.Config.UsesNetworkResourceInDifferentTenant() {
+	if az.Config.UsesNetworkResourceInDifferentTenantOrSubscription() {
 		return az.NetworkResourceSubscriptionID
 	}
 	return az.SubscriptionID


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Update tenantid or subscription id when network resource is in different tenant or subscription

#### Which issue(s) this PR fixes:

Fixes #984 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
