### PR TITLE
VMSS Flex Support: Computer hostName rather than VMName should be used as nodeName

### DIFF
--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -39,8 +39,9 @@ type FlexScaleSet struct {
 
 	vmssFlexCache *azcache.TimedCache
 
-	vmssFlexVMNameToVmssID *sync.Map
-	vmssFlexVMCache        *azcache.TimedCache
+	vmssFlexVMNameToVmssID   *sync.Map
+	vmssFlexVMNameToNodeName *sync.Map
+	vmssFlexVMCache          *azcache.TimedCache
 
 	// lockMap in cache refresh
 	lockMap *lockMap
@@ -48,9 +49,10 @@ type FlexScaleSet struct {
 
 func newFlexScaleSet(az *Cloud) (VMSet, error) {
 	fs := &FlexScaleSet{
-		Cloud:                  az,
-		vmssFlexVMNameToVmssID: &sync.Map{},
-		lockMap:                newLockMap(),
+		Cloud:                    az,
+		vmssFlexVMNameToVmssID:   &sync.Map{},
+		vmssFlexVMNameToNodeName: &sync.Map{},
+		lockMap:                  newLockMap(),
 	}
 
 	var err error

--- a/pkg/provider/azure_vmssflex_cache.go
+++ b/pkg/provider/azure_vmssflex_cache.go
@@ -24,9 +24,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-07-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 
-	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 
@@ -92,9 +90,10 @@ func (fs *FlexScaleSet) newVmssFlexVMCache() (*azcache.TimedCache, error) {
 
 		for i := range vms {
 			vm := vms[i]
-			if vm.Name != nil {
-				localCache.Store(*vm.Name, &vm)
-				fs.vmssFlexVMNameToVmssID.Store(*vm.Name, key)
+			if vm.OsProfile != nil && vm.OsProfile.ComputerName != nil {
+				localCache.Store(*vm.OsProfile.ComputerName, &vm)
+				fs.vmssFlexVMNameToVmssID.Store(*vm.OsProfile.ComputerName, key)
+				fs.vmssFlexVMNameToNodeName.Store(*vm.Name, *vm.OsProfile.ComputerName)
 			}
 		}
 
@@ -106,8 +105,8 @@ func (fs *FlexScaleSet) newVmssFlexVMCache() (*azcache.TimedCache, error) {
 
 		for i := range vms {
 			vm := vms[i]
-			if vm.Name != nil {
-				cached, ok := localCache.Load(*vm.Name)
+			if vm.OsProfile != nil && vm.OsProfile.ComputerName != nil {
+				cached, ok := localCache.Load(*vm.OsProfile.ComputerName)
 				if ok {
 					cachedVM := cached.(*compute.VirtualMachine)
 					cachedVM.VirtualMachineProperties.InstanceView = vm.VirtualMachineProperties.InstanceView
@@ -127,24 +126,33 @@ func (fs *FlexScaleSet) newVmssFlexVMCache() (*azcache.TimedCache, error) {
 func (fs *FlexScaleSet) getNodeVmssFlexID(nodeName string) (string, error) {
 	fs.lockMap.LockEntry(consts.GetNodeVmssFlexIDLockKey)
 	defer fs.lockMap.UnlockEntry(consts.GetNodeVmssFlexIDLockKey)
-	vmssFlexID, isCached := fs.vmssFlexVMNameToVmssID.Load(nodeName)
-	if !isCached {
-		klog.V(12).Infof("nodeName %s is not saved in vmssFlexVMnameToVmssID map, send a GET request to retrieve its VmssID", nodeName)
-		machine, err := fs.getVirtualMachine(types.NodeName(nodeName), azcache.CacheReadTypeUnsafe)
-		if err != nil {
-			return "", err
-		}
-		vmssFlexID = to.String(machine.VirtualMachineScaleSet.ID)
-		if vmssFlexID == "" {
-			return "", ErrorVmssIDIsEmpty
-		}
-		fs.vmssFlexVMNameToVmssID.Store(nodeName, vmssFlexID)
-		_, err = fs.vmssFlexVMCache.Get(fmt.Sprintf("%v", vmssFlexID), azcache.CacheReadTypeForceRefresh)
-		if err != nil {
-			return "", err
-		}
+	cachedVmssFlexID, isCached := fs.vmssFlexVMNameToVmssID.Load(nodeName)
+
+	if isCached {
+		return fmt.Sprintf("%v", cachedVmssFlexID), nil
 	}
-	return fmt.Sprintf("%v", vmssFlexID), nil
+
+	cached, err := fs.vmssFlexCache.Get(consts.VmssFlexKey, azcache.CacheReadTypeDefault)
+	if err != nil {
+		return "", err
+	}
+	vmssFlexes := cached.(*sync.Map)
+
+	vmssFlexes.Range(func(key, value interface{}) bool {
+		vmssFlexID := key.(string)
+		_, err := fs.vmssFlexVMCache.Get(vmssFlexID, azcache.CacheReadTypeForceRefresh)
+		if err != nil {
+			klog.V(12).Infof("failed to refresh vmss flex VM cache for vmssFlexID %s", vmssFlexID)
+		}
+		return true
+	})
+
+	cachedVmssFlexID, isCached = fs.vmssFlexVMNameToVmssID.Load(nodeName)
+	if isCached {
+		return fmt.Sprintf("%v", cachedVmssFlexID), nil
+	}
+	return "", cloudprovider.InstanceNotFound
+
 }
 
 func (fs *FlexScaleSet) getVmssFlexVM(nodeName string, crt azcache.AzureCacheReadType) (vm compute.VirtualMachine, err error) {

--- a/pkg/provider/azure_vmssflex_cache_test.go
+++ b/pkg/provider/azure_vmssflex_cache_test.go
@@ -35,12 +35,17 @@ import (
 )
 
 var (
+	testVmssFlex1ID = "subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1"
+
 	testVMWithoutInstanceView1 = compute.VirtualMachine{
 		Name: to.StringPtr("testvm1"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			OsProfile: &compute.OSProfile{
+				ComputerName: to.StringPtr("vmssflex1000001"),
+			},
 			ProvisioningState: nil,
 			VirtualMachineScaleSet: &compute.SubResource{
-				ID: to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1"),
+				ID: to.StringPtr(testVmssFlex1ID),
 			},
 		},
 	}
@@ -48,9 +53,12 @@ var (
 	testVMWithoutInstanceView2 = compute.VirtualMachine{
 		Name: to.StringPtr("testvm2"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			OsProfile: &compute.OSProfile{
+				ComputerName: to.StringPtr("vmssflex1000002"),
+			},
 			ProvisioningState: nil,
 			VirtualMachineScaleSet: &compute.SubResource{
-				ID: to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex2"),
+				ID: to.StringPtr(testVmssFlex1ID),
 			},
 		},
 	}
@@ -59,6 +67,9 @@ var (
 	testVMWithOnlyInstanceView1 = compute.VirtualMachine{
 		Name: to.StringPtr("testvm1"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			OsProfile: &compute.OSProfile{
+				ComputerName: to.StringPtr("vmssflex1000001"),
+			},
 			InstanceView: &compute.VirtualMachineInstanceView{
 				Statuses: &[]compute.InstanceViewStatus{
 					{
@@ -72,6 +83,9 @@ var (
 	testVMWithOnlyInstanceView2 = compute.VirtualMachine{
 		Name: to.StringPtr("testvm2"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			OsProfile: &compute.OSProfile{
+				ComputerName: to.StringPtr("vmssflex1000002"),
+			},
 			InstanceView: &compute.VirtualMachineInstanceView{
 				Statuses: &[]compute.InstanceViewStatus{
 					{
@@ -86,9 +100,12 @@ var (
 	testVM1 = compute.VirtualMachine{
 		Name: to.StringPtr("testvm1"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			OsProfile: &compute.OSProfile{
+				ComputerName: to.StringPtr("vmssflex1000001"),
+			},
 			ProvisioningState: nil,
 			VirtualMachineScaleSet: &compute.SubResource{
-				ID: to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1"),
+				ID: to.StringPtr(testVmssFlex1ID),
 			},
 			InstanceView: &compute.VirtualMachineInstanceView{
 				Statuses: &[]compute.InstanceViewStatus{
@@ -101,24 +118,19 @@ var (
 	}
 
 	testVmssFlex1 = compute.VirtualMachineScaleSet{
-		ID:   to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1"),
+		ID:   to.StringPtr(testVmssFlex1ID),
 		Name: to.StringPtr("vmssflex1"),
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
-			OrchestrationMode:     compute.OrchestrationModeFlexible,
+			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
+				OsProfile: &compute.VirtualMachineScaleSetOSProfile{
+					ComputerNamePrefix: to.StringPtr("vmssflex1"),
+				},
+			},
+			OrchestrationMode: compute.OrchestrationModeFlexible,
 		},
 	}
 
-	testVmssFlex2 = compute.VirtualMachineScaleSet{
-		ID:   to.StringPtr("subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex2"),
-		Name: to.StringPtr("vmssflex2"),
-		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
-			OrchestrationMode:     compute.OrchestrationModeFlexible,
-		},
-	}
-
-	testVmssFlexList = []compute.VirtualMachineScaleSet{testVmssFlex1, testVmssFlex2}
+	testVmssFlexList = []compute.VirtualMachineScaleSet{testVmssFlex1}
 )
 
 func TestGetNodeVmssFlexID(t *testing.T) {
@@ -128,8 +140,6 @@ func TestGetNodeVmssFlexID(t *testing.T) {
 	testCases := []struct {
 		description                    string
 		nodeName                       string
-		testVM                         compute.VirtualMachine
-		vmGetErr                       *retry.Error
 		testVMListWithoutInstanceView  []compute.VirtualMachine
 		testVMListWithOnlyInstanceView []compute.VirtualMachine
 		vmListErr                      error
@@ -138,9 +148,7 @@ func TestGetNodeVmssFlexID(t *testing.T) {
 	}{
 		{
 			description:                    "getNodeVmssFlexID should return the VmssFlex ID that the node belongs to",
-			nodeName:                       "testvm1",
-			testVM:                         testVMWithoutInstanceView1,
-			vmGetErr:                       nil,
+			nodeName:                       "vmssflex1000001",
 			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
 			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
 			vmListErr:                      nil,
@@ -150,8 +158,6 @@ func TestGetNodeVmssFlexID(t *testing.T) {
 		{
 			description:                    "getNodeVmssFlexID should throw InstanceNotFound error if the VM cannot be found",
 			nodeName:                       "testvm3",
-			testVM:                         compute.VirtualMachine{},
-			vmGetErr:                       &retry.Error{HTTPStatusCode: http.StatusNotFound},
 			testVMListWithoutInstanceView:  []compute.VirtualMachine{},
 			testVMListWithOnlyInstanceView: []compute.VirtualMachine{},
 			vmListErr:                      nil,
@@ -164,9 +170,10 @@ func TestGetNodeVmssFlexID(t *testing.T) {
 		fs, err := NewTestFlexScaleSet(ctrl)
 		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
 
-		mockVMClient := fs.VirtualMachinesClient.(*mockvmclient.MockInterface)
-		mockVMClient.EXPECT().Get(gomock.Any(), fs.ResourceGroup, tc.nodeName, gomock.Any()).Return(tc.testVM, tc.vmGetErr).AnyTimes()
+		mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(testVmssFlexList, nil).AnyTimes()
 
+		mockVMClient := fs.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
 		mockVMClient.EXPECT().ListVmssFlexVMsWithOnlyInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithOnlyInstanceView, tc.vmListErr).AnyTimes()
 
@@ -192,7 +199,7 @@ func TestGetVmssFlexVM(t *testing.T) {
 	}{
 		{
 			description:                    "getVmssFlexVM should return the VmssFlex VM",
-			nodeName:                       "testvm1",
+			nodeName:                       "vmssflex1000001",
 			testVM:                         testVMWithoutInstanceView1,
 			vmGetErr:                       nil,
 			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
@@ -203,7 +210,7 @@ func TestGetVmssFlexVM(t *testing.T) {
 		},
 		{
 			description:                    "getVmssFlexVM should throw InstanceNotFound error if the VM cannot be found",
-			nodeName:                       "testvm1",
+			nodeName:                       "vmssflex1000001",
 			testVM:                         compute.VirtualMachine{},
 			vmGetErr:                       &retry.Error{HTTPStatusCode: http.StatusNotFound},
 			testVMListWithoutInstanceView:  []compute.VirtualMachine{},
@@ -214,7 +221,7 @@ func TestGetVmssFlexVM(t *testing.T) {
 		},
 		{
 			description:                    "getVmssFlexVM should throw InstanceNotFound error if the VM is removed from VMSS Flex",
-			nodeName:                       "testvm1",
+			nodeName:                       "vmssflex1000001",
 			testVM:                         testVMWithoutInstanceView1,
 			vmGetErr:                       nil,
 			testVMListWithoutInstanceView:  []compute.VirtualMachine{testVMWithoutInstanceView2},
@@ -229,8 +236,10 @@ func TestGetVmssFlexVM(t *testing.T) {
 		fs, err := NewTestFlexScaleSet(ctrl)
 		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
 
+		mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(testVmssFlexList, nil).AnyTimes()
+
 		mockVMClient := fs.VirtualMachinesClient.(*mockvmclient.MockInterface)
-		mockVMClient.EXPECT().Get(gomock.Any(), fs.ResourceGroup, tc.nodeName, gomock.Any()).Return(tc.testVM, tc.vmGetErr).AnyTimes()
 		mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
 		mockVMClient.EXPECT().ListVmssFlexVMsWithOnlyInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithOnlyInstanceView, tc.vmListErr).AnyTimes()
 
@@ -264,7 +273,7 @@ func TestGetVmssFlexByVmssFlexID(t *testing.T) {
 		{
 			description:      "getVmssFlexByVmssFlexID should return cloudprovider.InstanceNotFound if there's no matching VMSS",
 			vmssFlexID:       "subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmssflex1",
-			testVmssFlexList: []compute.VirtualMachineScaleSet{testVmssFlex2},
+			testVmssFlexList: []compute.VirtualMachineScaleSet{},
 			vmssFlexListErr:  nil,
 			expectedVmssFlex: nil,
 			expectedErr:      cloudprovider.InstanceNotFound,
@@ -317,7 +326,7 @@ func TestGetVmssFlexIDByName(t *testing.T) {
 		{
 			description:        "getVmssFlexIDByName should return cloudprovider.InstanceNotFound if there's no matching VMSS",
 			vmssFlexName:       "vmssflex1",
-			testVmssFlexList:   []compute.VirtualMachineScaleSet{testVmssFlex2},
+			testVmssFlexList:   []compute.VirtualMachineScaleSet{},
 			vmssFlexListErr:    nil,
 			expectedVmssFlexID: "",
 			expectedErr:        cloudprovider.InstanceNotFound,
@@ -372,7 +381,7 @@ func TestGetVmssFlexByName(t *testing.T) {
 		{
 			description:      "getVmssFlexByName should return cloudprovider.InstanceNotFound if there's no matching VMSS",
 			vmssFlexName:     "vmssflex1",
-			testVmssFlexList: []compute.VirtualMachineScaleSet{testVmssFlex2},
+			testVmssFlexList: []compute.VirtualMachineScaleSet{},
 			vmssFlexListErr:  nil,
 			expectedVmssFlex: nil,
 			expectedErr:      cloudprovider.InstanceNotFound,
@@ -423,7 +432,7 @@ func TestGetVmssFlexByNodeName(t *testing.T) {
 	}{
 		{
 			description:                    "getVmssFlexByName should return the VmssFlex ID that the node belongs to",
-			nodeName:                       "testvm1",
+			nodeName:                       "vmssflex1000001",
 			testVM:                         testVMWithoutInstanceView1,
 			vmGetErr:                       nil,
 			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,


### PR DESCRIPTION
use hostName rather than VMName as nodeName


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
No matter how the node is provisioned, this always applies: K8s nodeName == hostname ==  compute.VirtualMachine.OSProfile.ComputerName

When VMSS Flex is used, the behavior is more complex, as there are two approaches to provision VMs inside the VMSS Flex, and the different provisioning approaches affect how the node is named:
Case 1: When VMSS Flex is created with default VM profile, VM can be created by increasing the VMSS capacity. In this case, VM name is not equal to hostname (nodeName). (@Jack’s capz implementation)
Case 2: When VMSS Flex is created without default VM profile, VMs can be individually created and attached to the existing VMSS Flex. In this case, VM Name == hostname. (@Juan-Lee’s capz implementation)
 
To find out which VMSS Flex the node belongs to in Cloud Controller Manager, we have to consider the above two different cases:
In case 1, since default VM profile exists, the behavior is similar to VMSS Uniform: the VMSS who has the same computerPrefix as the nodeName should be the VMSS the node belongs to.
In case 2, default VM profile does not exists, but the nodeName (hostname) equals VM name. So, we can send an extra GET VM request to find out the VMSS ID.

To make the Cloud Controller Manager code to be general and independent from the cluster provisioning method, both of the above two cases need to be supported. Now the issue is, if there are multiple VMSS in the same K8s cluster, how do we know if the VMSS that the target node belongs to satisfy case 1 or case 2?

One way I can think of is we can make a restriction that if multiple VMSS Flex exist, all the VMSS should be configured as the same way: either all VMSS have default VM profile and increasing capacity to add new node or non VMSS has default VM profile and creating VM individually and attaching it into the VMSS Flex. In this way, we can add a new configuration on CCM to specify which approach the nodes are provisioned.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer to #639 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
