### PR TITLE
chore: add subsID parameter in storage account client

### DIFF
--- a/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
+++ b/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
@@ -86,8 +86,11 @@ func New(config *azclients.ClientConfig) *Client {
 }
 
 // GetProperties gets properties of the StorageAccount.
-func (c *Client) GetProperties(ctx context.Context, resourceGroupName string, accountName string) (storage.Account, *retry.Error) {
-	mc := metrics.NewMetricContext("storage_account", "get", resourceGroupName, c.subscriptionID, "")
+func (c *Client) GetProperties(ctx context.Context, subsID, resourceGroupName, accountName string) (storage.Account, *retry.Error) {
+	if subsID == "" {
+		subsID = c.subscriptionID
+	}
+	mc := metrics.NewMetricContext("storage_account", "get", resourceGroupName, subsID, "")
 
 	// Report errors if the client is rate limited.
 	if !c.rateLimiterReader.TryAccept() {
@@ -102,7 +105,7 @@ func (c *Client) GetProperties(ctx context.Context, resourceGroupName string, ac
 		return storage.Account{}, rerr
 	}
 
-	result, rerr := c.getStorageAccount(ctx, resourceGroupName, accountName)
+	result, rerr := c.getStorageAccount(ctx, subsID, resourceGroupName, accountName)
 	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
@@ -117,9 +120,9 @@ func (c *Client) GetProperties(ctx context.Context, resourceGroupName string, ac
 }
 
 // getStorageAccount gets properties of the StorageAccount.
-func (c *Client) getStorageAccount(ctx context.Context, resourceGroupName string, accountName string) (storage.Account, *retry.Error) {
+func (c *Client) getStorageAccount(ctx context.Context, subsID, resourceGroupName string, accountName string) (storage.Account, *retry.Error) {
 	resourceID := armclient.GetResourceID(
-		c.subscriptionID,
+		subsID,
 		resourceGroupName,
 		"Microsoft.Storage/storageAccounts",
 		accountName,
@@ -147,8 +150,11 @@ func (c *Client) getStorageAccount(ctx context.Context, resourceGroupName string
 }
 
 // ListKeys get a list of storage account keys.
-func (c *Client) ListKeys(ctx context.Context, resourceGroupName string, accountName string) (storage.AccountListKeysResult, *retry.Error) {
-	mc := metrics.NewMetricContext("storage_account", "list_keys", resourceGroupName, c.subscriptionID, "")
+func (c *Client) ListKeys(ctx context.Context, subsID, resourceGroupName, accountName string) (storage.AccountListKeysResult, *retry.Error) {
+	if subsID == "" {
+		subsID = c.subscriptionID
+	}
+	mc := metrics.NewMetricContext("storage_account", "list_keys", resourceGroupName, subsID, "")
 
 	// Report errors if the client is rate limited.
 	if !c.rateLimiterReader.TryAccept() {
@@ -163,7 +169,7 @@ func (c *Client) ListKeys(ctx context.Context, resourceGroupName string, account
 		return storage.AccountListKeysResult{}, rerr
 	}
 
-	result, rerr := c.listStorageAccountKeys(ctx, resourceGroupName, accountName)
+	result, rerr := c.listStorageAccountKeys(ctx, subsID, resourceGroupName, accountName)
 	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
@@ -178,9 +184,9 @@ func (c *Client) ListKeys(ctx context.Context, resourceGroupName string, account
 }
 
 // listStorageAccountKeys get a list of storage account keys.
-func (c *Client) listStorageAccountKeys(ctx context.Context, resourceGroupName string, accountName string) (storage.AccountListKeysResult, *retry.Error) {
+func (c *Client) listStorageAccountKeys(ctx context.Context, subsID, resourceGroupName, accountName string) (storage.AccountListKeysResult, *retry.Error) {
 	resourceID := armclient.GetResourceID(
-		c.subscriptionID,
+		subsID,
 		resourceGroupName,
 		"Microsoft.Storage/storageAccounts",
 		accountName,
@@ -208,8 +214,11 @@ func (c *Client) listStorageAccountKeys(ctx context.Context, resourceGroupName s
 }
 
 // Create creates a StorageAccount.
-func (c *Client) Create(ctx context.Context, resourceGroupName string, accountName string, parameters storage.AccountCreateParameters) *retry.Error {
-	mc := metrics.NewMetricContext("storage_account", "create", resourceGroupName, c.subscriptionID, "")
+func (c *Client) Create(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountCreateParameters) *retry.Error {
+	if subsID == "" {
+		subsID = c.subscriptionID
+	}
+	mc := metrics.NewMetricContext("storage_account", "create", resourceGroupName, subsID, "")
 
 	// Report errors if the client is rate limited.
 	if !c.rateLimiterWriter.TryAccept() {
@@ -224,24 +233,22 @@ func (c *Client) Create(ctx context.Context, resourceGroupName string, accountNa
 		return rerr
 	}
 
-	rerr := c.createStorageAccount(ctx, resourceGroupName, accountName, parameters)
+	rerr := c.createStorageAccount(ctx, subsID, resourceGroupName, accountName, parameters)
 	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
 			c.RetryAfterWriter = rerr.RetryAfter
 		}
-
 		return rerr
 	}
-
 	return nil
 }
 
 // createStorageAccount creates or updates a StorageAccount.
-func (c *Client) createStorageAccount(ctx context.Context, resourceGroupName string, accountName string, parameters storage.AccountCreateParameters) *retry.Error {
+func (c *Client) createStorageAccount(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountCreateParameters) *retry.Error {
 	resourceID := armclient.GetResourceID(
-		c.subscriptionID,
+		subsID,
 		resourceGroupName,
 		"Microsoft.Storage/storageAccounts",
 		accountName,
@@ -276,8 +283,11 @@ func (c *Client) createResponder(resp *http.Response) (*storage.Account, *retry.
 }
 
 // Update updates a storage account.
-func (c *Client) Update(ctx context.Context, resourceGroupName string, accountName string, parameters storage.AccountUpdateParameters) *retry.Error {
-	mc := metrics.NewMetricContext("storage_account", "update", resourceGroupName, c.subscriptionID, "")
+func (c *Client) Update(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountUpdateParameters) *retry.Error {
+	if subsID == "" {
+		subsID = c.subscriptionID
+	}
+	mc := metrics.NewMetricContext("storage_account", "update", resourceGroupName, subsID, "")
 
 	// Report errors if the client is rate limited.
 	if !c.rateLimiterWriter.TryAccept() {
@@ -292,7 +302,7 @@ func (c *Client) Update(ctx context.Context, resourceGroupName string, accountNa
 		return rerr
 	}
 
-	rerr := c.updateStorageAccount(ctx, resourceGroupName, accountName, parameters)
+	rerr := c.updateStorageAccount(ctx, subsID, resourceGroupName, accountName, parameters)
 	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
@@ -305,9 +315,9 @@ func (c *Client) Update(ctx context.Context, resourceGroupName string, accountNa
 }
 
 // updateStorageAccount updates a StorageAccount.
-func (c *Client) updateStorageAccount(ctx context.Context, resourceGroupName string, accountName string, parameters storage.AccountUpdateParameters) *retry.Error {
+func (c *Client) updateStorageAccount(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountUpdateParameters) *retry.Error {
 	resourceID := armclient.GetResourceID(
-		c.subscriptionID,
+		subsID,
 		resourceGroupName,
 		"Microsoft.Storage/storageAccounts",
 		accountName,
@@ -342,8 +352,11 @@ func (c *Client) updateResponder(resp *http.Response) (*storage.Account, *retry.
 }
 
 // Delete deletes a StorageAccount by name.
-func (c *Client) Delete(ctx context.Context, resourceGroupName string, accountName string) *retry.Error {
-	mc := metrics.NewMetricContext("storage_account", "delete", resourceGroupName, c.subscriptionID, "")
+func (c *Client) Delete(ctx context.Context, subsID, resourceGroupName, accountName string) *retry.Error {
+	if subsID == "" {
+		subsID = c.subscriptionID
+	}
+	mc := metrics.NewMetricContext("storage_account", "delete", resourceGroupName, subsID, "")
 
 	// Report errors if the client is rate limited.
 	if !c.rateLimiterWriter.TryAccept() {
@@ -358,7 +371,7 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, accountNa
 		return rerr
 	}
 
-	rerr := c.deleteStorageAccount(ctx, resourceGroupName, accountName)
+	rerr := c.deleteStorageAccount(ctx, subsID, resourceGroupName, accountName)
 	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
@@ -373,9 +386,9 @@ func (c *Client) Delete(ctx context.Context, resourceGroupName string, accountNa
 }
 
 // deleteStorageAccount deletes a PublicIPAddress by name.
-func (c *Client) deleteStorageAccount(ctx context.Context, resourceGroupName string, accountName string) *retry.Error {
+func (c *Client) deleteStorageAccount(ctx context.Context, subsID, resourceGroupName, accountName string) *retry.Error {
 	resourceID := armclient.GetResourceID(
-		c.subscriptionID,
+		subsID,
 		resourceGroupName,
 		"Microsoft.Storage/storageAccounts",
 		accountName,
@@ -385,8 +398,11 @@ func (c *Client) deleteStorageAccount(ctx context.Context, resourceGroupName str
 }
 
 // ListByResourceGroup get a list storage accounts by resourceGroup.
-func (c *Client) ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]storage.Account, *retry.Error) {
-	mc := metrics.NewMetricContext("storage_account", "list_by_resource_group", resourceGroupName, c.subscriptionID, "")
+func (c *Client) ListByResourceGroup(ctx context.Context, subsID, resourceGroupName string) ([]storage.Account, *retry.Error) {
+	if subsID == "" {
+		subsID = c.subscriptionID
+	}
+	mc := metrics.NewMetricContext("storage_account", "list_by_resource_group", resourceGroupName, subsID, "")
 
 	// Report errors if the client is rate limited.
 	if !c.rateLimiterReader.TryAccept() {
@@ -401,24 +417,25 @@ func (c *Client) ListByResourceGroup(ctx context.Context, resourceGroupName stri
 		return nil, rerr
 	}
 
-	result, rerr := c.ListStorageAccountByResourceGroup(ctx, resourceGroupName)
+	result, rerr := c.ListStorageAccountByResourceGroup(ctx, subsID, resourceGroupName)
 	mc.Observe(rerr)
 	if rerr != nil {
 		if rerr.IsThrottled() {
 			// Update RetryAfterReader so that no more requests would be sent until RetryAfter expires.
 			c.RetryAfterReader = rerr.RetryAfter
 		}
-
 		return result, rerr
 	}
-
 	return result, nil
 }
 
 // ListStorageAccountByResourceGroup get a list storage accounts by resourceGroup.
-func (c *Client) ListStorageAccountByResourceGroup(ctx context.Context, resourceGroupName string) ([]storage.Account, *retry.Error) {
+func (c *Client) ListStorageAccountByResourceGroup(ctx context.Context, subsID, resourceGroupName string) ([]storage.Account, *retry.Error) {
+	if subsID == "" {
+		subsID = c.subscriptionID
+	}
 	resourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts",
-		autorest.Encode("path", c.subscriptionID),
+		autorest.Encode("path", subsID),
 		autorest.Encode("path", resourceGroupName))
 	result := make([]storage.Account, 0)
 	page := &AccountListResultPage{}

--- a/pkg/azureclients/storageaccountclient/azure_storageaccountclient_test.go
+++ b/pkg/azureclients/storageaccountclient/azure_storageaccountclient_test.go
@@ -107,7 +107,7 @@ func TestGetProperties(t *testing.T) {
 
 	saClient := getTestStorageAccountClient(armClient)
 	expected := storage.Account{Response: autorest.Response{Response: response}}
-	result, rerr := saClient.GetProperties(context.TODO(), "rg", "sa1")
+	result, rerr := saClient.GetProperties(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected, result)
 	assert.Nil(t, rerr)
 }
@@ -147,13 +147,13 @@ func TestAllNeverRateLimiter(t *testing.T) {
 	expected1 := storage.Account{}
 	expected2 := storage.AccountListKeysResult{}
 	expected3 := []storage.Account(nil)
-	result1, rerr1 := saClient.GetProperties(context.TODO(), "rg", "sa1")
+	result1, rerr1 := saClient.GetProperties(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected1, result1)
 	assert.Equal(t, saErr1, rerr1)
-	result2, rerr2 := saClient.ListKeys(context.TODO(), "rg", "sa1")
+	result2, rerr2 := saClient.ListKeys(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected2, result2)
 	assert.Equal(t, saErr2, rerr2)
-	result3, rerr3 := saClient.ListByResourceGroup(context.TODO(), "rg")
+	result3, rerr3 := saClient.ListByResourceGroup(context.TODO(), "", "rg")
 	assert.Equal(t, expected3, result3)
 	assert.Equal(t, saErr3, rerr3)
 
@@ -161,9 +161,9 @@ func TestAllNeverRateLimiter(t *testing.T) {
 		Location: to.StringPtr("eastus"),
 	}
 
-	rerr4 := saClient.Create(context.TODO(), "rg", "sa1", sa)
+	rerr4 := saClient.Create(context.TODO(), "", "rg", "sa1", sa)
 	assert.Equal(t, saErr4, rerr4)
-	rerr5 := saClient.Delete(context.TODO(), "rg", "sa1")
+	rerr5 := saClient.Delete(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, saErr5, rerr5)
 }
 
@@ -207,13 +207,13 @@ func TestAllRetryAfterReader(t *testing.T) {
 	expected1 := storage.Account{}
 	expected2 := storage.AccountListKeysResult{}
 	expected3 := []storage.Account(nil)
-	result1, rerr1 := saClient.GetProperties(context.TODO(), "rg", "sa1")
+	result1, rerr1 := saClient.GetProperties(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected1, result1)
 	assert.Equal(t, saErr1, rerr1)
-	result2, rerr2 := saClient.ListKeys(context.TODO(), "rg", "sa1")
+	result2, rerr2 := saClient.ListKeys(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected2, result2)
 	assert.Equal(t, saErr2, rerr2)
-	result3, rerr3 := saClient.ListByResourceGroup(context.TODO(), "rg")
+	result3, rerr3 := saClient.ListByResourceGroup(context.TODO(), "", "rg")
 	assert.Equal(t, expected3, result3)
 	assert.Equal(t, saErr3, rerr3)
 
@@ -221,9 +221,9 @@ func TestAllRetryAfterReader(t *testing.T) {
 		Location: to.StringPtr("eastus"),
 	}
 
-	rerr4 := saClient.Create(context.TODO(), "rg", "sa1", sa)
+	rerr4 := saClient.Create(context.TODO(), "", "rg", "sa1", sa)
 	assert.Equal(t, saErr4, rerr4)
-	rerr5 := saClient.Delete(context.TODO(), "rg", "sa1")
+	rerr5 := saClient.Delete(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, saErr5, rerr5)
 }
 
@@ -257,15 +257,15 @@ func TestAllThrottle(t *testing.T) {
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(3)
 
 	saClient := getTestStorageAccountClient(armClient)
-	result1, rerr1 := saClient.GetProperties(context.TODO(), "rg", "sa1")
+	result1, rerr1 := saClient.GetProperties(context.TODO(), "", "rg", "sa1")
 	assert.Empty(t, result1)
 	assert.Equal(t, throttleErr, rerr1)
-	result2, rerr2 := saClient.ListKeys(context.TODO(), "rg", "sa1")
+	result2, rerr2 := saClient.ListKeys(context.TODO(), "", "rg", "sa1")
 	assert.Empty(t, result2)
 	assert.Equal(t, throttleErr, rerr2)
-	rerr3 := saClient.Create(context.TODO(), "rg", "sa1", sa)
+	rerr3 := saClient.Create(context.TODO(), "", "rg", "sa1", sa)
 	assert.Equal(t, throttleErr, rerr3)
-	rerr4 := saClient.Delete(context.TODO(), "rg", "sa1")
+	rerr4 := saClient.Delete(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, throttleErr, rerr4)
 
 	armClient2 := mockarmclient.NewMockInterface(ctrl)
@@ -273,7 +273,7 @@ func TestAllThrottle(t *testing.T) {
 	armClient2.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	saClient2 := getTestStorageAccountClient(armClient2)
-	result5, rerr5 := saClient2.ListByResourceGroup(context.TODO(), "rg")
+	result5, rerr5 := saClient2.ListByResourceGroup(context.TODO(), "", "rg")
 	assert.Empty(t, result5)
 	assert.Equal(t, throttleErr, rerr5)
 }
@@ -292,7 +292,7 @@ func TestGetPropertiesNotFound(t *testing.T) {
 
 	saClient := getTestStorageAccountClient(armClient)
 	expected := storage.Account{Response: autorest.Response{}}
-	result, rerr := saClient.GetProperties(context.TODO(), "rg", "sa1")
+	result, rerr := saClient.GetProperties(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected, result)
 	assert.NotNil(t, rerr)
 	assert.Equal(t, http.StatusNotFound, rerr.HTTPStatusCode)
@@ -312,7 +312,7 @@ func TestGetPropertiesInternalError(t *testing.T) {
 
 	saClient := getTestStorageAccountClient(armClient)
 	expected := storage.Account{Response: autorest.Response{}}
-	result, rerr := saClient.GetProperties(context.TODO(), "rg", "sa1")
+	result, rerr := saClient.GetProperties(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected, result)
 	assert.NotNil(t, rerr)
 	assert.Equal(t, http.StatusInternalServerError, rerr.HTTPStatusCode)
@@ -332,7 +332,7 @@ func TestListKeys(t *testing.T) {
 
 	saClient := getTestStorageAccountClient(armClient)
 	expected := storage.AccountListKeysResult{Response: autorest.Response{Response: response}}
-	result, rerr := saClient.ListKeys(context.TODO(), "rg", "sa1")
+	result, rerr := saClient.ListKeys(context.TODO(), "", "rg", "sa1")
 	assert.Nil(t, rerr)
 	assert.Equal(t, expected, result)
 }
@@ -351,7 +351,7 @@ func TestListKeysResponderError(t *testing.T) {
 
 	saClient := getTestStorageAccountClient(armClient)
 	expected := storage.AccountListKeysResult{Response: autorest.Response{}}
-	result, rerr := saClient.ListKeys(context.TODO(), "rg", "sa1")
+	result, rerr := saClient.ListKeys(context.TODO(), "", "rg", "sa1")
 	assert.Equal(t, expected, result)
 	assert.NotNil(t, rerr)
 	assert.Equal(t, http.StatusNotFound, rerr.HTTPStatusCode)
@@ -467,7 +467,7 @@ func TestListByResourceGroup(t *testing.T) {
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	saClient := getTestStorageAccountClient(armClient)
-	result, rerr := saClient.ListByResourceGroup(context.TODO(), "rg")
+	result, rerr := saClient.ListByResourceGroup(context.TODO(), "", "rg")
 	assert.Nil(t, rerr)
 	assert.Equal(t, 3, len(result))
 }
@@ -488,7 +488,7 @@ func TestListByResourceGroupResponderError(t *testing.T) {
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	saClient := getTestStorageAccountClient(armClient)
-	result, rerr := saClient.ListByResourceGroup(context.TODO(), "rg")
+	result, rerr := saClient.ListByResourceGroup(context.TODO(), "", "rg")
 	assert.NotNil(t, rerr)
 	assert.Equal(t, 0, len(result))
 }
@@ -509,7 +509,7 @@ func TestCreate(t *testing.T) {
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	saClient := getTestStorageAccountClient(armClient)
-	rerr := saClient.Create(context.TODO(), "rg", "sa1", sa)
+	rerr := saClient.Create(context.TODO(), "", "rg", "sa1", sa)
 	assert.Nil(t, rerr)
 }
 
@@ -529,7 +529,7 @@ func TestCreateResponderError(t *testing.T) {
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	saClient := getTestStorageAccountClient(armClient)
-	rerr := saClient.Create(context.TODO(), "rg", "sa1", sa)
+	rerr := saClient.Create(context.TODO(), "", "rg", "sa1", sa)
 	assert.NotNil(t, rerr)
 }
 
@@ -549,7 +549,7 @@ func TestUpdate(t *testing.T) {
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	saClient := getTestStorageAccountClient(armClient)
-	rerr := saClient.Update(context.TODO(), "rg", "sa1", sa)
+	rerr := saClient.Update(context.TODO(), "", "rg", "sa1", sa)
 	assert.Nil(t, rerr)
 }
 
@@ -569,7 +569,7 @@ func TestUpdateResponderError(t *testing.T) {
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	saClient := getTestStorageAccountClient(armClient)
-	rerr := saClient.Update(context.TODO(), "rg", "sa1", sa)
+	rerr := saClient.Update(context.TODO(), "", "rg", "sa1", sa)
 	assert.NotNil(t, rerr)
 }
 
@@ -582,7 +582,7 @@ func TestDelete(t *testing.T) {
 	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
 
 	rtClient := getTestStorageAccountClient(armClient)
-	rerr := rtClient.Delete(context.TODO(), "rg", "sa1")
+	rerr := rtClient.Delete(context.TODO(), "", "rg", "sa1")
 	assert.Nil(t, rerr)
 }
 

--- a/pkg/azureclients/storageaccountclient/interface.go
+++ b/pkg/azureclients/storageaccountclient/interface.go
@@ -37,20 +37,20 @@ const (
 // Don't forget to run "hack/update-mock-clients.sh" command to generate the mock client.
 type Interface interface {
 	// Create creates a StorageAccount.
-	Create(ctx context.Context, resourceGroupName string, accountName string, parameters storage.AccountCreateParameters) *retry.Error
+	Create(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountCreateParameters) *retry.Error
 
 	// Update updates a StorageAccount.
-	Update(ctx context.Context, resourceGroupName string, accountName string, parameters storage.AccountUpdateParameters) *retry.Error
+	Update(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountUpdateParameters) *retry.Error
 
 	// Delete deletes a StorageAccount by name.
-	Delete(ctx context.Context, resourceGroupName string, accountName string) *retry.Error
+	Delete(ctx context.Context, subsID, resourceGroupName, accountName string) *retry.Error
 
 	// ListKeys get a list of storage account keys.
-	ListKeys(ctx context.Context, resourceGroupName string, accountName string) (storage.AccountListKeysResult, *retry.Error)
+	ListKeys(ctx context.Context, subsID, resourceGroupName, accountName string) (storage.AccountListKeysResult, *retry.Error)
 
 	// ListByResourceGroup get a list storage accounts by resourceGroup.
-	ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]storage.Account, *retry.Error)
+	ListByResourceGroup(ctx context.Context, subsID, resourceGroupName string) ([]storage.Account, *retry.Error)
 
 	// GetProperties gets properties of the StorageAccount.
-	GetProperties(ctx context.Context, resourceGroupName string, accountName string) (result storage.Account, rerr *retry.Error)
+	GetProperties(ctx context.Context, subsID, resourceGroupName, accountName string) (result storage.Account, rerr *retry.Error)
 }

--- a/pkg/azureclients/storageaccountclient/mockstorageaccountclient/interface.go
+++ b/pkg/azureclients/storageaccountclient/mockstorageaccountclient/interface.go
@@ -54,88 +54,88 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockInterface) Create(ctx context.Context, resourceGroupName, accountName string, parameters storage.AccountCreateParameters) *retry.Error {
+func (m *MockInterface) Create(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountCreateParameters) *retry.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, resourceGroupName, accountName, parameters)
+	ret := m.ctrl.Call(m, "Create", ctx, subsID, resourceGroupName, accountName, parameters)
 	ret0, _ := ret[0].(*retry.Error)
 	return ret0
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockInterfaceMockRecorder) Create(ctx, resourceGroupName, accountName, parameters interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Create(ctx, subsID, resourceGroupName, accountName, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInterface)(nil).Create), ctx, resourceGroupName, accountName, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInterface)(nil).Create), ctx, subsID, resourceGroupName, accountName, parameters)
 }
 
 // Delete mocks base method.
-func (m *MockInterface) Delete(ctx context.Context, resourceGroupName, accountName string) *retry.Error {
+func (m *MockInterface) Delete(ctx context.Context, subsID, resourceGroupName, accountName string) *retry.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, resourceGroupName, accountName)
+	ret := m.ctrl.Call(m, "Delete", ctx, subsID, resourceGroupName, accountName)
 	ret0, _ := ret[0].(*retry.Error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockInterfaceMockRecorder) Delete(ctx, resourceGroupName, accountName interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Delete(ctx, subsID, resourceGroupName, accountName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, resourceGroupName, accountName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, subsID, resourceGroupName, accountName)
 }
 
 // GetProperties mocks base method.
-func (m *MockInterface) GetProperties(ctx context.Context, resourceGroupName, accountName string) (storage.Account, *retry.Error) {
+func (m *MockInterface) GetProperties(ctx context.Context, subsID, resourceGroupName, accountName string) (storage.Account, *retry.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProperties", ctx, resourceGroupName, accountName)
+	ret := m.ctrl.Call(m, "GetProperties", ctx, subsID, resourceGroupName, accountName)
 	ret0, _ := ret[0].(storage.Account)
 	ret1, _ := ret[1].(*retry.Error)
 	return ret0, ret1
 }
 
 // GetProperties indicates an expected call of GetProperties.
-func (mr *MockInterfaceMockRecorder) GetProperties(ctx, resourceGroupName, accountName interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) GetProperties(ctx, subsID, resourceGroupName, accountName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProperties", reflect.TypeOf((*MockInterface)(nil).GetProperties), ctx, resourceGroupName, accountName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProperties", reflect.TypeOf((*MockInterface)(nil).GetProperties), ctx, subsID, resourceGroupName, accountName)
 }
 
 // ListByResourceGroup mocks base method.
-func (m *MockInterface) ListByResourceGroup(ctx context.Context, resourceGroupName string) ([]storage.Account, *retry.Error) {
+func (m *MockInterface) ListByResourceGroup(ctx context.Context, subsID, resourceGroupName string) ([]storage.Account, *retry.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByResourceGroup", ctx, resourceGroupName)
+	ret := m.ctrl.Call(m, "ListByResourceGroup", ctx, subsID, resourceGroupName)
 	ret0, _ := ret[0].([]storage.Account)
 	ret1, _ := ret[1].(*retry.Error)
 	return ret0, ret1
 }
 
 // ListByResourceGroup indicates an expected call of ListByResourceGroup.
-func (mr *MockInterfaceMockRecorder) ListByResourceGroup(ctx, resourceGroupName interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) ListByResourceGroup(ctx, subsID, resourceGroupName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByResourceGroup", reflect.TypeOf((*MockInterface)(nil).ListByResourceGroup), ctx, resourceGroupName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByResourceGroup", reflect.TypeOf((*MockInterface)(nil).ListByResourceGroup), ctx, subsID, resourceGroupName)
 }
 
 // ListKeys mocks base method.
-func (m *MockInterface) ListKeys(ctx context.Context, resourceGroupName, accountName string) (storage.AccountListKeysResult, *retry.Error) {
+func (m *MockInterface) ListKeys(ctx context.Context, subsID, resourceGroupName, accountName string) (storage.AccountListKeysResult, *retry.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListKeys", ctx, resourceGroupName, accountName)
+	ret := m.ctrl.Call(m, "ListKeys", ctx, subsID, resourceGroupName, accountName)
 	ret0, _ := ret[0].(storage.AccountListKeysResult)
 	ret1, _ := ret[1].(*retry.Error)
 	return ret0, ret1
 }
 
 // ListKeys indicates an expected call of ListKeys.
-func (mr *MockInterfaceMockRecorder) ListKeys(ctx, resourceGroupName, accountName interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) ListKeys(ctx, subsID, resourceGroupName, accountName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeys", reflect.TypeOf((*MockInterface)(nil).ListKeys), ctx, resourceGroupName, accountName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeys", reflect.TypeOf((*MockInterface)(nil).ListKeys), ctx, subsID, resourceGroupName, accountName)
 }
 
 // Update mocks base method.
-func (m *MockInterface) Update(ctx context.Context, resourceGroupName, accountName string, parameters storage.AccountUpdateParameters) *retry.Error {
+func (m *MockInterface) Update(ctx context.Context, subsID, resourceGroupName, accountName string, parameters storage.AccountUpdateParameters) *retry.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, resourceGroupName, accountName, parameters)
+	ret := m.ctrl.Call(m, "Update", ctx, subsID, resourceGroupName, accountName, parameters)
 	ret0, _ := ret[0].(*retry.Error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, accountName, parameters interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Update(ctx, subsID, resourceGroupName, accountName, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, accountName, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, subsID, resourceGroupName, accountName, parameters)
 }

--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -80,8 +80,8 @@ type ManagedDiskOptions struct {
 	DiskAccessID *string
 	// BurstingEnabled - Set to true to enable bursting beyond the provisioned performance target of the disk.
 	BurstingEnabled *bool
-	// SubscrtionID - specify a different SubscrtionID
-	SubscrtionID string
+	// SubscriptionID - specify a different SubscriptionID
+	SubscriptionID string
 }
 
 //CreateManagedDisk : create managed disk
@@ -117,12 +117,12 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 	if options.ResourceGroup != "" {
 		rg = options.ResourceGroup
 	}
-	subsID := c.common.subscriptionID
-	if options.SubscrtionID != "" {
-		subsID = options.SubscrtionID
+	if options.SubscriptionID != "" && !strings.EqualFold(options.SubscriptionID, c.common.subscriptionID) && options.ResourceGroup == "" {
+		return "", fmt.Errorf("resourceGroup must be specified when subscriptionID(%s) is not empty", options.SubscriptionID)
 	}
-	if options.SubscrtionID != "" && !strings.EqualFold(options.SubscrtionID, c.common.subscriptionID) && options.ResourceGroup == "" {
-		return "", fmt.Errorf("resourceGroup must be specified when subscriptionID(%s) is not empty", subsID)
+	subsID := c.common.subscriptionID
+	if options.SubscriptionID != "" {
+		subsID = options.SubscriptionID
 	}
 
 	creationData, err := getValidCreationData(subsID, rg, options.SourceResourceID, options.SourceType)

--- a/pkg/provider/azure_managedDiskController_test.go
+++ b/pkg/provider/azure_managedDiskController_test.go
@@ -236,7 +236,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			MaxShares:           maxShare,
 			NetworkAccessPolicy: test.networkAccessPolicy,
 			DiskAccessID:        test.diskAccessID,
-			SubscrtionID:        test.subscriptionID,
+			SubscriptionID:      test.subscriptionID,
 		}
 
 		mockDisksClient := testCloud.DisksClient.(*mockdiskclient.MockInterface)

--- a/pkg/provider/azure_storage_test.go
+++ b/pkg/provider/azure_storage_test.go
@@ -153,9 +153,9 @@ func TestCreateFileShare(t *testing.T) {
 
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
-		mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), "rg", gomock.Any()).Return(test.keys, nil).AnyTimes()
-		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), "rg").Return(test.accounts, nil).AnyTimes()
-		mockStorageAccountsClient.EXPECT().Create(gomock.Any(), "rg", gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), "", "rg", gomock.Any()).Return(test.keys, nil).AnyTimes()
+		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), gomock.Any(), "rg").Return(test.accounts, nil).AnyTimes()
+		mockStorageAccountsClient.EXPECT().Create(gomock.Any(), "", "rg", gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		mockAccount := &AccountOptions{
 			Name:          test.acct,

--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -41,6 +41,7 @@ const PrivateDNSZoneName = "privatelink.file.core.windows.net"
 
 // AccountOptions contains the fields which are used to create storage account.
 type AccountOptions struct {
+	SubscriptionID                            string
 	Name, Type, Kind, ResourceGroup, Location string
 	EnableHTTPSTrafficOnly                    bool
 	// indicate whether create new account when Name is empty or when account does not exists
@@ -67,7 +68,7 @@ func (az *Cloud) getStorageAccounts(ctx context.Context, accountOptions *Account
 	if az.StorageAccountClient == nil {
 		return nil, fmt.Errorf("StorageAccountClient is nil")
 	}
-	result, rerr := az.StorageAccountClient.ListByResourceGroup(ctx, accountOptions.ResourceGroup)
+	result, rerr := az.StorageAccountClient.ListByResourceGroup(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup)
 	if rerr != nil {
 		return nil, rerr.Error()
 	}
@@ -94,12 +95,12 @@ func (az *Cloud) getStorageAccounts(ctx context.Context, accountOptions *Account
 }
 
 // GetStorageAccesskey gets the storage account access key
-func (az *Cloud) GetStorageAccesskey(ctx context.Context, account, resourceGroup string) (string, error) {
+func (az *Cloud) GetStorageAccesskey(ctx context.Context, subsID, account, resourceGroup string) (string, error) {
 	if az.StorageAccountClient == nil {
 		return "", fmt.Errorf("StorageAccountClient is nil")
 	}
 
-	result, rerr := az.StorageAccountClient.ListKeys(ctx, resourceGroup, account)
+	result, rerr := az.StorageAccountClient.ListKeys(ctx, subsID, resourceGroup, account)
 	if rerr != nil {
 		return "", rerr.Error()
 	}
@@ -166,7 +167,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 		createNewAccount = false
 		if accountOptions.CreateAccount {
 			// check whether account exists
-			if _, err := az.GetStorageAccesskey(ctx, accountName, resourceGroup); err != nil {
+			if _, err := az.GetStorageAccesskey(ctx, accountOptions.SubscriptionID, accountName, resourceGroup); err != nil {
 				klog.V(2).Infof("get storage key for storage account %s returned with %v", accountName, err)
 				createNewAccount = true
 			}
@@ -258,7 +259,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 			return "", "", fmt.Errorf("StorageAccountClient is nil")
 		}
 
-		if rerr := az.StorageAccountClient.Create(ctx, resourceGroup, accountName, cp); rerr != nil {
+		if rerr := az.StorageAccountClient.Create(ctx, accountOptions.SubscriptionID, resourceGroup, accountName, cp); rerr != nil {
 			return "", "", fmt.Errorf("failed to create storage account %s, error: %v", accountName, rerr)
 		}
 
@@ -279,7 +280,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 
 		if accountOptions.CreatePrivateEndpoint {
 			// Get properties of the storageAccount
-			storageAccount, err := az.StorageAccountClient.GetProperties(ctx, resourceGroup, accountName)
+			storageAccount, err := az.StorageAccountClient.GetProperties(ctx, accountOptions.SubscriptionID, resourceGroup, accountName)
 			if err != nil {
 				return "", "", fmt.Errorf("Failed to get the properties of storage account(%s), resourceGroup(%s), error: %v", accountName, resourceGroup, err)
 			}
@@ -305,7 +306,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 	}
 
 	// find the access key with this account
-	accountKey, err := az.GetStorageAccesskey(ctx, accountName, resourceGroup)
+	accountKey, err := az.GetStorageAccesskey(ctx, accountOptions.SubscriptionID, accountName, resourceGroup)
 	if err != nil {
 		return "", "", fmt.Errorf("could not get storage key for storage account %s: %w", accountName, err)
 	}
@@ -389,11 +390,11 @@ func (az *Cloud) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGroupName
 }
 
 // AddStorageAccountTags add tags to storage account
-func (az *Cloud) AddStorageAccountTags(ctx context.Context, resourceGroup, account string, tags map[string]*string) *retry.Error {
+func (az *Cloud) AddStorageAccountTags(ctx context.Context, subsID, resourceGroup, account string, tags map[string]*string) *retry.Error {
 	if az.StorageAccountClient == nil {
 		return retry.NewError(false, fmt.Errorf("StorageAccountClient is nil"))
 	}
-	result, rerr := az.StorageAccountClient.GetProperties(ctx, resourceGroup, account)
+	result, rerr := az.StorageAccountClient.GetProperties(ctx, subsID, resourceGroup, account)
 	if rerr != nil {
 		return rerr
 	}
@@ -409,15 +410,15 @@ func (az *Cloud) AddStorageAccountTags(ctx context.Context, resourceGroup, accou
 	}
 
 	updateParams := storage.AccountUpdateParameters{Tags: newTags}
-	return az.StorageAccountClient.Update(ctx, resourceGroup, account, updateParams)
+	return az.StorageAccountClient.Update(ctx, subsID, resourceGroup, account, updateParams)
 }
 
 // RemoveStorageAccountTag remove tag from storage account
-func (az *Cloud) RemoveStorageAccountTag(ctx context.Context, resourceGroup, account, key string) *retry.Error {
+func (az *Cloud) RemoveStorageAccountTag(ctx context.Context, subsID, resourceGroup, account, key string) *retry.Error {
 	if az.StorageAccountClient == nil {
 		return retry.NewError(false, fmt.Errorf("StorageAccountClient is nil"))
 	}
-	result, rerr := az.StorageAccountClient.GetProperties(ctx, resourceGroup, account)
+	result, rerr := az.StorageAccountClient.GetProperties(ctx, subsID, resourceGroup, account)
 	if rerr != nil {
 		return rerr
 	}
@@ -430,7 +431,7 @@ func (az *Cloud) RemoveStorageAccountTag(ctx context.Context, resourceGroup, acc
 	delete(result.Tags, key)
 	if originalLen != len(result.Tags) {
 		updateParams := storage.AccountUpdateParameters{Tags: result.Tags}
-		return az.StorageAccountClient.Update(ctx, resourceGroup, account, updateParams)
+		return az.StorageAccountClient.Update(ctx, subsID, resourceGroup, account, updateParams)
 	}
 	return nil
 }

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -82,8 +82,8 @@ func TestGetStorageAccessKeys(t *testing.T) {
 	for _, test := range tests {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
-		mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), "rg", gomock.Any()).Return(test.results, nil).AnyTimes()
-		key, err := cloud.GetStorageAccesskey(ctx, "acct", "rg")
+		mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), "", "rg", gomock.Any()).Return(test.results, nil).AnyTimes()
+		key, err := cloud.GetStorageAccesskey(ctx, "", "acct", "rg")
 		if test.expectErr && err == nil {
 			t.Errorf("Unexpected non-error")
 			continue
@@ -142,7 +142,7 @@ func TestGetStorageAccount(t *testing.T) {
 	mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 	cloud.StorageAccountClient = mockStorageAccountsClient
 
-	mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), "rg").Return(testResourceGroups, nil).Times(1)
+	mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), "", "rg").Return(testResourceGroups, nil).Times(1)
 
 	accountsWithLocations, err := cloud.getStorageAccounts(ctx, accountOptions)
 	if err != nil {
@@ -317,7 +317,7 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
 
-		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), "rg").Return(test.testResourceGroups, nil).AnyTimes()
+		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), "", "rg").Return(test.testResourceGroups, nil).AnyTimes()
 
 		accountsWithLocations, err := cloud.getStorageAccounts(ctx, test.testAccountOptions)
 		if !errors.Is(err, test.expectedError) {
@@ -383,13 +383,13 @@ func TestEnsureStorageAccountWithPrivateEndpoint(t *testing.T) {
 
 	for _, test := range tests {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
-		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), gomock.Any()).Return(testStorageAccounts, nil).AnyTimes()
-		mockStorageAccountsClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		mockStorageAccountsClient.EXPECT().GetProperties(gomock.Any(), gomock.Any(), gomock.Any()).Return(testStorageAccounts[0], nil).AnyTimes()
+		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(testStorageAccounts, nil).AnyTimes()
+		mockStorageAccountsClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockStorageAccountsClient.EXPECT().GetProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testStorageAccounts[0], nil).AnyTimes()
 		if test.AccountName == "" {
-			mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, nil).AnyTimes()
+			mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, nil).AnyTimes()
 		} else {
-			mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, &retry.Error{}).AnyTimes()
+			mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, &retry.Error{}).AnyTimes()
 		}
 		cloud.StorageAccountClient = mockStorageAccountsClient
 

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
@@ -330,7 +331,7 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 	}
 }
 
-func TestEnsureStorageAccountWithPrivateEndpoint(t *testing.T) {
+func TestEnsureStorageAccount(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -368,62 +369,114 @@ func TestEnsureStorageAccountWithPrivateEndpoint(t *testing.T) {
 	}
 
 	tests := []struct {
-		CreateAccount bool
-		AccountName   string
+		name                      string
+		createAccount             bool
+		createPrivateEndpoint     bool
+		mockStorageAccountsClient bool
+		setAccountOptions         bool
+		accountName               string
+		subscriptionID            string
+		resourceGroup             string
+		expectedErr               string
 	}{
 		{
-			CreateAccount: false,
-			AccountName:   "",
+			name:                      "[Success] EnsureStorageAccount with createPrivateEndpoint",
+			createAccount:             true,
+			createPrivateEndpoint:     true,
+			mockStorageAccountsClient: true,
+			setAccountOptions:         true,
+			resourceGroup:             "rg",
+			accountName:               "",
+			expectedErr:               "",
 		},
 		{
-			CreateAccount: true,
-			AccountName:   "accountname",
+			name:                      "[Failed] EnsureStorageAccount with createPrivateEndpoint: get storage key failed",
+			createAccount:             true,
+			createPrivateEndpoint:     true,
+			mockStorageAccountsClient: true,
+			setAccountOptions:         true,
+			resourceGroup:             "rg",
+			accountName:               "accountname",
+			expectedErr:               "could not get storage key for storage account",
+		},
+		{
+			name:                      "[Failed] account options is nil",
+			mockStorageAccountsClient: false,
+			setAccountOptions:         false,
+			expectedErr:               "account options is nil",
+		},
+		{
+			name:              "[Failed] resourceGroup must be specified when subscriptionID is not empty",
+			subscriptionID:    "abc",
+			resourceGroup:     "",
+			setAccountOptions: true,
+			expectedErr:       "resourceGroup must be specified when subscriptionID(abc) is not empty",
+		},
+		{
+			name:              "[Failed] could not get storage key for storage account",
+			subscriptionID:    "",
+			resourceGroup:     "",
+			setAccountOptions: true,
+			expectedErr:       "could not get storage key for storage account",
 		},
 	}
 
 	for _, test := range tests {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
-		mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(testStorageAccounts, nil).AnyTimes()
-		mockStorageAccountsClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		mockStorageAccountsClient.EXPECT().GetProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testStorageAccounts[0], nil).AnyTimes()
-		if test.AccountName == "" {
-			mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, nil).AnyTimes()
-		} else {
-			mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, &retry.Error{}).AnyTimes()
+		if test.mockStorageAccountsClient {
+			cloud.StorageAccountClient = mockStorageAccountsClient
 		}
-		cloud.StorageAccountClient = mockStorageAccountsClient
 
-		subnet := network.Subnet{SubnetPropertiesFormat: &network.SubnetPropertiesFormat{}}
+		if test.createPrivateEndpoint {
+			mockStorageAccountsClient.EXPECT().ListByResourceGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(testStorageAccounts, nil).AnyTimes()
+			mockStorageAccountsClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockStorageAccountsClient.EXPECT().GetProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testStorageAccounts[0], nil).AnyTimes()
+			if test.accountName == "" {
+				mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, nil).AnyTimes()
+			} else {
+				mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, &retry.Error{}).AnyTimes()
+			}
 
-		mockSubnetsClient := mocksubnetclient.NewMockInterface(ctrl)
-		mockSubnetsClient.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetName, gomock.Any()).Return(subnet, nil).Times(1)
-		mockSubnetsClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, vnetName, subnetName, gomock.Any()).Return(nil).Times(1)
-		cloud.SubnetsClient = mockSubnetsClient
+			subnet := network.Subnet{SubnetPropertiesFormat: &network.SubnetPropertiesFormat{}}
 
-		mockPrivateDNSClient := mockprivatednsclient.NewMockInterface(ctrl)
-		mockPrivateDNSClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), true).Return(nil).Times(1)
-		cloud.privatednsclient = mockPrivateDNSClient
+			mockSubnetsClient := mocksubnetclient.NewMockInterface(ctrl)
+			mockSubnetsClient.EXPECT().Get(gomock.Any(), vnetResourceGroup, vnetName, subnetName, gomock.Any()).Return(subnet, nil).Times(1)
+			mockSubnetsClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, vnetName, subnetName, gomock.Any()).Return(nil).Times(1)
+			cloud.SubnetsClient = mockSubnetsClient
 
-		mockPrivateDNSZoneGroup := mockprivatednszonegroupclient.NewMockInterface(ctrl)
-		mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).Times(1)
-		cloud.privatednszonegroupclient = mockPrivateDNSZoneGroup
+			mockPrivateDNSClient := mockprivatednsclient.NewMockInterface(ctrl)
+			mockPrivateDNSClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), true).Return(nil).Times(1)
+			cloud.privatednsclient = mockPrivateDNSClient
 
-		mockPrivateEndpointClient := mockprivateendpointclient.NewMockInterface(ctrl)
-		mockPrivateEndpointClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), true).Return(nil).Times(1)
-		cloud.privateendpointclient = mockPrivateEndpointClient
+			mockPrivateDNSZoneGroup := mockprivatednszonegroupclient.NewMockInterface(ctrl)
+			mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).Times(1)
+			cloud.privatednszonegroupclient = mockPrivateDNSZoneGroup
 
-		mockVirtualNetworkLinksClient := mockvirtualnetworklinksclient.NewMockInterface(ctrl)
-		mockVirtualNetworkLinksClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).Times(1)
-		cloud.virtualNetworkLinksClient = mockVirtualNetworkLinksClient
+			mockPrivateEndpointClient := mockprivateendpointclient.NewMockInterface(ctrl)
+			mockPrivateEndpointClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), true).Return(nil).Times(1)
+			cloud.privateendpointclient = mockPrivateEndpointClient
 
-		testAccountOptions := &AccountOptions{
-			ResourceGroup:         "rg",
-			CreatePrivateEndpoint: true,
-			Name:                  test.AccountName,
-			CreateAccount:         test.CreateAccount,
+			mockVirtualNetworkLinksClient := mockvirtualnetworklinksclient.NewMockInterface(ctrl)
+			mockVirtualNetworkLinksClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any(), false).Return(nil).Times(1)
+			cloud.virtualNetworkLinksClient = mockVirtualNetworkLinksClient
 		}
+
+		var testAccountOptions *AccountOptions
+		if test.setAccountOptions {
+			testAccountOptions = &AccountOptions{
+				ResourceGroup:         test.resourceGroup,
+				CreatePrivateEndpoint: test.createPrivateEndpoint,
+				Name:                  test.accountName,
+				CreateAccount:         test.createAccount,
+				SubscriptionID:        test.subscriptionID,
+			}
+		}
+
 		_, _, err := cloud.EnsureStorageAccount(ctx, testAccountOptions, "test")
-		assert.Equal(t, err == nil, test.AccountName == "")
+		assert.Equal(t, err == nil, test.expectedErr == "", fmt.Sprintf("returned error: %v", err), test.name)
+		if test.expectedErr != "" {
+			assert.Equal(t, err != nil, strings.Contains(err.Error(), test.expectedErr), err.Error(), test.name)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
chore: add subsID parameter in storage account client

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
chore: add subsID parameter in storage account client
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
chore: add subsID parameter in storage account client
```
