### PR TITLE
Fix: Add spinlock in cache to block concurrent ARM request

### DIFF
--- a/pkg/cache/azure_cache.go
+++ b/pkg/cache/azure_cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -44,7 +45,6 @@ type GetFunc func(key string) (interface{}, error)
 
 // AzureCacheEntry is the internal structure stores inside TTLStore.
 type AzureCacheEntry struct {
-	Key  string
 	Data interface{}
 
 	// time when entry was fetched and created
@@ -54,7 +54,6 @@ type AzureCacheEntry struct {
 // TimedCache is a cache with TTL.
 type TimedCache struct {
 	Store  sync.Map
-	Lock   sync.Mutex
 	Getter GetFunc
 	TTL    time.Duration
 }
@@ -73,36 +72,50 @@ func NewTimedcache(ttl time.Duration, getter GetFunc) (*TimedCache, error) {
 
 // Get returns the requested item by key.
 func (t *TimedCache) Get(key string, crt AzureCacheReadType) (interface{}, error) {
-	rawEntry, _ := t.Store.LoadOrStore(key, &AzureCacheEntry{
-		Key:  key,
+	rawEntry, loaded := t.Store.LoadOrStore(key, &AzureCacheEntry{
 		Data: nil,
 	})
-
 	entry := rawEntry.(*AzureCacheEntry)
-	// entry exists and if cache is not force refreshed
-	if entry.Data != nil && crt != CacheReadTypeForceRefresh {
-		// allow unsafe read, so return data even if expired
-		if crt == CacheReadTypeUnsafe {
-			return entry.Data, nil
+
+	// spin lock is introduced to make sure one ARM call only for one resource
+	for loaded {
+		if entry.Data != nil {
+			switch crt {
+			case CacheReadTypeUnsafe:
+				return entry.Data, nil
+			case CacheReadTypeDefault:
+				if time.Since(entry.CreatedOn) < t.TTL {
+					return entry.Data, nil
+				}
+				fallthrough
+			case CacheReadTypeForceRefresh:
+				t.Store.Delete(key)
+			}
 		}
-		// if cached data is not expired, return cached data
-		if crt == CacheReadTypeDefault && time.Since(entry.CreatedOn) < t.TTL {
-			return entry.Data, nil
-		}
-	}
-	// Data is not cached yet, cache data is expired or requested force refresh
-	// cache it by getter. entry is locked before getting to ensure concurrent
-	// gets don't result in multiple ARM calls.
-	data, err := t.Getter(key)
-	if err != nil {
-		return nil, err
+		runtime.Gosched()
+		rawEntry, loaded = t.Store.LoadOrStore(key, &AzureCacheEntry{
+			Data: nil,
+		})
+		entry = rawEntry.(*AzureCacheEntry)
 	}
 
-	// set the data in cache and also set the last update time
-	// to now as the data was recently fetched
-	t.Set(key, data)
-
-	return data, nil
+	return func() (data interface{}, reterr error) {
+		defer func() {
+			if err := recover(); err != nil {
+				t.Store.Delete(key)
+				reterr = err.(error)
+			}
+		}()
+		data, reterr = t.Getter(key)
+		if reterr != nil || data == nil {
+			t.Store.Delete(key)
+			return nil, reterr
+		}
+		// set the data in cache and also set the last update time
+		// to now as the data was recently fetched
+		t.Set(key, data)
+		return data, nil
+	}()
 }
 
 // Delete removes an item from the cache.
@@ -115,7 +128,6 @@ func (t *TimedCache) Delete(key string) error {
 // It is only used for testing.
 func (t *TimedCache) Set(key string, data interface{}) {
 	t.Store.Store(key, &AzureCacheEntry{
-		Key:       key,
 		Data:      data,
 		CreatedOn: time.Now().UTC(),
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

cache removed mutex lock which may allow concurrent update and is not thread safe. 
Here we introduced a spin lock to ensure only one thread is updating the data. 

we shouldn't use sync.map as data store while we are depending on locks in entry because we will copy mutex object due to atomic update in sync.Map.

And for get value part, spin lock is more efficient. 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
Thanks for the review from @jwtty @nilo19 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
