### PR TITLE
chore: hard-code -flake-attempts instead of using CCM_E2E_ARGS

### DIFF
--- a/.pipelines/scripts/run-e2e.sh
+++ b/.pipelines/scripts/run-e2e.sh
@@ -93,7 +93,6 @@ if [[ "${CLUSTER_TYPE}" == "autoscaling-multipool" ]]; then
 fi
 
 export E2E_ON_AKS_CLUSTER=true
-export CCM_E2E_ARGS="-flake-attempts 2"
 if [[ "${CLUSTER_TYPE}" =~ "autoscaling" ]]; then
   export LABEL_FILTER="Feature:Autoscaling || !Serial && !Slow"
 fi

--- a/hack/test-ccm-e2e.sh
+++ b/hack/test-ccm-e2e.sh
@@ -20,8 +20,7 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 DEFAULT_LABEL_FILTER="!Serial && !Slow"
 LABEL_FILTER="${LABEL_FILTER:-${DEFAULT_LABEL_FILTER}}"
-CCM_E2E_ARGS="${CCM_E2E_ARGS:-}"
 
 source "${REPO_ROOT}/hack/ensure-ginkgo-v2.sh"
 
-ginkgo -label-filter "${LABEL_FILTER}" ${CCM_E2E_ARGS} "${REPO_ROOT}"/tests/e2e/
+ginkgo -flake-attempts 3 -label-filter "${LABEL_FILTER}" "${REPO_ROOT}"/tests/e2e/

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -62,7 +62,7 @@ var (
 	}
 )
 
-var _ = Describe("Ensure LoadBalancer", FlakeAttempts(3), Label(utils.TestSuiteLabelLB), func() {
+var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 	basename := testBaseName
 
 	var cs clientset.Interface
@@ -744,7 +744,7 @@ var _ = Describe("Ensure LoadBalancer", FlakeAttempts(3), Label(utils.TestSuiteL
 	})
 })
 
-var _ = Describe("EnsureLoadBalancer should not update any resources when service config is not changed", FlakeAttempts(3), Label(utils.TestSuiteLabelLB), func() {
+var _ = Describe("EnsureLoadBalancer should not update any resources when service config is not changed", Label(utils.TestSuiteLabelLB), func() {
 	basename := testBaseName
 
 	var cs clientset.Interface

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -39,7 +39,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Network security group", FlakeAttempts(3), Label(utils.TestSuiteLabelNSG), func() {
+var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func() {
 	basename := "nsg"
 	serviceName := "nsg-test"
 

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -59,7 +59,7 @@ const (
 	nginxStatusCode = 200
 )
 
-var _ = Describe("Service with annotation", FlakeAttempts(3), Label(utils.TestSuiteLabelServiceAnnotation), func() {
+var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnnotation), func() {
 	basename := "service"
 	serviceName := "annotation-test"
 	initSuccess := false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes-sigs/cloud-provider-azure/pull/2162 use CCM_E2E_ARGS to setup -flake-attempts. But this will conflict settings in the [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml#L248). This PR hard-codes the -flake-attempts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
