### PR TITLE
Backport/pr963

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -374,3 +374,26 @@ const RateLimited = "rate limited"
 
 // CreatedByTag tag key for CSI drivers
 const CreatedByTag = "k8s-azure-created-by"
+
+// health probe
+const (
+	HealthProbeAnnotationPrefixPattern = "service.beta.kubernetes.io/port_%d_health-probe_"
+
+	// HealthProbeParamsProbeInterval determines the probe interval of the load balancer health probe.
+	// The minimum probe interval is 5 seconds and the default value is 5. The total duration of all intervals cannot exceed 120 seconds.
+	HealthProbeParamsProbeInterval  HealthProbeParams = "interval"
+	HealthProbeDefaultProbeInterval int32             = 5
+
+	// HealthProbeParamsNumOfProbe determines the minimum number of unhealthy responses which load balancer cannot tolerate.
+	// The minimum number of probe is 2. The total duration of all intervals cannot exceed 120 seconds.
+	HealthProbeParamsNumOfProbe  HealthProbeParams = "num-of-probe"
+	HealthProbeDefaultNumOfProbe int32             = 2
+
+	// HealthProbeParamsRequestPath determines the request path of the load balancer health probe.
+	// This is only useful for the HTTP and HTTPS, and would be ignored when using TCP. If not set,
+	// `/healthz` would be configured by default.
+	HealthProbeParamsRequestPath  HealthProbeParams = "request-path"
+	HealthProbeDefaultRequestPath string            = "/healthz"
+)
+
+type HealthProbeParams string

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -260,6 +260,14 @@ const (
 	// If not set, the local service would use the HTTP and the cluster service would use the TCP by default.
 	ServiceAnnotationLoadBalancerHealthProbeProtocol = "service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"
 
+	// ServiceAnnotationLoadBalancerHealthProbeInterval determines the probe interval of the load balancer health probe.
+	// The minimum probe interval is 5 seconds and the default value is 15. The total duration of all intervals cannot exceed 120 seconds.
+	ServiceAnnotationLoadBalancerHealthProbeInterval = "service.beta.kubernetes.io/azure-load-balancer-health-probe-interval"
+
+	// ServiceAnnotationLoadBalancerHealthProbeNumOfProbe determines the minimum number of unhealthy responses which load balancer cannot tolerate.
+	// The minimum number of probe is 1. The total duration of all intervals cannot exceed 120 seconds.
+	ServiceAnnotationLoadBalancerHealthProbeNumOfProbe = "service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe"
+
 	// ServiceAnnotationLoadBalancerHealthProbeRequestPath determines the request path of the load balancer health probe.
 	// This is only useful for the HTTP and HTTPS, and would be ignored when using TCP. If not set,
 	// `/healthz` would be configured by default.

--- a/pkg/consts/helpers.go
+++ b/pkg/consts/helpers.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package consts stages all the consts under pkg/.
+package consts
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// IsK8sServiceHasHAModeEnabled return if HA Mode is enabled in kuberntes service annotations
+func IsK8sServiceHasHAModeEnabled(service *v1.Service) bool {
+	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts, TrueAnnotationValue)
+}
+
+// IsK8sServiceUsingInternalLoadBalancer return if service is using an internal load balancer.
+func IsK8sServiceUsingInternalLoadBalancer(service *v1.Service) bool {
+	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationLoadBalancerInternal, TrueAnnotationValue)
+}
+
+// GetHealthProbeConfigOfPortFromK8sSvcAnnotation get health probe configuration for port
+func GetHealthProbeConfigOfPortFromK8sSvcAnnotation(annotations map[string]string, port int32, key HealthProbeParams, validators ...BusinessValidator) (*string, error) {
+	return GetAttributeValueInSvcAnnotation(annotations, BuildHealthProbeAnnotationKeyForPort(port, key), validators...)
+}
+
+// Getint32ValueFromK8sSvcAnnotation get health probe configuration for port
+func Getint32ValueFromK8sSvcAnnotation(annotations map[string]string, key string, validators ...Int32BusinessValidator) (*int32, error) {
+	val, err := GetAttributeValueInSvcAnnotation(annotations, key)
+	if err == nil && val != nil {
+		return extractInt32FromString(*val, validators...)
+	}
+	return nil, err
+}
+
+// BuildHealthProbeAnnotationKeyForPort get health probe configuration key for port
+func BuildHealthProbeAnnotationKeyForPort(port int32, key HealthProbeParams) string {
+	return fmt.Sprintf(HealthProbeAnnotationPrefixPattern, port) + string(key)
+}
+
+// GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation get health probe configuration for port
+func GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(annotations map[string]string, port int32, key HealthProbeParams, validators ...Int32BusinessValidator) (*int32, error) {
+	return Getint32ValueFromK8sSvcAnnotation(annotations, BuildHealthProbeAnnotationKeyForPort(port, key), validators...)
+}
+
+// Int32BusinessValidator is validator function which is invoked after values are parsed in order to make sure input value meets the businees need.
+type Int32BusinessValidator func(*int32) error
+
+// getInt32FromAnnotations parse integer value from annotation and return an reference to int32 object
+func extractInt32FromString(val string, businessValidator ...Int32BusinessValidator) (*int32, error) {
+	val = strings.TrimSpace(val)
+	errKey := fmt.Errorf("%s value must be a whole number", val)
+	toInt, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("error value: %w: %v", err, errKey)
+	}
+	parsedInt := int32(toInt)
+	for _, validator := range businessValidator {
+		if validator != nil {
+			err := validator(&parsedInt)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing value: %w", err)
+			}
+		}
+	}
+	return &parsedInt, nil
+}
+
+// BusinessValidator is validator function which is invoked after values are parsed in order to make sure input value meets the businees need.
+type BusinessValidator func(*string) error
+
+// GetAttributeValueInSvcAnnotation get value in annotation map using key
+func GetAttributeValueInSvcAnnotation(annotations map[string]string, key string, validators ...BusinessValidator) (*string, error) {
+	if l, found := annotations[key]; found {
+		for _, validateFunc := range validators {
+			if validateFunc != nil {
+				if err := validateFunc(&l); err != nil {
+					return nil, err
+				}
+			}
+		}
+		return &l, nil
+	}
+	return nil, nil
+}
+
+// expectAttributeInSvcAnnotation get key in svc annotation and compare with target value
+func expectAttributeInSvcAnnotationBeEqualTo(annotations map[string]string, key string, value string) bool {
+	if l, err := GetAttributeValueInSvcAnnotation(annotations, key); err == nil && l != nil {
+		return strings.EqualFold(*l, value)
+	}
+	return false
+}

--- a/pkg/consts/helpers_test.go
+++ b/pkg/consts/helpers_test.go
@@ -1,0 +1,378 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package consts stages all the consts under pkg/.
+package consts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsK8sServiceHasHAModeEnabled(t *testing.T) {
+	type args struct {
+		service *v1.Service
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ha mode is enabled",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ha mode is missing",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ha mode is corrupted",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true1",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ha annotation key is missing",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts + "1": "true1",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsK8sServiceHasHAModeEnabled(tt.args.service); got != tt.want {
+				t.Errorf("IsK8sServiceHasHAModeEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsK8sServiceUsingInternalLoadBalancer(t *testing.T) {
+	type args struct {
+		service *v1.Service
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "internal flag is set",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ServiceAnnotationLoadBalancerInternal: TrueAnnotationValue},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "internal flag is not set",
+			args: args{
+				service: &v1.Service{},
+			},
+			want: false,
+		},
+		{
+			name: "internal flag is corrupted",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ServiceAnnotationLoadBalancerInternal: TrueAnnotationValue + TrueAnnotationValue},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsK8sServiceUsingInternalLoadBalancer(tt.args.service); got != tt.want {
+				t.Errorf("IsK8sServiceUsingInternalLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetHealthProbeConfigOfPortFromK8sSvcAnnotation(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		port        int32
+		key         HealthProbeParams
+		validators  []BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *string
+		wantErr bool
+	}{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetHealthProbeConfigOfPortFromK8sSvcAnnotation(tt.args.annotations, tt.args.port, tt.args.key, tt.args.validators...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetHealthProbeConfigOfPortFromK8sSvcAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetHealthProbeConfigOfPortFromK8sSvcAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractInt32FromString(t *testing.T) {
+	type args struct {
+		val               string
+		businessValidator []Int32BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *int32
+		wantErr bool
+	}{
+		{name: "value is not a number", args: args{val: "cookies"}, wantErr: true},
+		{name: "value is zero", args: args{val: "0"}, wantErr: false, want: to.Int32Ptr(0)},
+		{name: "value is a float number", args: args{val: "0.1"}, wantErr: true},
+		{name: "value is a positive integer", args: args{val: "24"}, want: to.Int32Ptr(24), wantErr: false},
+		{name: "value negative integer", args: args{val: "-6"}, want: to.Int32Ptr(-6), wantErr: false},
+		{name: "validator is nil", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
+			nil,
+		}}, want: to.Int32Ptr(-6), wantErr: false},
+		{name: "validation failed", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
+			func(i *int32) error {
+				return fmt.Errorf("validator failed")
+			},
+		}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractInt32FromString(tt.args.val, tt.args.businessValidator...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractInt32FromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractInt32FromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getAttributeValueInSvcAnnotation(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		key         string
+		validators  []BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *string
+		wantErr bool
+	}{
+		{name: "annotation set is empty", args: args{key: "key"}, want: nil, wantErr: false},
+		{name: "key is not specified even though annotation set is not empty", args: args{annotations: map[string]string{"key": ""}}, want: nil, wantErr: false},
+		{name: "validation failed", args: args{annotations: map[string]string{"key": ""}, key: "key", validators: []BusinessValidator{
+			func(s *string) error {
+				return fmt.Errorf("validator failed")
+			},
+		}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAttributeValueInSvcAnnotation(tt.args.annotations, tt.args.key, tt.args.validators...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAttributeValueInSvcAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAttributeValueInSvcAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_expectAttributeInSvcAnnotationBeEqualTo(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		key         string
+		value       string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "assertion is successful",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value: "true",
+			},
+			want: true,
+		}, {
+			name: "assertion is successful especially when value is not exactly equal",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "True",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value: "true",
+			},
+			want: true,
+		},
+		{
+			name: "assertion is unsuccessful when key is not equal",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "True",
+				},
+				key:   strings.ToUpper(ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts),
+				value: "true",
+			},
+			want: false,
+		},
+		{
+			name: "assertion is unsuccessful when key is not found",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "True",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts + "notfound",
+				value: "true",
+			},
+			want: false,
+		},
+		{
+			name: "assertion is unsuccessful when value is empty",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value: "true",
+			},
+			want: false,
+		},
+		{
+			name: "assertion is unsuccessful when value is notfound",
+			args: args{
+				annotations: map[string]string{},
+				key:         ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value:       "true",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expectAttributeInSvcAnnotationBeEqualTo(tt.args.annotations, tt.args.key, tt.args.value); got != tt.want {
+				t.Errorf("expectAttributeInSvcAnnotationBeEqualTo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		port        int32
+		key         HealthProbeParams
+		validators  []Int32BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *int32
+		wantErr bool
+	}{
+		{
+			name: "get numeric value from health probe related annotation",
+			args: args{
+				annotations: map[string]string{BuildHealthProbeAnnotationKeyForPort(80, HealthProbeParamsNumOfProbe): "2"},
+				port:        80,
+				key:         HealthProbeParamsNumOfProbe,
+			},
+			want:    to.Int32Ptr(2),
+			wantErr: false,
+		},
+		{
+			name: "health probe related annotation is not found",
+			args: args{
+				annotations: map[string]string{},
+				port:        80,
+				key:         HealthProbeParamsNumOfProbe,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(tt.args.annotations, tt.args.port, tt.args.key, tt.args.validators...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1271,31 +1271,6 @@ func getDomainNameLabel(pip *network.PublicIPAddress) string {
 	return to.String(pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel)
 }
 
-func getIdleTimeout(s *v1.Service) (*int32, error) {
-	const (
-		min = 4
-		max = 30
-	)
-
-	val, ok := s.Annotations[consts.ServiceAnnotationLoadBalancerIdleTimeout]
-	if !ok {
-		// Return a nil here as this will set the value to the azure default
-		return nil, nil
-	}
-
-	errInvalidTimeout := fmt.Errorf("idle timeout value must be a whole number representing minutes between %d and %d", min, max)
-	toInt, err := strconv.ParseInt(val, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing idle timeout value: %w: %v", err, errInvalidTimeout)
-	}
-	to32 := int32(toInt)
-
-	if to32 < min || to32 > max {
-		return nil, errInvalidTimeout
-	}
-	return &to32, nil
-}
-
 func (az *Cloud) isFrontendIPChanged(clusterName string, config network.FrontendIPConfiguration, service *v1.Service, lbFrontendIPConfigName string) (bool, error) {
 	isServiceOwnsFrontendIP, isPrimaryService, err := az.serviceOwnsFrontendIP(config, service)
 	if err != nil {
@@ -1501,11 +1476,6 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	defaultLBFrontendIPConfigID := az.getFrontendIPConfigID(lbName, lbResourceGroup, defaultLBFrontendIPConfigName)
 	dirtyLb := false
 
-	lbIdleTimeout, err := getIdleTimeout(service)
-	if wantLb && err != nil {
-		return nil, err
-	}
-
 	// reconcile the load balancer's backend pool configuration.
 	if wantLb {
 		preConfig, changed, err := az.LoadBalancerBackendPool.ReconcileBackendPools(clusterName, service, lb)
@@ -1543,9 +1513,13 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		}
 	}
 
-	expectedProbes, expectedRules, err := az.getExpectedLBRules(service, wantLb, defaultLBFrontendIPConfigID, lbBackendPoolID, lbName, lbIdleTimeout)
-	if err != nil {
-		return nil, err
+	var expectedProbes []network.Probe
+	var expectedRules []network.LoadBalancingRule
+	if wantLb {
+		expectedProbes, expectedRules, err = az.getExpectedLBRules(service, defaultLBFrontendIPConfigID, lbBackendPoolID, lbName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if changed := az.reconcileLBProbes(lb, service, serviceName, wantLb, expectedProbes); changed {
@@ -1981,164 +1955,302 @@ func lbRuleConflictsWithPort(rule network.LoadBalancingRule, frontendIPConfigID 
 		*rule.FrontendPort == port.Port
 }
 
-func parseHealthProbeProtocolAndPath(service *v1.Service) (string, string) {
-	var protocol, path string
-	if v, ok := service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeProtocol]; ok {
-		protocol = v
-	} else {
-		return protocol, path
+// buildHealthProbeRulesForPort
+// for following sku: basic loadbalancer vs standard load balancer
+// for following protocols: TCP HTTP HTTPS(SLB only)
+func (az *Cloud) buildHealthProbeRulesForPort(annotations map[string]string, port v1.ServicePort, lbrule string) (*network.Probe, error) {
+	properties := &network.ProbePropertiesFormat{}
+	// get request path ,only used with http/https probe
+	path, err := consts.GetHealthProbeConfigOfPortFromK8sSvcAnnotation(annotations, port.Port, consts.HealthProbeParamsRequestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.BuildHealthProbeAnnotationKeyForPort(port.Port, consts.HealthProbeParamsRequestPath), err)
 	}
-	// ignore the request path if using TCP
-	if strings.EqualFold(protocol, string(network.ProbeProtocolHTTP)) ||
-		strings.EqualFold(protocol, string(network.ProbeProtocolHTTPS)) {
-		if v, ok := service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath]; ok {
-			path = v
+	if path == nil {
+		if path, err = consts.GetAttributeValueInSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath, err)
 		}
 	}
-	return protocol, path
+	if path == nil {
+		path = to.StringPtr(consts.HealthProbeDefaultRequestPath)
+	}
+	if port.AppProtocol == nil {
+		if port.AppProtocol, err = consts.GetAttributeValueInSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeProtocol); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeProtocol, err)
+		}
+		if port.AppProtocol == nil {
+			if port.Protocol == v1.ProtocolTCP {
+				port.AppProtocol = to.StringPtr(string(network.ProtocolTCP))
+			}
+		}
+		if port.AppProtocol == nil {
+			// health probe not set, return
+			return nil, nil
+		}
+	}
+	switch protocol := strings.TrimSpace(*port.AppProtocol); {
+	case strings.EqualFold(protocol, string(network.ProtocolHTTPS)):
+		//HTTPS probe is only supported in standard loadbalancer
+		if !az.useStandardLoadBalancer() {
+			return nil, fmt.Errorf("HTTPS protocol is not supported in health probe when basic lb is used")
+		}
+		//HTTP and HTTPS share the same configuration
+		properties.Protocol = network.ProbeProtocolHTTPS
+		properties.RequestPath = path
+	case strings.EqualFold(protocol, string(network.ProtocolHTTP)):
+		properties.Protocol = network.ProbeProtocolHTTP
+		properties.RequestPath = path
+	case strings.EqualFold(protocol, string(network.ProtocolTCP)):
+		properties.Protocol = network.ProbeProtocolTCP
+	default:
+		return nil, fmt.Errorf("unsupported protocol %s", protocol)
+	}
+
+	// get number of probes
+	var numOfProbeValidator = func(val *int32) error {
+		//minimum number of unhealthy responses is 2. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+		const (
+			MinimumNumOfProbe = 2
+		)
+		if *val < MinimumNumOfProbe {
+			return fmt.Errorf("the minimum value of %s is %d", consts.HealthProbeParamsNumOfProbe, MinimumNumOfProbe)
+		}
+		return nil
+	}
+	numberOfProbes, err := consts.GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(annotations, port.Port, consts.HealthProbeParamsNumOfProbe, numOfProbeValidator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.BuildHealthProbeAnnotationKeyForPort(port.Port, consts.HealthProbeParamsNumOfProbe), err)
+	}
+	if numberOfProbes == nil {
+		if numberOfProbes, err = consts.Getint32ValueFromK8sSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, numOfProbeValidator); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, err)
+		}
+	}
+
+	// if numberOfProbes is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if numberOfProbes == nil {
+		numberOfProbes = to.Int32Ptr(consts.HealthProbeDefaultNumOfProbe)
+	}
+
+	// get probe interval in seconds
+	var probeIntervalValidator = func(val *int32) error {
+		//minimum probe interval in seconds is 5. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+		const (
+			MinimumProbeIntervalInSecond = 5
+		)
+		if *val < 5 {
+			return fmt.Errorf("the minimum value of %s is %d", consts.HealthProbeParamsProbeInterval, MinimumProbeIntervalInSecond)
+		}
+		return nil
+	}
+	probeInterval, err := consts.GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(annotations, port.Port, consts.HealthProbeParamsProbeInterval, probeIntervalValidator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse annotation %s:%w", consts.BuildHealthProbeAnnotationKeyForPort(port.Port, consts.HealthProbeParamsProbeInterval), err)
+	}
+	if probeInterval == nil {
+		if probeInterval, err = consts.Getint32ValueFromK8sSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeInterval, probeIntervalValidator); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeInterval, err)
+		}
+	}
+	// if probeInterval is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if probeInterval == nil {
+		probeInterval = to.Int32Ptr(consts.HealthProbeDefaultProbeInterval)
+	}
+
+	// total probe should be less than 120 seconds ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if (*probeInterval)*(*numberOfProbes) >= 120 {
+		return nil, fmt.Errorf("total probe should be less than 120, please adjust interval and number of probe accordingly")
+	}
+	properties.IntervalInSeconds = probeInterval
+	properties.NumberOfProbes = numberOfProbes
+	properties.Port = &port.NodePort
+	probe := &network.Probe{
+		Name:                  &lbrule,
+		ProbePropertiesFormat: properties,
+	}
+	return probe, nil
 }
 
+// buildLBRules
+// for following sku: basic loadbalancer vs standard load balancer
+// for following scenario: internal vs external
 func (az *Cloud) getExpectedLBRules(
 	service *v1.Service,
-	wantLb bool,
 	lbFrontendIPConfigID string,
 	lbBackendPoolID string,
-	lbName string,
-	lbIdleTimeout *int32) ([]network.Probe, []network.LoadBalancingRule, error) {
+	lbName string) ([]network.Probe, []network.LoadBalancingRule, error) {
 
-	var ports []v1.ServicePort
-	if wantLb {
-		ports = service.Spec.Ports
-	} else {
-		ports = []v1.ServicePort{}
-	}
-
-	var enableTCPReset, nilTCPReset *bool
-	if az.useStandardLoadBalancer() {
-		enableTCPReset = to.BoolPtr(true)
-	}
-
-	var expectedProbes []network.Probe
 	var expectedRules []network.LoadBalancingRule
-	highAvailabilityPortsEnabled := false
-	for _, port := range ports {
-		if !requiresInternalLoadBalancer(service) && port.Protocol == v1.ProtocolSCTP {
-			return nil, nil, fmt.Errorf("SCTP is only supported on internal LoadBalancer")
-		}
+	var expectedProbes []network.Probe
 
-		if highAvailabilityPortsEnabled {
-			// Since the port is always 0 when enabling HA, only one rule should be configured.
-			break
-		}
+	// support podPresence health check when External Traffic Policy is local
+	// take precedence over user defined probe configuration
+	// healthcheck proxy server serves http requests
+	// https://github.com/kubernetes/kubernetes/blob/7c013c3f64db33cf19f38bb2fc8d9182e42b0b7b/pkg/proxy/healthcheck/service_health.go#L236
+	var nodeEndpointHealthprobe *network.Probe
+	if servicehelpers.NeedsHealthCheck(service) {
+		podPresencePath, podPresencePort := servicehelpers.GetServiceHealthCheckPathPort(service)
+		lbRuleName := az.getLoadBalancerRuleName(service, v1.ProtocolTCP, podPresencePort)
 
-		lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port)
-		klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
-
-		transportProto, _, probeProto, err := getProtocolsFromKubernetesProtocol(port.Protocol)
-		if err != nil {
-			return expectedProbes, expectedRules, err
-		}
-
-		probeProtocol, requestPath := parseHealthProbeProtocolAndPath(service)
-		if servicehelpers.NeedsHealthCheck(service) {
-			podPresencePath, podPresencePort := servicehelpers.GetServiceHealthCheckPathPort(service)
-			if probeProtocol == "" {
-				probeProtocol = string(network.ProbeProtocolHTTP)
-			}
-
-			needRequestPath := strings.EqualFold(probeProtocol, string(network.ProbeProtocolHTTP)) || strings.EqualFold(probeProtocol, string(network.ProbeProtocolHTTPS))
-			if requestPath == "" && needRequestPath {
-				requestPath = podPresencePath
-			}
-
-			expectedProbes = append(expectedProbes, network.Probe{
-				Name: &lbRuleName,
-				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					RequestPath:       to.StringPtr(requestPath),
-					Protocol:          network.ProbeProtocol(probeProtocol),
-					Port:              to.Int32Ptr(podPresencePort),
-					IntervalInSeconds: to.Int32Ptr(5),
-					NumberOfProbes:    to.Int32Ptr(2),
-				},
-			})
-		} else if port.Protocol != v1.ProtocolUDP && port.Protocol != v1.ProtocolSCTP {
-			// we only add the expected probe if we're doing TCP
-			if probeProtocol == "" {
-				probeProtocol = string(*probeProto)
-			}
-			var actualPath *string
-			if !strings.EqualFold(probeProtocol, string(network.ProbeProtocolTCP)) {
-				if requestPath != "" {
-					actualPath = to.StringPtr(requestPath)
-				} else {
-					actualPath = to.StringPtr("/healthz")
-				}
-			}
-			expectedProbes = append(expectedProbes, network.Probe{
-				Name: &lbRuleName,
-				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Protocol:          network.ProbeProtocol(probeProtocol),
-					RequestPath:       actualPath,
-					Port:              to.Int32Ptr(port.NodePort),
-					IntervalInSeconds: to.Int32Ptr(5),
-					NumberOfProbes:    to.Int32Ptr(2),
-				},
-			})
-		}
-
-		loadDistribution := network.LoadDistributionDefault
-		if service.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
-			loadDistribution = network.LoadDistributionSourceIP
-		}
-
-		tcpReset := enableTCPReset
-		if port.Protocol != v1.ProtocolTCP {
-			tcpReset = nilTCPReset
-		}
-		expectedRule := network.LoadBalancingRule{
+		nodeEndpointHealthprobe = &network.Probe{
 			Name: &lbRuleName,
-			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-				Protocol: *transportProto,
-				FrontendIPConfiguration: &network.SubResource{
-					ID: to.StringPtr(lbFrontendIPConfigID),
-				},
-				BackendAddressPool: &network.SubResource{
-					ID: to.StringPtr(lbBackendPoolID),
-				},
-				LoadDistribution:    loadDistribution,
-				FrontendPort:        to.Int32Ptr(port.Port),
-				BackendPort:         to.Int32Ptr(port.Port),
-				DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
-				EnableTCPReset:      tcpReset,
-				EnableFloatingIP:    to.BoolPtr(true),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				RequestPath:       to.StringPtr(podPresencePath),
+				Protocol:          network.ProbeProtocolHTTP,
+				Port:              to.Int32Ptr(podPresencePort),
+				IntervalInSeconds: to.Int32Ptr(consts.HealthProbeDefaultProbeInterval),
+				NumberOfProbes:    to.Int32Ptr(consts.HealthProbeDefaultNumOfProbe),
 			},
 		}
+		expectedProbes = append(expectedProbes, *nodeEndpointHealthprobe)
+	}
 
-		if port.Protocol == v1.ProtocolTCP {
-			expectedRule.LoadBalancingRulePropertiesFormat.IdleTimeoutInMinutes = lbIdleTimeout
+	// In HA mode, lb forward traffic of all port to backend
+	// HA mode is only supported on standard loadbalancer SKU in internal mode
+	if consts.IsK8sServiceUsingInternalLoadBalancer(service) &&
+		az.useStandardLoadBalancer() &&
+		consts.IsK8sServiceHasHAModeEnabled(service) {
+
+		lbRuleName := az.getloadbalancerHAmodeRuleName(service)
+		klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
+
+		props, err := az.getExpectedHAModeLoadBalancingRuleProperties(service, lbFrontendIPConfigID, lbBackendPoolID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
 		}
-
-		if requiresInternalLoadBalancer(service) &&
-			strings.EqualFold(az.LoadBalancerSku, consts.LoadBalancerSkuStandard) &&
-			(strings.EqualFold(service.Annotations[consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts], consts.TrueAnnotationValue) || port.Protocol == v1.ProtocolSCTP) {
-			expectedRule.FrontendPort = to.Int32Ptr(0)
-			expectedRule.BackendPort = to.Int32Ptr(0)
-			expectedRule.Protocol = network.TransportProtocolAll
-			highAvailabilityPortsEnabled = true
-		}
-
-		// we didn't construct the probe objects for UDP or SCTP because they're not allowed on Azure.
-		// However, when externalTrafficPolicy is Local, Kubernetes HTTP health check would be used for probing.
-		if servicehelpers.NeedsHealthCheck(service) || (port.Protocol != v1.ProtocolUDP && port.Protocol != v1.ProtocolSCTP) {
-			expectedRule.Probe = &network.SubResource{
-				ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), lbRuleName)),
+		//Here we need to find one health probe rule for the HA lb rule.
+		var probe *network.Probe = nodeEndpointHealthprobe
+		if probe == nil {
+			// use user customized health probe rule if any
+			for _, port := range service.Spec.Ports {
+				if probe, err = az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName); err != nil {
+					klog.V(2).ErrorS(err, "error occurred when buildHealthProbeRulesForPort", "service", service.Name, "namespace", service.Namespace,
+						"rule-name", lbRuleName, "port", port.Port)
+					//ignore error because we only need one correct rule
+				} else if probe != nil {
+					expectedProbes = append(expectedProbes, *probe)
+					break
+				}
 			}
 		}
 
-		expectedRules = append(expectedRules, expectedRule)
+		// if we found one valid probe, append it to lb rule.
+		if probe != nil {
+			props.Probe = &network.SubResource{
+				ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *probe.Name)),
+			}
+		}
+
+		expectedRules = append(expectedRules, network.LoadBalancingRule{
+			Name:                              &lbRuleName,
+			LoadBalancingRulePropertiesFormat: props,
+		})
+		// end of HA mode handling
+	} else {
+		// generate lb rule for each port defined in svc object
+
+		for _, port := range service.Spec.Ports {
+			lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port)
+			klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
+
+			if port.Protocol == v1.ProtocolSCTP && !(az.useStandardLoadBalancer() && consts.IsK8sServiceUsingInternalLoadBalancer(service)) {
+				return expectedProbes, expectedRules, fmt.Errorf("SCTP is only supported on standard loadbalancer in internal mode")
+			}
+
+			transportProto, _, _, err := getProtocolsFromKubernetesProtocol(port.Protocol)
+			if err != nil {
+				return expectedProbes, expectedRules, fmt.Errorf("failed to parse transport protocol: %w", err)
+			}
+			props, err := az.getExpectedLoadBalancingRulePropertiesForPort(service, lbFrontendIPConfigID, lbBackendPoolID, to.Int32Ptr(port.Port), *transportProto)
+			if err != nil {
+				return expectedProbes, expectedRules, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
+			}
+
+			var probe *network.Probe = nodeEndpointHealthprobe
+			if probe == nil {
+				if probe, err = az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName); err != nil {
+					klog.V(2).ErrorS(err, "error occurred when buildHealthProbeRulesForPort", "service", service.Name, "namespace", service.Namespace,
+						"rule-name", lbRuleName, "port", port.Port)
+					return expectedProbes, expectedRules, err
+				} else if probe != nil {
+					expectedProbes = append(expectedProbes, *probe)
+				}
+			}
+			if probe != nil {
+				props.Probe = &network.SubResource{
+					ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *probe.Name)),
+				}
+			}
+			expectedRules = append(expectedRules, network.LoadBalancingRule{
+				Name:                              &lbRuleName,
+				LoadBalancingRulePropertiesFormat: props,
+			})
+
+		}
 	}
 
 	return expectedProbes, expectedRules, nil
+}
+
+//getDefaultLoadBalancingRulePropertiesFormat returns the loadbalancing rule for one port
+func (az *Cloud) getExpectedLoadBalancingRulePropertiesForPort(
+	service *v1.Service,
+	lbFrontendIPConfigID string,
+	lbBackendPoolID string, port *int32, transportProto network.TransportProtocol) (*network.LoadBalancingRulePropertiesFormat, error) {
+	var err error
+
+	loadDistribution := network.LoadDistributionDefault
+	if service.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
+		loadDistribution = network.LoadDistributionSourceIP
+	}
+
+	var lbIdleTimeout *int32
+	if lbIdleTimeout, err = consts.Getint32ValueFromK8sSvcAnnotation(service.Annotations, consts.ServiceAnnotationLoadBalancerIdleTimeout, func(val *int32) error {
+		const (
+			min = 4
+			max = 30
+		)
+		if *val < min || *val > max {
+			return fmt.Errorf("idle timeout value must be a whole number representing minutes between %d and %d, actual value: %d", min, max, *val)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("error parsing idle timeout key: %s, err: %w", consts.ServiceAnnotationLoadBalancerIdleTimeout, err)
+	} else if lbIdleTimeout == nil {
+		lbIdleTimeout = to.Int32Ptr(4)
+	}
+
+	props := &network.LoadBalancingRulePropertiesFormat{
+		Protocol:            transportProto,
+		FrontendPort:        port,
+		BackendPort:         port,
+		DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
+		EnableFloatingIP:    to.BoolPtr(true),
+		LoadDistribution:    loadDistribution,
+		FrontendIPConfiguration: &network.SubResource{
+			ID: to.StringPtr(lbFrontendIPConfigID),
+		},
+		BackendAddressPool: &network.SubResource{
+			ID: to.StringPtr(lbBackendPoolID),
+		},
+		IdleTimeoutInMinutes: lbIdleTimeout,
+	}
+	if strings.EqualFold(string(transportProto), string(network.TransportProtocolTCP)) && az.useStandardLoadBalancer() {
+		props.EnableTCPReset = to.BoolPtr(true)
+	}
+	return props, nil
+}
+
+//getExpectedHAModeLoadBalancingRuleProperties build load balancing rule for lb in HA mode
+func (az *Cloud) getExpectedHAModeLoadBalancingRuleProperties(
+	service *v1.Service,
+	lbFrontendIPConfigID string,
+	lbBackendPoolID string) (*network.LoadBalancingRulePropertiesFormat, error) {
+	props, err := az.getExpectedLoadBalancingRulePropertiesForPort(service, lbFrontendIPConfigID, lbBackendPoolID, to.Int32Ptr(0), network.TransportProtocolAll)
+	if err != nil {
+		return nil, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
+	}
+	props.EnableTCPReset = to.BoolPtr(true)
+	return props, nil
 }
 
 // This reconciles the Network Security Group similar to how the LB is reconciled.

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -274,37 +273,6 @@ func TestFindRule(t *testing.T) {
 	for i, test := range tests {
 		findResult := findRule(test.existingRule, test.curRule, true)
 		assert.Equal(t, test.expected, findResult, fmt.Sprintf("TestCase[%d]: %s", i, test.msg))
-	}
-}
-
-func TestGetIdleTimeout(t *testing.T) {
-	for _, c := range []struct {
-		desc        string
-		annotations map[string]string
-		i           *int32
-		err         bool
-	}{
-		{desc: "no annotation"},
-		{desc: "annotation empty value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: ""}, err: true},
-		{desc: "annotation not a number", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "cookies"}, err: true},
-		{desc: "annotation negative value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "-6"}, err: true},
-		{desc: "annotation zero value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "0"}, err: true},
-		{desc: "annotation too low value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "3"}, err: true},
-		{desc: "annotation too high value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "31"}, err: true},
-		{desc: "annotation good value", annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIdleTimeout: "24"}, i: to.Int32Ptr(24)},
-	} {
-		t.Run(c.desc, func(t *testing.T) {
-			s := &v1.Service{}
-			s.Annotations = c.annotations
-			i, err := getIdleTimeout(s)
-
-			if !reflect.DeepEqual(c.i, i) {
-				t.Fatalf("got unexpected value: %d", to.Int32(i))
-			}
-			if (err != nil) != c.err {
-				t.Fatalf("expected error=%v, got %v", c.err, err)
-			}
-		})
 	}
 }
 
@@ -1725,39 +1693,36 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		desc            string
 		service         v1.Service
 		loadBalancerSku string
-		wantLb          bool
 		probeProtocol   string
 		probePath       string
 		expectedProbes  []network.Probe
 		expectedRules   []network.LoadBalancingRule
-		expectedErr     error
+		expectedErr     bool
 	}{
 		{
-			desc:    "getExpectedLBRules shall return nil if wantLb is false",
-			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
-			wantLb:  false,
-		},
-		{
 			desc:            "getExpectedLBRules shall return corresponding probe and lbRule(blb)",
-			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "true"}, false, 80),
+			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{}, false, 80),
 			loadBalancerSku: "basic",
-			wantLb:          true,
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getDefaultTestRules(false),
 		},
 		{
-			desc:            "getExpectedLBRules shall return corresponding probe and lbRule (slb without tcp reset)",
-			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "True"}, false, 80),
+			desc:            "getExpectedLBRules shall return error on non supported protocols",
+			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{}, false, 80),
+			loadBalancerSku: "basic",
+			probeProtocol:   "Https",
+			expectedErr:     true,
+		},
+		{
+			desc:            "getExpectedLBRules shall return error (slb with external mode and SCTP)",
+			service:         getTestService("test1", v1.ProtocolSCTP, map[string]string{}, false, 80),
 			loadBalancerSku: "standard",
-			wantLb:          true,
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
-			expectedRules:   getDefaultTestRules(true),
+			expectedErr:     true,
 		},
 		{
 			desc:            "getExpectedLBRules shall return corresponding probe and lbRule(slb with tcp reset)",
 			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			loadBalancerSku: "standard",
-			wantLb:          true,
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getDefaultTestRules(true),
 		},
@@ -1765,10 +1730,18 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			desc:            "getExpectedLBRules shall respect the probe protocol and path configuration in the config file",
 			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			loadBalancerSku: "standard",
-			wantLb:          true,
-			probeProtocol:   "http",
+			probeProtocol:   "Http",
 			probePath:       "/healthy",
-			expectedProbes:  getDefaultTestProbes("http", "/healthy"),
+			expectedProbes:  getDefaultTestProbes("Http", "/healthy"),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc:            "getExpectedLBRules shall respect the probe protocol and path configuration in the config file",
+			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Https",
+			probePath:       "/healthy1",
+			expectedProbes:  getDefaultTestProbes("Https", "/healthy1"),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -1778,19 +1751,17 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 				"service.beta.kubernetes.io/azure-load-balancer-internal":                       "true",
 			}, false, 80),
 			loadBalancerSku: "standard",
-			wantLb:          true,
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getHATestRules(true, true, v1.ProtocolTCP),
 		},
 		{
-			desc: "getExpectedLBRules shall return corresponding probe and lbRule (slb with SCTP)",
+			desc: "getExpectedLBRules shall return corresponding probe and lbRule (slb with HA mode and SCTP)",
 			service: getTestService("test1", v1.ProtocolSCTP, map[string]string{
 				"service.beta.kubernetes.io/azure-load-balancer-enable-high-availability-ports": "true",
 				"service.beta.kubernetes.io/azure-load-balancer-internal":                       "true",
 			}, false, 80),
 			loadBalancerSku: "standard",
-			wantLb:          true,
-			expectedRules:   getHATestRules(false, false, v1.ProtocolSCTP),
+			expectedRules:   getHATestRules(true, false, v1.ProtocolSCTP),
 		},
 		{
 			desc: "getExpectedLBRules shall return corresponding probe and lbRule (slb with HA enabled multi-ports services)",
@@ -1799,7 +1770,6 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 				"service.beta.kubernetes.io/azure-load-balancer-internal":                       "true",
 			}, false, 80, 8080),
 			loadBalancerSku: "standard",
-			wantLb:          true,
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getHATestRules(true, true, v1.ProtocolTCP),
 		},
@@ -1807,27 +1777,206 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			desc:            "getExpectedLBRules should leave probe path empty when using TCP probe",
 			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			loadBalancerSku: "standard",
-			wantLb:          true,
 			probeProtocol:   "Tcp",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getDefaultTestRules(true),
 		},
+		{
+			desc: "getExpectedLBRules should return error when invalid protocol is defined",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_request-path": "/healthy1",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "TCP1",
+			expectedErr:     true,
+		},
+		{
+			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthy1",
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol":     "https",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			expectedProbes:  getDefaultTestProbes("Https", "/healthy1"),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthy1",
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol":     "http",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			expectedProbes:  getDefaultTestProbes("Http", "/healthy1"),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthy1",
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol":     "tcp",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			expectedProbes:  getDefaultTestProbes("Tcp", ""),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthy1",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Https",
+			expectedProbes:  getDefaultTestProbes("Https", "/healthy1"),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc: "getExpectedLBRules should overwrite value defined in deprecated annotation when deprecated annotations and probe path are defined",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthy1",
+				"service.beta.kubernetes.io/port_80_health-probe_request-path":             "/healthy2",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Https",
+			expectedProbes:  getDefaultTestProbes("Https", "/healthy2"),
+			expectedRules:   getDefaultTestRules(true)},
+		{
+			desc: "getExpectedLBRules should return error when deprecated tcp health probe annotations and protocols are added and config is not valid",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":             "10",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe":         "20",
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol": "https",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Tcp",
+			expectedErr:     true,
+		},
+		{
+			desc: "getExpectedLBRules should return error when deprecated tcp health probe annotations and protocols are added and config is not valid",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":             "10",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe":         "20",
+				"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol": "tcp",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Tcp",
+			expectedErr:     true,
+		},
+		{
+			desc: "getExpectedLBRules should return correct rule when health probe annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":     "20",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "5",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Https",
+			probePath:       "/healthy1",
+			expectedProbes:  getTestProbes("Https", "/healthy1", to.Int32Ptr(20), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc: "getExpectedLBRules should return correct rule when health probe annotations are added,default path should be /healthy",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":     "20",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "5",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Http",
+			expectedProbes:  getTestProbes("Http", "/healthz", to.Int32Ptr(20), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc: "getExpectedLBRules should return correct rule when tcp health probe annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":     "20",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "5",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Tcp",
+			expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(20), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedRules:   getDefaultTestRules(true),
+		},
+		{
+			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":     "20",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "5a",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Tcp",
+			expectedErr:     true,
+		},
+		{
+			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":     "1",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "5",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Tcp",
+			expectedErr:     true,
+		},
+		{
+			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":     "10",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "1",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Tcp",
+			expectedErr:     true,
+		},
+		{
+			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				"service.beta.kubernetes.io/port_80_health-probe_interval":     "10",
+				"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "20",
+			}, false, 80),
+			loadBalancerSku: "standard",
+			probeProtocol:   "Tcp",
+			expectedErr:     true,
+		},
 	}
+	rules := getDefaultTestRules(true)
+	rules[0].IdleTimeoutInMinutes = to.Int32Ptr(5)
+	testCases = append(testCases, struct {
+		desc            string
+		service         v1.Service
+		loadBalancerSku string
+		probeProtocol   string
+		probePath       string
+		expectedProbes  []network.Probe
+		expectedRules   []network.LoadBalancingRule
+		expectedErr     bool
+	}{
+		desc: "getExpectedLBRules should expected rules when timeout are added",
+		service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			"service.beta.kubernetes.io/port_80_health-probe_interval":        "10",
+			"service.beta.kubernetes.io/port_80_health-probe_num-of-probe":    "10",
+			"service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout": "5",
+		}, false, 80),
+		loadBalancerSku: "standard",
+		probeProtocol:   "Tcp",
+		expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(10), to.Int32Ptr(10080), to.Int32Ptr(10)),
+		expectedRules:   rules,
+	})
+
 	for i, test := range testCases {
 		az := GetTestCloud(ctrl)
 		az.Config.LoadBalancerSku = test.loadBalancerSku
 		service := test.service
+		firstPort := service.Spec.Ports[0]
 		if test.probeProtocol != "" {
-			service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeProtocol] = test.probeProtocol
+			service.Spec.Ports[0].AppProtocol = &test.probeProtocol
 		}
 		if test.probePath != "" {
-			service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath] = test.probePath
+			service.Annotations[consts.BuildHealthProbeAnnotationKeyForPort(firstPort.Port, consts.HealthProbeParamsRequestPath)] = test.probePath
 		}
-		probe, lbrule, err := az.getExpectedLBRules(&test.service, test.wantLb,
-			"frontendIPConfigID", "backendPoolID", "lbname", to.Int32Ptr(0))
+		probe, lbrule, err := az.getExpectedLBRules(&test.service,
+			"frontendIPConfigID", "backendPoolID", "lbname")
 
-		if test.expectedErr != nil {
-			assert.Equal(t, test.expectedErr, err, "TestCase[%d]: %s", i, test.desc)
+		if test.expectedErr {
+			assert.Error(t, err, "TestCase[%d]: %s", i, test.desc)
 		} else {
 			assert.Equal(t, test.expectedProbes, probe, "TestCase[%d]: %s", i, test.desc)
 			assert.Equal(t, test.expectedRules, lbrule, "TestCase[%d]: %s", i, test.desc)
@@ -1835,23 +1984,26 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		}
 	}
 }
-
-func getDefaultTestProbes(protocol, path string) []network.Probe {
+func getTestProbes(protocol, path string, interval, port, numOfProbe *int32) []network.Probe {
 	expectedProbes := []network.Probe{
 		{
 			Name: to.StringPtr("atest1-TCP-80"),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
 				Protocol:          network.ProbeProtocol(protocol),
-				Port:              to.Int32Ptr(10080),
-				IntervalInSeconds: to.Int32Ptr(5),
-				NumberOfProbes:    to.Int32Ptr(2),
+				Port:              port,
+				IntervalInSeconds: interval,
+				NumberOfProbes:    numOfProbe,
 			},
 		},
 	}
-	if path != "" {
+	if (strings.EqualFold(protocol, "Http") || strings.EqualFold(protocol, "Https")) && len(strings.TrimSpace(path)) > 0 {
 		expectedProbes[0].RequestPath = to.StringPtr(path)
 	}
 	return expectedProbes
+}
+
+func getDefaultTestProbes(protocol, path string) []network.Probe {
+	return getTestProbes(protocol, path, to.Int32Ptr(5), to.Int32Ptr(10080), to.Int32Ptr(2))
 }
 
 func getDefaultTestRules(enableTCPReset bool) []network.LoadBalancingRule {
@@ -1871,7 +2023,7 @@ func getDefaultTestRules(enableTCPReset bool) []network.LoadBalancingRule {
 				BackendPort:          to.Int32Ptr(80),
 				EnableFloatingIP:     to.BoolPtr(true),
 				DisableOutboundSnat:  to.BoolPtr(false),
-				IdleTimeoutInMinutes: to.Int32Ptr(0),
+				IdleTimeoutInMinutes: to.Int32Ptr(4),
 				Probe: &network.SubResource{
 					ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
 						"Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-80"),
@@ -1897,19 +2049,15 @@ func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol) []netwo
 				BackendAddressPool: &network.SubResource{
 					ID: to.StringPtr("backendPoolID"),
 				},
-				LoadDistribution:    "Default",
-				FrontendPort:        to.Int32Ptr(0),
-				BackendPort:         to.Int32Ptr(0),
-				EnableFloatingIP:    to.BoolPtr(true),
-				DisableOutboundSnat: to.BoolPtr(false),
+				LoadDistribution:     "Default",
+				FrontendPort:         to.Int32Ptr(0),
+				BackendPort:          to.Int32Ptr(0),
+				EnableFloatingIP:     to.BoolPtr(true),
+				DisableOutboundSnat:  to.BoolPtr(false),
+				IdleTimeoutInMinutes: to.Int32Ptr(4),
+				EnableTCPReset:       to.BoolPtr(true),
 			},
 		},
-	}
-	if protocol == v1.ProtocolTCP {
-		expectedRules[0].IdleTimeoutInMinutes = to.Int32Ptr(0)
-	}
-	if enableTCPReset {
-		expectedRules[0].EnableTCPReset = to.BoolPtr(true)
 	}
 	if hasProbe {
 		expectedRules[0].Probe = &network.SubResource{
@@ -1963,12 +2111,13 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 								"Microsoft.Network/loadBalancers/" + *name + "/backendAddressPools/" + *clusterName),
 						},
-						LoadDistribution:    network.LoadDistribution("Default"),
-						FrontendPort:        to.Int32Ptr(service.Spec.Ports[0].Port),
-						BackendPort:         to.Int32Ptr(service.Spec.Ports[0].Port),
-						EnableFloatingIP:    to.BoolPtr(true),
-						EnableTCPReset:      to.BoolPtr(strings.EqualFold(lbSku, "standard")),
-						DisableOutboundSnat: to.BoolPtr(false),
+						LoadDistribution:     network.LoadDistribution("Default"),
+						FrontendPort:         to.Int32Ptr(service.Spec.Ports[0].Port),
+						BackendPort:          to.Int32Ptr(service.Spec.Ports[0].Port),
+						EnableFloatingIP:     to.BoolPtr(true),
+						EnableTCPReset:       to.BoolPtr(strings.EqualFold(lbSku, "standard")),
+						DisableOutboundSnat:  to.BoolPtr(false),
+						IdleTimeoutInMinutes: to.Int32Ptr(4),
 						Probe: &network.SubResource{
 							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-80"),
 						},
@@ -2052,7 +2201,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 		},
 	}
 
-	service4 := getTestService("service1", v1.ProtocolTCP, map[string]string{"service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": "true"}, false, 80)
+	service4 := getTestService("service1", v1.ProtocolTCP, map[string]string{}, false, 80)
 	existingSLB := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service4, "Standard")
 	existingSLB.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
@@ -2090,6 +2239,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	expectedSLb := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service4, "Standard")
 	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
 	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = to.BoolPtr(true)
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = to.Int32Ptr(4)
 	expectedSLb.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
 			Name: to.StringPtr("aservice1"),
@@ -2147,6 +2297,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 
 	expectedSLb5 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service5, "Standard")
 	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
+	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = to.Int32Ptr(4)
 	expectedSLb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
 			Name: to.StringPtr("aservice1"),
@@ -2189,7 +2340,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	lb7.Probes = &[]network.Probe{}
 	expectedLB7 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service7, "basic")
 	(*expectedLB7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].Probe = &network.SubResource{
-		ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-UDP-80"),
+		ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-10081"),
 	}
 	(*expectedLB7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = nil
 	(*lb7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
@@ -2204,8 +2355,8 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	}
 	expectedLB7.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(service7.Spec.Ports[0].Protocol) +
-				"-" + strconv.Itoa(int(service7.Spec.Ports[0].Port))),
+			Name: to.StringPtr("aservice1-" + string(v1.ProtocolTCP) +
+				"-" + strconv.Itoa(int(service7.Spec.HealthCheckNodePort))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
 				Port:              to.Int32Ptr(10081),
 				RequestPath:       to.StringPtr("/healthz"),

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -33,10 +33,8 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/securitygroupclient/mocksecuritygroupclient"

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -295,6 +295,10 @@ func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protoc
 	return fmt.Sprintf("%s-%s-%s-%d", prefix, subnetSegment, protocol, port)
 }
 
+func (az *Cloud) getloadbalancerHAmodeRuleName(service *v1.Service) string {
+	return az.getLoadBalancerRuleName(service, service.Spec.Ports[0].Protocol, service.Spec.Ports[0].Port)
+}
+
 func (az *Cloud) getSecurityRuleName(service *v1.Service, port v1.ServicePort, sourceAddrPrefix string) string {
 	if useSharedSecurityRule(service) {
 		safePrefix := strings.Replace(sourceAddrPrefix, "/", "_", -1)

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -1732,6 +1732,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 			foundProbe := false
 			if servicehelpers.NeedsHealthCheck(&services[i]) {
 				path, port := servicehelpers.GetServiceHealthCheckPathPort(&services[i])
+				wantedRuleName := az.getLoadBalancerRuleName(&services[i], v1.ProtocolTCP, port)
 				for _, actualProbe := range *loadBalancer.Probes {
 					if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
 						*actualProbe.Port == port &&

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -87,6 +87,10 @@ var _ = Describe("Service with annotation", func() {
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
+		utils.Logf("Waiting for backend pods to be ready")
+		err = utils.WaitPodsToBeReady(cs, ns.Name)
+		Expect(err).NotTo(HaveOccurred())
+
 		utils.Logf("Creating Azure clients")
 		tc, err = utils.CreateAzureTestClient()
 		Expect(err).NotTo(HaveOccurred())
@@ -409,6 +413,58 @@ var _ = Describe("Service with annotation", func() {
 		By("Waiting for service IP to be updated")
 		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, to.String(pip2.IPAddress))
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe' and port specific configs", func() {
+		By("Creating a service with health probe annotations")
+		annotation := map[string]string{
+			consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe:                                  "5",
+			consts.BuildHealthProbeAnnotationKeyForPort(nginxPort, consts.HealthProbeParamsNumOfProbe): "3",
+		}
+
+		// create service with given annotation and wait it to expose
+		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		defer func() {
+			By("Cleaning up service and public IP")
+			err := utils.DeleteService(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			err = utils.DeletePIPWithRetry(tc, publicIP, tc.GetResourceGroup())
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		// get lb from azure client
+		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
+
+		By("Validating health probe configs")
+		var numberOfProbes *int32
+		for _, probe := range *lb.Probes {
+			if probe.NumberOfProbes != nil {
+				numberOfProbes = probe.NumberOfProbes
+			}
+		}
+		Expect(*numberOfProbes).To(Equal(int32(3)))
+	})
+	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol' and port specific configs", func() {
+		By("Creating a service with health probe annotations")
+		annotation := map[string]string{
+			consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:    "Http",
+			consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath: "/",
+		}
+
+		// create service with given annotation and wait it to expose
+		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		defer func() {
+			By("Cleaning up service and public IP")
+			err := utils.DeleteService(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			err = utils.DeletePIPWithRetry(tc, publicIP, tc.GetResourceGroup())
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		// get lb from azure client
+		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
+		By("Validating health probe configs")
+		probes := *lb.Probes
+		Expect((len(probes))).To(Equal(1))
+		Expect(probes[0].Protocol).To(Equal(network.ProbeProtocolHTTP))
 	})
 })
 


### PR DESCRIPTION

#### What type of PR is this?


/kind bug

/kind feature

#### What this PR does / why we need it:
backport https://github.com/kubernetes-sigs/cloud-provider-azure/pull/963 to release-1.23
#### Which issue(s) this PR fixes:

Fixes #949

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

Following  configuration will be applied to the all ports of service.

"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"
"service.beta.kubernetes.io/azure-load-balancer-health-probe-interval"
"service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe"
"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path"

If health probe is needed, user should specify AppProtocol in port object of Service spec.
And following protocols are supported: http, tcp, https

Additional annotations are added. where port is the port number of port object

service.beta.kubernetes.io/port_{port}_health-probe_interval
service.beta.kubernetes.io/port_{port}_health-probe_num-of-probe
service.beta.kubernetes.io/port_{port}_health-probe_request-path

Please refer to docs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
