### PR TITLE
VMSS Flex Support: Add vmssflex_cache.go and unit tests

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -137,6 +137,13 @@ const (
 	VMASKey = "k8svmasKey"
 	// AvailabilitySetNodesKey is the availability set nodes key
 	AvailabilitySetNodesKey = "k8sAvailabilitySetNodesKey"
+
+	// VmssFlexKey is the key when querying vmssFlexVM cache
+	VmssFlexKey = "k8sVmssFlexKey"
+
+	// GetNodeVmssFlexIDLockKey is the key for getting the lock for getNodeVmssFlexID function
+	GetNodeVmssFlexIDLockKey = "k8sGetNodeVmssFlexIDLockKey"
+
 	// AvailabilitySetNodesCacheTTLDefaultInSeconds is the TTL of the availabilitySet node cache
 	AvailabilitySetNodesCacheTTLDefaultInSeconds = 900
 	// VMSSCacheTTLDefaultInSeconds is the TTL of the vmss cache
@@ -145,6 +152,13 @@ const (
 	VMSSVirtualMachinesCacheTTLDefaultInSeconds = 600
 	// VMASCacheTTLDefaultInSeconds is the TTL of the vmas cache
 	VMASCacheTTLDefaultInSeconds = 600
+
+	// VmssFlexCacheTTLDefaultInSeconds is the TTL of the vmss flex cache
+	VmssFlexCacheTTLDefaultInSeconds = 600
+	// VmssFlexVMCacheTTLInSeconds is the TTL of the vmss flex vm cache
+	VmssFlexVMCacheTTLInSeconds = 600
+	// VmssFlexVMStatusCacheTTLInSeconds is the TTL of the vmss flex vm status cache
+	VmssFlexVMStatusCacheTTLInSeconds = 600
 
 	// ZoneFetchingInterval defines the interval of performing zoneClient.GetZones
 	ZoneFetchingInterval = 30 * time.Minute

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -221,6 +221,12 @@ type Config struct {
 	VmssCacheTTLInSeconds int `json:"vmssCacheTTLInSeconds,omitempty" yaml:"vmssCacheTTLInSeconds,omitempty"`
 	// VmssVirtualMachinesCacheTTLInSeconds sets the cache TTL for vmssVirtualMachines
 	VmssVirtualMachinesCacheTTLInSeconds int `json:"vmssVirtualMachinesCacheTTLInSeconds,omitempty" yaml:"vmssVirtualMachinesCacheTTLInSeconds,omitempty"`
+
+	// VmssFlexCacheTTLInSeconds sets the cache TTL for VMSS Flex
+	VmssFlexCacheTTLInSeconds int `json:"vmssFlexCacheTTLInSeconds,omitempty" yaml:"vmssFlexCacheTTLInSeconds,omitempty"`
+	// VmssFlexVMCacheTTLInSeconds sets the cache TTL for vmss flex vms
+	VmssFlexVMCacheTTLInSeconds int `json:"vmssFlexVMCacheTTLInSeconds,omitempty" yaml:"vmssFlexVMCacheTTLInSeconds,omitempty"`
+
 	// VmCacheTTLInSeconds sets the cache TTL for vm
 	VMCacheTTLInSeconds int `json:"vmCacheTTLInSeconds,omitempty" yaml:"vmCacheTTLInSeconds,omitempty"`
 	// LoadBalancerCacheTTLInSeconds sets the cache TTL for load balancer

--- a/pkg/provider/azure_controller_vmssflex.go
+++ b/pkg/provider/azure_controller_vmssflex.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"k8s.io/apimachinery/pkg/types"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+)
+
+// AttachDisk attaches a disk to vm
+func (fs *FlexScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName, diskMap map[string]*AttachDiskOptions) (*azure.Future, error) {
+	return nil, nil
+}
+
+// DetachDisk detaches a disk from VM
+func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, diskMap map[string]string) error {
+	return nil
+}
+
+// WaitForUpdateResult waits for the response of the update request
+func (fs *FlexScaleSet) WaitForUpdateResult(ctx context.Context, future *azure.Future, resourceGroupName, source string) error {
+	return nil
+}
+
+// UpdateVM updates a vm
+func (fs *FlexScaleSet) UpdateVM(ctx context.Context, nodeName types.NodeName) error {
+	return nil
+}
+
+// GetDataDisks gets a list of data disks attached to the node.
+func (fs *FlexScaleSet) GetDataDisks(nodeName types.NodeName, crt azcache.AzureCacheReadType) ([]compute.DataDisk, *string, error) {
+	return nil, nil, nil
+}

--- a/pkg/provider/azure_fakes.go
+++ b/pkg/provider/azure_fakes.go
@@ -60,6 +60,16 @@ func newTestScaleSetWithState(ctrl *gomock.Controller) (*ScaleSet, error) {
 	return ss.(*ScaleSet), nil
 }
 
+func NewTestFlexScaleSet(ctrl *gomock.Controller) (*FlexScaleSet, error) {
+	cloud := GetTestCloud(ctrl)
+	fs, err := newFlexScaleSet(cloud)
+	if err != nil {
+		return nil, err
+	}
+
+	return fs.(*FlexScaleSet), nil
+}
+
 // GetTestCloud returns a fake azure cloud for unit tests in Azure related CSI drivers
 func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 	az = &Cloud{

--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+)
+
+var (
+	// ErrorVmssIDIsEmpty indicates the vmss id is empty.
+	ErrorVmssIDIsEmpty = errors.New("VMSS ID is empty")
+)
+
+// FlexScaleSet implements VMSet interface for Azure Flexible VMSS.
+type FlexScaleSet struct {
+	*Cloud
+
+	vmssFlexCache *azcache.TimedCache
+
+	vmssFlexVMNameToVmssID *sync.Map
+	vmssFlexVMCache        *azcache.TimedCache
+
+	// lockMap in cache refresh
+	lockMap *lockMap
+}
+
+func newFlexScaleSet(az *Cloud) (VMSet, error) {
+	fs := &FlexScaleSet{
+		Cloud:                  az,
+		vmssFlexVMNameToVmssID: &sync.Map{},
+		lockMap:                newLockMap(),
+	}
+
+	var err error
+	fs.vmssFlexCache, err = fs.newVmssFlexCache()
+	if err != nil {
+		return nil, err
+	}
+	fs.vmssFlexVMCache, err = fs.newVmssFlexVMCache()
+	if err != nil {
+		return nil, err
+	}
+
+	return fs, nil
+}
+
+// GetNodeNameByProviderID gets the node name by provider ID.
+func (fs *FlexScaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, error) {
+
+	return types.NodeName(""), nil
+}
+
+// GetPrimaryVMSetName returns the VM set name depending on the configured vmType.
+// It returns config.PrimaryScaleSetName for vmss and config.PrimaryAvailabilitySetName for standard vmType.
+func (fs *FlexScaleSet) GetPrimaryVMSetName() string {
+	return fs.Config.PrimaryScaleSetName
+}
+
+// GetNodeVMSetName returns the availability set or vmss name by the node name.
+// It will return empty string when using standalone vms.
+func (fs *FlexScaleSet) GetNodeVMSetName(node *v1.Node) (string, error) {
+	return "", nil
+}
+
+// GetAgentPoolVMSetNames returns all vmSet names according to the nodes
+func (fs *FlexScaleSet) GetAgentPoolVMSetNames(nodes []*v1.Node) (*[]string, error) {
+	return nil, nil
+}
+
+// GetVMSetNames selects all possible availability sets or scale sets
+// (depending vmType configured) for service load balancer, if the service has
+// no loadbalancer mode annotation returns the primary VMSet. If service annotation
+// for loadbalancer exists then returns the eligible VMSet. The mode selection
+// annotation would be ignored when using one SLB per cluster.
+func (fs *FlexScaleSet) GetVMSetNames(service *v1.Service, nodes []*v1.Node) (*[]string, error) {
+	return nil, nil
+}
+
+// GetInstanceIDByNodeName gets the cloud provider ID by node name.
+// It must return ("", cloudprovider.InstanceNotFound) if the instance does
+// not exist or is no longer running.
+func (fs *FlexScaleSet) GetInstanceIDByNodeName(name string) (string, error) {
+	return "", nil
+
+}
+
+// GetInstanceTypeByNodeName gets the instance type by node name.
+func (fs *FlexScaleSet) GetInstanceTypeByNodeName(name string) (string, error) {
+	return "", nil
+}
+
+// GetZoneByNodeName gets availability zone for the specified node. If the node is not running
+// with availability zone, then it returns fault domain.
+// for details, refer to https://kubernetes-sigs.github.io/cloud-provider-azure/topics/availability-zones/#node-labels
+func (fs *FlexScaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
+	return cloudprovider.Zone{}, nil
+}
+
+// GetProvisioningStateByNodeName returns the provisioningState for the specified node.
+func (fs *FlexScaleSet) GetProvisioningStateByNodeName(name string) (provisioningState string, err error) {
+	return "", nil
+}
+
+// GetPowerStatusByNodeName returns the powerState for the specified node.
+func (fs *FlexScaleSet) GetPowerStatusByNodeName(name string) (powerState string, err error) {
+	return "", nil
+}
+
+// GetPrimaryInterface gets machine primary network interface by node name.
+func (fs *FlexScaleSet) GetPrimaryInterface(nodeName string) (network.Interface, error) {
+	return network.Interface{}, nil
+}
+
+// GetIPByNodeName gets machine private IP and public IP by node name.
+func (fs *FlexScaleSet) GetIPByNodeName(name string) (string, string, error) {
+	return "", "", nil
+
+}
+
+// GetPrivateIPsByNodeName returns a slice of all private ips assigned to node (ipv6 and ipv4)
+// TODO (khenidak): This should read all nics, not just the primary
+// allowing users to split ipv4/v6 on multiple nics
+func (fs *FlexScaleSet) GetPrivateIPsByNodeName(name string) ([]string, error) {
+	ips := make([]string, 0)
+	return ips, nil
+}
+
+// GetNodeNameByIPConfigurationID gets the nodeName and vmSetName by IP configuration ID.
+func (fs *FlexScaleSet) GetNodeNameByIPConfigurationID(ipConfigurationID string) (string, string, error) {
+	return "", "", nil
+}
+
+// GetNodeCIDRMaskByProviderID returns the node CIDR subnet mask by provider ID.
+func (fs *FlexScaleSet) GetNodeCIDRMasksByProviderID(providerID string) (int, int, error) {
+	return 0, 0, nil
+}
+
+// EnsureHostInPool ensures the given VM's Primary NIC's Primary IP Configuration is
+// participating in the specified LoadBalancer Backend Pool, which returns (resourceGroup, vmasName, instanceID, vmssVM, error).
+func (fs *FlexScaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID string, vmSetNameOfLB string) (string, string, string, *compute.VirtualMachineScaleSetVM, error) {
+	return "", "", "", nil, nil
+
+}
+
+// EnsureHostsInPool ensures the given Node's primary IP configurations are
+// participating in the specified LoadBalancer Backend Pool.
+func (fs *FlexScaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetNameOfLB string) error {
+	return nil
+}
+
+// EnsureBackendPoolDeletedFromVMSets ensures the loadBalancer backendAddressPools deleted from the specified VMSS Flex
+func (fs *FlexScaleSet) EnsureBackendPoolDeletedFromVMSets(vmssNamesMap map[string]bool, backendPoolID string) error {
+	return nil
+}
+
+// EnsureBackendPoolDeleted ensures the loadBalancer backendAddressPools deleted from the specified nodes.
+func (fs *FlexScaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID, vmSetName string, backendAddressPools *[]network.BackendAddressPool, deleteFromVMSet bool) error {
+	return nil
+
+}

--- a/pkg/provider/azure_vmssflex_cache.go
+++ b/pkg/provider/azure_vmssflex_cache.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
+
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
+)
+
+func (fs *FlexScaleSet) newVmssFlexCache() (*azcache.TimedCache, error) {
+
+	getter := func(key string) (interface{}, error) {
+		localCache := &sync.Map{}
+
+		allResourceGroups, err := fs.GetResourceGroups()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resourceGroup := range allResourceGroups.List() {
+			allScaleSets, rerr := fs.VirtualMachineScaleSetsClient.List(context.Background(), resourceGroup)
+			if rerr != nil {
+				if rerr.IsNotFound() {
+					klog.Warningf("Skip caching vmss for resource group %s due to error: %v", resourceGroup, rerr.Error())
+					continue
+				}
+				klog.Errorf("VirtualMachineScaleSetsClient.List failed: %v", rerr)
+				return nil, rerr.Error()
+			}
+
+			for i := range allScaleSets {
+				scaleSet := allScaleSets[i]
+				if scaleSet.ID == nil || *scaleSet.ID == "" {
+					klog.Warning("failed to get the ID of VMSS Flex")
+					continue
+				}
+
+				if scaleSet.OrchestrationMode == compute.OrchestrationModeFlexible {
+					localCache.Store(*scaleSet.ID, &scaleSet)
+				}
+			}
+		}
+
+		return localCache, nil
+	}
+
+	if fs.Config.VmssFlexCacheTTLInSeconds == 0 {
+		fs.Config.VmssFlexCacheTTLInSeconds = consts.VmssFlexCacheTTLDefaultInSeconds
+	}
+	return azcache.NewTimedcache(time.Duration(fs.Config.VmssFlexCacheTTLInSeconds)*time.Second, getter)
+}
+
+func (fs *FlexScaleSet) newVmssFlexVMCache() (*azcache.TimedCache, error) {
+	getter := func(key string) (interface{}, error) {
+		localCache := &sync.Map{}
+
+		ctx, cancel := getContextWithCancel()
+		defer cancel()
+
+		vms, rerr := fs.VirtualMachinesClient.ListVmssFlexVMsWithoutInstanceView(ctx, key)
+		if rerr != nil {
+			klog.Errorf("ListVmssFlexVMsWithoutInstanceView failed: %v", rerr)
+			return nil, rerr.Error()
+		}
+
+		for i := range vms {
+			vm := vms[i]
+			if vm.Name != nil {
+				localCache.Store(*vm.Name, &vm)
+				fs.vmssFlexVMNameToVmssID.Store(*vm.Name, key)
+			}
+		}
+
+		vms, rerr = fs.VirtualMachinesClient.ListVmssFlexVMsWithOnlyInstanceView(ctx, key)
+		if rerr != nil {
+			klog.Errorf("ListVmssFlexVMsWithOnlyInstanceView failed: %v", rerr)
+			return nil, rerr.Error()
+		}
+
+		for i := range vms {
+			vm := vms[i]
+			if vm.Name != nil {
+				cached, ok := localCache.Load(*vm.Name)
+				if ok {
+					cachedVM := cached.(*compute.VirtualMachine)
+					cachedVM.VirtualMachineProperties.InstanceView = vm.VirtualMachineProperties.InstanceView
+				}
+			}
+		}
+
+		return localCache, nil
+	}
+
+	if fs.Config.VmssFlexVMCacheTTLInSeconds == 0 {
+		fs.Config.VmssFlexVMCacheTTLInSeconds = consts.VmssFlexVMCacheTTLInSeconds
+	}
+	return azcache.NewTimedcache(time.Duration(fs.Config.VmssFlexVMCacheTTLInSeconds)*time.Second, getter)
+}
+
+func (fs *FlexScaleSet) getNodeVmssFlexID(nodeName string) (string, error) {
+	fs.lockMap.LockEntry(consts.GetNodeVmssFlexIDLockKey)
+	defer fs.lockMap.UnlockEntry(consts.GetNodeVmssFlexIDLockKey)
+	vmssFlexID, isCached := fs.vmssFlexVMNameToVmssID.Load(nodeName)
+	if !isCached {
+		klog.V(12).Infof("nodeName %s is not saved in vmssFlexVMnameToVmssID map, send a GET request to retrieve its VmssID", nodeName)
+		machine, err := fs.getVirtualMachine(types.NodeName(nodeName), azcache.CacheReadTypeUnsafe)
+		if err != nil {
+			return "", err
+		}
+		vmssFlexID = to.String(machine.VirtualMachineScaleSet.ID)
+		if vmssFlexID == "" {
+			return "", ErrorVmssIDIsEmpty
+		}
+		fs.vmssFlexVMNameToVmssID.Store(nodeName, vmssFlexID)
+		_, err = fs.vmssFlexVMCache.Get(fmt.Sprintf("%v", vmssFlexID), azcache.CacheReadTypeForceRefresh)
+		if err != nil {
+			return "", err
+		}
+	}
+	return fmt.Sprintf("%v", vmssFlexID), nil
+}
+
+func (fs *FlexScaleSet) getVmssFlexVM(nodeName string, crt azcache.AzureCacheReadType) (vm compute.VirtualMachine, err error) {
+	vmssFlexID, err := fs.getNodeVmssFlexID(nodeName)
+	if err != nil {
+		return vm, err
+	}
+
+	cached, err := fs.vmssFlexVMCache.Get(vmssFlexID, crt)
+	if err != nil {
+		return vm, err
+	}
+
+	vmMap := cached.(*sync.Map)
+	cachvmedVM, ok := vmMap.Load(nodeName)
+	if !ok {
+		klog.V(2).Infof("did not find node (%s) in the existing cache, which means it is deleted...", nodeName)
+		return vm, cloudprovider.InstanceNotFound
+	}
+
+	return *(cachvmedVM.(*compute.VirtualMachine)), nil
+}
+
+func (fs *FlexScaleSet) getVmssFlexByVmssFlexID(vmssFlexID string, crt azcache.AzureCacheReadType) (*compute.VirtualMachineScaleSet, error) {
+	cached, err := fs.vmssFlexCache.Get(consts.VmssFlexKey, crt)
+	if err != nil {
+		return nil, err
+	}
+
+	vmssFlexes := cached.(*sync.Map)
+	if vmssFlex, ok := vmssFlexes.Load(vmssFlexID); ok {
+		result := vmssFlex.(*compute.VirtualMachineScaleSet)
+		return result, nil
+	}
+
+	klog.V(2).Infof("Couldn't find VMSS Flex with ID %s, refreshing the cache", vmssFlexID)
+	cached, err = fs.vmssFlexCache.Get(consts.VmssFlexKey, azcache.CacheReadTypeForceRefresh)
+	if err != nil {
+		return nil, err
+	}
+
+	vmssFlexes = cached.(*sync.Map)
+	if vmssFlex, ok := vmssFlexes.Load(vmssFlexID); ok {
+		result := vmssFlex.(*compute.VirtualMachineScaleSet)
+		return result, nil
+	}
+	return nil, cloudprovider.InstanceNotFound
+}
+
+func (fs *FlexScaleSet) getVmssFlexByNodeName(nodeName string, crt azcache.AzureCacheReadType) (*compute.VirtualMachineScaleSet, error) {
+	vmssFlexID, err := fs.getNodeVmssFlexID(nodeName)
+	if err != nil {
+		return nil, err
+	}
+	vmssFlex, err := fs.getVmssFlexByVmssFlexID(vmssFlexID, crt)
+	if err != nil {
+		return nil, err
+	}
+	return vmssFlex, nil
+}
+
+func (fs *FlexScaleSet) getVmssFlexIDByName(vmssFlexName string) (string, error) {
+	cached, err := fs.vmssFlexCache.Get(consts.VmssFlexKey, azcache.CacheReadTypeDefault)
+	if err != nil {
+		return "", err
+	}
+
+	var targetVmssFlexID string
+	vmssFlexes := cached.(*sync.Map)
+	vmssFlexes.Range(func(key, value interface{}) bool {
+		vmssFlexID := key.(string)
+		name, err := getLastSegment(vmssFlexID, "/")
+		if err != nil {
+			return true
+		}
+		if strings.EqualFold(name, vmssFlexName) {
+			targetVmssFlexID = vmssFlexID
+			return false
+		}
+		return true
+	})
+	if targetVmssFlexID != "" {
+		return targetVmssFlexID, nil
+	}
+	return "", cloudprovider.InstanceNotFound
+}
+
+func (fs *FlexScaleSet) getVmssFlexByName(vmssFlexName string) (*compute.VirtualMachineScaleSet, error) {
+	cached, err := fs.vmssFlexCache.Get(consts.VmssFlexKey, azcache.CacheReadTypeDefault)
+	if err != nil {
+		return nil, err
+	}
+
+	var targetVmssFlex *compute.VirtualMachineScaleSet
+	vmssFlexes := cached.(*sync.Map)
+	vmssFlexes.Range(func(key, value interface{}) bool {
+		vmssFlexID := key.(string)
+		vmssFlex := value.(*compute.VirtualMachineScaleSet)
+		name, err := getLastSegment(vmssFlexID, "/")
+		if err != nil {
+			return true
+		}
+		if strings.EqualFold(name, vmssFlexName) {
+			targetVmssFlex = vmssFlex
+			return false
+		}
+		return true
+	})
+	if targetVmssFlex != nil {
+		return targetVmssFlex, nil
+	}
+	return nil, cloudprovider.InstanceNotFound
+}

--- a/pkg/provider/azure_vmssflex_cache_test.go
+++ b/pkg/provider/azure_vmssflex_cache_test.go
@@ -1,0 +1,455 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	cloudprovider "k8s.io/cloud-provider"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
+)
+
+var (
+	testVMWithoutInstanceView1 = compute.VirtualMachine{
+		Name: to.StringPtr("testvm1"),
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			ProvisioningState: nil,
+			VirtualMachineScaleSet: &compute.SubResource{
+				ID: to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1"),
+			},
+		},
+	}
+
+	testVMWithoutInstanceView2 = compute.VirtualMachine{
+		Name: to.StringPtr("testvm2"),
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			ProvisioningState: nil,
+			VirtualMachineScaleSet: &compute.SubResource{
+				ID: to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex2"),
+			},
+		},
+	}
+	testVMListWithoutInstanceView = []compute.VirtualMachine{testVMWithoutInstanceView1, testVMWithoutInstanceView2}
+
+	testVMWithOnlyInstanceView1 = compute.VirtualMachine{
+		Name: to.StringPtr("testvm1"),
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			InstanceView: &compute.VirtualMachineInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: to.StringPtr("PowerState/running"),
+					},
+				},
+			},
+		},
+	}
+
+	testVMWithOnlyInstanceView2 = compute.VirtualMachine{
+		Name: to.StringPtr("testvm2"),
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			InstanceView: &compute.VirtualMachineInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: to.StringPtr("PowerState/running"),
+					},
+				},
+			},
+		},
+	}
+	testVMListWithOnlyInstanceView = []compute.VirtualMachine{testVMWithOnlyInstanceView1, testVMWithOnlyInstanceView2}
+
+	testVM1 = compute.VirtualMachine{
+		Name: to.StringPtr("testvm1"),
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			ProvisioningState: nil,
+			VirtualMachineScaleSet: &compute.SubResource{
+				ID: to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1"),
+			},
+			InstanceView: &compute.VirtualMachineInstanceView{
+				Statuses: &[]compute.InstanceViewStatus{
+					{
+						Code: to.StringPtr("PowerState/running"),
+					},
+				},
+			},
+		},
+	}
+
+	testVmssFlex1 = compute.VirtualMachineScaleSet{
+		ID:   to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1"),
+		Name: to.StringPtr("vmssflex1"),
+		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
+			OrchestrationMode:     compute.OrchestrationModeFlexible,
+		},
+	}
+
+	testVmssFlex2 = compute.VirtualMachineScaleSet{
+		ID:   to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex2"),
+		Name: to.StringPtr("vmssflex2"),
+		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
+			OrchestrationMode:     compute.OrchestrationModeFlexible,
+		},
+	}
+
+	testVmssFlexList = []compute.VirtualMachineScaleSet{testVmssFlex1, testVmssFlex2}
+)
+
+func TestGetNodeVmssFlexID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		description                    string
+		nodeName                       string
+		testVM                         compute.VirtualMachine
+		vmGetErr                       *retry.Error
+		testVMListWithoutInstanceView  []compute.VirtualMachine
+		testVMListWithOnlyInstanceView []compute.VirtualMachine
+		vmListErr                      error
+		expectedVmssFlexID             string
+		expectedErr                    error
+	}{
+		{
+			description:                    "getNodeVmssFlexID should return the VmssFlex ID that the node belongs to",
+			nodeName:                       "testvm1",
+			testVM:                         testVMWithoutInstanceView1,
+			vmGetErr:                       nil,
+			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
+			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
+			vmListErr:                      nil,
+			expectedVmssFlexID:             "subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1",
+			expectedErr:                    nil,
+		},
+		{
+			description:                    "getNodeVmssFlexID should throw InstanceNotFound error if the VM cannot be found",
+			nodeName:                       "testvm3",
+			testVM:                         compute.VirtualMachine{},
+			vmGetErr:                       &retry.Error{HTTPStatusCode: http.StatusNotFound},
+			testVMListWithoutInstanceView:  []compute.VirtualMachine{},
+			testVMListWithOnlyInstanceView: []compute.VirtualMachine{},
+			vmListErr:                      nil,
+			expectedVmssFlexID:             "",
+			expectedErr:                    cloudprovider.InstanceNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		fs, err := NewTestFlexScaleSet(ctrl)
+		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
+
+		mockVMClient := fs.VirtualMachinesClient.(*mockvmclient.MockInterface)
+		mockVMClient.EXPECT().Get(gomock.Any(), fs.ResourceGroup, tc.nodeName, gomock.Any()).Return(tc.testVM, tc.vmGetErr).AnyTimes()
+
+		mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
+		mockVMClient.EXPECT().ListVmssFlexVMsWithOnlyInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithOnlyInstanceView, tc.vmListErr).AnyTimes()
+
+		vmssFlexID, err := fs.getNodeVmssFlexID(tc.nodeName)
+		assert.Equal(t, tc.expectedErr, err, tc.description)
+		assert.Equal(t, tc.expectedVmssFlexID, vmssFlexID, tc.description)
+	}
+}
+
+func TestGetVmssFlexVM(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	testCases := []struct {
+		description                    string
+		nodeName                       string
+		testVM                         compute.VirtualMachine
+		vmGetErr                       *retry.Error
+		testVMListWithoutInstanceView  []compute.VirtualMachine
+		testVMListWithOnlyInstanceView []compute.VirtualMachine
+		vmListErr                      error
+		expectedVmssFlexVM             compute.VirtualMachine
+		expectedErr                    error
+	}{
+		{
+			description:                    "getVmssFlexVM should return the VmssFlex VM",
+			nodeName:                       "testvm1",
+			testVM:                         testVMWithoutInstanceView1,
+			vmGetErr:                       nil,
+			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
+			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
+			vmListErr:                      nil,
+			expectedVmssFlexVM:             testVM1,
+			expectedErr:                    nil,
+		},
+		{
+			description:                    "getVmssFlexVM should throw InstanceNotFound error if the VM cannot be found",
+			nodeName:                       "testvm1",
+			testVM:                         compute.VirtualMachine{},
+			vmGetErr:                       &retry.Error{HTTPStatusCode: http.StatusNotFound},
+			testVMListWithoutInstanceView:  []compute.VirtualMachine{},
+			testVMListWithOnlyInstanceView: []compute.VirtualMachine{},
+			vmListErr:                      nil,
+			expectedVmssFlexVM:             compute.VirtualMachine{},
+			expectedErr:                    cloudprovider.InstanceNotFound,
+		},
+		{
+			description:                    "getVmssFlexVM should throw InstanceNotFound error if the VM is removed from VMSS Flex",
+			nodeName:                       "testvm1",
+			testVM:                         testVMWithoutInstanceView1,
+			vmGetErr:                       nil,
+			testVMListWithoutInstanceView:  []compute.VirtualMachine{testVMWithoutInstanceView2},
+			testVMListWithOnlyInstanceView: []compute.VirtualMachine{testVMWithOnlyInstanceView2},
+			vmListErr:                      nil,
+			expectedVmssFlexVM:             compute.VirtualMachine{},
+			expectedErr:                    cloudprovider.InstanceNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		fs, err := NewTestFlexScaleSet(ctrl)
+		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
+
+		mockVMClient := fs.VirtualMachinesClient.(*mockvmclient.MockInterface)
+		mockVMClient.EXPECT().Get(gomock.Any(), fs.ResourceGroup, tc.nodeName, gomock.Any()).Return(tc.testVM, tc.vmGetErr).AnyTimes()
+		mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
+		mockVMClient.EXPECT().ListVmssFlexVMsWithOnlyInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithOnlyInstanceView, tc.vmListErr).AnyTimes()
+
+		vmssFlexVM, err := fs.getVmssFlexVM(tc.nodeName, azcache.CacheReadTypeDefault)
+		assert.Equal(t, tc.expectedErr, err, tc.description)
+		assert.Equal(t, tc.expectedVmssFlexVM, vmssFlexVM, tc.description)
+	}
+
+}
+
+func TestGetVmssFlexByVmssFlexID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		description      string
+		vmssFlexID       string
+		testVmssFlexList []compute.VirtualMachineScaleSet
+		vmssFlexListErr  *retry.Error
+		expectedVmssFlex *compute.VirtualMachineScaleSet
+		expectedErr      error
+	}{
+		{
+			description:      "getVmssFlexByVmssFlexID should return the corresponding vmssFlex by its ID",
+			vmssFlexID:       "subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1",
+			testVmssFlexList: testVmssFlexList,
+			vmssFlexListErr:  nil,
+			expectedVmssFlex: &testVmssFlex1,
+			expectedErr:      nil,
+		},
+		{
+			description:      "getVmssFlexByVmssFlexID should return cloudprovider.InstanceNotFound if there's no matching VMSS",
+			vmssFlexID:       "subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1",
+			testVmssFlexList: []compute.VirtualMachineScaleSet{testVmssFlex2},
+			vmssFlexListErr:  nil,
+			expectedVmssFlex: nil,
+			expectedErr:      cloudprovider.InstanceNotFound,
+		},
+		{
+			description:      "getVmssFlexByVmssFlexID  should report an error if there's something wrong during an api call",
+			vmssFlexID:       "subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1",
+			testVmssFlexList: []compute.VirtualMachineScaleSet{},
+			vmssFlexListErr:  &retry.Error{RawError: fmt.Errorf("error during vmss list")},
+			expectedVmssFlex: nil,
+			expectedErr:      fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: error during vmss list"),
+		},
+	}
+
+	for _, tc := range testCases {
+		fs, err := NewTestFlexScaleSet(ctrl)
+		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
+
+		mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.testVmssFlexList, tc.vmssFlexListErr).AnyTimes()
+
+		vmssFlex, err := fs.getVmssFlexByVmssFlexID(tc.vmssFlexID, azcache.CacheReadTypeDefault)
+		if tc.expectedErr != nil {
+			assert.EqualError(t, tc.expectedErr, err.Error(), tc.description)
+		}
+		assert.Equal(t, tc.expectedVmssFlex, vmssFlex, tc.description)
+	}
+}
+
+func TestGetVmssFlexIDByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		description        string
+		vmssFlexName       string
+		testVmssFlexList   []compute.VirtualMachineScaleSet
+		vmssFlexListErr    *retry.Error
+		expectedVmssFlexID string
+		expectedErr        error
+	}{
+		{
+			description:        "getVmssFlexIDByName should return the corresponding vmssFlex by its ID",
+			vmssFlexName:       "vmssflex1",
+			testVmssFlexList:   testVmssFlexList,
+			vmssFlexListErr:    nil,
+			expectedVmssFlexID: "subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1",
+			expectedErr:        nil,
+		},
+		{
+			description:        "getVmssFlexIDByName should return cloudprovider.InstanceNotFound if there's no matching VMSS",
+			vmssFlexName:       "vmssflex1",
+			testVmssFlexList:   []compute.VirtualMachineScaleSet{testVmssFlex2},
+			vmssFlexListErr:    nil,
+			expectedVmssFlexID: "",
+			expectedErr:        cloudprovider.InstanceNotFound,
+		},
+		{
+			description:        "getVmssFlexIDByName should report an error if there's something wrong during an api call",
+			vmssFlexName:       "vmssflex1",
+			testVmssFlexList:   []compute.VirtualMachineScaleSet{},
+			vmssFlexListErr:    &retry.Error{RawError: fmt.Errorf("error during vmss list")},
+			expectedVmssFlexID: "",
+			expectedErr:        fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: error during vmss list"),
+		},
+	}
+
+	for _, tc := range testCases {
+		fs, err := NewTestFlexScaleSet(ctrl)
+		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
+
+		mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.testVmssFlexList, tc.vmssFlexListErr).AnyTimes()
+
+		vmssFlexID, err := fs.getVmssFlexIDByName(tc.vmssFlexName)
+
+		assert.Equal(t, tc.expectedVmssFlexID, vmssFlexID, tc.description)
+		if tc.expectedErr != nil {
+			assert.EqualError(t, tc.expectedErr, err.Error(), tc.description)
+		}
+	}
+
+}
+
+func TestGetVmssFlexByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		description      string
+		vmssFlexName     string
+		testVmssFlexList []compute.VirtualMachineScaleSet
+		vmssFlexListErr  *retry.Error
+		expectedVmssFlex *compute.VirtualMachineScaleSet
+		expectedErr      error
+	}{
+		{
+			description:      "getVmssFlexByName should return the corresponding vmssFlex by its ID",
+			vmssFlexName:     "vmssflex1",
+			testVmssFlexList: testVmssFlexList,
+			vmssFlexListErr:  nil,
+			expectedVmssFlex: &testVmssFlex1,
+			expectedErr:      nil,
+		},
+		{
+			description:      "getVmssFlexByName should return cloudprovider.InstanceNotFound if there's no matching VMSS",
+			vmssFlexName:     "vmssflex1",
+			testVmssFlexList: []compute.VirtualMachineScaleSet{testVmssFlex2},
+			vmssFlexListErr:  nil,
+			expectedVmssFlex: nil,
+			expectedErr:      cloudprovider.InstanceNotFound,
+		},
+		{
+			description:      "getVmssFlexByName should report an error if there's something wrong during an api call",
+			vmssFlexName:     "vmssflex1",
+			testVmssFlexList: []compute.VirtualMachineScaleSet{},
+			vmssFlexListErr:  &retry.Error{RawError: fmt.Errorf("error during vmss list")},
+			expectedVmssFlex: nil,
+			expectedErr:      fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: error during vmss list"),
+		},
+	}
+
+	for _, tc := range testCases {
+		fs, err := NewTestFlexScaleSet(ctrl)
+		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
+
+		mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.testVmssFlexList, tc.vmssFlexListErr).AnyTimes()
+
+		vmssFlex, err := fs.getVmssFlexByName(tc.vmssFlexName)
+
+		assert.Equal(t, tc.expectedVmssFlex, vmssFlex, tc.description)
+		if tc.expectedErr != nil {
+			assert.EqualError(t, tc.expectedErr, err.Error(), tc.description)
+		}
+	}
+
+}
+
+func TestGetVmssFlexByNodeName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		description                    string
+		nodeName                       string
+		testVM                         compute.VirtualMachine
+		vmGetErr                       *retry.Error
+		testVMListWithoutInstanceView  []compute.VirtualMachine
+		testVMListWithOnlyInstanceView []compute.VirtualMachine
+		vmListErr                      error
+		testVmssFlexList               []compute.VirtualMachineScaleSet
+		vmssFlexListErr                *retry.Error
+		expectedVmssFlex               *compute.VirtualMachineScaleSet
+		expectedErr                    error
+	}{
+		{
+			description:                    "getVmssFlexByName should return the VmssFlex ID that the node belongs to",
+			nodeName:                       "testvm1",
+			testVM:                         testVMWithoutInstanceView1,
+			vmGetErr:                       nil,
+			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
+			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
+			vmListErr:                      nil,
+			testVmssFlexList:               testVmssFlexList,
+			vmssFlexListErr:                nil,
+			expectedVmssFlex:               &testVmssFlex1,
+			expectedErr:                    nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		fs, err := NewTestFlexScaleSet(ctrl)
+		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
+
+		mockVMClient := fs.VirtualMachinesClient.(*mockvmclient.MockInterface)
+		mockVMClient.EXPECT().Get(gomock.Any(), fs.ResourceGroup, tc.nodeName, gomock.Any()).Return(tc.testVM, tc.vmGetErr).AnyTimes()
+		mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
+		mockVMClient.EXPECT().ListVmssFlexVMsWithOnlyInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithOnlyInstanceView, tc.vmListErr).AnyTimes()
+		mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.testVmssFlexList, tc.vmssFlexListErr).AnyTimes()
+
+		vmssFlex, err := fs.getVmssFlexByNodeName(tc.nodeName, azcache.CacheReadTypeDefault)
+		assert.Equal(t, tc.expectedErr, err, tc.description)
+		assert.Equal(t, tc.expectedVmssFlex, vmssFlex, tc.description)
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is to support using VMSS Flex VMs as K8s cluster nodes. This PR added caches used for VMSS Flex nodes

This PR does the following things:
-  Define a FlexScaleSet struct to be used for managing VMSS Flex nodes
- Define the caches needed for VMSS Flex and the operations to query VMSS Flex VM info and VMSS Flex info from the caches
- Unit tests for functions to query vmss Flex related caches.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer to #639 

#### Special notes for your reviewer:
Similar to VMSS Uniform, 2 types of caches are used for VMSS Flex:
- cache for list of VMSS Flex: vmssFlexCache
- cache for list of VMSS Flex VMs: vmssFlexVMCache, vmssFlexVMStatusCache
Both of the above caches are populated in batch behavior.

Note:

1. Batch query needed

VMSS Uniform API support query VM properties and IntanceView with one single API:
GET `https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}?$expand=InstanceView&api-version=2022-03-01`
	
However, VMSS Flex API does not support adding IntanceView as expand. So 2 queries are needed:

- Get VM properties:

`GET https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachines?api-version=2022-03-01&$filter="virtualMachineScaleSet/id' eq /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmssName}'"`
		

- Get InstanceView properties:

`GET https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachines?api-version=2022-03-01&statusOnly=true&$filter="virtualMachineScaleSet/id' eq /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmssName}'"`

So, two caches are used for holding VMSS Flex VM properties: vmssFlexVMCache, vmssFlexVMStatusCache

2. Infer VMSS name from VM name/ID
	When using VMSS Uniform, the VMSS name can be easily infered by VM name or VM ID
	
	VMSS ID: `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}`
	
	VMSS Uniform VM ID: (share the same prefix as VMSS ID)
	`/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}`
	
	VMSS Uniform VM name:
	`{vmScaleSetName}_{random_characters}`
	
	VMSS Flex VM ID:
	`/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}`
	
	So when using Flex VM, we need to first query the VM to get its parent VMSS ID, then query all the VMs under the VMSS to populate the cache. To do so, vmssFlexVMnameToVmssID is used for store this mapping relationship.



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Other doc]: https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/orchestration-modes-api-comparison
```
