### PR TITLE
fix: Do not retry regional when request is not GET

### DIFF
--- a/pkg/azureclients/armclient/azure_armclient_test.go
+++ b/pkg/azureclients/armclient/azure_armclient_test.go
@@ -74,7 +74,7 @@ func TestSend(t *testing.T) {
 	assert.Equal(t, 2, count)
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 }
-func TestSendFailureRegionalRetry(t *testing.T) {
+func TestDoHackRegionalRetryForGET(t *testing.T) {
 	testcases := []struct {
 		description               string
 		globalServerErrMsg        string
@@ -120,24 +120,13 @@ func TestSendFailureRegionalRetry(t *testing.T) {
 			armClient := New(nil, azConfig, server.URL, "2019-01-01")
 			targetURL, _ := url.Parse(server.URL)
 			armClient.regionalEndpoint = targetURL.Host
-			pathParameters := map[string]interface{}{
-				"resourceGroupName": autorest.Encode("path", "testgroup"),
-				"subscriptionId":    autorest.Encode("path", "testid"),
-				"resourceName":      autorest.Encode("path", "testname"),
-			}
+			armClient.baseURI = globalServer.URL
 
-			decorators := []autorest.PrepareDecorator{
-				autorest.WithPathParameters(
-					"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vNets/{resourceName}", pathParameters),
-				autorest.WithBaseURL(globalServer.URL),
-			}
-
+			resourceID := "/subscriptions/testid/resourceGroups/restgroup/providers/Microsoft.Network/vNets/testname"
 			ctx := context.Background()
-			request, err := armClient.PrepareGetRequest(ctx, decorators...)
-			assert.NoError(t, err)
-
-			response, rerr := armClient.Send(ctx, request)
-			assert.Nil(t, rerr, rerr.Error())
+			response, rerr := armClient.GetResource(ctx, resourceID)
+			assert.Nil(t, rerr)
+			assert.NotNil(t, response)
 			assert.Equal(t, http.StatusOK, response.StatusCode)
 			assert.Equal(t, targetURL.Host, response.Request.URL.Host)
 		})

--- a/pkg/azureclients/armclient/util.go
+++ b/pkg/azureclients/armclient/util.go
@@ -103,8 +103,8 @@ func WithMetricsSendDecoratorWrapper(prefix, request, resourceGroup, subscriptio
 	return nil
 }
 
-// DoHackRegionalRetryDecorator returns an autorest.SendDecorator which performs retry with customizable backoff policy.
-func DoHackRegionalRetryDecorator(c *Client) autorest.SendDecorator {
+// DoHackRegionalRetryForGET checks if GET request returns empty response and retries regional server or returns error.
+func DoHackRegionalRetryForGET(c *Client) autorest.SendDecorator {
 	return func(s autorest.Sender) autorest.Sender {
 		return autorest.SenderFunc(func(request *http.Request) (*http.Response, error) {
 			response, rerr := s.Do(request)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Only check response body length when request is GET.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
related #2296 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Only check response body length when request is GET. Avoids unnecessary retry when deleting an LB.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
