### PR TITLE
Improve ccm printing version and docker buildx logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ docker-pull-prerequisites: ## Pull prerequisite images.
 	docker pull gcr.io/distroless/static:latest
 
 buildx-setup:
-	$(DOCKER_BUILDX) inspect img-builder > /dev/null || $(DOCKER_BUILDX) create --name img-builder --use
+	$(DOCKER_BUILDX) inspect img-builder > /dev/null 2>&1 || $(DOCKER_BUILDX) create --name img-builder --use
 	# enable qemu for arm64 build
 	# https://github.com/docker/buildx/issues/464#issuecomment-741507760
 	docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64

--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -301,7 +301,7 @@ func StartHTTPServer(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan str
 // Run runs the ExternalCMServer.  This should never exit.
 func Run(ctx context.Context, c *cloudcontrollerconfig.CompletedConfig, h *controllerhealthz.MutableHealthzHandler) error {
 	// To help debugging, immediately log version
-	klog.Infof("Version: %+v", version.Get())
+	klog.Infof("Version: %#v", version.Get())
 
 	var (
 		cloud cloudprovider.Interface

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -55,7 +55,7 @@ var (
 	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
 	// companion .gitattributes file containing 'export-subst' in this same
 	// directory.  See also https://git-scm.com/docs/gitattributes
-	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitVersion   = "v0.0.0-master+$Format:%H$"
 	gitCommit    = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState = ""            // state of git tree, either "clean" or "dirty"
 


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Print whole version var in ccm log
  Version: v1.24.0-22-g4ff19d66e
  ->
  Version: version.Info{Major:"1", Minor:"24+",
  GitVersion:"v1.24.0-19-g87cfaf2d3",
  GitCommit:"87cfaf2d36e1b51f1e1627dc132651383f26d9ff", GitTreeState:"",
  BuildDate:"2022-05-10T09:33:33Z", GoVersion:"go1.18.1", Compiler:"gc",
  Platform:"linux/amd64"}
* Don't print stderr when docker buildx inspect img-buidler
  "error: no builder "img-builder" found" -> NONE
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
* Print whole version var in ccm log
  Version: v1.23.0-466-g0b76f0943
  ->
  Version: version.Info{Major:"1", Minor:"24+",
  GitVersion:"v1.24.0-19-g87cfaf2d3",
  GitCommit:"87cfaf2d36e1b51f1e1627dc132651383f26d9ff", GitTreeState:"",
  BuildDate:"2022-05-10T09:33:33Z", GoVersion:"go1.18.1", Compiler:"gc",
  Platform:"linux/amd64"}
* Don't print stderr when docker buildx inspect img-buidler
  "error: no builder "img-builder" found" -> NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
