### PR TITLE
fix: Invalidate vmssVMCache when rg is not found

### DIFF
--- a/pkg/provider/azure_vmss_cache_test.go
+++ b/pkg/provider/azure_vmss_cache_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package provider
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -30,6 +33,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
 func TestExtractVmssVMName(t *testing.T) {
@@ -160,4 +164,48 @@ func TestVMSSVMCacheWithDeletingNodes(t *testing.T) {
 		assert.Nil(t, realVM)
 		assert.Equal(t, cloudprovider.InstanceNotFound, err)
 	}
+}
+
+func TestVMSSVMCacheClearedWhenRGDeleted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	vmList := []string{"vmssee6c2000000", "vmssee6c2000001", "vmssee6c2000002"}
+	ss, err := NewTestScaleSet(ctrl)
+	assert.NoError(t, err)
+
+	mockVMSSClient := mockvmssclient.NewMockInterface(ctrl)
+	mockVMSSVMClient := mockvmssvmclient.NewMockInterface(ctrl)
+	ss.cloud.VirtualMachineScaleSetsClient = mockVMSSClient
+	ss.cloud.VirtualMachineScaleSetVMsClient = mockVMSSVMClient
+
+	expectedScaleSet := buildTestVMSS(testVMSSName, "vmssee6c2")
+	mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]compute.VirtualMachineScaleSet{expectedScaleSet}, nil).Times(1)
+
+	expectedVMs, _, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, vmList, "", false)
+	mockVMSSVMClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+
+	// validate getting VMSS VM via cache.
+	vm := expectedVMs[0]
+	vmName := to.String(vm.OsProfile.ComputerName)
+	realVM, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
+	assert.NoError(t, err)
+	assert.Equal(t, "vmss", realVM.VMSSName)
+	assert.Equal(t, to.String(vm.InstanceID), realVM.InstanceID)
+	assert.Equal(t, &vm, realVM.AsVirtualMachineScaleSetVM())
+
+	// verify cache has test vmss.
+	cacheKey := strings.ToLower(fmt.Sprintf("%s/%s", "rg", testVMSSName))
+	_, ok := ss.vmssVMCache.Load(cacheKey)
+	assert.Equal(t, true, ok)
+
+	// refresh the cache with error.
+	mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]compute.VirtualMachineScaleSet{}, &retry.Error{HTTPStatusCode: http.StatusNotFound}).Times(2)
+	realVM, err = ss.getVmssVM(vmName, azcache.CacheReadTypeForceRefresh)
+	assert.Nil(t, realVM)
+	assert.Equal(t, cloudprovider.InstanceNotFound, err)
+
+	// verify cache is cleared.
+	_, ok = ss.vmssVMCache.Load(cacheKey)
+	assert.Equal(t, false, ok)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Invalidate vmssVMCache when rg is not found, so that node lifecycle controller can detect node does not exist any more 
and stop querying vmss list in a loop.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
