### PR TITLE
add encryption setting in storage account creation

### DIFF
--- a/pkg/provider/azure_backoff.go
+++ b/pkg/provider/azure_backoff.go
@@ -98,7 +98,7 @@ func (az *Cloud) ListVirtualMachines(resourceGroup string) ([]compute.VirtualMac
 		klog.Errorf("VirtualMachinesClient.List(%v) failure with err=%v", resourceGroup, rerr)
 		return nil, rerr.Error()
 	}
-	klog.V(2).Infof("VirtualMachinesClient.List(%v) success", resourceGroup)
+	klog.V(6).Infof("VirtualMachinesClient.List(%v) success", resourceGroup)
 	return allNodes, nil
 }
 

--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -52,6 +52,10 @@ type AccountOptions struct {
 	IsHnsEnabled                            *bool
 	EnableNfsV3                             *bool
 	AllowBlobPublicAccess                   *bool
+	RequireInfrastructureEncryption         *bool
+	KeyName                                 *string
+	KeyVersion                              *string
+	KeyVaultURI                             *string
 	Tags                                    map[string]string
 	VirtualNetworkResourceIDs               []string
 	VNetResourceGroup                       string
@@ -272,6 +276,23 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 		if accountOptions.AllowBlobPublicAccess != nil {
 			klog.V(2).Infof("set AllowBlobPublicAccess(%v) for storage account(%s)", *accountOptions.AllowBlobPublicAccess, accountName)
 			cp.AccountPropertiesCreateParameters.AllowBlobPublicAccess = accountOptions.AllowBlobPublicAccess
+		}
+		if accountOptions.RequireInfrastructureEncryption != nil {
+			klog.V(2).Infof("set RequireInfrastructureEncryption(%v) for storage account(%s)", *accountOptions.RequireInfrastructureEncryption, accountName)
+			cp.AccountPropertiesCreateParameters.Encryption = &storage.Encryption{
+				RequireInfrastructureEncryption: accountOptions.RequireInfrastructureEncryption,
+			}
+		}
+		if accountOptions.KeyVaultURI != nil {
+			klog.V(2).Infof("set KeyVault(%v) for storage account(%s)", accountOptions.KeyVaultURI, accountName)
+			if cp.AccountPropertiesCreateParameters.Encryption == nil {
+				cp.AccountPropertiesCreateParameters.Encryption = &storage.Encryption{}
+			}
+			cp.AccountPropertiesCreateParameters.Encryption.KeyVaultProperties = &storage.KeyVaultProperties{
+				KeyName:     accountOptions.KeyName,
+				KeyVersion:  accountOptions.KeyVersion,
+				KeyVaultURI: accountOptions.KeyVaultURI,
+			}
 		}
 		if az.StorageAccountClient == nil {
 			return "", "", fmt.Errorf("StorageAccountClient is nil")

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -369,26 +369,30 @@ func TestEnsureStorageAccount(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                      string
-		createAccount             bool
-		createPrivateEndpoint     bool
-		SubnetPropertiesFormatNil bool
-		mockStorageAccountsClient bool
-		setAccountOptions         bool
-		accountName               string
-		subscriptionID            string
-		resourceGroup             string
-		expectedErr               string
+		name                            string
+		createAccount                   bool
+		createPrivateEndpoint           bool
+		SubnetPropertiesFormatNil       bool
+		mockStorageAccountsClient       bool
+		setAccountOptions               bool
+		requireInfrastructureEncryption *bool
+		keyVaultURL                     *string
+		accountName                     string
+		subscriptionID                  string
+		resourceGroup                   string
+		expectedErr                     string
 	}{
 		{
-			name:                      "[Success] EnsureStorageAccount with createPrivateEndpoint",
-			createAccount:             true,
-			createPrivateEndpoint:     true,
-			mockStorageAccountsClient: true,
-			setAccountOptions:         true,
-			resourceGroup:             "rg",
-			accountName:               "",
-			expectedErr:               "",
+			name:                            "[Success] EnsureStorageAccount with createPrivateEndpoint",
+			createAccount:                   true,
+			createPrivateEndpoint:           true,
+			mockStorageAccountsClient:       true,
+			setAccountOptions:               true,
+			requireInfrastructureEncryption: to.BoolPtr(true),
+			keyVaultURL:                     to.StringPtr("keyVaultURL"),
+			resourceGroup:                   "rg",
+			accountName:                     "",
+			expectedErr:                     "",
 		},
 		{
 			name:                      "[Failed] EnsureStorageAccount with createPrivateEndpoint: get storage key failed",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
add encryption setting in storage account creation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
add encryption setting in storage account creation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
add encryption setting in storage account creation
```
