### PR TITLE
Fix Bug: NetworkApiVersionMustBeSpecifiedWithNetworkInterfaceConfigurations for VMSS Flex Network Profile operation

### DIFF
--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -724,6 +724,7 @@ func (fs *FlexScaleSet) ensureVMSSFlexInPool(service *v1.Service, nodes []*v1.No
 				VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
 					NetworkProfile: &compute.VirtualMachineScaleSetNetworkProfile{
 						NetworkInterfaceConfigurations: &vmssNIC,
+						NetworkAPIVersion:              compute.TwoZeroTwoZeroHyphenMinusOneOneHyphenMinusZeroOne,
 					},
 				},
 			},
@@ -854,6 +855,7 @@ func (fs *FlexScaleSet) EnsureBackendPoolDeletedFromVMSets(vmssNamesMap map[stri
 					VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
 						NetworkProfile: &compute.VirtualMachineScaleSetNetworkProfile{
 							NetworkInterfaceConfigurations: &vmssNIC,
+							NetworkAPIVersion:              compute.TwoZeroTwoZeroHyphenMinusOneOneHyphenMinusZeroOne,
 						},
 					},
 				},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In the current code, CCM fails to add/delete LB backendPool from VMSS Flex with error:
```
E1101 21:37:22.222983 1 controller.go:320] error processing service default/elb (will retry): failed to ensure load balancer: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
"error": {
"details": [],
"code": "NetworkApiVersionMustBeSpecifiedWithNetworkInterfaceConfigurations",
"message": "Network api version in network profile of virtual machine /subscriptions/ccde0aa8-3434-40ee-8442-13c8e4160d62/resourceGroups/MIZHE-K8SFLEX/providers/Microsoft.Compute/virtualMachines/k8sflex-mp-079f5ae27-ce00-4aa4-a161-18803ce7a3d5 must be specified if network interface configurations are specified."
}
}
```
Below is the reponse from VMSS Flex team:

**"With VMSS Uniform, the NetworkProfile is a subset of what is available in the full NIC API. Someone from NRP has to remember to update the VMSS Network Profile after they make updates to the NIC API.  With VMSS Flex we wanted to get out of that business. We pass the NetworkProfile params directly to NRP for them to create the NICs, but we also need you to pass the correct NetworkAPIVersion to NRP so they know what to valdiate against. This way, when they make updates/additions to the NIC API, you can take advantage of it immediately by updating the vmss.networkApiVersion "**

To fix this issue, below field is added to the VMSS Flex update request:

NetworkAPIVersion:  compute.TwoZeroTwoZeroHyphenMinusOneOneHyphenMinusZeroOne,

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2697 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
