### PR TITLE
add e2e tests for service annotations

### DIFF
--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -617,7 +617,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 	})
 
 	It("should support disabling floating IP in load balancer rule with kubernetes service annotations", func() {
-		By("creating a public IP with tags")
+		By("creating a public IP")
 		ipName := basename + "-public-IP" + string(uuid.NewUUID())[0:4]
 		pip := defaultPublicIPAddress(ipName)
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), pip)

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -238,6 +238,31 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		Expect(ret).To(BeTrue(), "external ip %s is not in the target subnet %s", ip, newSubnetCIDR)
 	})
 
+	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-enable-high-availability-ports'", func() {
+		if !strings.EqualFold(os.Getenv(utils.LoadBalancerSkuEnv), string(network.PublicIPAddressSkuNameStandard)) {
+			Skip("azure-load-balancer-enable-high-availability-ports only work with Standard Load Balancer")
+		}
+
+		annotation := map[string]string{
+			consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
+			consts.ServiceAnnotationLoadBalancerInternal:                    "true",
+		}
+		// create service with given annotation and wait it to expose
+		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		defer func() {
+			utils.Logf("cleaning up test service %s", serviceName)
+			err := utils.DeleteService(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		lb := getAzureInternalLoadBalancerFromPrivateIP(tc, ip, "")
+
+		Expect(len(*lb.LoadBalancingRules)).To(Equal(1))
+		rule := (*lb.LoadBalancingRules)[0]
+		Expect(*rule.FrontendPort).To(Equal(int32(0)))
+		Expect(*rule.BackendPort).To(Equal(int32(0)))
+	})
+
 	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout'", func() {
 		annotation := map[string]string{
 			consts.ServiceAnnotationLoadBalancerIdleTimeout: "5",
@@ -245,6 +270,11 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		// create service with given annotation and wait it to expose
 		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		defer func() {
+			By("Cleaning up service")
+			err := utils.DeleteService(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+		}()
 
 		// get lb from azure client
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
@@ -321,6 +351,62 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		ipList := []string{ip1, ip2}
 		Expect(validateSharedSecurityRuleExists(nsgs, ipList, port)).To(BeTrue(), "Security rule for service %s not exists", serviceName)
+	})
+
+	It("should support service annotation `service.beta.kubernetes.io/azure-additional-public-ips`", func() {
+		By("creating a public IP")
+		ipName := basename + "-public-IP" + string(uuid.NewUUID())[0:4]
+		pip := defaultPublicIPAddress(ipName)
+		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), pip)
+		Expect(err).NotTo(HaveOccurred())
+		additionalPIP := to.String(pip.IPAddress)
+		utils.Logf("created pip with address %s", additionalPIP)
+
+		By("Exposing service with additional pip")
+		annotation := map[string]string{
+			consts.ServiceAnnotationAdditionalPublicIPs: additionalPIP,
+		}
+		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		defer func() {
+			By("cleaning up")
+			err := utils.DeleteServiceIfExists(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			err = utils.DeletePIPWithRetry(tc, ipName, "")
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		err = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
+			service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
+			if err != nil {
+				if utils.IsRetryableAPIError(err) {
+					return false, nil
+				}
+				return false, err
+			}
+
+			utils.Logf("Checking additionalPIP in ingress")
+			foundInIngress := false
+			ingressList := service.Status.LoadBalancer.Ingress
+			Expect(ingressList).NotTo(BeNil())
+			for _, ingress := range ingressList {
+				if additionalPIP == ingress.IP {
+					foundInIngress = true
+					break
+				}
+			}
+
+			utils.Logf("Checking additionalPIP in nsg")
+			ipList := []string{ip, additionalPIP}
+			port := fmt.Sprintf("%d", serverPort)
+			nsgs, err := tc.GetClusterSecurityGroups()
+			if err != nil {
+				return false, err
+			}
+			foundInNsg := validateSharedSecurityRuleExists(nsgs, ipList, port)
+
+			return foundInIngress && foundInNsg, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should support service annotation `service.beta.kubernetes.io/azure-pip-tags`", func() {
@@ -504,20 +590,22 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 	})
 
-	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe' and port specific configs", func() {
+	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probe', 'service.beta.kubernetes.io/azure-load-balancer-health-probe-interval', 'service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol' and port specific configs", func() {
 		By("Creating a service with health probe annotations")
 		annotation := map[string]string{
-			consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe:                                   "5",
-			consts.BuildHealthProbeAnnotationKeyForPort(serverPort, consts.HealthProbeParamsNumOfProbe): "3",
+			consts.ServiceAnnotationLoadBalancerHealthProbeNumOfProbe:                                      "5",
+			consts.BuildHealthProbeAnnotationKeyForPort(serverPort, consts.HealthProbeParamsNumOfProbe):    "3",
+			consts.ServiceAnnotationLoadBalancerHealthProbeInterval:                                        "15",
+			consts.BuildHealthProbeAnnotationKeyForPort(serverPort, consts.HealthProbeParamsProbeInterval): "10",
+			consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:                                        "Http",
+			consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath:                                     "/",
 		}
 
 		// create service with given annotation and wait it to expose
 		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
-			By("Cleaning up service and public IP")
+			By("Cleaning up service")
 			err := utils.DeleteService(cs, ns.Name, serviceName)
-			Expect(err).NotTo(HaveOccurred())
-			err = utils.DeletePIPWithRetry(tc, publicIP, tc.GetResourceGroup())
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		pipFrontendConfigID := getPIPFrontendConfigurationID(tc, publicIP, tc.GetResourceGroup(), "")
@@ -546,53 +634,20 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		By("Validating health probe configs")
 		var numberOfProbes *int32
+		var intervalInSeconds *int32
 		for _, probe := range targetProbes {
 			if probe.NumberOfProbes != nil {
 				numberOfProbes = probe.NumberOfProbes
 			}
-		}
-		Expect(*numberOfProbes).To(Equal(int32(3)))
-	})
-	It("should support service annotation 'service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol' and port specific configs", func() {
-		By("Creating a service with health probe annotations")
-		annotation := map[string]string{
-			consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:    "Http",
-			consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath: "/",
-		}
-
-		// create service with given annotation and wait it to expose
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
-		defer func() {
-			By("Cleaning up service and public IP")
-			err := utils.DeleteService(cs, ns.Name, serviceName)
-			Expect(err).NotTo(HaveOccurred())
-			err = utils.DeletePIPWithRetry(tc, publicIP, tc.GetResourceGroup())
-			Expect(err).NotTo(HaveOccurred())
-		}()
-		pipFrontendConfigID := getPIPFrontendConfigurationID(tc, publicIP, tc.GetResourceGroup(), "")
-		pipFrontendConfigIDSplit := strings.Split(pipFrontendConfigID, "/")
-		Expect(len(pipFrontendConfigIDSplit)).NotTo(Equal(0))
-
-		var lb *network.LoadBalancer
-		var targetProbes []*network.Probe
-		//wait for backend update
-		err := wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
-			lb = getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
-			targetProbes = []*network.Probe{}
-			for i := range *lb.LoadBalancerPropertiesFormat.Probes {
-				probe := (*lb.LoadBalancerPropertiesFormat.Probes)[i]
-				utils.Logf("One probe of LB is %q", *probe.Name)
-				probeSplit := strings.Split(*probe.Name, "-")
-				Expect(len(probeSplit)).NotTo(Equal(0))
-				if pipFrontendConfigIDSplit[len(pipFrontendConfigIDSplit)-1] == probeSplit[0] {
-					targetProbes = append(targetProbes, &probe)
-				}
+			if probe.IntervalInSeconds != nil {
+				intervalInSeconds = probe.IntervalInSeconds
 			}
-			return len(targetProbes) == 1, nil
-		})
-		Expect(err).NotTo(HaveOccurred())
-		// get lb from azure client
-		By("Validating health probe configs")
+		}
+		utils.Logf("Validating health probe config numberOfProbes")
+		Expect(*numberOfProbes).To(Equal(int32(3)))
+		utils.Logf("Validating health probe config intervalInSeconds")
+		Expect(*intervalInSeconds).To(Equal(int32(10)))
+		utils.Logf("Validating health probe config protocol")
 		Expect((len(targetProbes))).To(Equal(1))
 		Expect(targetProbes[0].Protocol).To(Equal(network.ProbeProtocolHTTP))
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add missing e2e tests for following service annotations:
1. `ServiceAnnotationAdditionalPublicIPs`
2. `ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts`
3. `ServiceAnnotationLoadBalancerHealthProbeInterval`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Note that improving test for annotation `ServiceAnnotationLoadBalancerMode` needs to change cloud-config. I will implement that in the next PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
