### PR TITLE
Node manager should retry when not able to get providerID

### DIFF
--- a/pkg/nodemanager/nodemanager.go
+++ b/pkg/nodemanager/nodemanager.go
@@ -378,9 +378,16 @@ func (cnc *CloudNodeController) initializeNode(ctx context.Context, node *v1.Nod
 		}
 	}
 
-	nodeModifiers, err := cnc.getNodeModifiersFromCloudProvider(ctx, curNode)
+	var nodeModifiers []nodeModifier
+	err = clientretry.OnError(UpdateNodeSpecBackoff, func(err error) bool {
+		return err != nil && strings.HasPrefix(err.Error(), "failed to set node provider id")
+	}, func() error {
+		nodeModifiers, err = cnc.getNodeModifiersFromCloudProvider(ctx, curNode)
+		return err
+	})
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to initialize node %s at cloudprovider: %w", node.Name, err))
+		// Instead of just logging the error, panic and node manager can restart
+		utilruntime.Must(fmt.Errorf("failed to initialize node %s at cloudprovider: %w", node.Name, err))
 		return
 	}
 
@@ -435,10 +442,9 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Co
 				}
 			})
 		} else {
-			// we should attempt to set providerID on node, but
-			// we can continue if we fail since we will attempt to set
-			// node addresses given the node name in getNodeAddressesByName
-			klog.Errorf("failed to set node provider id: %v", err)
+			// if we are not able to get node provider id,
+			// we return error here and retry in the caller initializeNode()
+			return nil, fmt.Errorf("failed to set node provider id: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Existing code just logs an error when node manager failed to get `providerID` and leaves the field empty. But in reality,
there are other control-plane components requiring `providerID` to not be empty. So node manager should at least retry
to get `providerID` and report error.

This fix allows node manager try 20 times with a time backoff and panic if still failing. UT is also added. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1155 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Current behavior when node manager not able to get providerID (node manager log):

E0228 03:55:11.893444       1 runtime.go:78] Observed a panic: &fmt.wrapError{msg:"failed to initialize node providertest2-vmss-1000001 at cloudprovider: failed to set node provider id: no credentials provided for Azure cloud provider", err:(*fmt.wrapError)(0xc0002d8a20)} (failed to initialize node providertest2-vmss-1000001 at cloudprovider: failed to set node provider id: no credentials provided for Azure cloud provider)
goroutine 100 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1bfd420, 0xc0002d8a40})
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x7d
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x203000})
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x1bfd420, 0xc0002d8a40})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
k8s.io/apimachinery/pkg/util/runtime.Must(...)
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:171
sigs.k8s.io/cloud-provider-azure/pkg/nodemanager.(*CloudNodeController).initializeNode(0xc0001069c0, {0x2195ba8, 0xc000058028}, 0xc000680000)
        /go/src/sigs.k8s.io/cloud-provider-azure/pkg/nodemanager/nodemanager.go:390 +0x77c
sigs.k8s.io/cloud-provider-azure/pkg/nodemanager.(*CloudNodeController).AddCloudNode(0xc0001069c0, {0x2195ba8, 0xc000058028}, {0x1e88040, 0xc000680000})
        /go/src/sigs.k8s.io/cloud-provider-azure/pkg/nodemanager/nodemanager.go:352 +0x1a9
sigs.k8s.io/cloud-provider-azure/pkg/nodemanager.NewCloudNodeController.func1({0x1e88040, 0xc000680000})
       ...
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x88
panic: failed to initialize node providertest2-vmss-1000001 at cloudprovider: failed to set node provider id: no credentials provided for Azure cloud provider [recovered]
        panic: failed to initialize node providertest2-vmss-1000001 at cloudprovider: failed to set node provider id: no credentials provided for Azure cloud provider
```
