### PR TITLE
Refactor store and use sync.map as data store

### DIFF
--- a/pkg/cache/azure_cache.go
+++ b/pkg/cache/azure_cache.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	"k8s.io/client-go/tools/cache"
 )
 
 // AzureCacheReadType defines the read type for cache data
@@ -49,20 +47,13 @@ type AzureCacheEntry struct {
 	Key  string
 	Data interface{}
 
-	// The lock to ensure not updating same entry simultaneously.
-	Lock sync.Mutex
 	// time when entry was fetched and created
 	CreatedOn time.Time
 }
 
-// cacheKeyFunc defines the key function required in TTLStore.
-func cacheKeyFunc(obj interface{}) (string, error) {
-	return obj.(*AzureCacheEntry).Key, nil
-}
-
 // TimedCache is a cache with TTL.
 type TimedCache struct {
-	Store  cache.Store
+	Store  sync.Map
 	Lock   sync.Mutex
 	Getter GetFunc
 	TTL    time.Duration
@@ -76,60 +67,18 @@ func NewTimedcache(ttl time.Duration, getter GetFunc) (*TimedCache, error) {
 
 	return &TimedCache{
 		Getter: getter,
-		// switch to using NewStore instead of NewTTLStore so that we can
-		// reuse entries for calls that are fine with reading expired/stalled data.
-		// with NewTTLStore, entries are not returned if they have already expired.
-		Store: cache.NewStore(cacheKeyFunc),
-		TTL:   ttl,
+		TTL:    ttl,
 	}, nil
-}
-
-// getInternal returns AzureCacheEntry by key. If the key is not cached yet,
-// it returns a AzureCacheEntry with nil data.
-func (t *TimedCache) getInternal(key string) (*AzureCacheEntry, error) {
-	entry, exists, err := t.Store.GetByKey(key)
-	if err != nil {
-		return nil, err
-	}
-	// if entry exists, return the entry
-	if exists {
-		return entry.(*AzureCacheEntry), nil
-	}
-
-	// lock here to ensure if entry doesn't exist, we add a new entry
-	// avoiding overwrites
-	t.Lock.Lock()
-	defer t.Lock.Unlock()
-
-	// Another goroutine might have written the same key.
-	entry, exists, err = t.Store.GetByKey(key)
-	if err != nil {
-		return nil, err
-	}
-	if exists {
-		return entry.(*AzureCacheEntry), nil
-	}
-
-	// Still not found, add new entry with nil data.
-	// Note the data will be filled later by getter.
-	newEntry := &AzureCacheEntry{
-		Key:  key,
-		Data: nil,
-	}
-	_ = t.Store.Add(newEntry)
-	return newEntry, nil
 }
 
 // Get returns the requested item by key.
 func (t *TimedCache) Get(key string, crt AzureCacheReadType) (interface{}, error) {
-	entry, err := t.getInternal(key)
-	if err != nil {
-		return nil, err
-	}
+	rawEntry, _ := t.Store.LoadOrStore(key, &AzureCacheEntry{
+		Key:  key,
+		Data: nil,
+	})
 
-	entry.Lock.Lock()
-	defer entry.Lock.Unlock()
-
+	entry := rawEntry.(*AzureCacheEntry)
 	// entry exists and if cache is not force refreshed
 	if entry.Data != nil && crt != CacheReadTypeForceRefresh {
 		// allow unsafe read, so return data even if expired
@@ -151,23 +100,21 @@ func (t *TimedCache) Get(key string, crt AzureCacheReadType) (interface{}, error
 
 	// set the data in cache and also set the last update time
 	// to now as the data was recently fetched
-	entry.Data = data
-	entry.CreatedOn = time.Now().UTC()
+	t.Set(key, data)
 
-	return entry.Data, nil
+	return data, nil
 }
 
 // Delete removes an item from the cache.
 func (t *TimedCache) Delete(key string) error {
-	return t.Store.Delete(&AzureCacheEntry{
-		Key: key,
-	})
+	t.Store.Delete(key)
+	return nil
 }
 
 // Set sets the data cache for the key.
 // It is only used for testing.
 func (t *TimedCache) Set(key string, data interface{}) {
-	_ = t.Store.Add(&AzureCacheEntry{
+	t.Store.Store(key, &AzureCacheEntry{
 		Key:       key,
 		Data:      data,
 		CreatedOn: time.Now().UTC(),

--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -159,10 +159,7 @@ func (ss *ScaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cac
 		if vmssCache, ok := ss.vmssVMCache.Load(cacheKey); ok {
 			// get old cache before refreshing the cache
 			cache := vmssCache.(*azcache.TimedCache)
-			entry, exists, err := cache.Store.GetByKey(cacheKey)
-			if err != nil {
-				return nil, err
-			}
+			entry, exists := cache.Store.Load(cacheKey)
 			if exists {
 				cached := entry.(*azcache.AzureCacheEntry).Data
 				if cached != nil {


### PR DESCRIPTION
Signed-off-by: MartinForReal <fanshangxiang@gmail.com>



#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
remove k/client-go/tools/cache dependency and provide a more performant cache.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
