### PR TITLE
fix: avoid recreate vmss cache in race condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20220908164124-27713097b956
 	golang.org/x/text v0.4.0
 	k8s.io/api v0.25.3
@@ -100,7 +101,6 @@ require (
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -121,7 +121,7 @@ func (c *controllerCommon) getNodeVMSet(nodeName types.NodeName, crt azcache.Azu
 	}
 
 	// 2. vmType is Virtual Machine Scale Set (vmss), convert vmSet to ScaleSet.
-	// 2.1 all the nodes in the cluster are vmss unifrom nodes.
+	// 2.1 all the nodes in the cluster are vmss uniform nodes.
 	// 2.2 mix node: the nodes in the cluster can be any of avset nodes, vmss uniform nodes and vmssflex nodes.
 	ss, ok := c.cloud.VMSet.(*ScaleSet)
 	if !ok {

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	"golang.org/x/sync/singleflight"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -91,6 +92,8 @@ type ScaleSet struct {
 
 	// lockMap in cache refresh
 	lockMap *lockMap
+	// group represents a class of work and units of work can be executed with duplicate suppression
+	group singleflight.Group
 }
 
 // newScaleSet creates a new ScaleSet.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: avoid recreate vmss cache in race condition
In race condition, there could be duplicated `getVMSSVMCache` calls, and it would end up with creating two vmss cache objects, related logs:
<details>

```
I1018 03:18:45.242671       1 azure_vmss.go:204] Couldn't find VMSS VM with nodeName aks-agentpool-34156162-vmss00000j, refreshing the cache(vmss: aks-agentpool-34156162-vmss, rg: aksdiskscaleai2f68d-nodegroup)
I1018 03:18:45.242671       1 azure_vmss.go:204] Couldn't find VMSS VM with nodeName aks-agentpool-34156162-vmss00000j, refreshing the cache(vmss: aks-agentpool-34156162-vmss, rg: aksdiskscaleai2f68d-nodegroup)

I1018 03:18:47.272599       1 azure_vmss.go:204] Couldn't find VMSS VM with nodeName aks-agentpool-34156162-vmss00000x, refreshing the cache(vmss: aks-agentpool-34156162-vmss, rg: aksdiskscaleai2f68d-nodegroup)
I1018 03:18:47.272599       1 azure_vmss.go:204] Couldn't find VMSS VM with nodeName aks-agentpool-34156162-vmss00000x, refreshing the cache(vmss: aks-agentpool-34156162-vmss, rg: aksdiskscaleai2f68d-nodegroup)

I1018 03:18:51.474445       1 azure_vmss.go:204] Couldn't find VMSS VM with nodeName aks-agentpool-34156162-vmss00000l, refreshing the cache(vmss: aks-agentpool-34156162-vmss, rg: aksdiskscaleai2f68d-nodegroup)
I1018 03:18:51.474445       1 azure_vmss.go:204] Couldn't find VMSS VM with nodeName aks-agentpool-34156162-vmss00000l, refreshing the cache(vmss: aks-agentpool-34156162-vmss, rg: aksdiskscaleai2f68d-nodegroup)
```

</details>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: avoid recreate vmss cache in race condition
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: avoid recreate vmss cache in race condition
```
