### PR TITLE
test: Recycle pip-prefix after test

### DIFF
--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -436,7 +436,10 @@ var _ = Describe("Service with annotation", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			// TODO: clean up PIPPrefix
+			{
+				Expect(utils.DeletePIPPrefixWithRetry(tc, prefix1Name)).NotTo(HaveOccurred())
+				Expect(utils.DeletePIPPrefixWithRetry(tc, prefix2Name)).NotTo(HaveOccurred())
+			}
 		}()
 
 		By("Creating a service referring to the prefix")

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -209,9 +209,9 @@ func WaitCreatePIP(azureTestClient *AzureTestClient, ipName, rgName string, ipPa
 }
 
 func WaitCreatePIPPrefix(
-		cli *AzureTestClient,
-		name, rgName string,
-		parameter aznetwork.PublicIPPrefix,
+	cli *AzureTestClient,
+	name, rgName string,
+	parameter aznetwork.PublicIPPrefix,
 ) (aznetwork.PublicIPPrefix, error) {
 	Logf("Creating PublicIPPrefix named %s", name)
 
@@ -235,8 +235,8 @@ func WaitCreatePIPPrefix(
 }
 
 func WaitGetPIPPrefix(
-		cli *AzureTestClient,
-		name string,
+	cli *AzureTestClient,
+	name string,
 ) (aznetwork.PublicIPPrefix, error) {
 	Logf("Getting PublicIPPrefix named %s", name)
 
@@ -261,9 +261,9 @@ func WaitGetPIPPrefix(
 // WaitGetPIPByPrefix retrieves the ONLY one PIP that created by specified prefix.
 // If untilPIPCreated is true, it will retry until 1 PIP is associated to the prefix.
 func WaitGetPIPByPrefix(
-		cli *AzureTestClient,
-		prefixName string,
-		untilPIPCreated bool,
+	cli *AzureTestClient,
+	prefixName string,
+	untilPIPCreated bool,
 ) (network.PublicIPAddress, error) {
 
 	var pip network.PublicIPAddress

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -275,9 +275,9 @@ func WaitGetPIPByPrefix(
 			if prefix.PublicIPAddresses != nil {
 				numOfIPs = len(*prefix.PublicIPAddresses)
 			}
-			Logf("prefix[%s] not ready with error [%s] and ip [%s]", prefixName, err, numOfIPs)
+			Logf("prefix[%s] not ready with error [%v] and ip [%s]", prefixName, err, numOfIPs)
 			if !untilPIPCreated {
-				return true, fmt.Errorf("get pip by prefix, err: [%s], num-ip: [%d]", err, numOfIPs)
+				return true, fmt.Errorf("get pip by prefix, err: [%v], num-ip: [%d]", err, numOfIPs)
 			}
 			return false, nil
 		}

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -275,9 +275,9 @@ func WaitGetPIPByPrefix(
 			if prefix.PublicIPAddresses != nil {
 				numOfIPs = len(*prefix.PublicIPAddresses)
 			}
-			Logf("prefix[%s] not ready with error [%v] and ip [%s]", prefixName, err, numOfIPs)
+			Logf("prefix = [%s] not ready with error = [%v] and number of IP = [%s]", prefixName, err, numOfIPs)
 			if !untilPIPCreated {
-				return true, fmt.Errorf("get pip by prefix, err: [%v], num-ip: [%d]", err, numOfIPs)
+				return true, fmt.Errorf("get pip by prefix = [%s], err = [%v], number of IP = [%d]", prefixName, err, numOfIPs)
 			}
 			return false, nil
 		}

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -257,6 +257,22 @@ func WaitGetPIPPrefix(
 	return prefix, err
 }
 
+func DeletePIPPrefixWithRetry(cli *AzureTestClient, name string) error {
+	Logf("Deleting PublicIPPrefix named %s", name)
+
+	resourceClient := cli.createPublicIPPrefixesClient()
+
+	err := wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
+		_, err := resourceClient.Delete(context.Background(), cli.GetResourceGroup(), name)
+		if err != nil {
+			Logf("error: %s, will retry soon", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	return err
+}
+
 // DeletePIPWithRetry tries to delete a public ip resource
 func DeletePIPWithRetry(azureTestClient *AzureTestClient, ipName, rgName string) error {
 	if rgName == "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
