### PR TITLE
fix: remove auto approval restriction

### DIFF
--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -451,11 +451,8 @@ func reconcilePLSVisibility(
 	service *v1.Service,
 ) (bool, error) {
 	changed := false
-	visibilitySubs, anyoneCanView := getPLSVisibility(service)
+	visibilitySubs, _ := getPLSVisibility(service)
 	autoApprovalSubs := getPLSAutoApproval(service)
-	if !anyoneCanView && len(autoApprovalSubs) > 0 {
-		return false, fmt.Errorf("reconcilePLSVisibility: autoApproval only takes effect when visibility is set to \"*\"")
-	}
 
 	if existingPLS.Visibility == nil || existingPLS.Visibility.Subscriptions == nil {
 		if len(visibilitySubs) != 0 {

--- a/pkg/provider/azure_privatelinkservice_test.go
+++ b/pkg/provider/azure_privatelinkservice_test.go
@@ -1075,16 +1075,6 @@ func TestReconcilePLSVisibility(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("reconcilePLSVisibility should return error if visibility is not * but auto-approval is not empty", func(t *testing.T) {
-		annotations := map[string]string{
-			consts.ServiceAnnotationPLSVisibility:   "sub1 sub2",
-			consts.ServiceAnnotationPLSAutoApproval: "sub1",
-		}
-		service.Annotations = annotations
-		_, err := reconcilePLSVisibility(&pls, &service)
-		assert.Error(t, err)
-	})
-
 	t.Run("reconcilePLSVisibility should return not changed if both Visibility and autoApproval are same", func(t *testing.T) {
 		annotations := map[string]string{
 			consts.ServiceAnnotationPLSVisibility: "sub1 sub2",
@@ -1098,7 +1088,7 @@ func TestReconcilePLSVisibility(t *testing.T) {
 		assert.False(t, changed)
 	})
 
-	t.Run("reconcilePLSVisibility should return not changed if both Visibility and autoApproval are same", func(t *testing.T) {
+	t.Run("reconcilePLSVisibility should return not changed if both Visibility and autoApproval are same with *", func(t *testing.T) {
 		annotations := map[string]string{
 			consts.ServiceAnnotationPLSVisibility:   "*",
 			consts.ServiceAnnotationPLSAutoApproval: "sub1 sub2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove redundant restriction on pls autoApproval and visibility.
User can specify a list of subscriptions for visibility and a subset of this list for autoApproval.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1859 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove redundant restriction on pls autoApproval and visibility.
User can specify a list of subscriptions for visibility (e.g. "sub1 sub2") and a subset of this list for autoApproval (e.g. "sub1").
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
