### PR TITLE
fix-1.0: update probe when protocol or request path change

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3098,7 +3098,12 @@ func (az *Cloud) safeDeletePublicIP(service *v1.Service, pipResourceGroup string
 
 func findProbe(probes []network.Probe, probe network.Probe) bool {
 	for _, existingProbe := range probes {
-		if strings.EqualFold(to.String(existingProbe.Name), to.String(probe.Name)) && to.Int32(existingProbe.Port) == to.Int32(probe.Port) {
+		if strings.EqualFold(to.String(existingProbe.Name), to.String(probe.Name)) &&
+			to.Int32(existingProbe.Port) == to.Int32(probe.Port) &&
+			strings.EqualFold(string(existingProbe.Protocol), string(probe.Protocol)) &&
+			strings.EqualFold(to.String(existingProbe.RequestPath), to.String(probe.RequestPath)) &&
+			to.Int32(existingProbe.IntervalInSeconds) == to.Int32(probe.IntervalInSeconds) &&
+			to.Int32(existingProbe.NumberOfProbes) == to.Int32(probe.NumberOfProbes) {
 			return true
 		}
 	}

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -108,7 +108,49 @@ func TestFindProbe(t *testing.T) {
 			expected: false,
 		},
 		{
-			msg: "both probe ports and names match should return true",
+			msg: "probe path don't match should return false",
+			existingProbe: []network.Probe{
+				{
+					Name: to.StringPtr("probe1"),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Port:        to.Int32Ptr(1),
+						RequestPath: to.StringPtr("/path1"),
+					},
+				},
+			},
+			curProbe: network.Probe{
+				Name: to.StringPtr("probe2"),
+				ProbePropertiesFormat: &network.ProbePropertiesFormat{
+					Port:        to.Int32Ptr(1),
+					RequestPath: to.StringPtr("/path2"),
+				},
+			},
+			expected: false,
+		},
+		{
+			msg: "probe interval don't match should return false",
+			existingProbe: []network.Probe{
+				{
+					Name: to.StringPtr("probe1"),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Port:              to.Int32Ptr(1),
+						RequestPath:       to.StringPtr("/path"),
+						IntervalInSeconds: to.Int32Ptr(5),
+					},
+				},
+			},
+			curProbe: network.Probe{
+				Name: to.StringPtr("probe2"),
+				ProbePropertiesFormat: &network.ProbePropertiesFormat{
+					Port:              to.Int32Ptr(1),
+					RequestPath:       to.StringPtr("/path"),
+					IntervalInSeconds: to.Int32Ptr(10),
+				},
+			},
+			expected: false,
+		},
+		{
+			msg: "probe match should return true",
 			existingProbe: []network.Probe{
 				{
 					Name: to.StringPtr("matchName"),
@@ -2223,7 +2265,10 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 					Name: to.StringPtr(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
 						"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port: to.Int32Ptr(10080),
+						Port:              to.Int32Ptr(10080),
+						Protocol:          network.ProbeProtocolTCP,
+						IntervalInSeconds: to.Int32Ptr(5),
+						NumberOfProbes:    to.Int32Ptr(2),
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

fix-0.7: update probe when protocol or request path change

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix-0.7: update probe when protocol or request path change
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
