### PR TITLE
Avoid Panic when using `--port`

### DIFF
--- a/cmd/cloud-node-manager/app/nodemanager.go
+++ b/cmd/cloud-node-manager/app/nodemanager.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/config"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
+	"k8s.io/component-base/config"
 	"k8s.io/component-base/term"
 	genericcontrollermanager "k8s.io/controller-manager/app"
 	controllerhealthz "k8s.io/controller-manager/pkg/healthz"

--- a/cmd/cloud-node-manager/app/nodemanager.go
+++ b/cmd/cloud-node-manager/app/nodemanager.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"k8s.io/component-base/config"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
@@ -107,7 +108,7 @@ func Run(c *cloudnodeconfig.Config, stopCh <-chan struct{}) error {
 	var checks []healthz.HealthChecker
 	healthzHandler := controllerhealthz.NewMutableHealthzHandler(checks...)
 	if c.SecureServing != nil {
-		unsecuredMux := genericcontrollermanager.NewBaseHandler(nil, healthzHandler)
+		unsecuredMux := genericcontrollermanager.NewBaseHandler(&config.DebuggingConfiguration{}, healthzHandler)
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)
 		// TODO: handle stoppedCh returned by c.SecureServing.Serve
 		if _, err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
@@ -115,7 +116,7 @@ func Run(c *cloudnodeconfig.Config, stopCh <-chan struct{}) error {
 		}
 	}
 	if c.InsecureServing != nil {
-		unsecuredMux := genericcontrollermanager.NewBaseHandler(nil, healthzHandler)
+		unsecuredMux := genericcontrollermanager.NewBaseHandler(&config.DebuggingConfiguration{}, healthzHandler)
 		insecureSuperuserAuthn := server.AuthenticationInfo{Authenticator: &server.InsecureSuperuser{}}
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, nil, &insecureSuperuserAuthn)
 		if err := c.InsecureServing.Serve(handler, 0, stopCh); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When running `azure-cloud-node-manager` with the `--port` flag, it panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x199847c]

goroutine 1 [running]:
k8s.io/controller-manager/app.NewBaseHandler(0x0, 0x0, 0x0, 0x0, 0x0)
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/controller-manager/app/serve.go:61 +0x9c
sigs.k8s.io/cloud-provider-azure/cmd/cloud-node-manager/app.Run(0xc000500d80, 0xc000114360, 0x0, 0x0)
        /go/src/sigs.k8s.io/cloud-provider-azure/cmd/cloud-node-manager/app/nodemanager.go:111 +0x245
sigs.k8s.io/cloud-provider-azure/cmd/cloud-node-manager/app.NewCloudNodeManagerCommand.func1(0xc000712280, 0xc000511d60, 0x0, 0xa)
        /go/src/sigs.k8s.io/cloud-provider-azure/cmd/cloud-node-manager/app/nodemanager.go:64 +0x11f
github.com/spf13/cobra.(*Command).execute(0xc000712280, 0xc000138010, 0xa, 0xa, 0xc000712280, 0xc000138010)
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/github.com/spf13/cobra/command.go:860 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc000712280, 0x16dc46f1bfd0ee80, 0x3273b20, 0x406565)
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/github.com/spf13/cobra/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /go/src/sigs.k8s.io/cloud-provider-azure/vendor/github.com/spf13/cobra/command.go:902
main.main()
        /go/src/sigs.k8s.io/cloud-provider-azure/cmd/cloud-node-manager/node-manager.go:43 +0xe5
```

and indeed there is a nil as first parameter here https://github.com/kubernetes-sigs/cloud-provider-azure/blob/v1.1.8/cmd/cloud-node-manager/app/nodemanager.go#L111
but the function doesn't have any check about the pointer being nil https://github.com/kubernetes-sigs/cloud-provider-azure/blob/v1.1.8/vendor/k8s.io/controller-manager/app/serve.go#L58

This PR attempts to fix this problem.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
Fixed a panic in azure-cloud-node-manager when the `--port` flag was specified.
```
