### PR TITLE
Feature: Add ServiceAnnotationLoadBalancerIP for deprecated LoadBalancerIP

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -197,6 +197,10 @@ const (
 	// to specify what subnet it is exposed on
 	ServiceAnnotationLoadBalancerInternalSubnet = "service.beta.kubernetes.io/azure-load-balancer-internal-subnet"
 
+	// ServiceAnnotationLoadBalancerIP is the annotation used on the service
+	// to specify the IP of Azure load balancer
+	ServiceAnnotationLoadBalancerIP = "service.beta.kubernetes.io/azure-load-balancer-ip"
+
 	// ServiceAnnotationLoadBalancerMode is the annotation used on the service to specify
 	// which load balancer should be associated with the service. This is valid when using the basic
 	// load balancer or turn on the multiple standard load balancers mode, or it would be ignored.

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -352,7 +352,7 @@ func (az *Cloud) serviceOwnsFrontendIP(fip network.FrontendIPConfiguration, serv
 		return true, isPrimaryService, nil
 	}
 
-	loadBalancerIP := service.Spec.LoadBalancerIP
+	loadBalancerIP := service.Annotations[consts.ServiceAnnotationLoadBalancerIP]
 	if loadBalancerIP == "" {
 		// it is a must that the secondary services set the loadBalancer IP
 		return false, isPrimaryService, nil

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -1675,9 +1675,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
 					UID: types.UID("secondary"),
-				},
-				Spec: v1.ServiceSpec{
-					LoadBalancerIP: "1.2.3.4",
+					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIP: "4.3.2.1"},
 				},
 			},
 		},
@@ -1703,10 +1701,9 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
 					UID: types.UID("secondary"),
+					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIP: "4.3.2.1"},
 				},
-				Spec: v1.ServiceSpec{
-					LoadBalancerIP: "4.3.2.1",
-				},
+
 			},
 		},
 		{
@@ -1730,9 +1727,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
 					UID: types.UID("secondary"),
-				},
-				Spec: v1.ServiceSpec{
-					LoadBalancerIP: "4.3.2.1",
+					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIP: "4.3.2.1"},
 				},
 			},
 		},
@@ -1757,10 +1752,9 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
 					UID: types.UID("secondary"),
+					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIP: "4.3.2.1"},
 				},
-				Spec: v1.ServiceSpec{
-					LoadBalancerIP: "4.3.2.1",
-				},
+
 			},
 			isOwned: true,
 		},
@@ -1775,10 +1769,8 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
 					UID:         types.UID("secondary"),
-					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerInternal: "true"},
-				},
-				Spec: v1.ServiceSpec{
-					LoadBalancerIP: "4.3.2.1",
+					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerInternal: "true", consts.ServiceAnnotationLoadBalancerIP: "4.3.2.1"},
+					
 				},
 			},
 			isOwned: true,

--- a/site/content/en/development/design-docs/pls-integration.md
+++ b/site/content/en/development/design-docs/pls-integration.md
@@ -35,7 +35,7 @@ For more details about each configuration, please refer to [Azure Private Link S
 
 ### Creating managed PrivateLinkService
 
-When a `LoadBalancer` typed service is created without the `loadBalancerIP` field specified, an LB frontend IP configuration is created with a dynamically generated IP. If the service has `loadBalancerIP` in its spec, an existing LB frontend IP configuration may be reused if one exists; otherwise a static configuration is created with the specified IP. When a service is created with annotation `service.beta.kubernetes.io/azure-pls-create` set to `true` or updated later with the annotation added, a PLS resource attached to the LB frontend is created in the default resource group or the resource group user set in config file with key `PrivateLinkServiceResourceGroup`. 
+When a `LoadBalancer` typed service is created without the annotation `service.beta.kubernetes.io/azure-load-balancer-ip` set, an LB frontend IP configuration is created with a dynamically generated IP. If the service has the annotation `service.beta.kubernetes.io/azure-load-balancer-ip` set , an existing LB frontend IP configuration may be reused if one exists; otherwise a static configuration is created with the specified IP. When a service is created with annotation `service.beta.kubernetes.io/azure-pls-create` set to `true` or updated later with the annotation added, a PLS resource attached to the LB frontend is created in the default resource group or the resource group user set in config file with key `PrivateLinkServiceResourceGroup`. 
 
 The Kubernetes service creating the PLS is assigned as the owner of the resource. Azure cloud provider tags the PLS with cluster name and service name `kubernetes-owner-service: <namespace>/<service name>`. Only the owner service can later update the properties of the PLS resource.
 
@@ -51,7 +51,7 @@ If there are active PE connections to the PLS, all connections are removed and t
 
 ### Sharing managed PrivateLinkService
 
-Multiple Kubernetes services can share the same LB frontend by specifying the same `loadBalancerIP` (for more details, please refer to [Multiple Services Sharing One IP Address](../../../topics/shared-ip)). Once a PLS is attached to the LB frontend, these services automatically share the PLS. Users can access these services via the same PE but different ports. 
+Multiple Kubernetes services can share the same LB frontend by specifying the same annotation `service.beta.kubernetes.io/azure-load-balancer-ip` value set (for more details, please refer to [Multiple Services Sharing One IP Address](../../../topics/shared-ip)). Once a PLS is attached to the LB frontend, these services automatically share the PLS. Users can access these services via the same PE but different ports. 
 
 Azure cloud provider tags the service creating the PLS as the owner (`kubernetes-owner-service: <namespace>/<service name>`) and only allows that service to update the configurations of the PLS. If the owner service is deleted or if user wants some other service to take control, user can modify the tag value to a new service in `<namespace>/<service name>` pattern.
 

--- a/site/content/en/topics/shared-ip.md
+++ b/site/content/en/topics/shared-ip.md
@@ -27,7 +27,7 @@ spec:
   type: LoadBalancer
 ```
 
-Note that the `loadBalancerIP` is not set, or Azure would find a pre-allocated public IP with the address. After obtaining the IP address of the service, you could create other services using this address.
+Note that the annotation `service.beta.kubernetes.io/azure-load-balancer-ip` is not set, or Azure would find a pre-allocated public IP with the address. After obtaining the IP address of the service, you could create other services using this address.
 
 ```yaml
 apiVersion: v1
@@ -35,8 +35,9 @@ kind: Service
 metadata:
   name: https
   namespace: default
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-ip: 1.2.3.4  # the IP address could be the same as it is of `nginx` service
 spec:
-  loadBalancerIP: 1.2.3.4 # the IP address could be the same as it is of `nginx` service
   ports:
     - port: 443
       protocol: TCP
@@ -46,7 +47,7 @@ spec:
   type: LoadBalancer
 ```
 
-Note that if you specify the `loadBalancerIP` but there is no corresponding public IP pre-allocated, an error would be reported.
+Note that if you specify the annotation `service.beta.kubernetes.io/azure-load-balancer-ip` but there is no corresponding public IP pre-allocated, an error would be reported.
 
 ## DNS
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change
/kind deprecation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/cloud-provider-azure/issues/1781

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
As Kubernetes v1.24, service.Spec.LoadbalancerIP may be removed in future Kubernetes API version, so we need to add a new annotation service.beta.kubernetes.io/azure-load-balancer-ip for setting Azure LoadBalancerIP
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
