### PR TITLE
[release-1.1] Retry if response StatusCode 200 and ContentLength -1

### DIFF
--- a/pkg/azureclients/armclient/azure_armclient.go
+++ b/pkg/azureclients/armclient/azure_armclient.go
@@ -146,6 +146,7 @@ func DoHackRegionalRetryDecorator(c *Client) autorest.SendDecorator {
 			// Hack: retry the regional ARM endpoint in case of ARM traffic split and arm resource group replication is too slow
 			// Empty content and 2xx http status code are returned in this case.
 			// Issue: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/1296
+			// Such situation also needs retrying that ContentLength is -1, StatusCode is 200 and an empty body is returned.
 			emptyResp := (response.ContentLength == 0 || trimmed == "" || trimmed == "{}") && response.StatusCode >= 200 && response.StatusCode < 300
 			if !emptyResp {
 				if rerr == nil || response.StatusCode == http.StatusNotFound || c.regionalEndpoint == "" {
@@ -154,7 +155,7 @@ func DoHackRegionalRetryDecorator(c *Client) autorest.SendDecorator {
 
 				var body map[string]interface{}
 				if e := json.Unmarshal(bodyBytes, &body); e != nil {
-					klog.Errorf("Send.sendRequest: error in parsing response body string: %s, Skip retrying regional host", e.Error())
+					klog.Errorf("Send.sendRequest: error in parsing response body string: %q, Skip retrying regional host", bodyBytes, e.Error())
 					return response, rerr
 				}
 				klog.V(5).Infof("Send.sendRequest original response: %s", bodyString)
@@ -166,6 +167,7 @@ func DoHackRegionalRetryDecorator(c *Client) autorest.SendDecorator {
 				}
 			}
 
+			// Do regional request
 			currentHost := request.URL.Host
 			if request.Host != "" {
 				currentHost = request.Host
@@ -190,9 +192,24 @@ func DoHackRegionalRetryDecorator(c *Client) autorest.SendDecorator {
 					regionalErrStr = regionalError.Error()
 				}
 
-				klog.V(5).Infof("Send.sendRegionalRequest failed to get response from regional host, error: '%s'. Ignoring the result.", regionalErrStr)
+				klog.V(5).Infof("Send.sendRegionalRequest failed to get response from regional host, error: %q. Ignoring the result.", regionalErrStr)
 				return response, rerr
 			}
+
+			// Do the same check on regional response just like the global one
+			bodyBytes, _ = ioutil.ReadAll(regionalResponse.Body)
+			defer func() {
+				regionalResponse.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+			}()
+			bodyString = string(bodyBytes)
+			trimmed = strings.TrimSpace(bodyString)
+			emptyResp = (regionalResponse.ContentLength == 0 || trimmed == "" || trimmed == "{}") && regionalResponse.StatusCode >= 200 && regionalResponse.StatusCode < 300
+			if emptyResp {
+				contentLengthErrStr := fmt.Sprintf("empty response with trimmed body %q, ContentLength %d and StatusCode %d", trimmed, regionalResponse.ContentLength, regionalResponse.StatusCode)
+				klog.Errorf(contentLengthErrStr)
+				return response, fmt.Errorf(contentLengthErrStr)
+			}
+
 			return regionalResponse, regionalError
 		})
 	}

--- a/pkg/azureclients/armclient/azure_armclient_test.go
+++ b/pkg/azureclients/armclient/azure_armclient_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -74,19 +75,28 @@ func TestSend(t *testing.T) {
 }
 func TestSendFailureRegionalRetry(t *testing.T) {
 	testcases := []struct {
-		description        string
-		globalServerErrMsg string
-		globalServerCode   int
+		description               string
+		globalServerErrMsg        string
+		globalServerCode          int
+		globalServerContentLength *string
 	}{
 		{
 			"RegionalRetry",
 			"{\"error\":{\"code\":\"ResourceGroupNotFound\"}}",
 			http.StatusInternalServerError,
+			to.StringPtr("100"),
 		},
 		{
-			"ReplicationLatency",
+			"ReplicationLatency-Content-Length-0",
 			"{}",
 			http.StatusOK,
+			to.StringPtr("0"),
+		},
+		{
+			"ReplicationLatency-Content-Length-minus-1",
+			"{}",
+			http.StatusOK,
+			to.StringPtr("-1"),
 		},
 	}
 
@@ -95,11 +105,14 @@ func TestSendFailureRegionalRetry(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
 				w.WriteHeader(http.StatusOK)
-				_, err := w.Write([]byte("{}"))
+				_, err := w.Write([]byte("{\"a\": \"b\"}"))
 				assert.NoError(t, err)
 			}))
 
 			globalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.globalServerContentLength != nil {
+					w.Header().Set("Content-Length", *tc.globalServerContentLength)
+				}
 				http.Error(w, tc.globalServerErrMsg, tc.globalServerCode)
 			}))
 			azConfig := azureclients.ClientConfig{Backoff: &retry.Backoff{Steps: 3}, UserAgent: "test", Location: "eastus"}
@@ -123,7 +136,7 @@ func TestSendFailureRegionalRetry(t *testing.T) {
 			assert.NoError(t, err)
 
 			response, rerr := armClient.Send(ctx, request)
-			assert.Nil(t, rerr)
+			assert.Nil(t, rerr, rerr.Error())
 			assert.Equal(t, http.StatusOK, response.StatusCode)
 			assert.Equal(t, targetURL.Host, response.Request.URL.Host)
 		})


### PR DESCRIPTION


Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
ARM will possibly return StatusCode 200 and ContentLength -1 which is a bug. However, cloudprovider can handle it better by retrying.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ARM will possibly return StatusCode 200 and ContentLength -1 which is a bug. However, cloudprovider can handle it better by retrying.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
