### PR TITLE
Add DeletePEConnection to plsClient

### DIFF
--- a/pkg/azureclients/privatelinkserviceclient/interface.go
+++ b/pkg/azureclients/privatelinkserviceclient/interface.go
@@ -48,4 +48,7 @@ type Interface interface {
 
 	// Delete deletes a private link service by name.
 	Delete(ctx context.Context, resourceGroupName string, privateLinkServiceName string) *retry.Error
+
+	// Delete deletes a private endpoint connection to the private link service by name
+	DeletePEConnection(ctx context.Context, resourceGroupName string, privateLinkServiceName string, privateEndpointConnectionName string) *retry.Error
 }

--- a/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient/interface.go
+++ b/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient/interface.go
@@ -81,6 +81,20 @@ func (mr *MockInterfaceMockRecorder) Delete(ctx, resourceGroupName, privateLinkS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, resourceGroupName, privateLinkServiceName)
 }
 
+// DeletePEConnection mocks base method.
+func (m *MockInterface) DeletePEConnection(ctx context.Context, resourceGroupName, privateLinkServiceName, privateEndpointConnectionName string) *retry.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePEConnection", ctx, resourceGroupName, privateLinkServiceName, privateEndpointConnectionName)
+	ret0, _ := ret[0].(*retry.Error)
+	return ret0
+}
+
+// DeletePEConnection indicates an expected call of DeletePEConnection.
+func (mr *MockInterfaceMockRecorder) DeletePEConnection(ctx, resourceGroupName, privateLinkServiceName, privateEndpointConnectionName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePEConnection", reflect.TypeOf((*MockInterface)(nil).DeletePEConnection), ctx, resourceGroupName, privateLinkServiceName, privateEndpointConnectionName)
+}
+
 // Get mocks base method.
 func (m *MockInterface) Get(ctx context.Context, resourceGroupName, privateLinkServiceName, expand string) (network.PrivateLinkService, *retry.Error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When deleting a PLS, need to delete all existing PE connections first. So add this client interface.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add azure private link service client interface to delete a private endpoint connection.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
