### PR TITLE
Pass the context for AzureFile

### DIFF
--- a/pkg/azureclients/fileclient/azure_fileclient.go
+++ b/pkg/azureclients/fileclient/azure_fileclient.go
@@ -84,7 +84,7 @@ func (c *Client) WithSubscriptionID(subscriptionID string) Interface {
 }
 
 // CreateFileShare creates a file share
-func (c *Client) CreateFileShare(resourceGroupName, accountName string, shareOptions *ShareOptions) error {
+func (c *Client) CreateFileShare(ctx context.Context, resourceGroupName, accountName string, shareOptions *ShareOptions) error {
 	mc := metrics.NewMetricContext("file_shares", "create", resourceGroupName, c.subscriptionID, "")
 
 	if shareOptions == nil {
@@ -110,7 +110,7 @@ func (c *Client) CreateFileShare(resourceGroupName, accountName string, shareOpt
 		Name:                &shareOptions.Name,
 		FileShareProperties: fileShareProperties,
 	}
-	_, err := c.fileSharesClient.Create(context.Background(), resourceGroupName, accountName, shareOptions.Name, fileShare, "")
+	_, err := c.fileSharesClient.Create(ctx, resourceGroupName, accountName, shareOptions.Name, fileShare, "")
 	var rerr *retry.Error
 	if err != nil {
 		rerr = &retry.Error{
@@ -123,10 +123,10 @@ func (c *Client) CreateFileShare(resourceGroupName, accountName string, shareOpt
 }
 
 // DeleteFileShare deletes a file share
-func (c *Client) DeleteFileShare(resourceGroupName, accountName, name string) error {
+func (c *Client) DeleteFileShare(ctx context.Context, resourceGroupName, accountName, name string) error {
 	mc := metrics.NewMetricContext("file_shares", "delete", resourceGroupName, c.subscriptionID, "")
 
-	_, err := c.fileSharesClient.Delete(context.Background(), resourceGroupName, accountName, name, "", "")
+	_, err := c.fileSharesClient.Delete(ctx, resourceGroupName, accountName, name, "", "")
 	var rerr *retry.Error
 	if err != nil {
 		rerr = &retry.Error{
@@ -139,13 +139,13 @@ func (c *Client) DeleteFileShare(resourceGroupName, accountName, name string) er
 }
 
 // ResizeFileShare resizes a file share
-func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+func (c *Client) ResizeFileShare(ctx context.Context, resourceGroupName, accountName, name string, sizeGiB int) error {
 	mc := metrics.NewMetricContext("file_shares", "resize", resourceGroupName, c.subscriptionID, "")
 	var rerr *retry.Error
 
 	quota := int32(sizeGiB)
 
-	share, err := c.fileSharesClient.Get(context.Background(), resourceGroupName, accountName, name, "stats", "")
+	share, err := c.fileSharesClient.Get(ctx, resourceGroupName, accountName, name, "stats", "")
 	if err != nil {
 		rerr = &retry.Error{
 			RawError: err,
@@ -160,7 +160,7 @@ func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, si
 	}
 
 	share.FileShareProperties.ShareQuota = &quota
-	_, err = c.fileSharesClient.Update(context.Background(), resourceGroupName, accountName, name, share)
+	_, err = c.fileSharesClient.Update(ctx, resourceGroupName, accountName, name, share)
 	if err != nil {
 		rerr = &retry.Error{
 			RawError: err,
@@ -176,10 +176,10 @@ func (c *Client) ResizeFileShare(resourceGroupName, accountName, name string, si
 }
 
 // GetFileShare gets a file share
-func (c *Client) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
+func (c *Client) GetFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error) {
 	mc := metrics.NewMetricContext("file_shares", "get", resourceGroupName, c.subscriptionID, "")
 
-	result, err := c.fileSharesClient.Get(context.Background(), resourceGroupName, accountName, name, "stats", "")
+	result, err := c.fileSharesClient.Get(ctx, resourceGroupName, accountName, name, "stats", "")
 	var rerr *retry.Error
 	if err != nil {
 		rerr = &retry.Error{
@@ -192,11 +192,11 @@ func (c *Client) GetFileShare(resourceGroupName, accountName, name string) (stor
 }
 
 // GetServiceProperties get service properties
-func (c *Client) GetServiceProperties(resourceGroupName, accountName string) (storage.FileServiceProperties, error) {
-	return c.fileServicesClient.GetServiceProperties(context.Background(), resourceGroupName, accountName)
+func (c *Client) GetServiceProperties(ctx context.Context, resourceGroupName, accountName string) (storage.FileServiceProperties, error) {
+	return c.fileServicesClient.GetServiceProperties(ctx, resourceGroupName, accountName)
 }
 
 // SetServiceProperties set service properties
-func (c *Client) SetServiceProperties(resourceGroupName, accountName string, parameters storage.FileServiceProperties) (storage.FileServiceProperties, error) {
-	return c.fileServicesClient.SetServiceProperties(context.Background(), resourceGroupName, accountName, parameters)
+func (c *Client) SetServiceProperties(ctx context.Context, resourceGroupName, accountName string, parameters storage.FileServiceProperties) (storage.FileServiceProperties, error) {
+	return c.fileServicesClient.SetServiceProperties(ctx, resourceGroupName, accountName, parameters)
 }

--- a/pkg/azureclients/fileclient/interface.go
+++ b/pkg/azureclients/fileclient/interface.go
@@ -17,17 +17,19 @@ limitations under the License.
 package fileclient
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 )
 
 // Interface is the client interface for creating file shares, interface for test injection.
 // Don't forget to run "hack/update-mock-clients.sh" command to generate the mock client.
 type Interface interface {
-	CreateFileShare(resourceGroupName, accountName string, shareOptions *ShareOptions) error
-	DeleteFileShare(resourceGroupName, accountName, name string) error
-	ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
-	GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error)
-	GetServiceProperties(resourceGroupName, accountName string) (storage.FileServiceProperties, error)
-	SetServiceProperties(resourceGroupName, accountName string, parameters storage.FileServiceProperties) (storage.FileServiceProperties, error)
+	CreateFileShare(ctx context.Context, resourceGroupName, accountName string, shareOptions *ShareOptions) error
+	DeleteFileShare(ctx context.Context, resourceGroupName, accountName, name string) error
+	ResizeFileShare(ctx context.Context, resourceGroupName, accountName, name string, sizeGiB int) error
+	GetFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error)
+	GetServiceProperties(ctx context.Context, resourceGroupName, accountName string) (storage.FileServiceProperties, error)
+	SetServiceProperties(ctx context.Context, resourceGroupName, accountName string, parameters storage.FileServiceProperties) (storage.FileServiceProperties, error)
 	WithSubscriptionID(subscriptionID string) Interface
 }

--- a/pkg/azureclients/fileclient/mockfileclient/interface.go
+++ b/pkg/azureclients/fileclient/mockfileclient/interface.go
@@ -22,6 +22,7 @@
 package mockfileclient
 
 import (
+	context "context"
 	reflect "reflect"
 
 	storage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
@@ -53,90 +54,90 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // CreateFileShare mocks base method.
-func (m *MockInterface) CreateFileShare(resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
+func (m *MockInterface) CreateFileShare(ctx context.Context, resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFileShare", resourceGroupName, accountName, shareOptions)
+	ret := m.ctrl.Call(m, "CreateFileShare", ctx, resourceGroupName, accountName, shareOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateFileShare indicates an expected call of CreateFileShare.
-func (mr *MockInterfaceMockRecorder) CreateFileShare(resourceGroupName, accountName, shareOptions interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) CreateFileShare(ctx, resourceGroupName, accountName, shareOptions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), resourceGroupName, accountName, shareOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), ctx, resourceGroupName, accountName, shareOptions)
 }
 
 // DeleteFileShare mocks base method.
-func (m *MockInterface) DeleteFileShare(resourceGroupName, accountName, name string) error {
+func (m *MockInterface) DeleteFileShare(ctx context.Context, resourceGroupName, accountName, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteFileShare", resourceGroupName, accountName, name)
+	ret := m.ctrl.Call(m, "DeleteFileShare", ctx, resourceGroupName, accountName, name)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteFileShare indicates an expected call of DeleteFileShare.
-func (mr *MockInterfaceMockRecorder) DeleteFileShare(resourceGroupName, accountName, name interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteFileShare(ctx, resourceGroupName, accountName, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileShare", reflect.TypeOf((*MockInterface)(nil).DeleteFileShare), resourceGroupName, accountName, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileShare", reflect.TypeOf((*MockInterface)(nil).DeleteFileShare), ctx, resourceGroupName, accountName, name)
 }
 
 // GetFileShare mocks base method.
-func (m *MockInterface) GetFileShare(resourceGroupName, accountName, name string) (storage.FileShare, error) {
+func (m *MockInterface) GetFileShare(ctx context.Context, resourceGroupName, accountName, name string) (storage.FileShare, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileShare", resourceGroupName, accountName, name)
+	ret := m.ctrl.Call(m, "GetFileShare", ctx, resourceGroupName, accountName, name)
 	ret0, _ := ret[0].(storage.FileShare)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFileShare indicates an expected call of GetFileShare.
-func (mr *MockInterfaceMockRecorder) GetFileShare(resourceGroupName, accountName, name interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) GetFileShare(ctx, resourceGroupName, accountName, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileShare", reflect.TypeOf((*MockInterface)(nil).GetFileShare), resourceGroupName, accountName, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileShare", reflect.TypeOf((*MockInterface)(nil).GetFileShare), ctx, resourceGroupName, accountName, name)
 }
 
 // GetServiceProperties mocks base method.
-func (m *MockInterface) GetServiceProperties(resourceGroupName, accountName string) (storage.FileServiceProperties, error) {
+func (m *MockInterface) GetServiceProperties(ctx context.Context, resourceGroupName, accountName string) (storage.FileServiceProperties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceProperties", resourceGroupName, accountName)
+	ret := m.ctrl.Call(m, "GetServiceProperties", ctx, resourceGroupName, accountName)
 	ret0, _ := ret[0].(storage.FileServiceProperties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetServiceProperties indicates an expected call of GetServiceProperties.
-func (mr *MockInterfaceMockRecorder) GetServiceProperties(resourceGroupName, accountName interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) GetServiceProperties(ctx, resourceGroupName, accountName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceProperties", reflect.TypeOf((*MockInterface)(nil).GetServiceProperties), resourceGroupName, accountName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceProperties", reflect.TypeOf((*MockInterface)(nil).GetServiceProperties), ctx, resourceGroupName, accountName)
 }
 
 // ResizeFileShare mocks base method.
-func (m *MockInterface) ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+func (m *MockInterface) ResizeFileShare(ctx context.Context, resourceGroupName, accountName, name string, sizeGiB int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResizeFileShare", resourceGroupName, accountName, name, sizeGiB)
+	ret := m.ctrl.Call(m, "ResizeFileShare", ctx, resourceGroupName, accountName, name, sizeGiB)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ResizeFileShare indicates an expected call of ResizeFileShare.
-func (mr *MockInterfaceMockRecorder) ResizeFileShare(resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) ResizeFileShare(ctx, resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileShare", reflect.TypeOf((*MockInterface)(nil).ResizeFileShare), resourceGroupName, accountName, name, sizeGiB)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileShare", reflect.TypeOf((*MockInterface)(nil).ResizeFileShare), ctx, resourceGroupName, accountName, name, sizeGiB)
 }
 
 // SetServiceProperties mocks base method.
-func (m *MockInterface) SetServiceProperties(resourceGroupName, accountName string, parameters storage.FileServiceProperties) (storage.FileServiceProperties, error) {
+func (m *MockInterface) SetServiceProperties(ctx context.Context, resourceGroupName, accountName string, parameters storage.FileServiceProperties) (storage.FileServiceProperties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetServiceProperties", resourceGroupName, accountName, parameters)
+	ret := m.ctrl.Call(m, "SetServiceProperties", ctx, resourceGroupName, accountName, parameters)
 	ret0, _ := ret[0].(storage.FileServiceProperties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetServiceProperties indicates an expected call of SetServiceProperties.
-func (mr *MockInterfaceMockRecorder) SetServiceProperties(resourceGroupName, accountName, parameters interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) SetServiceProperties(ctx, resourceGroupName, accountName, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetServiceProperties", reflect.TypeOf((*MockInterface)(nil).SetServiceProperties), resourceGroupName, accountName, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetServiceProperties", reflect.TypeOf((*MockInterface)(nil).SetServiceProperties), ctx, resourceGroupName, accountName, parameters)
 }
 
 // WithSubscriptionID mocks base method.

--- a/pkg/provider/azure_file.go
+++ b/pkg/provider/azure_file.go
@@ -17,24 +17,26 @@ limitations under the License.
 package provider
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/fileclient"
 )
 
 // create file share
-func (az *Cloud) createFileShare(subsID, resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
-	return az.FileClient.WithSubscriptionID(subsID).CreateFileShare(resourceGroupName, accountName, shareOptions)
+func (az *Cloud) createFileShare(ctx context.Context, subsID, resourceGroupName, accountName string, shareOptions *fileclient.ShareOptions) error {
+	return az.FileClient.WithSubscriptionID(subsID).CreateFileShare(ctx, resourceGroupName, accountName, shareOptions)
 }
 
-func (az *Cloud) deleteFileShare(subsID, resourceGroupName, accountName, name string) error {
-	return az.FileClient.WithSubscriptionID(subsID).DeleteFileShare(resourceGroupName, accountName, name)
+func (az *Cloud) deleteFileShare(ctx context.Context, subsID, resourceGroupName, accountName, name string) error {
+	return az.FileClient.WithSubscriptionID(subsID).DeleteFileShare(ctx, resourceGroupName, accountName, name)
 }
 
-func (az *Cloud) resizeFileShare(subsID, resourceGroupName, accountName, name string, sizeGiB int) error {
-	return az.FileClient.WithSubscriptionID(subsID).ResizeFileShare(resourceGroupName, accountName, name, sizeGiB)
+func (az *Cloud) resizeFileShare(ctx context.Context, subsID, resourceGroupName, accountName, name string, sizeGiB int) error {
+	return az.FileClient.WithSubscriptionID(subsID).ResizeFileShare(ctx, resourceGroupName, accountName, name, sizeGiB)
 }
 
-func (az *Cloud) getFileShare(subsID, resourceGroupName, accountName, name string) (storage.FileShare, error) {
-	return az.FileClient.WithSubscriptionID(subsID).GetFileShare(resourceGroupName, accountName, name)
+func (az *Cloud) getFileShare(ctx context.Context, subsID, resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return az.FileClient.WithSubscriptionID(subsID).GetFileShare(ctx, resourceGroupName, accountName, name)
 }

--- a/pkg/provider/azure_storage.go
+++ b/pkg/provider/azure_storage.go
@@ -54,7 +54,7 @@ func (az *Cloud) CreateFileShare(ctx context.Context, accountOptions *AccountOpt
 		return "", "", fmt.Errorf("could not get storage key for storage account %s: %w", accountOptions.Name, err)
 	}
 
-	if err := az.createFileShare(accountOptions.SubscriptionID, accountOptions.ResourceGroup, accountName, shareOptions); err != nil {
+	if err := az.createFileShare(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, accountName, shareOptions); err != nil {
 		return "", "", fmt.Errorf("failed to create share %s in account %s: %w", shareOptions.Name, accountName, err)
 	}
 	klog.V(4).Infof("created share %s in account %s", shareOptions.Name, accountOptions.Name)
@@ -62,8 +62,8 @@ func (az *Cloud) CreateFileShare(ctx context.Context, accountOptions *AccountOpt
 }
 
 // DeleteFileShare deletes a file share using storage account name and key
-func (az *Cloud) DeleteFileShare(subsID, resourceGroup, accountName, shareName string) error {
-	if err := az.deleteFileShare(subsID, resourceGroup, accountName, shareName); err != nil {
+func (az *Cloud) DeleteFileShare(ctx context.Context, subsID, resourceGroup, accountName, shareName string) error {
+	if err := az.deleteFileShare(ctx, subsID, resourceGroup, accountName, shareName); err != nil {
 		return err
 	}
 	klog.V(4).Infof("share %s deleted", shareName)
@@ -71,11 +71,11 @@ func (az *Cloud) DeleteFileShare(subsID, resourceGroup, accountName, shareName s
 }
 
 // ResizeFileShare resizes a file share
-func (az *Cloud) ResizeFileShare(subsID, resourceGroup, accountName, name string, sizeGiB int) error {
-	return az.resizeFileShare(subsID, resourceGroup, accountName, name, sizeGiB)
+func (az *Cloud) ResizeFileShare(ctx context.Context, subsID, resourceGroup, accountName, name string, sizeGiB int) error {
+	return az.resizeFileShare(ctx, subsID, resourceGroup, accountName, name, sizeGiB)
 }
 
 // GetFileShare gets a file share
-func (az *Cloud) GetFileShare(subsID, resourceGroupName, accountName, name string) (storage.FileShare, error) {
-	return az.getFileShare(subsID, resourceGroupName, accountName, name)
+func (az *Cloud) GetFileShare(ctx context.Context, subsID, resourceGroupName, accountName, name string) (storage.FileShare, error) {
+	return az.getFileShare(ctx, subsID, resourceGroupName, accountName, name)
 }

--- a/pkg/provider/azure_storage_test.go
+++ b/pkg/provider/azure_storage_test.go
@@ -150,7 +150,7 @@ func TestCreateFileShare(t *testing.T) {
 		mockFileClient := mockfileclient.NewMockInterface(ctrl)
 		cloud.FileClient = mockFileClient
 		mockFileClient.EXPECT().WithSubscriptionID(gomock.Any()).Return(mockFileClient).AnyTimes()
-		mockFileClient.EXPECT().CreateFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).AnyTimes()
+		mockFileClient.EXPECT().CreateFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).AnyTimes()
 
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
@@ -194,6 +194,9 @@ func TestDeleteFileShare(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
 	cloud := &Cloud{}
 	tests := []struct {
 		rg   string
@@ -224,9 +227,9 @@ func TestDeleteFileShare(t *testing.T) {
 		mockFileClient := mockfileclient.NewMockInterface(ctrl)
 		cloud.FileClient = mockFileClient
 		mockFileClient.EXPECT().WithSubscriptionID(gomock.Any()).Return(mockFileClient).AnyTimes()
-		mockFileClient.EXPECT().DeleteFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).Times(1)
+		mockFileClient.EXPECT().DeleteFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err).Times(1)
 
-		err := cloud.DeleteFileShare("", test.rg, test.acct, test.name)
+		err := cloud.DeleteFileShare(ctx, "", test.rg, test.acct, test.name)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue
@@ -242,10 +245,13 @@ func TestResizeFileShare(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
 	cloud := &Cloud{}
 	mockFileClient := mockfileclient.NewMockInterface(ctrl)
 	mockFileClient.EXPECT().WithSubscriptionID(gomock.Any()).Return(mockFileClient).AnyTimes()
-	mockFileClient.EXPECT().ResizeFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockFileClient.EXPECT().ResizeFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	cloud.FileClient = mockFileClient
 
 	tests := []struct {
@@ -270,7 +276,7 @@ func TestResizeFileShare(t *testing.T) {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
 
-		err := cloud.ResizeFileShare("", test.rg, test.acct, test.name, test.gb)
+		err := cloud.ResizeFileShare(ctx, "", test.rg, test.acct, test.name, test.gb)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue
@@ -286,10 +292,13 @@ func TestGetFileShare(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
 	cloud := &Cloud{}
 	mockFileClient := mockfileclient.NewMockInterface(ctrl)
 	mockFileClient.EXPECT().WithSubscriptionID(gomock.Any()).Return(mockFileClient).AnyTimes()
-	mockFileClient.EXPECT().GetFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(storage.FileShare{}, nil).AnyTimes()
+	mockFileClient.EXPECT().GetFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storage.FileShare{}, nil).AnyTimes()
 	cloud.FileClient = mockFileClient
 
 	tests := []struct {
@@ -312,7 +321,7 @@ func TestGetFileShare(t *testing.T) {
 		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
 		cloud.StorageAccountClient = mockStorageAccountsClient
 
-		_, err := cloud.GetFileShare("", test.rg, test.acct, test.name)
+		_, err := cloud.GetFileShare(ctx, "", test.rg, test.acct, test.name)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
 			continue

--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -318,7 +318,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 
 		if accountOptions.DisableFileServiceDeleteRetentionPolicy {
 			klog.V(2).Infof("disable DisableFileServiceDeleteRetentionPolicy on account(%s), subscroption(%s), resource group(%s)", accountName, subsID, resourceGroup)
-			prop, err := az.FileClient.WithSubscriptionID(subsID).GetServiceProperties(resourceGroup, accountName)
+			prop, err := az.FileClient.WithSubscriptionID(subsID).GetServiceProperties(ctx, resourceGroup, accountName)
 			if err != nil {
 				return "", "", err
 			}
@@ -326,7 +326,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 				return "", "", fmt.Errorf("FileServicePropertiesProperties of account(%s), subscroption(%s), resource group(%s) is nil", accountName, subsID, resourceGroup)
 			}
 			prop.FileServicePropertiesProperties.ShareDeleteRetentionPolicy = &storage.DeleteRetentionPolicy{Enabled: to.BoolPtr(false)}
-			if _, err := az.FileClient.WithSubscriptionID(subsID).SetServiceProperties(resourceGroup, accountName, prop); err != nil {
+			if _, err := az.FileClient.WithSubscriptionID(subsID).SetServiceProperties(ctx, resourceGroup, accountName, prop); err != nil {
 				return "", "", err
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
As the description in the issue https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1083, here we reuse the context from external-provisioner to cancel the context when timeout. Then the volume won't be locked in driver.
Now, we update the parameters in cloud provider azure. Then we will update azurefile csi driver repo to consume the new parameters.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1083

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
