### PR TITLE
Rollback pr #1300 Refactor store and use sync.map as data store

### DIFF
--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -159,7 +159,10 @@ func (ss *ScaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cac
 		if vmssCache, ok := ss.vmssVMCache.Load(cacheKey); ok {
 			// get old cache before refreshing the cache
 			cache := vmssCache.(*azcache.TimedCache)
-			entry, exists := cache.Store.Load(cacheKey)
+			entry, exists, err := cache.Store.GetByKey(cacheKey)
+			if err != nil {
+				return nil, err
+			}
 			if exists {
 				cached := entry.(*azcache.AzureCacheEntry).Data
 				if cached != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

cocurrent get requests are generated if sync.map is used. 


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

As @jwtty @nilo19 mentioned, The code change may introduce a regression bug.

update entry logic doesn't fulfill the requirement documented here 
More than one routine will update cache store at the same time.

https://github.com/kubernetes-sigs/cloud-provider-azure/blob/4f83f549efd056c3ed9cc5cbacab2915c6374b6a/pkg/cache/azure_cache.go#L144-L147

The original code had held a Mutex lock before entered into update section.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
