### PR TITLE
cleanup: don't print error logging for user assigned client id

### DIFF
--- a/pkg/auth/azure_auth.go
+++ b/pkg/auth/azure_auth.go
@@ -110,7 +110,7 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment, r
 					config.UserAssignedIdentityID)
 			}
 
-			klog.V(4).Info("azure: User Assigned MSI ID is client ID. Resource ID parsing error: %+v", err)
+			klog.V(4).Info("azure: User Assigned MSI ID is client ID")
 			return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint,
 				resource,
 				config.UserAssignedIdentityID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
cleanup: don't print error logging for user assigned client id

related to https://github.com/kubernetes-sigs/cloud-provider-azure/pull/1290/files#r944238069

I got this error now, from current code logic, looks like it's just an info log, I think we need to refine the logging, otherwise there will be following error as long as User Assigned MSI ID is client ID
```
[pod/csi-blob-node-8trh8/blob] I0812 03:15:51.934107       1 azure_auth.go:245] Using AzurePublicCloud environment
[pod/csi-blob-node-8trh8/blob] I0812 03:15:51.934127       1 azure_auth.go:96] azure: using managed identity extension to retrieve access token
[pod/csi-blob-node-8trh8/blob] I0812 03:15:51.934131       1 azure_auth.go:102] azure: using User Assigned MSI ID to retrieve access token
[pod/csi-blob-node-8trh8/blob] I0812 03:15:51.934162       1 azure_auth.go:113] azure: User Assigned MSI ID is client ID. Resource ID parsing error: %+vparsing failed for 82e9bd91-c283-4b2d-8708-6d11b07d630d. Invalid resource Id format
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
