### PR TITLE
Revert "fix: don't set vm entry as nil in cache when vm is in Deleting state to avoid VMSSList throttling"

### DIFF
--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -170,8 +170,8 @@ func (ss *ScaleSet) getVmssVMByNodeIdentity(node *nodeIdentity, crt azcache.Azur
 		if entry, ok := virtualMachines.Load(nodeName); ok {
 			result := entry.(*vmssVirtualMachinesEntry)
 			if result.virtualMachine == nil {
-				klog.Warningf("failed to get VM with vmssVirtualMachinesEntry on Node %q", nodeName)
-				return nil, false, nil
+				klog.Warningf("VM is nil on Node %q, VM is in deleting state", nodeName)
+				return nil, true, nil
 			}
 			found = true
 			return virtualmachine.FromVirtualMachineScaleSetVM(result.virtualMachine, virtualmachine.ByVMSS(result.vmssName)), found, nil

--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -223,9 +223,11 @@ func (ss *ScaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cac
 				virtualMachine: &vm,
 				lastUpdate:     time.Now().UTC(),
 			}
+			// set cache entry to nil when the VM is under deleting.
 			if vm.VirtualMachineScaleSetVMProperties != nil &&
 				strings.EqualFold(to.String(vm.VirtualMachineScaleSetVMProperties.ProvisioningState), string(compute.ProvisioningStateDeleting)) {
-				klog.V(4).Infof("VMSS virtualMachine %q is under deleting", computerName)
+				klog.V(4).Infof("VMSS virtualMachine %q is under deleting, setting its cache to nil", computerName)
+				vmssVMCacheEntry.virtualMachine = nil
 			}
 			localCache.Store(computerName, vmssVMCacheEntry)
 

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -983,7 +983,7 @@ func TestGetVmssVMByNodeIdentity(t *testing.T) {
 			virtualMachines = cached.(*sync.Map)
 			for _, vm := range test.goneVMList {
 				_, ok := virtualMachines.Load(vm)
-				assert.False(t, ok)
+				assert.True(t, ok)
 			}
 		})
 	}


### PR DESCRIPTION
Reverts kubernetes-sigs/cloud-provider-azure#2060
This PR returns InstanceNotFound when vm in cache is nil, this PR would fix following issue in another way:
When VM is in Deleting state, original behavior is setting as nil, and then with this PR(https://github.com/kubernetes-sigs/cloud-provider-azure/pull/1578), Deleting state VM will be not found in cache, then it would trigger VMSSList again, found VM is still in Deleting state, return nil, trigger VMSSList again and again, finally get VMSSList throttling.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```