### PR TITLE
VMSS Flex Support: Cloud Node Manager should query resourceId field of IMDS endpoint to retrieve providerID

### DIFF
--- a/pkg/provider/azure_instance_metadata.go
+++ b/pkg/provider/azure_instance_metadata.go
@@ -72,6 +72,7 @@ type ComputeMetadata struct {
 	ResourceGroup          string `json:"resourceGroupName,omitempty"`
 	VMScaleSetName         string `json:"vmScaleSetName,omitempty"`
 	SubscriptionID         string `json:"subscriptionId,omitempty"`
+	ResourceID             string `json:"resourceId,omitempty"`
 }
 
 // InstanceMetadata represents instance information.

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -117,6 +117,7 @@ func TestInstanceID(t *testing.T) {
 		nodeName            string
 		vmssName            string
 		metadataName        string
+		resourceID          string
 		metadataTemplate    string
 		vmType              string
 		expectedID          string
@@ -130,6 +131,7 @@ func TestInstanceID(t *testing.T) {
 			vmList:              []string{"vm1"},
 			nodeName:            "vm1",
 			metadataName:        "vm1",
+			resourceID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
 			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
@@ -140,6 +142,7 @@ func TestInstanceID(t *testing.T) {
 			vmssName:            "vmss1",
 			nodeName:            "vmss1_0",
 			metadataName:        "vmss1_0",
+			resourceID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0",
 			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0",
@@ -150,6 +153,7 @@ func TestInstanceID(t *testing.T) {
 			vmssName:            "vmss1",
 			nodeName:            "vmss1-0",
 			metadataName:        "vmss1-0",
+			resourceID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vmss1-0",
 			vmType:              consts.VMTypeStandard,
 			useInstanceMetadata: true,
 			expectedID:          "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vmss1-0",
@@ -225,7 +229,7 @@ func TestInstanceID(t *testing.T) {
 			if test.metadataTemplate != "" {
 				fmt.Fprintf(w, test.metadataTemplate)
 			} else {
-				fmt.Fprintf(w, "{\"compute\":{\"name\":\"%s\",\"VMScaleSetName\":\"%s\",\"subscriptionId\":\"subscription\",\"resourceGroupName\":\"rg\"}}", test.metadataName, test.vmssName)
+				fmt.Fprintf(w, "{\"compute\":{\"name\":\"%s\",\"VMScaleSetName\":\"%s\",\"subscriptionId\":\"subscription\",\"resourceGroupName\":\"rg\", \"resourceId\":\"%s\"}}", test.metadataName, test.vmssName, test.resourceID)
 			}
 		}))
 		go func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Error Description:
When using VMSS Flex as K8s nodes, if the VM is created by using the VMSS default VM profile and increasing the capacity, then Cloud Node Manager (CNM) will generate the wrong ProviderID for the node.
 
Root Causes:
There are 2 issues in the existing CNM code that cause the error:
 
Issue 1: CNM UNSAFELY distinguishes Uniform VM and Non Uniform VM by just checking if the VM name contains underscore (_): if the VM name contains underscore, then CNM treats the VM as VMSS Uniform node, then further assumes the part before underscore is vmss name; if the VM name does not contain underscore, then CNM treats the VM as non Uniform node : [https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/pkg/provider/azure_instances.go#L394-L403](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fkubernetes-sigs%2Fcloud-provider-azure%2Fblob%2Fmaster%2Fpkg%2Fprovider%2Fazure_instances.go%23L394-L403&data=05%7C01%7CMingyang.Zheng%40microsoft.com%7Cc54c9eca910b449c47d508da9d1f9f69%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637995056425554883%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Cz7VTKMgpJgJXIdLgIOYeQSOZcSLNE0yqS520NqXw2E%3D&reserved=0)
 
Issue 2: By using the node type checking result in Issue 1, CNM manually combine resourceGroupName, subId, vmName to generate a providerID: [https://github.com/kubernetes-sigs/cloud-provider-azure/blob/8752101d1949db993c918052eb27a58c439c312b/pkg/provider/azure_vmss.go#L611-L617](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fkubernetes-sigs%2Fcloud-provider-azure%2Fblob%2F8752101d1949db993c918052eb27a58c439c312b%2Fpkg%2Fprovider%2Fazure_vmss.go%23L611-L617&data=05%7C01%7CMingyang.Zheng%40microsoft.com%7Cc54c9eca910b449c47d508da9d1f9f69%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637995056425554883%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=jyftxM2BX9Fb%2FG4eDR2knqt%2FkH8y3VcY5ykw2sfFm%2Fo%3D&reserved=0)
 
Why These 2 Issues Cause Wrong ProviderID:
When using VMSS Flex VM as K8s cluster nodes, if the VM is provisioned by using the VMSS default VM profile, then the VM Name always have VMSS Flex name as prefiex (vmssFlexName_). In this case, CNM finds the underscore behind the vmssFlexName and judges it as a VMSS Uniform VM because of Issue 1. Then CNM manually generate a VMSS Uniform format ProviderID by combining the resourceGroup and subId because of Issue 2.

Proposal:
CNM can directly use the resourceId field in the IMDS response as ProviderID, no matter what the vm type it is: [https://learn.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux#access-azure-instance-metadata-service](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fvirtual-machines%2Flinux%2Finstance-metadata-service%3Ftabs%3Dlinux%23access-azure-instance-metadata-service&data=05%7C01%7CMingyang.Zheng%40microsoft.com%7Cc54c9eca910b449c47d508da9d1f9f69%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637995056425554883%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=MwwXqfDSK6c%2F9Nc05egWTpaIX%2FIdynJiEEn3%2BoE5Xts%3D&reserved=0).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer to #639 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
