### PR TITLE
refactor(logging): add logging helper and minor refactor

### DIFF
--- a/pkg/logging/span.go
+++ b/pkg/logging/span.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"runtime"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+const VerbosityForSpan klog.Level = 5
+
+// Span is a helper for logging the start point and the end point of the process block.
+type Span interface {
+
+	// Start prints the log indicating the process block has started.
+	// It should be called only once.
+	Start() Span
+
+	// Finish prints the log indicating the process block has reached the end.
+	// And it should be called only once too.
+	Finish(err error, extraFields ...interface{})
+}
+
+var (
+	_ Span = &span{}
+	_ Span = &noOpSpan{}
+)
+
+type span struct {
+	name   string
+	fields []interface{}
+	now    time.Time
+}
+
+// SpanForFunc is a helper to create `Span` block with caller's name.
+// If the level of verbosity is less than *5*, it returns the `no-op` implementation.
+func SpanForFunc(fields ...interface{}) Span {
+	if !klog.V(VerbosityForSpan).Enabled() {
+		return &noOpSpan{}
+	}
+
+	name := "unknown"
+	if pc, _, _, ok := runtime.Caller(1); ok {
+		name = runtime.FuncForPC(pc).Name()
+	}
+
+	return SpanForBlock(name, fields...)
+}
+
+// SpanForBlock returns an `Span` for logging block.
+// The given name will be logged as logr's key-value pair with `name` as the key.
+// If the level of verbosity is less than *5*, it returns the `no-op` implementation.
+func SpanForBlock(name string, fields ...interface{}) Span {
+	if !klog.V(VerbosityForSpan).Enabled() {
+		return &noOpSpan{}
+	}
+
+	return &span{
+		name:   name,
+		fields: fields,
+		now:    time.Now(),
+	}
+}
+
+func (l *span) Start() Span {
+	klog.InfoSDepth(1, "process started", append(l.fields, "name", l.name)...)
+	return l
+}
+
+func (l *span) Finish(err error, extraFields ...interface{}) {
+	fields := append(l.fields, extraFields...)
+	fields = append(fields,
+		"name", l.name,
+		"error", err,
+		"took-ms", time.Since(l.now).Milliseconds())
+
+	klog.InfoSDepth(1, "process finished", fields...)
+}
+
+type noOpSpan struct{}
+
+func (e *noOpSpan) Start() Span                      { return e }
+func (e *noOpSpan) Finish(_ error, _ ...interface{}) {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### What this PR does / why we need it:

Currently, logging seems arbitrary, and it mixed-use `plain-text logging` and `structural logging`. The PR tries to propose consistently using `structural logging` and introduces some helper functions to ease the pain of handling mass log fields.

Please feel free to add any input or suggestions!

Sample logs
```
E0414 18:26:13.043600   83448 azure_loadbalancer.go:107] "failed to reconcile load balancer" err="Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: instance not found" cluster="testCluster" service="default/service5"
I0414 18:26:13.043620   83448 azure_loadbalancer.go:158] "process finished" cluster="testCluster" service="default/service5" name="sigs.k8s.io/cloud-provider-azure/pkg/provider.(*Cloud).EnsureLoadBalancer" error="Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: instance not found" took-ms=0
I0414 18:26:13.043702   83448 azure_loadbalancer.go:214] "process started" cluster="testCluster" service="default/service5" service-spec="&Service{ObjectMeta:{service5  default  service5  0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[service.beta.kubernetes.io/azure-load-balancer-resource-group:random-rg] [] []  []},Spec:ServiceSpec{Ports:[]ServicePort{ServicePort{Name:port-tcp-80,Protocol:TCP,Port:80,TargetPort:{0 0 },NodePort:10080,AppProtocol:nil,},},Selector:map[string]string{},ClusterIP:10.0.0.2,Type:LoadBalancer,ExternalIPs:[],SessionAffinity:,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalName:,ExternalTrafficPolicy:,HealthCheckNodePort:0,PublishNotReadyAddresses:false,SessionAffinityConfig:nil,IPFamilyPolicy:nil,ClusterIPs:[],IPFamilies:[],AllocateLoadBalancerNodePorts:nil,LoadBalancerClass:nil,InternalTrafficPolicy:nil,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingress:[]LoadBalancerIngress{},},Conditions:[]Condition{},},}" name="sigs.k8s.io/cloud-provider-azure/pkg/provider.(*Cloud).EnsureLoadBalancerDeleted"
W0414 18:26:13.043725   83448 azure_backoff.go:333] ListManagedLBs: no LBs found
```

refs:
- https://github.com/kubernetes-sigs/controller-runtime/blob/master/TMP-LOGGING.md
- https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
