### PR TITLE
Less mem usage for golangci-lint by less concurrency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,32 +1,14 @@
 run:
-  deadline: 10m
+  deadline: 30m
+  concurrency: 2
+  go: '1.18'
+  allow-serial-runners: true
 skip-dirs:
     - vendor
 linters:
   disable-all: true
   enable:
-    - deadcode
-    - errcheck
-#    - errorlint
-    - goconst
-#    - gocyclo
-    - gofmt
-    - goimports
-    - revive
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-#    - interfacer
-    - misspell
-    - nakedret
-#    - prealloc
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unconvert
-    - unused
-    - varcheck
+    - LINTER_TO_RUN
   # Run with --fast=false for more extensive checks
   fast: false
   govet:

--- a/cmd/cloud-controller-manager/app/core.go
+++ b/cmd/cloud-controller-manager/app/core.go
@@ -17,7 +17,6 @@ limitations under the License.
 // Package app implements a server that runs a set of active
 // components.  This includes node controllers, service and
 // route controller, and so on.
-//
 package app
 
 import (

--- a/cmd/cloud-controller-manager/app/testing/testserver.go
+++ b/cmd/cloud-controller-manager/app/testing/testserver.go
@@ -57,8 +57,8 @@ type Logger interface {
 // and location of the tmpdir are returned.
 //
 // Note: we return a tear-down func instead of a stop channel because the later will leak temporary
-// 		 files that because Golang testing's call to os.Exit will not give a stop channel go routine
-// 		 enough time to remove temporary files.
+// files that because Golang testing's call to os.Exit will not give a stop channel go routine
+// enough time to remove temporary files.
 func StartTestServer(t Logger, customFlags []string) (result TestServer, err error) {
 	stopCh := make(chan struct{})
 	tearDown := func() {

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -25,6 +25,14 @@ fi
 echo "Verifying golint"
 readonly PKG_ROOT="$(git rev-parse --show-toplevel)"
 
-golangci-lint run -v --config ${PKG_ROOT}/.golangci.yml
+LINTERS=("deadcode" "errcheck" "goconst" "gofmt" "goimports" "revive" "gosec" "gosimple" "govet" "ineffassign" "misspell" "nakedret" "staticcheck" "structcheck" "typecheck" "unconvert" "unused" "varcheck" )
+GOLANGCI_YML="${PKG_ROOT}/.golangci.yml"
+GOLANGCI_YML_TEST="${PKG_ROOT}/.golangci-test.yml"
+for LINTER in "${LINTERS[@]}"; do
+  cp -rf "${GOLANGCI_YML}" "${GOLANGCI_YML_TEST}"
+  sed -i "s|LINTER_TO_RUN|${LINTER}|g" "${GOLANGCI_YML_TEST}"
+  golangci-lint run -v --config "${GOLANGCI_YML_TEST}"
+  echo ""
+done
 
 echo "Congratulations! Lint check completed for all Go source files."

--- a/pkg/azureclients/armclient/azure_armclient_test.go
+++ b/pkg/azureclients/armclient/azure_armclient_test.go
@@ -19,7 +19,7 @@ package armclient
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -372,7 +372,7 @@ func TestGetResource(t *testing.T) {
 			response, rerr := tc.getResource(ctx, armClient, tc.expectedAPIVersion, tc.params)
 			assert.Nil(t, rerr)
 			assert.NotNil(t, response)
-			byteResponseBody, _ := ioutil.ReadAll(response.Body)
+			byteResponseBody, _ := io.ReadAll(response.Body)
 			stringResponseBody := string(byteResponseBody)
 			assert.Equal(t, "{data: testPIP}", stringResponseBody)
 			assert.Equal(t, 1, count)

--- a/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient.go
+++ b/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient.go
@@ -214,7 +214,7 @@ func (c *Client) getPLS(ctx context.Context, resourceGroupName string, privateLi
 	return result, nil
 }
 
-/// List gets a list of PrivateLinkServices in the resource group.
+// List gets a list of PrivateLinkServices in the resource group.
 func (c *Client) List(ctx context.Context, resourceGroupName string) ([]network.PrivateLinkService, *retry.Error) {
 	mc := metrics.NewMetricContext("private_link_services", "list", resourceGroupName, c.subscriptionID, "")
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -67,7 +67,7 @@ func (np *IMDSNodeProvider) InstanceID(ctx context.Context, name types.NodeName)
 // InstanceType returns the type of the specified instance.
 // Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 // (Implementer Note): This is used by kubelet. Kubelet will label the node. Real log from kubelet:
-//       Adding node label from cloud provider: beta.kubernetes.io/instance-type=[value]
+// Adding node label from cloud provider: beta.kubernetes.io/instance-type=[value]
 func (np *IMDSNodeProvider) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
 	return np.azure.InstanceType(ctx, name)
 }

--- a/pkg/node/nodearm.go
+++ b/pkg/node/nodearm.go
@@ -81,7 +81,7 @@ func (np *ARMNodeProvider) InstanceID(ctx context.Context, name types.NodeName) 
 // InstanceType returns the type of the specified instance.
 // Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 // (Implementer Note): This is used by kubelet. Kubelet will label the node. Real log from kubelet:
-//       Adding node label from cloud provider: beta.kubernetes.io/instance-type=[value]
+// Adding node label from cloud provider: beta.kubernetes.io/instance-type=[value]
 func (np *ARMNodeProvider) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
 	return np.azure.InstanceType(ctx, name)
 }

--- a/pkg/nodeipam/ipam/doc.go
+++ b/pkg/nodeipam/ipam/doc.go
@@ -18,13 +18,13 @@ limitations under the License.
 // We currently support several kinds of IPAM allocators (these are denoted by
 // the CIDRAllocatorType):
 // - RangeAllocator is an allocator that assigns PodCIDRs to nodes and works
-//   in conjunction with the RouteController to configure the network to get
-//   connectivity.
+// in conjunction with the RouteController to configure the network to get
+// connectivity.
 // - CloudAllocator is an allocator that synchronizes PodCIDRs from IP
-//   ranges assignments from the underlying cloud platform.
+// ranges assignments from the underlying cloud platform.
 // - (Alpha only) IPAMFromCluster is an allocator that has the similar
-//   functionality as the RangeAllocator but also synchronizes cluster-managed
-//   ranges into the cloud platform.
+// functionality as the RangeAllocator but also synchronizes cluster-managed
+// ranges into the cloud platform.
 // - (Alpha only) IPAMFromCloud is the same as CloudAllocator (synchronizes
-//   from cloud into the cluster.)
+// from cloud into the cluster.)
 package ipam

--- a/pkg/nodemanager/nodemanager.go
+++ b/pkg/nodemanager/nodemanager.go
@@ -64,10 +64,10 @@ type NodeProvider interface {
 
 // labelReconcileInfo lists Node labels to reconcile, and how to reconcile them.
 // primaryKey and secondaryKey are keys of labels to reconcile.
-//   - If both keys exist, but their values don't match. Use the value from the
-//   primaryKey as the source of truth to reconcile.
-//   - If ensureSecondaryExists is true, and the secondaryKey does not
-//   exist, secondaryKey will be added with the value of the primaryKey.
+// - If both keys exist, but their values don't match. Use the value from the
+// primaryKey as the source of truth to reconcile.
+// - If ensureSecondaryExists is true, and the secondaryKey does not
+// exist, secondaryKey will be added with the value of the primaryKey.
 var labelReconcileInfo = []struct {
 	primaryKey            string
 	secondaryKey          string

--- a/pkg/provider/azure_instances.go
+++ b/pkg/provider/azure_instances.go
@@ -433,7 +433,7 @@ func (az *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string
 // InstanceType returns the type of the specified instance.
 // Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 // (Implementer Note): This is used by kubelet. Kubelet will label the node. Real log from kubelet:
-//       Adding node label from cloud provider: beta.kubernetes.io/instance-type=[value]
+// Adding node label from cloud provider: beta.kubernetes.io/instance-type=[value]
 func (az *Cloud) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
 	// Returns "" for unmanaged nodes because azure cloud provider couldn't fetch information for them.
 	unmanaged, err := az.IsNodeUnmanaged(string(name))

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2212,7 +2212,7 @@ func (az *Cloud) getExpectedLBRules(
 	return expectedProbes, expectedRules, nil
 }
 
-//getDefaultLoadBalancingRulePropertiesFormat returns the loadbalancing rule for one port
+// getDefaultLoadBalancingRulePropertiesFormat returns the loadbalancing rule for one port
 func (az *Cloud) getExpectedLoadBalancingRulePropertiesForPort(
 	service *v1.Service,
 	lbFrontendIPConfigID string,
@@ -2268,7 +2268,7 @@ func (az *Cloud) getExpectedLoadBalancingRulePropertiesForPort(
 	return props, nil
 }
 
-//getExpectedHAModeLoadBalancingRuleProperties build load balancing rule for lb in HA mode
+// getExpectedHAModeLoadBalancingRuleProperties build load balancing rule for lb in HA mode
 func (az *Cloud) getExpectedHAModeLoadBalancingRuleProperties(
 	service *v1.Service,
 	lbFrontendIPConfigID string,

--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
-//ManagedDiskController : managed disk controller struct
+// ManagedDiskController : managed disk controller struct
 type ManagedDiskController struct {
 	common *controllerCommon
 }
@@ -86,7 +86,7 @@ type ManagedDiskOptions struct {
 	SubscriptionID string
 }
 
-//CreateManagedDisk : create managed disk
+// CreateManagedDisk: create managed disk
 func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *ManagedDiskOptions) (string, error) {
 	var err error
 	klog.V(4).Infof("azureDisk - creating new managed Name:%s StorageAccountType:%s Size:%v", options.DiskName, options.StorageAccountType, options.SizeGB)
@@ -267,7 +267,7 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 	return diskID, nil
 }
 
-//DeleteManagedDisk : delete managed disk
+// DeleteManagedDisk : delete managed disk
 func (c *ManagedDiskController) DeleteManagedDisk(ctx context.Context, diskURI string) error {
 	resourceGroup, subsID, err := getInfoFromDiskURI(diskURI)
 	if err != nil {

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -70,8 +70,8 @@ func (op *delayedRouteOperation) wait() error {
 // delayedRouteUpdater defines a delayed route updater, which batches all the
 // route updating operations within "interval" period.
 // Example usage:
-//   op, err := updater.addRouteOperation(routeOperationAdd, route)
-//   err = op.wait()
+// op, err := updater.addRouteOperation(routeOperationAdd, route)
+// err = op.wait()
 type delayedRouteUpdater struct {
 	az       *Cloud
 	interval time.Duration
@@ -552,7 +552,7 @@ func findFirstIPByFamily(ips []string, v6 bool) (string, error) {
 	return "", fmt.Errorf("no match found matching the ipfamily requested")
 }
 
-//strips : . /
+// strips : . /
 func cidrtoRfc1035(cidr string) string {
 	cidr = strings.ReplaceAll(cidr, ":", "")
 	cidr = strings.ReplaceAll(cidr, ".", "")

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -265,8 +265,8 @@ func isInternalLoadBalancer(lb *network.LoadBalancer) bool {
 // SingleStack -v4 (pre v1.16) => BackendPool name == clusterName
 // SingleStack -v6 => BackendPool name == <clusterName>-IPv6 (all cluster bootstrap uses this name)
 // DualStack
-//	=> IPv4 BackendPool name == clusterName
-//  => IPv6 BackendPool name == <clusterName>-IPv6
+// => IPv4 BackendPool name == clusterName
+// => IPv6 BackendPool name == <clusterName>-IPv6
 // This means:
 // clusters moving from IPv4 to dualstack will require no changes
 // clusters moving from IPv6 to dualstack will require no changes as the IPv4 backend pool will created with <clusterName>
@@ -434,7 +434,7 @@ outer:
 
 var polyTable = crc32.MakeTable(crc32.Koopman)
 
-//MakeCRC32 : convert string to CRC32 format
+// MakeCRC32 : convert string to CRC32 format
 func MakeCRC32(str string) string {
 	crc := crc32.New(polyTable)
 	_, _ = crc.Write([]byte(str))
@@ -1316,7 +1316,7 @@ func (as *availabilitySet) GetNodeCIDRMasksByProviderID(providerID string) (int,
 	return ipv4Mask, ipv6Mask, nil
 }
 
-//EnsureBackendPoolDeletedFromVMSets ensures the loadBalancer backendAddressPools deleted from the specified VMAS
+// EnsureBackendPoolDeletedFromVMSets ensures the loadBalancer backendAddressPools deleted from the specified VMAS
 func (as *availabilitySet) EnsureBackendPoolDeletedFromVMSets(vmasNamesMap map[string]bool, backendPoolID string) error {
 	return nil
 }

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -3233,12 +3233,12 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 		t.Fatalf("Expected security rule %q but it was not present", testRuleName23)
 	}
 
-	_, securityRule2, rule2Found = findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
+	_, _, rule2Found = findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
 	if !rule2Found {
 		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
 	}
 
-	_, securityRule4, rule4Found = findSecurityRuleByName(*sg.SecurityRules, expectedRuleName4)
+	_, _, rule4Found = findSecurityRuleByName(*sg.SecurityRules, expectedRuleName4)
 	if !rule4Found {
 		t.Fatalf("Expected security rule %q but it was not present", expectedRuleName4)
 	}

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -379,10 +379,10 @@ func (ss *ScaleSet) GetInstanceIDByNodeName(name string) (string, error) {
 
 // GetNodeNameByProviderID gets the node name by provider ID.
 // providerID example:
-// 	 1. vmas providerID: azure:///subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/aks-nodepool1-27053986-0
-// 	 2. vmss providerID:
-//		azure:///subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/1
-//	    /subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/k8s-agentpool-36841236-vmss_1
+// 1. vmas providerID: azure:///subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/aks-nodepool1-27053986-0
+// 2. vmss providerID:
+// azure:///subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/1
+// /subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/k8s-agentpool-36841236-vmss_1
 func (ss *ScaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, error) {
 	// NodeName is not part of providerID for vmss instances.
 	scaleSetName, err := extractScaleSetNameByProviderID(providerID)
@@ -1683,7 +1683,7 @@ func (ss *ScaleSet) GetNodeCIDRMasksByProviderID(providerID string) (int, int, e
 	return ipv4Mask, ipv6Mask, nil
 }
 
-//EnsureBackendPoolDeletedFromVMSets ensures the loadBalancer backendAddressPools deleted from the specified VMSS
+// EnsureBackendPoolDeletedFromVMSets ensures the loadBalancer backendAddressPools deleted from the specified VMSS
 func (ss *ScaleSet) EnsureBackendPoolDeletedFromVMSets(vmssNamesMap map[string]bool, backendPoolID string) error {
 	vmssUpdaters := make([]func() error, 0, len(vmssNamesMap))
 	errors := make([]error, 0, len(vmssNamesMap))

--- a/pkg/provider/azure_wrap.go
+++ b/pkg/provider/azure_wrap.go
@@ -63,9 +63,9 @@ func checkResourceExistsFromError(err *retry.Error) (bool, *retry.Error) {
 	return false, err
 }
 
-/// getVirtualMachine calls 'VirtualMachinesClient.Get' with a timed cache
-/// The service side has throttling control that delays responses if there are multiple requests onto certain vm
-/// resource request in short period.
+// getVirtualMachine calls 'VirtualMachinesClient.Get' with a timed cache
+// The service side has throttling control that delays responses if there are multiple requests onto certain vm
+// resource request in short period.
 func (az *Cloud) getVirtualMachine(nodeName types.NodeName, crt azcache.AzureCacheReadType) (vm compute.VirtualMachine, err error) {
 	vmName := string(nodeName)
 	cachedVM, err := az.vmCache.Get(vmName, crt)

--- a/pkg/retry/azure_retry.go
+++ b/pkg/retry/azure_retry.go
@@ -218,7 +218,7 @@ func delayForBackOff(backoff *Backoff, cancel <-chan struct{}) bool {
 	}
 }
 
-//DoFilterOutNonRetriableError decorator works with autorest.DoRetryForAttempts
+// DoFilterOutNonRetriableError decorator works with autorest.DoRetryForAttempts
 func DoFilterOutNonRetriableError(shouldRetry func(rerr *Error) bool) autorest.SendDecorator {
 	return func(s autorest.Sender) autorest.Sender {
 		return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {

--- a/tests/e2e/utils/node_utils.go
+++ b/tests/e2e/utils/node_utils.go
@@ -188,7 +188,7 @@ func DeleteNodes(cs clientset.Interface, names []string) error {
 	return nil
 }
 
-//deleteNodes deletes nodes according to names
+// deleteNodes deletes nodes according to names
 func deleteNode(cs clientset.Interface, name string) error {
 	Logf("Deleting node: %s", name)
 	if err := cs.CoreV1().Nodes().Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Less mem usage for golangci-lint by less concurrency 
Each linter is consuming a lot of memory usage so it is better to run them separately. It still uses golangci-lint's `--config` option because it is hard to do the same with other command line options.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
