### PR TITLE
chore: remove GA IPv6DualStack feature-gate

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-02-01/storage"
-
-	"k8s.io/component-base/featuregate"
 )
 
 const (
@@ -72,10 +70,6 @@ const (
 	DefaultDiskMBpsReadWrite = 100
 
 	DiskEncryptionSetIDFormat = "/subscriptions/{subs-id}/resourceGroups/{rg-name}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSet-name}"
-
-	// IPv6DualStack is here to avoid having to import features pkg
-	// and violate import rules
-	IPv6DualStack featuregate.Feature = "IPv6DualStack"
 
 	// MachineIDTemplate is the template of the virtual machine
 	MachineIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -34,7 +34,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -374,7 +373,7 @@ func NewCloud(configReader io.Reader, callFromCCM bool) (cloudprovider.Interface
 	if err != nil {
 		return nil, err
 	}
-	az.ipv6DualStackEnabled = utilfeature.DefaultFeatureGate.Enabled(consts.IPv6DualStack)
+	az.ipv6DualStackEnabled = true
 
 	return az, nil
 }
@@ -449,7 +448,7 @@ func NewCloudFromSecret(clientBuilder cloudprovider.ControllerClientBuilder, sec
 		return nil, fmt.Errorf("NewCloudFromSecret: failed to initialize cloud from secret %s/%s: %v", az.SecretNamespace, az.SecretName, err)
 	}
 
-	az.ipv6DualStackEnabled = utilfeature.DefaultFeatureGate.Enabled(consts.IPv6DualStack)
+	az.ipv6DualStackEnabled = true
 
 	return az, nil
 }

--- a/tests/k8s-azure/manifest/linux-dual-stack-iptables-kubenet.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-iptables-kubenet.json
@@ -16,15 +16,11 @@
                 "kubeProxyMode": "iptables",
                 "networkPlugin": "azure",
                 "containerRuntime": "containerd",
-                "apiServerConfig": {
-                    "--feature-gates": "IPv6DualStack=true"
-                },
                 "kubeletConfig": {
-                    "--feature-gates": "IPv6DualStack=true",
                     "--max-pods": "110"
                 },
                 "controllerManagerConfig": {
-                    "--feature-gates": "IPv6DualStack=true,LegacyServiceAccountTokenNoAutoGeneration=false"
+                    "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
                 },
                 "addons": [
                     {

--- a/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet-1.23.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet-1.23.json
@@ -16,16 +16,9 @@
                 "kubeProxyMode": "ipvs",
                 "networkPlugin": "azure",
                 "containerRuntime": "containerd",
-                "apiServerConfig": {
-                    "--feature-gates": "IPv6DualStack=true"
-                },
                 "kubeletConfig": {
-                    "--feature-gates": "IPv6DualStack=true",
                     "--hairpin-mode": "hairpin-veth",
                     "--max-pods": "110"
-                },
-                "controllerManagerConfig": {
-                    "--feature-gates": "IPv6DualStack=true"
                 },
                 "addons": [
                     {

--- a/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet.json
+++ b/tests/k8s-azure/manifest/linux-dual-stack-ipvs-kubenet.json
@@ -16,16 +16,12 @@
                 "kubeProxyMode": "ipvs",
                 "networkPlugin": "azure",
                 "containerRuntime": "containerd",
-                "apiServerConfig": {
-                    "--feature-gates": "IPv6DualStack=true"
-                },
                 "kubeletConfig": {
-                    "--feature-gates": "IPv6DualStack=true",
                     "--hairpin-mode": "hairpin-veth",
                     "--max-pods": "110"
                 },
                 "controllerManagerConfig": {
-                    "--feature-gates": "IPv6DualStack=true,LegacyServiceAccountTokenNoAutoGeneration=false"
+                    "--feature-gates": "LegacyServiceAccountTokenNoAutoGeneration=false"
                 },
                 "addons": [
                     {

--- a/tests/k8s-azure/manifest/windows-dual-stack.json
+++ b/tests/k8s-azure/manifest/windows-dual-stack.json
@@ -8,15 +8,6 @@
             "orchestratorType": "Kubernetes",
             "orchestratorRelease": "",
             "kubernetesConfig": {
-                "apiServerConfig": {
-                    "--feature-gates": "IPv6DualStack=true"
-                },
-                "kubeletConfig": {
-                    "--feature-gates": "IPv6DualStack=true"
-                },
-                "controllerManagerConfig": {
-                    "--feature-gates": "IPv6DualStack=true"
-                },
                 "networkPlugin": "azure",
                 "networkMode": "bridge",
                 "networkPolicy": "",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR removes references to the `IPv6DualStack` feature-gate as it is now locked to true and GA in upstream Kubernetes.

See:

- https://github.com/kubernetes/kubernetes/pull/109435

This change will break any future v0.7 releases of cloud-provider-azure because the feature-flag was not default to true until 1.21.0, so we'll have to be careful when we cherry-pick changes there. I observe that we are still releasing that version:

- https://github.com/kubernetes-sigs/cloud-provider-azure/releases/tag/v0.7.21

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
remove GA IPv6DualStack feature-gate
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
