### PR TITLE
VMSS Flex support: Add GetResourceWithQueries function in azure_armclient.go

### DIFF
--- a/pkg/azureclients/armclient/azure_armclient.go
+++ b/pkg/azureclients/armclient/azure_armclient.go
@@ -285,6 +285,17 @@ func (c *Client) GetResourceWithExpandAPIVersionQuery(ctx context.Context, resou
 	return c.Send(ctx, request)
 }
 
+// GetResourceWithQueries get a resource by resource ID with queries.
+func (c *Client) GetResourceWithQueries(ctx context.Context, resourceID string, queries map[string]interface{}) (*http.Response, *retry.Error) {
+	queryParameters := make(map[string]interface{})
+	for queryKey, queryValue := range queryParameters {
+		queryParameters[queryKey] = autorest.Encode("query", queryValue)
+	}
+
+	decorators := autorest.WithQueryParameters(queryParameters)
+	return c.GetResource(ctx, resourceID, decorators)
+}
+
 // GetResourceWithDecorators get a resource with decorators by resource ID
 func (c *Client) GetResource(ctx context.Context, resourceID string, decorators ...autorest.PrepareDecorator) (*http.Response, *retry.Error) {
 	getDecorators := append([]autorest.PrepareDecorator{

--- a/pkg/azureclients/armclient/azure_armclient.go
+++ b/pkg/azureclients/armclient/azure_armclient.go
@@ -287,13 +287,17 @@ func (c *Client) GetResourceWithExpandAPIVersionQuery(ctx context.Context, resou
 
 // GetResourceWithQueries get a resource by resource ID with queries.
 func (c *Client) GetResourceWithQueries(ctx context.Context, resourceID string, queries map[string]interface{}) (*http.Response, *retry.Error) {
+
 	queryParameters := make(map[string]interface{})
-	for queryKey, queryValue := range queryParameters {
+	for queryKey, queryValue := range queries {
 		queryParameters[queryKey] = autorest.Encode("query", queryValue)
 	}
 
-	decorators := autorest.WithQueryParameters(queryParameters)
-	return c.GetResource(ctx, resourceID, decorators)
+	decorators := []autorest.PrepareDecorator{
+		autorest.WithQueryParameters(queryParameters),
+	}
+
+	return c.GetResource(ctx, resourceID, decorators...)
 }
 
 // GetResourceWithDecorators get a resource with decorators by resource ID

--- a/pkg/azureclients/armclient/azure_armclient_test.go
+++ b/pkg/azureclients/armclient/azure_armclient_test.go
@@ -338,6 +338,19 @@ func TestGetResource(t *testing.T) {
 				return armClient.GetResourceWithExpandAPIVersionQuery(ctx, testResourceID, "", apiVersion)
 			},
 		},
+		{
+			description:         "GetResourceWithQueries",
+			expectedURIResource: "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP?api-version=2019-01-01&param1=value1&param2=value2",
+			apiVersion:          "2019-01-01",
+			expectedAPIVersion:  "2019-01-01",
+			params: map[string]interface{}{
+				"param1": "value1",
+				"param2": "value2",
+			},
+			getResource: func(ctx context.Context, armClient *Client, apiVersion string, params map[string]interface{}) (*http.Response, *retry.Error) {
+				return armClient.GetResourceWithQueries(ctx, testResourceID, params)
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/azureclients/armclient/interface.go
+++ b/pkg/azureclients/armclient/interface.go
@@ -86,6 +86,9 @@ type Interface interface {
 	// GetResourceWithExpandAPIVersionQuery get a resource by resource ID with expand and API version.
 	GetResourceWithExpandAPIVersionQuery(ctx context.Context, resourceID, expand, apiVersion string) (*http.Response, *retry.Error)
 
+	// GetResourceWithQueries get a resource by resource ID with queries.
+	GetResourceWithQueries(ctx context.Context, resourceID string, queries map[string]interface{}) (*http.Response, *retry.Error)
+
 	// GetResource get a resource with decorators by resource ID
 	GetResource(ctx context.Context, resourceID string, decorators ...autorest.PrepareDecorator) (*http.Response, *retry.Error)
 

--- a/pkg/azureclients/armclient/mockarmclient/interface.go
+++ b/pkg/azureclients/armclient/mockarmclient/interface.go
@@ -157,6 +157,21 @@ func (mr *MockInterfaceMockRecorder) GetResourceWithExpandQuery(ctx, resourceID,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceWithExpandQuery", reflect.TypeOf((*MockInterface)(nil).GetResourceWithExpandQuery), ctx, resourceID, expand)
 }
 
+// GetResourceWithQueries mocks base method.
+func (m *MockInterface) GetResourceWithQueries(ctx context.Context, resourceID string, queries map[string]interface{}) (*http.Response, *retry.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourceWithQueries", ctx, resourceID, queries)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(*retry.Error)
+	return ret0, ret1
+}
+
+// GetResourceWithQueries indicates an expected call of GetResourceWithQueries.
+func (mr *MockInterfaceMockRecorder) GetResourceWithQueries(ctx, resourceID, queries interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceWithQueries", reflect.TypeOf((*MockInterface)(nil).GetResourceWithQueries), ctx, resourceID, queries)
+}
+
 // HeadResource mocks base method.
 func (m *MockInterface) HeadResource(ctx context.Context, resourceID string) (*http.Response, *retry.Error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR add a new function GetResourceWithQueries(ctx context.Context, resourceID string, queries map[string]interface{}) (*http.Response, *retry.Error) in pkg/azureclients/armclient/interface.go and add an implementation of it in azure_armclient.go.  

This function supports querying Azure resource with a list of query parameters. 

This function will be used to query VMs under a VMSS Flex in batch behavior: https://docs.microsoft.com/en-us/rest/api/compute/virtual-machines/list-all


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer to #639

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
