### PR TITLE
fix: avoid unnessary NSG updating on service reconciling

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -36,6 +36,7 @@ import (
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/strings/slices"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -3074,7 +3075,7 @@ func findSecurityRule(rules []network.SecurityRule, rule network.SecurityRule) b
 			if !strings.EqualFold(to.String(existingRule.DestinationAddressPrefix), to.String(rule.DestinationAddressPrefix)) {
 				continue
 			}
-			if !reflect.DeepEqual(to.StringSlice(existingRule.DestinationAddressPrefixes), to.StringSlice(rule.DestinationAddressPrefixes)) {
+			if !slices.Equal(to.StringSlice(existingRule.DestinationAddressPrefixes), to.StringSlice(rule.DestinationAddressPrefixes)) {
 				continue
 			}
 		}

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -62,6 +62,7 @@ const (
 	testRuleName    = "shared-TCP-80-Internet"
 	testRuleName2   = "shared-TCP-4444-Internet"
 	testRuleName3   = "shared-TCP-8888-Internet"
+	testRuleName4   = "TCP-80-Internet"
 )
 
 // Test flipServiceInternalAnnotation
@@ -3613,15 +3614,16 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 
 func TestFindSecurityRule(t *testing.T) {
 	sg := network.SecurityRule{
-		Name: to.StringPtr(testRuleName),
+		Name: to.StringPtr(testRuleName4),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Protocol:                 network.SecurityRuleProtocolTCP,
-			SourcePortRange:          to.StringPtr("*"),
-			SourceAddressPrefix:      to.StringPtr("Internet"),
-			DestinationPortRange:     to.StringPtr("80"),
-			DestinationAddressPrefix: to.StringPtr(testIP1),
-			Access:                   network.SecurityRuleAccessAllow,
-			Direction:                network.SecurityRuleDirectionInbound,
+			Protocol:                   network.SecurityRuleProtocolTCP,
+			SourcePortRange:            to.StringPtr("*"),
+			SourceAddressPrefix:        to.StringPtr("Internet"),
+			DestinationPortRange:       to.StringPtr("80"),
+			DestinationAddressPrefix:   to.StringPtr(testIP1),
+			DestinationAddressPrefixes: to.StringSlicePtr([]string{}),
+			Access:                     network.SecurityRuleAccessAllow,
+			Direction:                  network.SecurityRuleDirectionInbound,
 		},
 	}
 	testCases := []struct {
@@ -3644,7 +3646,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when protocol doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol: network.SecurityRuleProtocolUDP,
 				},
@@ -3654,7 +3656,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourcePortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:        network.SecurityRuleProtocolUDP,
 					SourcePortRange: to.StringPtr("1.2.3.4/32"),
@@ -3665,7 +3667,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourceAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:            network.SecurityRuleProtocolUDP,
 					SourcePortRange:     to.StringPtr("*"),
@@ -3677,7 +3679,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationPortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:             network.SecurityRuleProtocolUDP,
 					SourcePortRange:      to.StringPtr("*"),
@@ -3690,7 +3692,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
 					SourcePortRange:          to.StringPtr("*"),
@@ -3704,7 +3706,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Access doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
 					SourcePortRange:          to.StringPtr("*"),
@@ -3720,7 +3722,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Direction doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
 					SourcePortRange:          to.StringPtr("*"),
@@ -3736,7 +3738,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "true should be returned when everything matches but protocol is in different case",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName),
+				Name: to.StringPtr(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocol("TCP"),
 					SourcePortRange:          to.StringPtr("*"),
@@ -3745,6 +3747,23 @@ func TestFindSecurityRule(t *testing.T) {
 					DestinationAddressPrefix: to.StringPtr(testIP1),
 					Access:                   network.SecurityRuleAccessAllow,
 					Direction:                network.SecurityRuleDirectionInbound,
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "true should be returned when everything matches but DestinationAddressPrefixes is nil",
+			testRule: network.SecurityRule{
+				Name: to.StringPtr(testRuleName4),
+				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+					Protocol:                   network.SecurityRuleProtocolTCP,
+					SourcePortRange:            to.StringPtr("*"),
+					SourceAddressPrefix:        to.StringPtr("Internet"),
+					DestinationPortRange:       to.StringPtr("80"),
+					DestinationAddressPrefix:   to.StringPtr(testIP1),
+					DestinationAddressPrefixes: nil,
+					Access:                     network.SecurityRuleAccessAllow,
+					Direction:                  network.SecurityRuleDirectionInbound,
 				},
 			},
 			expected: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

fix: avoid unnessary NSG updating on service reconciling.

`reflect.DeepEqual()` returns false when comparing `nil` to `[]string{}`. This PR switches it to `slices.Equal()` to fix the issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: avoid unnessary NSG updating on service reconciling
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
