### PR TITLE
fix: disk attach/detach failure when operation is preempted

### DIFF
--- a/pkg/azureclients/vmclient/azure_vmclient.go
+++ b/pkg/azureclients/vmclient/azure_vmclient.go
@@ -294,12 +294,13 @@ func (c *Client) WaitForUpdateResult(ctx context.Context, future *azure.Future, 
 	response, err := c.armClient.WaitForAsyncOperationResult(ctx, future, "VMWaitForUpdateResult")
 	mc.Observe(retry.NewErrorOrNil(false, err))
 
-	if response != nil && response.StatusCode != http.StatusNoContent {
-		_, rerr := c.updateResponder(response)
-		if rerr != nil {
-			klog.V(5).Infof("Received error: %s", "vm.put.respond", rerr.Error())
-			return rerr
+	if err != nil {
+		if response != nil {
+			klog.V(5).Infof("Received error in WaitForAsyncOperationResult: '%s', response code %d", err.Error(), response.StatusCode)
+		} else {
+			klog.V(5).Infof("Received error in WaitForAsyncOperationResult: '%s', no response", err.Error())
 		}
+		return retry.GetError(response, err)
 	}
 	return nil
 }

--- a/pkg/azureclients/vmclient/azure_vmclient_test.go
+++ b/pkg/azureclients/vmclient/azure_vmclient_test.go
@@ -538,24 +538,39 @@ func TestWaitForUpdateResult(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		respondError   error
+		response       *http.Response
+		responseErr    error
 		expectedResult *retry.Error
 	}{
 		{
 			name:           "Success",
-			respondError:   nil,
+			response:       response,
+			responseErr:    nil,
+			expectedResult: nil,
+		},
+		{
+			name:           "Success with nil response",
+			response:       nil,
+			responseErr:    nil,
 			expectedResult: nil,
 		},
 		{
 			name:           "Failed",
-			respondError:   preemptErr,
+			response:       response,
+			responseErr:    preemptErr,
 			expectedResult: retry.GetError(response, preemptErr),
+		},
+		{
+			name:           "Failed with nil response",
+			response:       nil,
+			responseErr:    preemptErr,
+			expectedResult: retry.GetError(nil, preemptErr),
 		},
 	}
 
 	for _, test := range tests {
 		armClient := mockarmclient.NewMockInterface(ctrl)
-		armClient.EXPECT().WaitForAsyncOperationResult(gomock.Any(), gomock.Any(), "VMWaitForUpdateResult").Return(response, test.respondError).Times(1)
+		armClient.EXPECT().WaitForAsyncOperationResult(gomock.Any(), gomock.Any(), "VMWaitForUpdateResult").Return(test.response, test.responseErr).Times(1)
 
 		vmClient := getTestVMClient(armClient)
 		err := vmClient.WaitForUpdateResult(context.TODO(), &azure.Future{}, "rg", "test")

--- a/pkg/azureclients/vmclient/azure_vmclient_test.go
+++ b/pkg/azureclients/vmclient/azure_vmclient_test.go
@@ -530,16 +530,37 @@ func TestWaitForUpdateResult(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	preemptErr := fmt.Errorf("operation execution has been preempted by a more recent operation")
 	response := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().WaitForAsyncOperationResult(gomock.Any(), gomock.Any(), "VMWaitForUpdateResult").Return(response, nil).Times(1)
 
-	vmClient := getTestVMClient(armClient)
-	err := vmClient.WaitForUpdateResult(context.TODO(), &azure.Future{}, "rg", "test")
-	assert.Nil(t, err)
+	tests := []struct {
+		name           string
+		respondError   error
+		expectedResult *retry.Error
+	}{
+		{
+			name:           "Success",
+			respondError:   nil,
+			expectedResult: nil,
+		},
+		{
+			name:           "Failed",
+			respondError:   preemptErr,
+			expectedResult: retry.GetError(response, preemptErr),
+		},
+	}
+
+	for _, test := range tests {
+		armClient := mockarmclient.NewMockInterface(ctrl)
+		armClient.EXPECT().WaitForAsyncOperationResult(gomock.Any(), gomock.Any(), "VMWaitForUpdateResult").Return(response, test.respondError).Times(1)
+
+		vmClient := getTestVMClient(armClient)
+		err := vmClient.WaitForUpdateResult(context.TODO(), &azure.Future{}, "rg", "test")
+		assert.Equal(t, err, test.expectedResult)
+	}
 }
 
 func TestUpdateWithUpdateResponderError(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
fix: always check result code even returns http 200 success in VM update

There are cases that vm update returns `200` httpStatusCode, while it actually failed with `OperationPreempted`, vm update operation should return failure in such condition. Original code only checks http response which is incorrect.

```
resultType httpStatusCode resultCode	                         errorDetails
1	          200	            OperationPreempted		Operation execution has been preempted by a more recent operation.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: disk attach/detach failure when operation is preempted
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: disk attach/detach failure when operation is preempted
```
