### PR TITLE
test: add dual-stack manifest for < 1.24

### DIFF
--- a/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet-1.23.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet-1.23.json
@@ -1,0 +1,67 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "featureFlags": {
+            "enableIPv6DualStack": true
+        },
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "1.20",
+            "kubernetesConfig": {
+                "loadBalancerSku": "Standard",
+                "excludeMasterFromStandardLB": true,
+                "clusterSubnet": "10.244.0.0/16,fc00::/48",
+                "serviceCidr": "10.0.0.0/16,fd00::/108",
+                "dnsServiceIP": "10.0.0.10",
+                "kubeProxyMode": "ipvs",
+                "networkPlugin": "azure",
+                "containerRuntime": "containerd",
+                "apiServerConfig": {
+                    "--feature-gates": "IPv6DualStack=true"
+                },
+                "kubeletConfig": {
+                    "--feature-gates": "IPv6DualStack=true",
+                    "--hairpin-mode": "hairpin-veth",
+                    "--max-pods": "110"
+                },
+                "controllerManagerConfig": {
+                    "--feature-gates": "IPv6DualStack=true"
+                },
+                "addons": [
+                    {
+                        "name": "csi-secrets-store",
+                        "enabled": false
+                    }
+                ]
+            }
+        },
+        "masterProfile": {
+            "count": 3,
+            "dnsPrefix": "{dnsPrefix}",
+            "vmSize": "Standard_DS2_v2",
+            "distro": "aks-ubuntu-16.04"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "agentpool1",
+                "count": 2,
+                "vmSize": "Standard_DS3_v2",
+                "distro": "aks-ubuntu-16.04"
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "k8s-ci",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": "{keyData}"
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientId": "{servicePrincipalClientID}",
+            "secret": "{servicePrincipalClientSecret}"
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
https://github.com/kubernetes-sigs/cloud-provider-azure/pull/1227 added `LegacyServiceAccountTokenNoAutoGeneration=false` feature flag to controller manager config. The same config is used for < 1.24 as well which fails. Duplicating the config and removing `LegacyServiceAccountTokenNoAutoGeneration` feature flag, so we can use this new config for jobs running < 1.24 for dual-stack.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
