### PR TITLE
Hotfix: fix probe missing when external traffic is local with multiple port opened.

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2073,25 +2073,26 @@ func (az *Cloud) getExpectedLBRules(
 			return nil, nil, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
 		}
 		//Here we need to find one health probe rule for the HA lb rule.
-		var probe *network.Probe = nodeEndpointHealthprobe
-		if probe == nil {
+		if nodeEndpointHealthprobe == nil {
 			// use user customized health probe rule if any
 			for _, port := range service.Spec.Ports {
-				if probe, err = az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName); err != nil {
+				portprobe, err := az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName)
+				if err != nil {
 					klog.V(2).ErrorS(err, "error occurred when buildHealthProbeRulesForPort", "service", service.Name, "namespace", service.Namespace,
 						"rule-name", lbRuleName, "port", port.Port)
 					//ignore error because we only need one correct rule
-				} else if probe != nil {
-					expectedProbes = append(expectedProbes, *probe)
+				}
+				if portprobe != nil {
+					expectedProbes = append(expectedProbes, *portprobe)
+					props.Probe = &network.SubResource{
+						ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *portprobe.Name)),
+					}
 					break
 				}
 			}
-		}
-
-		// if we found one valid probe, append it to lb rule.
-		if probe != nil {
+		} else {
 			props.Probe = &network.SubResource{
-				ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *probe.Name)),
+				ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *nodeEndpointHealthprobe.Name)),
 			}
 		}
 
@@ -2120,19 +2121,22 @@ func (az *Cloud) getExpectedLBRules(
 				return expectedProbes, expectedRules, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
 			}
 
-			var probe *network.Probe = nodeEndpointHealthprobe
-			if probe == nil {
-				if probe, err = az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName); err != nil {
+			if nodeEndpointHealthprobe == nil {
+				portprobe, err := az.buildHealthProbeRulesForPort(service.Annotations, port, lbRuleName)
+				if err != nil {
 					klog.V(2).ErrorS(err, "error occurred when buildHealthProbeRulesForPort", "service", service.Name, "namespace", service.Namespace,
 						"rule-name", lbRuleName, "port", port.Port)
 					return expectedProbes, expectedRules, err
-				} else if probe != nil {
-					expectedProbes = append(expectedProbes, *probe)
 				}
-			}
-			if probe != nil {
+				if portprobe != nil {
+					expectedProbes = append(expectedProbes, *portprobe)
+					props.Probe = &network.SubResource{
+						ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *portprobe.Name)),
+					}
+				}
+			} else {
 				props.Probe = &network.SubResource{
-					ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *probe.Name)),
+					ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *nodeEndpointHealthprobe.Name)),
 				}
 			}
 			expectedRules = append(expectedRules, network.LoadBalancingRule{

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1996,7 +1996,39 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(10), to.Int32Ptr(10080), to.Int32Ptr(10)),
 		expectedRules:   rules,
 	})
-
+	rules1 := []network.LoadBalancingRule{
+		getTestRule(true, 80),
+		getTestRule(true, 443),
+		getTestRule(true, 421),
+	}
+	rules1[0].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[1].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[2].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	svc := getTestService("test1", v1.ProtocolTCP, map[string]string{
+		"service.beta.kubernetes.io/port_80_health-probe_interval":     "10",
+		"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "10",
+	}, false, 80, 443, 421)
+	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	svc.Spec.HealthCheckNodePort = 34567
+	probes := getTestProbes("Http", "/healthz", to.Int32Ptr(5), to.Int32Ptr(34567), to.Int32Ptr(2))
+	probes[0].Name = to.StringPtr("atest1-TCP-34567")
+	testCases = append(testCases, struct {
+		desc            string
+		service         v1.Service
+		loadBalancerSku string
+		probeProtocol   string
+		probePath       string
+		expectedProbes  []network.Probe
+		expectedRules   []network.LoadBalancingRule
+		expectedErr     bool
+	}{
+		desc:            "getExpectedLBRules should expected rules when externaltrafficpolicy is local",
+		service:         svc,
+		loadBalancerSku: "standard",
+		probeProtocol:   "Http",
+		expectedProbes:  probes,
+		expectedRules:   rules1,
+	})
 	for i, test := range testCases {
 		az := GetTestCloud(ctrl)
 		az.Config.LoadBalancerSku = test.loadBalancerSku
@@ -2021,54 +2053,61 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 	}
 }
 func getTestProbes(protocol, path string, interval, port, numOfProbe *int32) []network.Probe {
-	expectedProbes := []network.Probe{
-		{
-			Name: to.StringPtr("atest1-TCP-80"),
-			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Protocol:          network.ProbeProtocol(protocol),
-				Port:              port,
-				IntervalInSeconds: interval,
-				NumberOfProbes:    numOfProbe,
-			},
+	return []network.Probe{
+		getTestProbe(protocol, path, interval, port, numOfProbe),
+	}
+}
+
+func getTestProbe(protocol, path string, interval, port, numOfProbe *int32) network.Probe {
+	expectedProbes := network.Probe{
+		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", *port-10000)),
+		ProbePropertiesFormat: &network.ProbePropertiesFormat{
+			Protocol:          network.ProbeProtocol(protocol),
+			Port:              port,
+			IntervalInSeconds: interval,
+			NumberOfProbes:    numOfProbe,
 		},
 	}
 	if (strings.EqualFold(protocol, "Http") || strings.EqualFold(protocol, "Https")) && len(strings.TrimSpace(path)) > 0 {
-		expectedProbes[0].RequestPath = to.StringPtr(path)
+		expectedProbes.RequestPath = to.StringPtr(path)
 	}
 	return expectedProbes
 }
-
 func getDefaultTestProbes(protocol, path string) []network.Probe {
 	return getTestProbes(protocol, path, to.Int32Ptr(5), to.Int32Ptr(10080), to.Int32Ptr(2))
 }
 
 func getDefaultTestRules(enableTCPReset bool) []network.LoadBalancingRule {
-	expectedRules := []network.LoadBalancingRule{
-		{
-			Name: to.StringPtr("atest1-TCP-80"),
-			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-				Protocol: network.TransportProtocol("Tcp"),
-				FrontendIPConfiguration: &network.SubResource{
-					ID: to.StringPtr("frontendIPConfigID"),
-				},
-				BackendAddressPool: &network.SubResource{
-					ID: to.StringPtr("backendPoolID"),
-				},
-				LoadDistribution:     "Default",
-				FrontendPort:         to.Int32Ptr(80),
-				BackendPort:          to.Int32Ptr(80),
-				EnableFloatingIP:     to.BoolPtr(true),
-				DisableOutboundSnat:  to.BoolPtr(false),
-				IdleTimeoutInMinutes: to.Int32Ptr(4),
-				Probe: &network.SubResource{
-					ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
-						"Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-80"),
-				},
+	return []network.LoadBalancingRule{
+		getTestRule(enableTCPReset, 80),
+	}
+}
+
+func getTestRule(enableTCPReset bool, port int32) network.LoadBalancingRule {
+	expectedRules := network.LoadBalancingRule{
+		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", port)),
+		LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+			Protocol: network.TransportProtocol("Tcp"),
+			FrontendIPConfiguration: &network.SubResource{
+				ID: to.StringPtr("frontendIPConfigID"),
+			},
+			BackendAddressPool: &network.SubResource{
+				ID: to.StringPtr("backendPoolID"),
+			},
+			LoadDistribution:     "Default",
+			FrontendPort:         to.Int32Ptr(port),
+			BackendPort:          to.Int32Ptr(port),
+			EnableFloatingIP:     to.BoolPtr(true),
+			DisableOutboundSnat:  to.BoolPtr(false),
+			IdleTimeoutInMinutes: to.Int32Ptr(4),
+			Probe: &network.SubResource{
+				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+					fmt.Sprintf("Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-%d", port)),
 			},
 		},
 	}
 	if enableTCPReset {
-		expectedRules[0].EnableTCPReset = to.BoolPtr(true)
+		expectedRules.EnableTCPReset = to.BoolPtr(true)
 	}
 	return expectedRules
 }


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug in health probe generator. Probe related configuration is not updated due to variable scope
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
