### PR TITLE
[release-1.0][e2e] Improve pls and azure-pip-tags tests

### DIFF
--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -448,6 +448,9 @@ func getPrivateLinkServiceFromIP(tc *utils.AzureTestClient, ip, plsResourceGroup
 	err = wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
 		pls, err = tc.GetPrivateLinkService(plsResourceGroup, plsName)
 		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				return false, nil
+			}
 			return false, err
 		}
 		return *pls.Name == plsName, nil

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -722,9 +722,21 @@ func waitComparePIPTags(tc *utils.AzureTestClient, expectedTags map[string]*stri
 			return false, err
 		}
 		tags := pip.Tags
-		delete(tags, "kubernetes-cluster-name")
-		delete(tags, "service")
-		utils.Logf("\ntags: %v\nexpectedTags: %v", tags, expectedTags)
+
+		delete(tags, consts.ClusterNameKey)
+		delete(tags, "k8s-azure-cluster-name")
+		delete(tags, consts.ServiceTagKey)
+		delete(tags, "k8s-azure-service")
+
+		printTags := func(name string, ts map[string]*string) {
+			msg := ""
+			for t := range ts {
+				msg += fmt.Sprintf("%s:%s ", t, *ts[t])
+			}
+			utils.Logf("%s: [%s]", name, msg)
+		}
+		printTags("tags", tags)
+		printTags("expectedTags", expectedTags)
 		return reflect.DeepEqual(tags, expectedTags), nil
 	})
 	return err
@@ -775,7 +787,7 @@ func createAndExposeDefaultServiceWithAnnotation(cs clientset.Interface, service
 	Expect(err).NotTo(HaveOccurred())
 	utils.Logf("Successfully created LoadBalancer service " + serviceName + " in namespace " + nsName)
 
-	//wait and get service's public IP Address
+	//wait and get service's IP Address
 	utils.Logf("Waiting service to expose...")
 	publicIP, err := utils.WaitServiceExposureAndValidateConnectivity(cs, nsName, serviceName, "")
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION


Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* If failure to get a private link service, GetPrivateLinkService returns error with "not found"
* When checking azure-pip-tags, ignore "kubernetes-cluster-name" and "service"
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
