### PR TITLE
[e2e][Windows] Adjust Service validation for Windows cluster

### DIFF
--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -26,6 +26,7 @@ import (
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -41,7 +42,8 @@ import (
 )
 
 const (
-	testServiceName = "servicelb-test"
+	testServiceName    = "service-lb-test"
+	testDeploymentName = "deployment-lb-test"
 )
 
 var (
@@ -59,13 +61,14 @@ var _ = Describe("Ensure LoadBalancer", func() {
 	var cs clientset.Interface
 	var ns *v1.Namespace
 	var tc *utils.AzureTestClient
+	var deployment *appsv1.Deployment
 
 	labels := map[string]string{
 		"app": testServiceName,
 	}
 	ports := []v1.ServicePort{{
-		Port:       nginxPort,
-		TargetPort: intstr.FromInt(nginxPort),
+		Port:       serverPort,
+		TargetPort: intstr.FromInt(serverPort),
 	}}
 
 	BeforeEach(func() {
@@ -79,14 +82,14 @@ var _ = Describe("Ensure LoadBalancer", func() {
 		tc, err = utils.CreateAzureTestClient()
 		Expect(err).NotTo(HaveOccurred())
 
-		utils.Logf("Creating deployment " + testServiceName)
-		deployment := createNginxDeploymentManifest(testServiceName, labels)
+		utils.Logf("Creating deployment %s", testDeploymentName)
+		deployment = createServerDeploymentManifest(testDeploymentName, labels)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), testServiceName, metav1.DeleteOptions{})
+		err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), testDeploymentName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		err = utils.DeleteNamespace(cs, ns.Name)
@@ -98,12 +101,19 @@ var _ = Describe("Ensure LoadBalancer", func() {
 	})
 
 	It("should support mixed protocol services", func() {
+		utils.Logf("Updating deployment %s", testDeploymentName)
+		tcpPort := int32(serverPort)
+		udpPort := int32(testingPort)
+		deployment := createDeploymentManifest(testDeploymentName, labels, &tcpPort, &udpPort)
+		_, err := cs.AppsV1().Deployments(ns.Name).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
 		By("creating a mixed protocol service")
 		mixedProtocolPorts := []v1.ServicePort{
 			{
 				Name:       "tcp",
-				Port:       nginxPort,
-				TargetPort: intstr.FromInt(nginxPort),
+				Port:       serverPort,
+				TargetPort: intstr.FromInt(serverPort),
 				Protocol:   v1.ProtocolTCP,
 			},
 			{
@@ -114,7 +124,7 @@ var _ = Describe("Ensure LoadBalancer", func() {
 			},
 		}
 		service := utils.CreateLoadBalancerServiceManifest(testServiceName, nil, labels, ns.Name, mixedProtocolPorts)
-		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, testServiceName, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -125,7 +135,7 @@ var _ = Describe("Ensure LoadBalancer", func() {
 		for _, rule := range *lb.LoadBalancingRules {
 			switch {
 			case strings.EqualFold(string(rule.Protocol), string(v1.ProtocolTCP)):
-				if to.Int32(rule.FrontendPort) == nginxPort {
+				if to.Int32(rule.FrontendPort) == serverPort {
 					foundTCP = true
 				}
 			case strings.EqualFold(string(rule.Protocol), string(v1.ProtocolUDP)):
@@ -235,15 +245,7 @@ var _ = Describe("Ensure LoadBalancer", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		// Create host exec Pod
-		result, err := utils.CreateHostExecPod(cs, ns.Name, utils.ExecAgnhostPod)
-		Expect(result).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
-		defer func() {
-			err = utils.DeletePod(cs, ns.Name, utils.ExecAgnhostPod)
-			Expect(err).NotTo(HaveOccurred())
-		}()
-		By("Waiting for exposure of internal service with specific IP")
+		By(fmt.Sprintf("Waiting for exposure of internal service with specific IP %q", ip1))
 		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, testServiceName, ip1)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ip).To(Equal(ip1))
@@ -290,14 +292,6 @@ var _ = Describe("Ensure LoadBalancer", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		// Create host exec Pod
-		result, err := utils.CreateHostExecPod(cs, ns.Name, utils.ExecAgnhostPod)
-		Expect(result).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
-		defer func() {
-			err = utils.DeletePod(cs, ns.Name, utils.ExecAgnhostPod)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 		By("Waiting for exposure of the original service without assigned lb private IP")
 		ip1, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, testServiceName, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -330,22 +324,14 @@ var _ = Describe("Ensure LoadBalancer", func() {
 		By("Creating an internal Service")
 		service := utils.CreateLoadBalancerServiceManifest(testServiceName, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, ports)
 		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service %s in namespace %s", testServiceName, ns.Name)
 		defer func() {
 			By("Cleaning up")
 			err = utils.DeleteService(cs, ns.Name, testServiceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-
-		// Create host exec Pod
-		result, err := utils.CreateHostExecPod(cs, ns.Name, utils.ExecAgnhostPod)
-		Expect(result).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
-		defer func() {
-			err = utils.DeletePod(cs, ns.Name, utils.ExecAgnhostPod)
-			Expect(err).NotTo(HaveOccurred())
-		}()
+		utils.Logf("Successfully created LoadBalancer service %s in namespace %s", testServiceName, ns.Name)
+
 		By("Waiting for exposure of the internal Service")
 		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, testServiceName, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -390,22 +376,14 @@ var _ = Describe("Ensure LoadBalancer", func() {
 	It("should support updating a public Service to an internal one with specific IP", func() {
 		service := utils.CreateLoadBalancerServiceManifest(testServiceName, serviceAnnotationLoadBalancerInternalFalse, labels, ns.Name, ports)
 		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service %s in namespace %s", testServiceName, ns.Name)
 		defer func() {
 			By("Cleaning up")
 			err = utils.DeleteService(cs, ns.Name, testServiceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-
-		// Create host exec Pod
-		result, err := utils.CreateHostExecPod(cs, ns.Name, utils.ExecAgnhostPod)
-		Expect(result).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
-		defer func() {
-			err = utils.DeletePod(cs, ns.Name, utils.ExecAgnhostPod)
-			Expect(err).NotTo(HaveOccurred())
-		}()
+		utils.Logf("Successfully created LoadBalancer service %s in namespace %s", testServiceName, ns.Name)
+
 		By("Waiting for exposure of a public Service")
 		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, testServiceName, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -480,81 +458,138 @@ var _ = Describe("Ensure LoadBalancer", func() {
 				return false, nil
 			}
 			if targetIP == ingressList[0].IP {
-				utils.Logf("External IP is still %s", targetIP)
+				utils.Logf("External IP is still %s, as expected", targetIP)
 				return false, nil
 			}
-			utils.Logf("succeeded")
+			utils.Logf("External IP changed, unexpected")
 			return true, nil
 		})
 		Expect(err).To(Equal(wait.ErrWaitTimeout))
 	})
 
 	It("should support multiple external services sharing one preset public IP address", func() {
-		ipName := basename + "-public-remain" + string(uuid.NewUUID())[0:4]
+		ipName := fmt.Sprintf("%s-public-remain-%s", basename, string(uuid.NewUUID())[0:4])
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), defaultPublicIPAddress(ipName))
-		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
-
-		service1 := utils.CreateLoadBalancerServiceManifest("service1", nil, labels, ns.Name, ports)
-		service1 = updateServiceBalanceIP(service1, false, targetIP)
-		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service1, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, "service1", targetIP)
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service1 in namespace %s with IP %s", ns.Name, ip)
-
-		ports2 := []v1.ServicePort{{
-			Port:       testingPort,
-			TargetPort: intstr.FromInt(testingPort),
-		}}
-		service2 := utils.CreateLoadBalancerServiceManifest("service2", nil, labels, ns.Name, ports2)
-		service2 = updateServiceBalanceIP(service2, false, targetIP)
-		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		ip, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, "service2", targetIP)
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service2 in namespace %s with IP %s", ns.Name, ip)
-
 		defer func() {
-			By("Cleaning up")
-			err = utils.DeleteService(cs, ns.Name, "service1")
-			Expect(err).NotTo(HaveOccurred())
-			err = utils.DeleteService(cs, ns.Name, "service2")
-			Expect(err).NotTo(HaveOccurred())
 			err = utils.DeletePIPWithRetry(tc, ipName, "")
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(err).NotTo(HaveOccurred())
+		targetIP := to.String(pip.IPAddress)
+
+		serviceNames := []string{}
+		for i := 0; i < 2; i++ {
+			serviceLabels := labels
+			deploymentName := testDeploymentName
+			tcpPort := int32(80 + i)
+			if i != 0 {
+				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
+				utils.Logf("Creating deployment %q", deploymentName)
+				serviceLabels = map[string]string{
+					"app": deploymentName,
+				}
+				deployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPort, nil)
+				_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+				defer func() {
+					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}()
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
+			utils.Logf("Creating Service %q", serviceName)
+			serviceNames = append(serviceNames, serviceName)
+			servicePort := []v1.ServicePort{{
+				Port:       tcpPort,
+				TargetPort: intstr.FromInt(int(tcpPort)),
+			}}
+			service := utils.CreateLoadBalancerServiceManifest(serviceName, nil, serviceLabels, ns.Name, servicePort)
+			service = updateServiceBalanceIP(service, false, targetIP)
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			defer func() {
+				err = utils.DeleteService(cs, ns.Name, serviceName)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		for _, serviceName := range serviceNames {
+			ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, targetIP)
+			Expect(err).NotTo(HaveOccurred())
+			utils.Logf("Successfully created LoadBalancer Service %q in namespace %s with IP %s", serviceName, ns.Name, ip)
+		}
 	})
 
 	It("should support multiple external services sharing one newly created public IP address", func() {
-		service1 := utils.CreateLoadBalancerServiceManifest("service1", nil, labels, ns.Name, ports)
-		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service1, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, "service1", "")
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service1 in namespace %s with IP %s", ns.Name, ip)
+		serviceCount := 2
+		sharedIP := ""
+		serviceNames := []string{}
+		var serviceLabels map[string]string
+		for i := 0; i < serviceCount; i++ {
+			tcpPort := int32(80 + i)
+			serviceLabels = labels
+			deploymentName := testDeploymentName
+			if i != 0 {
+				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
+				utils.Logf("Creating deployment %s", deploymentName)
+				serviceLabels = map[string]string{
+					"app": deploymentName,
+				}
+				deployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPort, nil)
+				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+				defer func() {
+					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}()
+				Expect(err).NotTo(HaveOccurred())
+			}
 
-		ports2 := []v1.ServicePort{{
-			Port:       testingPort,
-			TargetPort: intstr.FromInt(testingPort),
-		}}
-		service2 := utils.CreateLoadBalancerServiceManifest("service2", nil, labels, ns.Name, ports2)
-		service2 = updateServiceBalanceIP(service2, false, ip)
-		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, "service2", ip)
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service2 in namespace %s with IP %s", ns.Name, ip)
+			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
+			serviceNames = append(serviceNames, serviceName)
+			servicePort := []v1.ServicePort{{
+				Port:       tcpPort,
+				TargetPort: intstr.FromInt(int(tcpPort)),
+			}}
+			service := utils.CreateLoadBalancerServiceManifest(serviceName, nil, serviceLabels, ns.Name, servicePort)
+			if sharedIP != "" {
+				service.Spec.LoadBalancerIP = sharedIP
+			}
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			// No need to defer delete Services here
+			ip, err := utils.WaitServiceExposureAndGetIP(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			if sharedIP == "" {
+				sharedIP = ip
+			}
+		}
 
-		By("Deleting one service and check if the other service works well")
-		err = utils.DeleteService(cs, ns.Name, "service1")
-		Expect(err).NotTo(HaveOccurred())
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, "service2", ip)
+		for _, serviceName := range serviceNames {
+			_, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, sharedIP)
+			Expect(err).NotTo(HaveOccurred())
+			utils.Logf("Successfully created LoadBalancer Service %q in namespace %q with IP %s", serviceName, ns.Name, sharedIP)
+		}
+
+		By("Deleting one Service and check if the other service works well")
+		if len(serviceNames) < 2 {
+			Skip("At least 2 Services are needed in this scenario")
+		}
+		err := utils.DeleteService(cs, ns.Name, serviceNames[0])
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Deleting all services")
-		err = utils.DeleteService(cs, ns.Name, "service2")
-		Expect(err).NotTo(HaveOccurred())
+		for i := 1; i < serviceCount; i++ {
+			serviceName := serviceNames[i]
+			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, sharedIP)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("Deleting all remaining services")
+		for i := 1; i < serviceCount; i++ {
+			serviceName := serviceNames[i]
+			err = utils.DeleteService(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 		By("Checking if the public IP has been deleted")
 		err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
@@ -564,8 +599,8 @@ var _ = Describe("Ensure LoadBalancer", func() {
 			}
 
 			for _, pip := range pips {
-				if strings.EqualFold(*pip.IPAddress, ip) {
-					utils.Logf("the public IP with address %s still exists", ip)
+				if strings.EqualFold(*pip.IPAddress, sharedIP) {
+					utils.Logf("the public IP with address %s still exists", sharedIP)
 					return false, nil
 				}
 			}
@@ -576,32 +611,55 @@ var _ = Describe("Ensure LoadBalancer", func() {
 	})
 
 	It("should support multiple internal services sharing one IP address", func() {
-		service1 := utils.CreateLoadBalancerServiceManifest("service1", serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, ports)
-		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service1, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, "service1", "")
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service1 in namespace %s with IP %s", ns.Name, ip)
+		sharedIP := ""
+		serviceNames := []string{}
+		for i := 0; i < 2; i++ {
+			serviceLabels := labels
+			deploymentName := testDeploymentName
+			tcpPort := int32(80 + i)
+			if i != 0 {
+				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
+				utils.Logf("Creating deployment %s", deploymentName)
+				serviceLabels = map[string]string{
+					"app": deploymentName,
+				}
+				deployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPort, nil)
+				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+				defer func() {
+					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}()
+				Expect(err).NotTo(HaveOccurred())
+			}
 
-		ports2 := []v1.ServicePort{{
-			Port:       testingPort,
-			TargetPort: intstr.FromInt(testingPort),
-		}}
-		service2 := utils.CreateLoadBalancerServiceManifest("service2", serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, ports2)
-		service2.Spec.LoadBalancerIP = ip
-		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service2, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, "service2", ip)
-		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service2 in namespace %s with IP %s", ns.Name, ip)
+			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
+			serviceNames = append(serviceNames, serviceName)
+			servicePort := []v1.ServicePort{{
+				Port:       tcpPort,
+				TargetPort: intstr.FromInt(int(tcpPort)),
+			}}
+			service := utils.CreateLoadBalancerServiceManifest(serviceName, serviceAnnotationLoadBalancerInternalTrue, serviceLabels, ns.Name, servicePort)
+			if sharedIP != "" {
+				service.Spec.LoadBalancerIP = sharedIP
+			}
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			defer func() {
+				err = utils.DeleteService(cs, ns.Name, serviceName)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+			Expect(err).NotTo(HaveOccurred())
+			ip, err := utils.WaitServiceExposureAndGetIP(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			if sharedIP == "" {
+				sharedIP = ip
+			}
+		}
 
-		defer func() {
-			By("Cleaning up")
-			err = utils.DeleteService(cs, ns.Name, "service1")
+		for _, serviceName := range serviceNames {
+			_, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, sharedIP)
 			Expect(err).NotTo(HaveOccurred())
-			err = utils.DeleteService(cs, ns.Name, "service2")
-			Expect(err).NotTo(HaveOccurred())
-		}()
+			utils.Logf("Successfully created LoadBalancer Service %q in namespace %q with IP %s", serviceName, ns.Name, sharedIP)
+		}
 	})
 
 	It("should support node label `node.kubernetes.io/exclude-from-external-load-balancers`", func() {

--- a/tests/e2e/network/node.go
+++ b/tests/e2e/network/node.go
@@ -287,8 +287,8 @@ var _ = Describe("Azure nodes", func() {
 		"app": serviceName,
 	}
 	ports := []v1.ServicePort{{
-		Port:       nginxPort,
-		TargetPort: intstr.FromInt(nginxPort),
+		Port:       serverPort,
+		TargetPort: intstr.FromInt(serverPort),
 	}}
 
 	BeforeEach(func() {
@@ -303,7 +303,7 @@ var _ = Describe("Azure nodes", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		utils.Logf("Creating deployment " + serviceName)
-		deployment := createNginxDeploymentManifest(serviceName, labels)
+		deployment := createServerDeploymentManifest(serviceName, labels)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/tests/e2e/node/vmss.go
+++ b/tests/e2e/node/vmss.go
@@ -92,7 +92,7 @@ var _ = Describe("Lifecycle of VMSS", func() {
 
 			vmssAfterTest, err := utils.GetVMSS(azCli, *vmss.Name)
 			Expect(err).NotTo(HaveOccurred())
-			utils.Logf("VMSS %q sku capacity after the test: %d", &vmssAfterTest.Name, *vmssAfterTest.Sku.Capacity)
+			utils.Logf("VMSS %q sku capacity after the test: %d", *vmssAfterTest.Name, *vmssAfterTest.Sku.Capacity)
 		}()
 
 		err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap)
@@ -134,7 +134,7 @@ var _ = Describe("Lifecycle of VMSS", func() {
 
 			vmssAfterTest, err := utils.GetVMSS(azCli, *vmss.Name)
 			Expect(err).NotTo(HaveOccurred())
-			utils.Logf("VMSS %q sku capacity after the test: %d", &vmssAfterTest.Name, *vmssAfterTest.Sku.Capacity)
+			utils.Logf("VMSS %q sku capacity after the test: %d", *vmssAfterTest.Name, *vmssAfterTest.Sku.Capacity)
 		}()
 
 		err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap)

--- a/tests/e2e/utils/kubectl.go
+++ b/tests/e2e/utils/kubectl.go
@@ -127,8 +127,8 @@ func (b KubectlBuilder) ExecOrDie(namespace string) string {
 
 // Exec runs the kubectl executable.
 func (b KubectlBuilder) Exec() (string, error) {
-	stdout, _, err := b.ExecWithFullOutput()
-	return stdout, err
+	stdout, stderr, err := b.ExecWithFullOutput()
+	return fmt.Sprintf("stdout:%s\nstderr:%s", stdout, stderr), err
 }
 
 // ExecWithFullOutput runs the kubectl executable, and returns the stdout and stderr.

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -142,7 +142,7 @@ func (azureTestClient *AzureTestClient) getSecurityGroupList() (result aznetwork
 	err = wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
 		result, err = securityGroupsClient.List(context.Background(), azureTestClient.GetResourceGroup())
 		if err != nil {
-			Logf("error when listing sgs: %w", err)
+			Logf("error when listing security groups: %w", err)
 			if !IsRetryableAPIError(err) {
 				return false, err
 			}

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -84,8 +84,6 @@ func CreateKubeClientSet() (clientset.Interface, error) {
 
 // CreateTestingNamespace builds namespace for each test baseName and labels determine name of the space
 func CreateTestingNamespace(baseName string, cs clientset.Interface) (*v1.Namespace, error) {
-	Logf("Creating a test namespace")
-
 	namespaceObj := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("e2e-tests-%v-", baseName),
@@ -108,6 +106,7 @@ func CreateTestingNamespace(baseName string, cs clientset.Interface) (*v1.Namesp
 	}); err != nil {
 		return nil, err
 	}
+	Logf("Created a test namespace %q", got.Name)
 	return got, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Use agnhost image to support Windows Service validation.
  nginx image is only for Linux. Allocate it to control plane node
* Customize deployment's port configuration to support
  more testcases (tcp + udp)
* Replace curl with nc to test UDP traffic
* Unify validate connectivity methods for external & internal IP
* Bug fix: validate connectivity should also consider
  non-80 port, instead of skipping
* Use HostExecPod's IP as LoadBalancerSourceRanges to
  validate rule
* Use 2 deployments & services for shared pls test
* refactor
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #705

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
