### PR TITLE
[release-1.0]Fix: health probe config should be port-specific

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -256,6 +256,14 @@ const (
 	// If not set, the local service would use the HTTP and the cluster service would use the TCP by default.
 	ServiceAnnotationLoadBalancerHealthProbeProtocol = "service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"
 
+	// ServiceAnnotationLoadBalancerHealthProbeInterval determines the probe interval of the load balancer health probe.
+	// The minimum probe interval is 5 seconds and the default value is 15. The total duration of all intervals cannot exceed 120 seconds.
+	ServiceAnnotationLoadBalancerHealthProbeInterval = "service.beta.kubernetes.io/azure-load-balancer-health-probe-interval"
+
+	// ServiceAnnotationLoadBalancerHealthProbeNumOfProbe determines the minimum number of unhealthy responses which load balancer cannot tolerate.
+	// The minimum number of probe is 1. The total duration of all intervals cannot exceed 120 seconds.
+	ServiceAnnotationLoadBalancerHealthProbeNumOfProbe = "service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe"
+
 	// ServiceAnnotationLoadBalancerHealthProbeRequestPath determines the request path of the load balancer health probe.
 	// This is only useful for the HTTP and HTTPS, and would be ignored when using TCP. If not set,
 	// `/healthz` would be configured by default.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -354,3 +354,39 @@ const (
 	RouteNameFmt       = "%s____%s"
 	RouteNameSeparator = "____"
 )
+
+// cloud provider config secret
+const (
+	DefaultCloudProviderConfigSecName      = "azure-cloud-provider"
+	DefaultCloudProviderConfigSecNamespace = "kube-system"
+	DefaultCloudProviderConfigSecKey       = "cloud-config"
+)
+
+// RateLimited error string
+const RateLimited = "rate limited"
+
+// CreatedByTag tag key for CSI drivers
+const CreatedByTag = "k8s-azure-created-by"
+
+// health probe
+const (
+	HealthProbeAnnotationPrefixPattern = "service.beta.kubernetes.io/port_%d_health-probe_"
+
+	// HealthProbeParamsProbeInterval determines the probe interval of the load balancer health probe.
+	// The minimum probe interval is 5 seconds and the default value is 5. The total duration of all intervals cannot exceed 120 seconds.
+	HealthProbeParamsProbeInterval  HealthProbeParams = "interval"
+	HealthProbeDefaultProbeInterval int32             = 5
+
+	// HealthProbeParamsNumOfProbe determines the minimum number of unhealthy responses which load balancer cannot tolerate.
+	// The minimum number of probe is 2. The total duration of all intervals cannot exceed 120 seconds.
+	HealthProbeParamsNumOfProbe  HealthProbeParams = "num-of-probe"
+	HealthProbeDefaultNumOfProbe int32             = 2
+
+	// HealthProbeParamsRequestPath determines the request path of the load balancer health probe.
+	// This is only useful for the HTTP and HTTPS, and would be ignored when using TCP. If not set,
+	// `/healthz` would be configured by default.
+	HealthProbeParamsRequestPath  HealthProbeParams = "request-path"
+	HealthProbeDefaultRequestPath string            = "/healthz"
+)
+
+type HealthProbeParams string

--- a/pkg/consts/helpers.go
+++ b/pkg/consts/helpers.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package consts stages all the consts under pkg/.
+package consts
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// IsK8sServiceHasHAModeEnabled return if HA Mode is enabled in kuberntes service annotations
+func IsK8sServiceHasHAModeEnabled(service *v1.Service) bool {
+	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts, TrueAnnotationValue)
+}
+
+// IsK8sServiceUsingInternalLoadBalancer return if service is using an internal load balancer.
+func IsK8sServiceUsingInternalLoadBalancer(service *v1.Service) bool {
+	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationLoadBalancerInternal, TrueAnnotationValue)
+}
+
+// GetHealthProbeConfigOfPortFromK8sSvcAnnotation get health probe configuration for port
+func GetHealthProbeConfigOfPortFromK8sSvcAnnotation(annotations map[string]string, port int32, key HealthProbeParams, validators ...BusinessValidator) (*string, error) {
+	return GetAttributeValueInSvcAnnotation(annotations, BuildHealthProbeAnnotationKeyForPort(port, key), validators...)
+}
+
+// Getint32ValueFromK8sSvcAnnotation get health probe configuration for port
+func Getint32ValueFromK8sSvcAnnotation(annotations map[string]string, key string, validators ...Int32BusinessValidator) (*int32, error) {
+	val, err := GetAttributeValueInSvcAnnotation(annotations, key)
+	if err == nil && val != nil {
+		return extractInt32FromString(*val, validators...)
+	}
+	return nil, err
+}
+
+// BuildHealthProbeAnnotationKeyForPort get health probe configuration key for port
+func BuildHealthProbeAnnotationKeyForPort(port int32, key HealthProbeParams) string {
+	return fmt.Sprintf(HealthProbeAnnotationPrefixPattern, port) + string(key)
+}
+
+// GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation get health probe configuration for port
+func GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(annotations map[string]string, port int32, key HealthProbeParams, validators ...Int32BusinessValidator) (*int32, error) {
+	return Getint32ValueFromK8sSvcAnnotation(annotations, BuildHealthProbeAnnotationKeyForPort(port, key), validators...)
+}
+
+// Int32BusinessValidator is validator function which is invoked after values are parsed in order to make sure input value meets the businees need.
+type Int32BusinessValidator func(*int32) error
+
+// getInt32FromAnnotations parse integer value from annotation and return an reference to int32 object
+func extractInt32FromString(val string, businessValidator ...Int32BusinessValidator) (*int32, error) {
+	val = strings.TrimSpace(val)
+	errKey := fmt.Errorf("%s value must be a whole number", val)
+	toInt, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("error value: %w: %v", err, errKey)
+	}
+	parsedInt := int32(toInt)
+	for _, validator := range businessValidator {
+		if validator != nil {
+			err := validator(&parsedInt)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing value: %w", err)
+			}
+		}
+	}
+	return &parsedInt, nil
+}
+
+// BusinessValidator is validator function which is invoked after values are parsed in order to make sure input value meets the businees need.
+type BusinessValidator func(*string) error
+
+// GetAttributeValueInSvcAnnotation get value in annotation map using key
+func GetAttributeValueInSvcAnnotation(annotations map[string]string, key string, validators ...BusinessValidator) (*string, error) {
+	if l, found := annotations[key]; found {
+		for _, validateFunc := range validators {
+			if validateFunc != nil {
+				if err := validateFunc(&l); err != nil {
+					return nil, err
+				}
+			}
+		}
+		return &l, nil
+	}
+	return nil, nil
+}
+
+// expectAttributeInSvcAnnotation get key in svc annotation and compare with target value
+func expectAttributeInSvcAnnotationBeEqualTo(annotations map[string]string, key string, value string) bool {
+	if l, err := GetAttributeValueInSvcAnnotation(annotations, key); err == nil && l != nil {
+		return strings.EqualFold(*l, value)
+	}
+	return false
+}

--- a/pkg/consts/helpers_test.go
+++ b/pkg/consts/helpers_test.go
@@ -1,0 +1,378 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package consts stages all the consts under pkg/.
+package consts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsK8sServiceHasHAModeEnabled(t *testing.T) {
+	type args struct {
+		service *v1.Service
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ha mode is enabled",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ha mode is missing",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ha mode is corrupted",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true1",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ha annotation key is missing",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts + "1": "true1",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsK8sServiceHasHAModeEnabled(tt.args.service); got != tt.want {
+				t.Errorf("IsK8sServiceHasHAModeEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsK8sServiceUsingInternalLoadBalancer(t *testing.T) {
+	type args struct {
+		service *v1.Service
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "internal flag is set",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ServiceAnnotationLoadBalancerInternal: TrueAnnotationValue},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "internal flag is not set",
+			args: args{
+				service: &v1.Service{},
+			},
+			want: false,
+		},
+		{
+			name: "internal flag is corrupted",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ServiceAnnotationLoadBalancerInternal: TrueAnnotationValue + TrueAnnotationValue},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsK8sServiceUsingInternalLoadBalancer(tt.args.service); got != tt.want {
+				t.Errorf("IsK8sServiceUsingInternalLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetHealthProbeConfigOfPortFromK8sSvcAnnotation(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		port        int32
+		key         HealthProbeParams
+		validators  []BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *string
+		wantErr bool
+	}{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetHealthProbeConfigOfPortFromK8sSvcAnnotation(tt.args.annotations, tt.args.port, tt.args.key, tt.args.validators...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetHealthProbeConfigOfPortFromK8sSvcAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetHealthProbeConfigOfPortFromK8sSvcAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractInt32FromString(t *testing.T) {
+	type args struct {
+		val               string
+		businessValidator []Int32BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *int32
+		wantErr bool
+	}{
+		{name: "value is not a number", args: args{val: "cookies"}, wantErr: true},
+		{name: "value is zero", args: args{val: "0"}, wantErr: false, want: to.Int32Ptr(0)},
+		{name: "value is a float number", args: args{val: "0.1"}, wantErr: true},
+		{name: "value is a positive integer", args: args{val: "24"}, want: to.Int32Ptr(24), wantErr: false},
+		{name: "value negative integer", args: args{val: "-6"}, want: to.Int32Ptr(-6), wantErr: false},
+		{name: "validator is nil", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
+			nil,
+		}}, want: to.Int32Ptr(-6), wantErr: false},
+		{name: "validation failed", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
+			func(i *int32) error {
+				return fmt.Errorf("validator failed")
+			},
+		}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractInt32FromString(tt.args.val, tt.args.businessValidator...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractInt32FromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractInt32FromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getAttributeValueInSvcAnnotation(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		key         string
+		validators  []BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *string
+		wantErr bool
+	}{
+		{name: "annotation set is empty", args: args{key: "key"}, want: nil, wantErr: false},
+		{name: "key is not specified even though annotation set is not empty", args: args{annotations: map[string]string{"key": ""}}, want: nil, wantErr: false},
+		{name: "validation failed", args: args{annotations: map[string]string{"key": ""}, key: "key", validators: []BusinessValidator{
+			func(s *string) error {
+				return fmt.Errorf("validator failed")
+			},
+		}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAttributeValueInSvcAnnotation(tt.args.annotations, tt.args.key, tt.args.validators...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAttributeValueInSvcAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAttributeValueInSvcAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_expectAttributeInSvcAnnotationBeEqualTo(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		key         string
+		value       string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "assertion is successful",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value: "true",
+			},
+			want: true,
+		}, {
+			name: "assertion is successful especially when value is not exactly equal",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "True",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value: "true",
+			},
+			want: true,
+		},
+		{
+			name: "assertion is unsuccessful when key is not equal",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "True",
+				},
+				key:   strings.ToUpper(ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts),
+				value: "true",
+			},
+			want: false,
+		},
+		{
+			name: "assertion is unsuccessful when key is not found",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "True",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts + "notfound",
+				value: "true",
+			},
+			want: false,
+		},
+		{
+			name: "assertion is unsuccessful when value is empty",
+			args: args{
+				annotations: map[string]string{
+					ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "",
+				},
+				key:   ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value: "true",
+			},
+			want: false,
+		},
+		{
+			name: "assertion is unsuccessful when value is notfound",
+			args: args{
+				annotations: map[string]string{},
+				key:         ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts,
+				value:       "true",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expectAttributeInSvcAnnotationBeEqualTo(tt.args.annotations, tt.args.key, tt.args.value); got != tt.want {
+				t.Errorf("expectAttributeInSvcAnnotationBeEqualTo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+		port        int32
+		key         HealthProbeParams
+		validators  []Int32BusinessValidator
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *int32
+		wantErr bool
+	}{
+		{
+			name: "get numeric value from health probe related annotation",
+			args: args{
+				annotations: map[string]string{BuildHealthProbeAnnotationKeyForPort(80, HealthProbeParamsNumOfProbe): "2"},
+				port:        80,
+				key:         HealthProbeParamsNumOfProbe,
+			},
+			want:    to.Int32Ptr(2),
+			wantErr: false,
+		},
+		{
+			name: "health probe related annotation is not found",
+			args: args{
+				annotations: map[string]string{},
+				port:        80,
+				key:         HealthProbeParamsNumOfProbe,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(tt.args.annotations, tt.args.port, tt.args.key, tt.args.validators...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1240,112 +1240,6 @@ func getDomainNameLabel(pip *network.PublicIPAddress) string {
 	return to.String(pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel)
 }
 
-func getIdleTimeout(s *v1.Service) (*int32, error) {
-	const (
-		min = 4
-		max = 30
-	)
-
-	val, ok := s.Annotations[consts.ServiceAnnotationLoadBalancerIdleTimeout]
-	if !ok {
-		// Return a nil here as this will set the value to the azure default
-		return nil, nil
-	}
-
-	errInvalidTimeout := fmt.Errorf("idle timeout value must be a whole number representing minutes between %d and %d", min, max)
-	toInt, err := strconv.ParseInt(val, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing idle timeout value: %w: %v", err, errInvalidTimeout)
-	}
-	to32 := int32(toInt)
-
-	if to32 < min || to32 > max {
-		return nil, errInvalidTimeout
-	}
-	return &to32, nil
-}
-
-// getProbeIntervalInSecondsAndNumOfProbe parse probeInterval and numberOfProbes from the annotations of service object.
-func getProbeIntervalInSecondsAndNumOfProbe(s *v1.Service) (*int32, *int32, error) {
-	// get number of probes
-	numberOfProbes, err := getInt32FromAnnotations(s.Annotations, consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, func(val *int32) error {
-		//minimum number of unhealthy responses is 2. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
-		const (
-			MinimumNumOfProbe = 2
-		)
-		if *val < MinimumNumOfProbe {
-			return fmt.Errorf("the minimum value of %s is %d", consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, MinimumNumOfProbe)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	// if numberOfProbes is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
-	if numberOfProbes == nil {
-		numberOfProbes = to.Int32Ptr(2)
-	}
-
-	probeInterval, err := getInt32FromAnnotations(s.Annotations, consts.ServiceAnnotationLoadBalancerHealthProbeInterval, func(val *int32) error {
-		//minimum probe interval in seconds is 5. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
-		const (
-			MinimumProbeIntervalInSecond = 5
-		)
-		if *val < 5 {
-			return fmt.Errorf("the minimum value of %s is %d", consts.ServiceAnnotationLoadBalancerHealthProbeInterval, MinimumProbeIntervalInSecond)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	// if probeInterval is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
-	if probeInterval == nil {
-		probeInterval = to.Int32Ptr(5)
-	}
-
-	// total probe should be less than 120 seconds ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
-	if (*probeInterval)*(*numberOfProbes) >= 120 {
-		return nil, nil, fmt.Errorf("total probe should be less than 120, please adjust interval and number of probe accordingly")
-	}
-
-	return probeInterval, numberOfProbes, nil
-}
-
-// Int32BusinessValidator is validator function which is invoked after values are parsed in order to make sure input value meets the businees need.
-type Int32BusinessValidator func(*int32) error
-
-// getInt32FromAnnotations parse integer value from annotation and return an reference to int32 object
-func getInt32FromAnnotations(annotations map[string]string, key string, businessValidator ...Int32BusinessValidator) (*int32, error) {
-	if len(key) <= 0 {
-		return nil, fmt.Errorf("annotation key should not be empty")
-	}
-	if annotations == nil {
-		// Return a nil here as this will set the value to the azure default
-		return nil, nil
-	}
-	val, ok := annotations[key]
-	if !ok {
-		// Return a nil here as this will set the value to the azure default
-		return nil, nil
-	}
-	errKey := fmt.Errorf("%s value must be a whole number", key)
-	toInt, err := strconv.ParseInt(val, 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing %s value: %w: %v", key, err, errKey)
-	}
-	parsedInt := int32(toInt)
-	for _, validator := range businessValidator {
-		if validator != nil {
-			err := validator(&parsedInt)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing %s value: %w", key, err)
-			}
-		}
-	}
-	return &parsedInt, nil
-}
-
 func (az *Cloud) isFrontendIPChanged(clusterName string, config network.FrontendIPConfiguration, service *v1.Service, lbFrontendIPConfigName string) (bool, error) {
 	isServiceOwnsFrontendIP, isPrimaryService, err := az.serviceOwnsFrontendIP(config, service)
 	if err != nil {
@@ -1551,11 +1445,6 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	defaultLBFrontendIPConfigID := az.getFrontendIPConfigID(lbName, lbResourceGroup, defaultLBFrontendIPConfigName)
 	dirtyLb := false
 
-	lbIdleTimeout, err := getIdleTimeout(service)
-	if wantLb && err != nil {
-		return nil, err
-	}
-
 	// reconcile the load balancer's backend pool configuration.
 	if wantLb {
 		preConfig, changed, err := az.reconcileBackendPools(clusterName, service, nodes, lb, isBackendPoolPreConfigured)
@@ -1593,9 +1482,13 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		}
 	}
 
-	expectedProbes, expectedRules, err := az.getExpectedLBRules(service, wantLb, defaultLBFrontendIPConfigID, lbBackendPoolID, lbName, lbIdleTimeout)
-	if err != nil {
-		return nil, err
+	var expectedProbes []network.Probe
+	var expectedRules []network.LoadBalancingRule
+	if wantLb {
+		expectedProbes, expectedRules, err = az.getExpectedLBRules(service, defaultLBFrontendIPConfigID, lbBackendPoolID, lbName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	changed = az.reconcileLBProbes(lb, service, serviceName, wantLb, expectedProbes)
@@ -2114,168 +2007,302 @@ func lbRuleConflictsWithPort(rule network.LoadBalancingRule, frontendIPConfigID 
 		*rule.FrontendPort == port.Port
 }
 
-func parseHealthProbeProtocolAndPath(service *v1.Service) (string, string) {
-	var protocol, path string
-	if v, ok := service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeProtocol]; ok {
-		protocol = v
-	} else {
-		return protocol, path
+// buildHealthProbeRulesForPort
+// for following sku: basic loadbalancer vs standard load balancer
+// for following protocols: TCP HTTP HTTPS(SLB only)
+func (az *Cloud) buildHealthProbeRulesForPort(annotations map[string]string, port v1.ServicePort, lbrule string) (*network.Probe, error) {
+	properties := &network.ProbePropertiesFormat{}
+	// get request path ,only used with http/https probe
+	path, err := consts.GetHealthProbeConfigOfPortFromK8sSvcAnnotation(annotations, port.Port, consts.HealthProbeParamsRequestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.BuildHealthProbeAnnotationKeyForPort(port.Port, consts.HealthProbeParamsRequestPath), err)
 	}
-	// ignore the request path if using TCP
-	if strings.EqualFold(protocol, string(network.ProbeProtocolHTTP)) ||
-		strings.EqualFold(protocol, string(network.ProbeProtocolHTTPS)) {
-		if v, ok := service.Annotations[consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath]; ok {
-			path = v
+	if path == nil {
+		if path, err = consts.GetAttributeValueInSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath, err)
 		}
 	}
-	return protocol, path
+	if path == nil {
+		path = to.StringPtr(consts.HealthProbeDefaultRequestPath)
+	}
+	if port.AppProtocol == nil {
+		if port.AppProtocol, err = consts.GetAttributeValueInSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeProtocol); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeProtocol, err)
+		}
+		if port.AppProtocol == nil {
+			if port.Protocol == v1.ProtocolTCP {
+				port.AppProtocol = to.StringPtr(string(network.ProtocolTCP))
+			}
+		}
+		if port.AppProtocol == nil {
+			// health probe not set, return
+			return nil, nil
+		}
+	}
+	switch protocol := strings.TrimSpace(*port.AppProtocol); {
+	case strings.EqualFold(protocol, string(network.ProtocolHTTPS)):
+		//HTTPS probe is only supported in standard loadbalancer
+		if !az.useStandardLoadBalancer() {
+			return nil, fmt.Errorf("HTTPS protocol is not supported in health probe when basic lb is used")
+		}
+		//HTTP and HTTPS share the same configuration
+		properties.Protocol = network.ProbeProtocolHTTPS
+		properties.RequestPath = path
+	case strings.EqualFold(protocol, string(network.ProtocolHTTP)):
+		properties.Protocol = network.ProbeProtocolHTTP
+		properties.RequestPath = path
+	case strings.EqualFold(protocol, string(network.ProtocolTCP)):
+		properties.Protocol = network.ProbeProtocolTCP
+	default:
+		return nil, fmt.Errorf("unsupported protocol %s", protocol)
+	}
+
+	// get number of probes
+	var numOfProbeValidator = func(val *int32) error {
+		//minimum number of unhealthy responses is 2. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+		const (
+			MinimumNumOfProbe = 2
+		)
+		if *val < MinimumNumOfProbe {
+			return fmt.Errorf("the minimum value of %s is %d", consts.HealthProbeParamsNumOfProbe, MinimumNumOfProbe)
+		}
+		return nil
+	}
+	numberOfProbes, err := consts.GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(annotations, port.Port, consts.HealthProbeParamsNumOfProbe, numOfProbeValidator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.BuildHealthProbeAnnotationKeyForPort(port.Port, consts.HealthProbeParamsNumOfProbe), err)
+	}
+	if numberOfProbes == nil {
+		if numberOfProbes, err = consts.Getint32ValueFromK8sSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, numOfProbeValidator); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, err)
+		}
+	}
+
+	// if numberOfProbes is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if numberOfProbes == nil {
+		numberOfProbes = to.Int32Ptr(consts.HealthProbeDefaultNumOfProbe)
+	}
+
+	// get probe interval in seconds
+	var probeIntervalValidator = func(val *int32) error {
+		//minimum probe interval in seconds is 5. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+		const (
+			MinimumProbeIntervalInSecond = 5
+		)
+		if *val < 5 {
+			return fmt.Errorf("the minimum value of %s is %d", consts.HealthProbeParamsProbeInterval, MinimumProbeIntervalInSecond)
+		}
+		return nil
+	}
+	probeInterval, err := consts.GetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(annotations, port.Port, consts.HealthProbeParamsProbeInterval, probeIntervalValidator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse annotation %s:%w", consts.BuildHealthProbeAnnotationKeyForPort(port.Port, consts.HealthProbeParamsProbeInterval), err)
+	}
+	if probeInterval == nil {
+		if probeInterval, err = consts.Getint32ValueFromK8sSvcAnnotation(annotations, consts.ServiceAnnotationLoadBalancerHealthProbeInterval, probeIntervalValidator); err != nil {
+			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeInterval, err)
+		}
+	}
+	// if probeInterval is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if probeInterval == nil {
+		probeInterval = to.Int32Ptr(consts.HealthProbeDefaultProbeInterval)
+	}
+
+	// total probe should be less than 120 seconds ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if (*probeInterval)*(*numberOfProbes) >= 120 {
+		return nil, fmt.Errorf("total probe should be less than 120, please adjust interval and number of probe accordingly")
+	}
+	properties.IntervalInSeconds = probeInterval
+	properties.NumberOfProbes = numberOfProbes
+	properties.Port = &port.NodePort
+	probe := &network.Probe{
+		Name:                  &lbrule,
+		ProbePropertiesFormat: properties,
+	}
+	return probe, nil
 }
 
+// buildLBRules
+// for following sku: basic loadbalancer vs standard load balancer
+// for following scenario: internal vs external
 func (az *Cloud) getExpectedLBRules(
 	service *v1.Service,
-	wantLb bool,
 	lbFrontendIPConfigID string,
 	lbBackendPoolID string,
-	lbName string,
-	lbIdleTimeout *int32) ([]network.Probe, []network.LoadBalancingRule, error) {
+	lbName string) ([]network.Probe, []network.LoadBalancingRule, error) {
 
-	var ports []v1.ServicePort
-	if wantLb {
-		ports = service.Spec.Ports
-	} else {
-		ports = []v1.ServicePort{}
-	}
-
-	var enableTCPReset, nilTCPReset *bool
-	if az.useStandardLoadBalancer() {
-		enableTCPReset = to.BoolPtr(true)
-	}
-
-	var expectedProbes []network.Probe
 	var expectedRules []network.LoadBalancingRule
-	highAvailabilityPortsEnabled := false
-	for _, port := range ports {
-		if !requiresInternalLoadBalancer(service) && port.Protocol == v1.ProtocolSCTP {
-			return nil, nil, fmt.Errorf("SCTP is only supported on internal LoadBalancer")
-		}
+	var expectedProbes []network.Probe
 
-		if highAvailabilityPortsEnabled {
-			// Since the port is always 0 when enabling HA, only one rule should be configured.
-			break
-		}
+	// support podPresence health check when External Traffic Policy is local
+	// take precedence over user defined probe configuration
+	// healthcheck proxy server serves http requests
+	// https://github.com/kubernetes/kubernetes/blob/7c013c3f64db33cf19f38bb2fc8d9182e42b0b7b/pkg/proxy/healthcheck/service_health.go#L236
+	var nodeEndpointHealthprobe *network.Probe
+	if servicehelpers.NeedsHealthCheck(service) {
+		podPresencePath, podPresencePort := servicehelpers.GetServiceHealthCheckPathPort(service)
+		lbRuleName := az.getLoadBalancerRuleName(service, v1.ProtocolTCP, podPresencePort)
 
-		lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port)
-		klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
-
-		transportProto, _, probeProto, err := getProtocolsFromKubernetesProtocol(port.Protocol)
-		if err != nil {
-			return expectedProbes, expectedRules, err
-		}
-
-		probeProtocol, requestPath := parseHealthProbeProtocolAndPath(service)
-		probeInterval, numberOfProbe, err := getProbeIntervalInSecondsAndNumOfProbe(service)
-		if err != nil {
-			return expectedProbes, expectedRules, err
-		}
-		if servicehelpers.NeedsHealthCheck(service) {
-			podPresencePath, podPresencePort := servicehelpers.GetServiceHealthCheckPathPort(service)
-			if probeProtocol == "" {
-				probeProtocol = string(network.ProbeProtocolHTTP)
-			}
-
-			needRequestPath := strings.EqualFold(probeProtocol, string(network.ProbeProtocolHTTP)) || strings.EqualFold(probeProtocol, string(network.ProbeProtocolHTTPS))
-			if requestPath == "" && needRequestPath {
-				requestPath = podPresencePath
-			}
-
-			expectedProbes = append(expectedProbes, network.Probe{
-				Name: &lbRuleName,
-				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					RequestPath:       to.StringPtr(requestPath),
-					Protocol:          network.ProbeProtocol(probeProtocol),
-					Port:              to.Int32Ptr(podPresencePort),
-					IntervalInSeconds: probeInterval,
-					NumberOfProbes:    numberOfProbe,
-				},
-			})
-		} else if port.Protocol != v1.ProtocolUDP && port.Protocol != v1.ProtocolSCTP {
-			// we only add the expected probe if we're doing TCP
-			if probeProtocol == "" {
-				probeProtocol = string(*probeProto)
-			}
-			var actualPath *string
-			if !strings.EqualFold(probeProtocol, string(network.ProbeProtocolTCP)) {
-				if requestPath != "" {
-					actualPath = to.StringPtr(requestPath)
-				} else {
-					actualPath = to.StringPtr("/healthz")
-				}
-			}
-			expectedProbes = append(expectedProbes, network.Probe{
-				Name: &lbRuleName,
-				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Protocol:          network.ProbeProtocol(probeProtocol),
-					RequestPath:       actualPath,
-					Port:              to.Int32Ptr(port.NodePort),
-					IntervalInSeconds: probeInterval,
-					NumberOfProbes:    numberOfProbe,
-				},
-			})
-		}
-
-		loadDistribution := network.LoadDistributionDefault
-		if service.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
-			loadDistribution = network.LoadDistributionSourceIP
-		}
-
-		tcpReset := enableTCPReset
-		if port.Protocol != v1.ProtocolTCP {
-			tcpReset = nilTCPReset
-		}
-		expectedRule := network.LoadBalancingRule{
+		nodeEndpointHealthprobe = &network.Probe{
 			Name: &lbRuleName,
-			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-				Protocol: *transportProto,
-				FrontendIPConfiguration: &network.SubResource{
-					ID: to.StringPtr(lbFrontendIPConfigID),
-				},
-				BackendAddressPool: &network.SubResource{
-					ID: to.StringPtr(lbBackendPoolID),
-				},
-				LoadDistribution:    loadDistribution,
-				FrontendPort:        to.Int32Ptr(port.Port),
-				BackendPort:         to.Int32Ptr(port.Port),
-				DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
-				EnableTCPReset:      tcpReset,
-				EnableFloatingIP:    to.BoolPtr(true),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				RequestPath:       to.StringPtr(podPresencePath),
+				Protocol:          network.ProbeProtocolHTTP,
+				Port:              to.Int32Ptr(podPresencePort),
+				IntervalInSeconds: to.Int32Ptr(consts.HealthProbeDefaultProbeInterval),
+				NumberOfProbes:    to.Int32Ptr(consts.HealthProbeDefaultNumOfProbe),
 			},
 		}
+		expectedProbes = append(expectedProbes, *nodeEndpointHealthprobe)
+	}
 
-		if port.Protocol == v1.ProtocolTCP {
-			expectedRule.LoadBalancingRulePropertiesFormat.IdleTimeoutInMinutes = lbIdleTimeout
+	// In HA mode, lb forward traffic of all port to backend
+	// HA mode is only supported on standard loadbalancer SKU in internal mode
+	if consts.IsK8sServiceUsingInternalLoadBalancer(service) &&
+		az.useStandardLoadBalancer() &&
+		consts.IsK8sServiceHasHAModeEnabled(service) {
+
+		lbRuleName := az.getloadbalancerHAmodeRuleName(service)
+		klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
+
+		props, err := az.getExpectedHAModeLoadBalancingRuleProperties(service, lbFrontendIPConfigID, lbBackendPoolID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
 		}
-
-		if requiresInternalLoadBalancer(service) &&
-			strings.EqualFold(az.LoadBalancerSku, consts.LoadBalancerSkuStandard) &&
-			(strings.EqualFold(service.Annotations[consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts], consts.TrueAnnotationValue) || port.Protocol == v1.ProtocolSCTP) {
-			expectedRule.FrontendPort = to.Int32Ptr(0)
-			expectedRule.BackendPort = to.Int32Ptr(0)
-			expectedRule.Protocol = network.TransportProtocolAll
-			highAvailabilityPortsEnabled = true
-		}
-
-		// we didn't construct the probe objects for UDP or SCTP because they're not allowed on Azure.
-		// However, when externalTrafficPolicy is Local, Kubernetes HTTP health check would be used for probing.
-		if servicehelpers.NeedsHealthCheck(service) || (port.Protocol != v1.ProtocolUDP && port.Protocol != v1.ProtocolSCTP) {
-			expectedRule.Probe = &network.SubResource{
-				ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), lbRuleName)),
+		//Here we need to find one health probe rule for the HA lb rule.
+		var probe *network.Probe = nodeEndpointHealthprobe
+		if probe == nil {
+			// use user customized health probe rule if any
+			for _, port := range service.Spec.Ports {
+				if probe, err = az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName); err != nil {
+					klog.V(2).ErrorS(err, "error occurred when buildHealthProbeRulesForPort", "service", service.Name, "namespace", service.Namespace,
+						"rule-name", lbRuleName, "port", port.Port)
+					//ignore error because we only need one correct rule
+				} else if probe != nil {
+					expectedProbes = append(expectedProbes, *probe)
+					break
+				}
 			}
 		}
 
-		expectedRules = append(expectedRules, expectedRule)
+		// if we found one valid probe, append it to lb rule.
+		if probe != nil {
+			props.Probe = &network.SubResource{
+				ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *probe.Name)),
+			}
+		}
+
+		expectedRules = append(expectedRules, network.LoadBalancingRule{
+			Name:                              &lbRuleName,
+			LoadBalancingRulePropertiesFormat: props,
+		})
+		// end of HA mode handling
+	} else {
+		// generate lb rule for each port defined in svc object
+
+		for _, port := range service.Spec.Ports {
+			lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port)
+			klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
+
+			if port.Protocol == v1.ProtocolSCTP && !(az.useStandardLoadBalancer() && consts.IsK8sServiceUsingInternalLoadBalancer(service)) {
+				return expectedProbes, expectedRules, fmt.Errorf("SCTP is only supported on standard loadbalancer in internal mode")
+			}
+
+			transportProto, _, _, err := getProtocolsFromKubernetesProtocol(port.Protocol)
+			if err != nil {
+				return expectedProbes, expectedRules, fmt.Errorf("failed to parse transport protocol: %w", err)
+			}
+			props, err := az.getExpectedLoadBalancingRulePropertiesForPort(service, lbFrontendIPConfigID, lbBackendPoolID, to.Int32Ptr(port.Port), *transportProto)
+			if err != nil {
+				return expectedProbes, expectedRules, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
+			}
+
+			var probe *network.Probe = nodeEndpointHealthprobe
+			if probe == nil {
+				if probe, err = az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName); err != nil {
+					klog.V(2).ErrorS(err, "error occurred when buildHealthProbeRulesForPort", "service", service.Name, "namespace", service.Namespace,
+						"rule-name", lbRuleName, "port", port.Port)
+					return expectedProbes, expectedRules, err
+				} else if probe != nil {
+					expectedProbes = append(expectedProbes, *probe)
+				}
+			}
+			if probe != nil {
+				props.Probe = &network.SubResource{
+					ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *probe.Name)),
+				}
+			}
+			expectedRules = append(expectedRules, network.LoadBalancingRule{
+				Name:                              &lbRuleName,
+				LoadBalancingRulePropertiesFormat: props,
+			})
+
+		}
 	}
 
 	return expectedProbes, expectedRules, nil
+}
+
+//getDefaultLoadBalancingRulePropertiesFormat returns the loadbalancing rule for one port
+func (az *Cloud) getExpectedLoadBalancingRulePropertiesForPort(
+	service *v1.Service,
+	lbFrontendIPConfigID string,
+	lbBackendPoolID string, port *int32, transportProto network.TransportProtocol) (*network.LoadBalancingRulePropertiesFormat, error) {
+	var err error
+
+	loadDistribution := network.LoadDistributionDefault
+	if service.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
+		loadDistribution = network.LoadDistributionSourceIP
+	}
+
+	var lbIdleTimeout *int32
+	if lbIdleTimeout, err = consts.Getint32ValueFromK8sSvcAnnotation(service.Annotations, consts.ServiceAnnotationLoadBalancerIdleTimeout, func(val *int32) error {
+		const (
+			min = 4
+			max = 30
+		)
+		if *val < min || *val > max {
+			return fmt.Errorf("idle timeout value must be a whole number representing minutes between %d and %d, actual value: %d", min, max, *val)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("error parsing idle timeout key: %s, err: %w", consts.ServiceAnnotationLoadBalancerIdleTimeout, err)
+	} else if lbIdleTimeout == nil {
+		lbIdleTimeout = to.Int32Ptr(4)
+	}
+
+	props := &network.LoadBalancingRulePropertiesFormat{
+		Protocol:            transportProto,
+		FrontendPort:        port,
+		BackendPort:         port,
+		DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
+		EnableFloatingIP:    to.BoolPtr(true),
+		LoadDistribution:    loadDistribution,
+		FrontendIPConfiguration: &network.SubResource{
+			ID: to.StringPtr(lbFrontendIPConfigID),
+		},
+		BackendAddressPool: &network.SubResource{
+			ID: to.StringPtr(lbBackendPoolID),
+		},
+		IdleTimeoutInMinutes: lbIdleTimeout,
+	}
+	if strings.EqualFold(string(transportProto), string(network.TransportProtocolTCP)) && az.useStandardLoadBalancer() {
+		props.EnableTCPReset = to.BoolPtr(true)
+	}
+	return props, nil
+}
+
+//getExpectedHAModeLoadBalancingRuleProperties build load balancing rule for lb in HA mode
+func (az *Cloud) getExpectedHAModeLoadBalancingRuleProperties(
+	service *v1.Service,
+	lbFrontendIPConfigID string,
+	lbBackendPoolID string) (*network.LoadBalancingRulePropertiesFormat, error) {
+	props, err := az.getExpectedLoadBalancingRulePropertiesForPort(service, lbFrontendIPConfigID, lbBackendPoolID, to.Int32Ptr(0), network.TransportProtocolAll)
+	if err != nil {
+		return nil, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
+	}
+	props.EnableTCPReset = to.BoolPtr(true)
+	return props, nil
 }
 
 // This reconciles the Network Security Group similar to how the LB is reconciled.

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1265,6 +1265,87 @@ func getIdleTimeout(s *v1.Service) (*int32, error) {
 	return &to32, nil
 }
 
+// getProbeIntervalInSecondsAndNumOfProbe parse probeInterval and numberOfProbes from the annotations of service object.
+func getProbeIntervalInSecondsAndNumOfProbe(s *v1.Service) (*int32, *int32, error) {
+	// get number of probes
+	numberOfProbes, err := getInt32FromAnnotations(s.Annotations, consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, func(val *int32) error {
+		//minimum number of unhealthy responses is 2. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+		const (
+			MinimumNumOfProbe = 2
+		)
+		if *val < MinimumNumOfProbe {
+			return fmt.Errorf("the minimum value of %s is %d", consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe, MinimumNumOfProbe)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	// if numberOfProbes is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if numberOfProbes == nil {
+		numberOfProbes = to.Int32Ptr(2)
+	}
+
+	probeInterval, err := getInt32FromAnnotations(s.Annotations, consts.ServiceAnnotationLoadBalancerHealthProbeInterval, func(val *int32) error {
+		//minimum probe interval in seconds is 5. ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+		const (
+			MinimumProbeIntervalInSecond = 5
+		)
+		if *val < 5 {
+			return fmt.Errorf("the minimum value of %s is %d", consts.ServiceAnnotationLoadBalancerHealthProbeInterval, MinimumProbeIntervalInSecond)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	// if probeInterval is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if probeInterval == nil {
+		probeInterval = to.Int32Ptr(5)
+	}
+
+	// total probe should be less than 120 seconds ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
+	if (*probeInterval)*(*numberOfProbes) >= 120 {
+		return nil, nil, fmt.Errorf("total probe should be less than 120, please adjust interval and number of probe accordingly")
+	}
+
+	return probeInterval, numberOfProbes, nil
+}
+
+// Int32BusinessValidator is validator function which is invoked after values are parsed in order to make sure input value meets the businees need.
+type Int32BusinessValidator func(*int32) error
+
+// getInt32FromAnnotations parse integer value from annotation and return an reference to int32 object
+func getInt32FromAnnotations(annotations map[string]string, key string, businessValidator ...Int32BusinessValidator) (*int32, error) {
+	if len(key) <= 0 {
+		return nil, fmt.Errorf("annotation key should not be empty")
+	}
+	if annotations == nil {
+		// Return a nil here as this will set the value to the azure default
+		return nil, nil
+	}
+	val, ok := annotations[key]
+	if !ok {
+		// Return a nil here as this will set the value to the azure default
+		return nil, nil
+	}
+	errKey := fmt.Errorf("%s value must be a whole number", key)
+	toInt, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %s value: %w: %v", key, err, errKey)
+	}
+	parsedInt := int32(toInt)
+	for _, validator := range businessValidator {
+		if validator != nil {
+			err := validator(&parsedInt)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing %s value: %w", key, err)
+			}
+		}
+	}
+	return &parsedInt, nil
+}
+
 func (az *Cloud) isFrontendIPChanged(clusterName string, config network.FrontendIPConfiguration, service *v1.Service, lbFrontendIPConfigName string) (bool, error) {
 	isServiceOwnsFrontendIP, isPrimaryService, err := az.serviceOwnsFrontendIP(config, service)
 	if err != nil {
@@ -2092,6 +2173,10 @@ func (az *Cloud) getExpectedLBRules(
 		}
 
 		probeProtocol, requestPath := parseHealthProbeProtocolAndPath(service)
+		probeInterval, numberOfProbe, err := getProbeIntervalInSecondsAndNumOfProbe(service)
+		if err != nil {
+			return expectedProbes, expectedRules, err
+		}
 		if servicehelpers.NeedsHealthCheck(service) {
 			podPresencePath, podPresencePort := servicehelpers.GetServiceHealthCheckPathPort(service)
 			if probeProtocol == "" {
@@ -2109,8 +2194,8 @@ func (az *Cloud) getExpectedLBRules(
 					RequestPath:       to.StringPtr(requestPath),
 					Protocol:          network.ProbeProtocol(probeProtocol),
 					Port:              to.Int32Ptr(podPresencePort),
-					IntervalInSeconds: to.Int32Ptr(5),
-					NumberOfProbes:    to.Int32Ptr(2),
+					IntervalInSeconds: probeInterval,
+					NumberOfProbes:    numberOfProbe,
 				},
 			})
 		} else if port.Protocol != v1.ProtocolUDP && port.Protocol != v1.ProtocolSCTP {
@@ -2132,8 +2217,8 @@ func (az *Cloud) getExpectedLBRules(
 					Protocol:          network.ProbeProtocol(probeProtocol),
 					RequestPath:       actualPath,
 					Port:              to.Int32Ptr(port.NodePort),
-					IntervalInSeconds: to.Int32Ptr(5),
-					NumberOfProbes:    to.Int32Ptr(2),
+					IntervalInSeconds: probeInterval,
+					NumberOfProbes:    numberOfProbe,
 				},
 			})
 		}

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -34,11 +34,9 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cloudprovider "k8s.io/cloud-provider"
-
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -296,6 +296,10 @@ func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protoc
 	return fmt.Sprintf("%s-%s-%s-%d", prefix, subnetSegment, protocol, port)
 }
 
+func (az *Cloud) getloadbalancerHAmodeRuleName(service *v1.Service) string {
+	return az.getLoadBalancerRuleName(service, service.Spec.Ports[0].Protocol, service.Spec.Ports[0].Port)
+}
+
 func (az *Cloud) getSecurityRuleName(service *v1.Service, port v1.ServicePort, sourceAddrPrefix string) string {
 	if useSharedSecurityRule(service) {
 		safePrefix := strings.Replace(sourceAddrPrefix, "/", "_", -1)

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -1645,6 +1645,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 			foundProbe := false
 			if servicehelpers.NeedsHealthCheck(&services[i]) {
 				path, port := servicehelpers.GetServiceHealthCheckPathPort(&services[i])
+				wantedRuleName := az.getLoadBalancerRuleName(&services[i], v1.ProtocolTCP, port)
 				for _, actualProbe := range *loadBalancer.Probes {
 					if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
 						*actualProbe.Port == port &&

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -89,6 +89,10 @@ var _ = Describe("Service with annotation", func() {
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
+		utils.Logf("Waiting for backend pods to be ready")
+		err = utils.WaitPodsToBeReady(cs, ns.Name)
+		Expect(err).NotTo(HaveOccurred())
+
 		utils.Logf("Creating Azure clients")
 		tc, err = utils.CreateAzureTestClient()
 		Expect(err).NotTo(HaveOccurred())
@@ -416,6 +420,58 @@ var _ = Describe("Service with annotation", func() {
 		By("Waiting for service IP to be updated")
 		err = utils.WaitServiceIPEqualTo(cs, to.String(pip2.IPAddress), serviceName, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe' and port specific configs", func() {
+		By("Creating a service with health probe annotations")
+		annotation := map[string]string{
+			consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe:                                  "5",
+			consts.BuildHealthProbeAnnotationKeyForPort(nginxPort, consts.HealthProbeParamsNumOfProbe): "3",
+		}
+
+		// create service with given annotation and wait it to expose
+		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		defer func() {
+			By("Cleaning up service and public IP")
+			err := utils.DeleteService(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			err = utils.DeletePIPWithRetry(tc, publicIP, tc.GetResourceGroup())
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		// get lb from azure client
+		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
+
+		By("Validating health probe configs")
+		var numberOfProbes *int32
+		for _, probe := range *lb.Probes {
+			if probe.NumberOfProbes != nil {
+				numberOfProbes = probe.NumberOfProbes
+			}
+		}
+		Expect(*numberOfProbes).To(Equal(int32(3)))
+	})
+	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol' and port specific configs", func() {
+		By("Creating a service with health probe annotations")
+		annotation := map[string]string{
+			consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:    "Http",
+			consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath: "/",
+		}
+
+		// create service with given annotation and wait it to expose
+		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		defer func() {
+			By("Cleaning up service and public IP")
+			err := utils.DeleteService(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			err = utils.DeletePIPWithRetry(tc, publicIP, tc.GetResourceGroup())
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		// get lb from azure client
+		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
+		By("Validating health probe configs")
+		probes := *lb.Probes
+		Expect((len(probes))).To(Equal(1))
+		Expect(probes[0].Protocol).To(Equal(network.ProbeProtocolHTTP))
 	})
 })
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind feature
#### What this PR does / why we need it:
backport pr963 to release-1.0
#### Which issue(s) this PR fixes:
Fixes #949 #948

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

Following  configuration will be applied to the all ports of service.

"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"
"service.beta.kubernetes.io/azure-load-balancer-health-probe-interval"
"service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe"
"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path"

If health probe is needed, user should specify AppProtocol in port object of Service spec.
And following protocols are supported: http, tcp, https

Additional annotations are added. where port is the port number of port object

service.beta.kubernetes.io/port_{port}_health-probe_interval
service.beta.kubernetes.io/port_{port}_health-probe_num-of-probe
service.beta.kubernetes.io/port_{port}_health-probe_request-path

Please refer to docs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
