### PR TITLE
Cherry-pick: Fix incorrect EnableTCPReset for non-TCP protocols

### DIFF
--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1781,7 +1781,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			}, false, 80),
 			loadBalancerSku: "standard",
 			wantLb:          true,
-			expectedRules:   getHATestRules(true, false, v1.ProtocolSCTP),
+			expectedRules:   getHATestRules(false, false, v1.ProtocolSCTP),
 		},
 		{
 			desc: "getExpectedLBRules shall return corresponding probe and lbRule (slb with HA enabled multi-ports services)",
@@ -4645,5 +4645,50 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			assert.Equal(t, tc.expectedErr, err)
 			assert.Equal(t, tc.expectedLBs, lbs)
 		})
+	}
+}
+
+func TestEqualLoadBalancingRulePropertiesFormat(t *testing.T) {
+	var enableTCPReset, disableTCPReset *bool = to.BoolPtr(true), to.BoolPtr(false)
+	var frontPort *int32 = to.Int32Ptr(80)
+
+	testcases := []struct {
+		s        *network.LoadBalancingRulePropertiesFormat
+		t        *network.LoadBalancingRulePropertiesFormat
+		wantLb   bool
+		expected bool
+	}{
+		{
+			s: &network.LoadBalancingRulePropertiesFormat{
+				Protocol:       network.TransportProtocolTCP,
+				EnableTCPReset: enableTCPReset,
+				FrontendPort:   frontPort,
+			},
+			t: &network.LoadBalancingRulePropertiesFormat{
+				Protocol:       network.TransportProtocolTCP,
+				EnableTCPReset: enableTCPReset,
+				FrontendPort:   frontPort,
+			},
+			wantLb:   true,
+			expected: true,
+		},
+		{
+			s: &network.LoadBalancingRulePropertiesFormat{
+				Protocol:       network.TransportProtocolUDP,
+				EnableTCPReset: disableTCPReset,
+				FrontendPort:   frontPort,
+			},
+			t: &network.LoadBalancingRulePropertiesFormat{
+				Protocol:       network.TransportProtocolUDP,
+				EnableTCPReset: enableTCPReset,
+				FrontendPort:   frontPort,
+			},
+			wantLb:   true,
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		assert.Equal(t, tc.expected, equalLoadBalancingRulePropertiesFormat(tc.s, tc.t, tc.wantLb))
 	}
 }


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1087

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This code change fixes the bug that UDP services would trigger unnecessary LoadBalancer updates. The root cause is that a field not working for non-TCP protocols is considered.
ref: #1090
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
