### PR TITLE
[release-1.23] Deepcopy results of cache Get()

### DIFF
--- a/pkg/cache/azure_cache.go
+++ b/pkg/cache/azure_cache.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/util/deepcopy"
 )
 
 // AzureCacheReadType defines the read type for cache data
@@ -120,8 +122,14 @@ func (t *TimedCache) getInternal(key string) (*AzureCacheEntry, error) {
 	return newEntry, nil
 }
 
-// Get returns the requested item by key.
+// Get returns the requested item by key with deep copy.
 func (t *TimedCache) Get(key string, crt AzureCacheReadType) (interface{}, error) {
+	data, err := t.get(key, crt)
+	copied := deepcopy.Copy(data)
+	return copied, err
+}
+
+func (t *TimedCache) get(key string, crt AzureCacheReadType) (interface{}, error) {
 	entry, err := t.getInternal(key)
 	if err != nil {
 		return nil, err

--- a/pkg/cache/azure_cache_test.go
+++ b/pkg/cache/azure_cache_test.go
@@ -30,7 +30,7 @@ const (
 	fakeCacheTTL = 2 * time.Second
 )
 
-type fakeDataObj struct{}
+type fakeDataObj struct{ Data string }
 
 type fakeDataSource struct {
 	called int
@@ -116,6 +116,40 @@ func TestCacheGetError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, getError, err)
 	assert.Nil(t, val)
+}
+
+func TestCacheGetWithDeepCopy(t *testing.T) {
+	changed, unchanged := "changed", "unchanged"
+	valFake := &fakeDataObj{unchanged}
+	cases := []struct {
+		name     string
+		data     map[string]*fakeDataObj
+		key      string
+		expected interface{}
+	}{
+		{
+			name:     "cache should return data for existing key",
+			data:     map[string]*fakeDataObj{"key1": valFake},
+			key:      "key1",
+			expected: unchanged,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dataSource, cache := newFakeCache(t)
+			dataSource.set(c.data)
+			cache.Set(c.key, valFake)
+			val, err := cache.Get(c.key, CacheReadTypeDefault)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, val.(*fakeDataObj).Data)
+
+			// Change the value
+			valFake.Data = changed
+			cache.Set(c.key, valFake)
+			assert.Equal(t, c.expected, val.(*fakeDataObj).Data)
+		})
+	}
 }
 
 func TestCacheDelete(t *testing.T) {

--- a/pkg/provider/azure_routes_test.go
+++ b/pkg/provider/azure_routes_test.go
@@ -168,7 +168,8 @@ func TestDeleteRouteDualStack(t *testing.T) {
 			Routes: &[]network.Route{},
 		},
 	}
-	routeTableClient.EXPECT().Get(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, "").Return(routeTables, nil).AnyTimes()
+	routeTableClient.EXPECT().Get(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, "").Return(routeTables, nil)
+	routeTableClient.EXPECT().Get(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, "").Return(routeTablesAfterFirstDeletion, nil)
 	routeTableClient.EXPECT().CreateOrUpdate(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, routeTablesAfterFirstDeletion, "").Return(nil)
 	routeTableClient.EXPECT().CreateOrUpdate(gomock.Any(), cloud.RouteTableResourceGroup, cloud.RouteTableName, routeTablesAfterSecondDeletion, "").Return(nil)
 	err := cloud.DeleteRoute(context.TODO(), "cluster", &route)

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -449,9 +449,9 @@ type availabilitySet struct {
 	vmasCache *azcache.TimedCache
 }
 
-type availabilitySetEntry struct {
-	vmas          *compute.AvailabilitySet
-	resourceGroup string
+type AvailabilitySetEntry struct {
+	VMAS          *compute.AvailabilitySet
+	ResourceGroup string
 }
 
 func (as *availabilitySet) newVMASCache() (*azcache.TimedCache, error) {
@@ -476,9 +476,9 @@ func (as *availabilitySet) newVMASCache() (*azcache.TimedCache, error) {
 					klog.Warning("failed to get the name of the VMAS")
 					continue
 				}
-				localCache.Store(to.String(vmas.Name), &availabilitySetEntry{
-					vmas:          &vmas,
-					resourceGroup: resourceGroup,
+				localCache.Store(to.String(vmas.Name), &AvailabilitySetEntry{
+					VMAS:          &vmas,
+					ResourceGroup: resourceGroup,
 				})
 			}
 		}
@@ -1239,8 +1239,8 @@ func (as *availabilitySet) getAvailabilitySetByNodeName(nodeName string, crt azc
 
 	var result *compute.AvailabilitySet
 	vmasList.Range(func(_, value interface{}) bool {
-		vmasEntry := value.(*availabilitySetEntry)
-		vmas := vmasEntry.vmas
+		vmasEntry := value.(*AvailabilitySetEntry)
+		vmas := vmasEntry.VMAS
 		if vmas != nil && vmas.AvailabilitySetProperties != nil && vmas.VirtualMachines != nil {
 			for _, vmIDRef := range *vmas.VirtualMachines {
 				if vmIDRef.ID != nil {

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2545,13 +2545,14 @@ func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
@@ -2617,13 +2618,14 @@ func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCre
 	testRuleName3 := "shared-UDP-4444-Internet"
 
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
@@ -2689,13 +2691,14 @@ func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRules
 	testRuleName3 := "shared-TCP-80-192.168.34.0_24"
 
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
@@ -2763,18 +2766,20 @@ func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSepara
 
 	testRuleName23 := testRuleName2
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
-	_, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
@@ -2861,13 +2866,14 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 	expectedRuleName := testRuleName
 
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
@@ -2875,6 +2881,7 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 
 	validateSecurityGroup(t, sg, svc1, svc2)
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
@@ -2922,18 +2929,20 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 
 	testRuleName23 := testRuleName2
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
-	_, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
@@ -2941,6 +2950,7 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 
 	validateSecurityGroup(t, sg, svc1, svc2, svc3)
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
@@ -3030,18 +3040,20 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 
 	testRuleName23 := testRuleName2
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
-	_, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
@@ -3049,11 +3061,13 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 
 	validateSecurityGroup(t, sg, svc1, svc2, svc3)
 
-	_, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc3: %q", err)
@@ -3125,11 +3139,11 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	expectedRuleName5 := az.getSecurityRuleName(&svc5, v1.ServicePort{Port: 8888, Protocol: v1.ProtocolTCP}, "Internet")
 
 	sg := getTestSecurityGroup(az)
-	setMockSecurityGroup(az, ctrl, sg)
 
 	for i, svc := range testServices {
 		svc := svc
-		_, err := az.reconcileSecurityGroup(testClusterName, &testServices[i], to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
+		setMockSecurityGroup(az, ctrl, sg)
+		sg, err = az.reconcileSecurityGroup(testClusterName, &testServices[i], to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
 		if err != nil {
 			t.Errorf("Unexpected error adding svc%d: %q", i+1, err)
 		}
@@ -3221,11 +3235,13 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 		}
 	}
 
-	_, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
 
+	setMockSecurityGroup(az, ctrl, sg)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc5, to.StringPtr(getServiceLoadBalancerIP(&svc5)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc5: %q", err)

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -122,8 +122,8 @@ func (ss *ScaleSet) getVMSS(vmssName string, crt azcache.AzureCacheReadType) (*c
 
 		vmsses := cached.(*sync.Map)
 		if vmss, ok := vmsses.Load(vmssName); ok {
-			result := vmss.(*vmssEntry)
-			return result.vmss, nil
+			result := vmss.(*VMSSEntry)
+			return result.VMSS, nil
 		}
 
 		return nil, nil
@@ -167,9 +167,9 @@ func (ss *ScaleSet) getVmssVMByNodeIdentity(node *nodeIdentity, crt azcache.Azur
 
 		virtualMachines := cached.(*sync.Map)
 		if vm, ok := virtualMachines.Load(nodeName); ok {
-			result := vm.(*vmssVirtualMachinesEntry)
+			result := vm.(*VMSSVirtualMachinesEntry)
 			found = true
-			return result.vmssName, result.instanceID, result.virtualMachine, found, nil
+			return result.VMSSName, result.InstanceID, result.VirtualMachine, found, nil
 		}
 
 		return "", "", nil, found, nil
@@ -296,11 +296,11 @@ func (ss *ScaleSet) getVmssVMByInstanceID(resourceGroup, scaleSetName, instanceI
 
 		virtualMachines := cached.(*sync.Map)
 		virtualMachines.Range(func(key, value interface{}) bool {
-			vmEntry := value.(*vmssVirtualMachinesEntry)
-			if strings.EqualFold(vmEntry.resourceGroup, resourceGroup) &&
-				strings.EqualFold(vmEntry.vmssName, scaleSetName) &&
-				strings.EqualFold(vmEntry.instanceID, instanceID) {
-				vm = vmEntry.virtualMachine
+			vmEntry := value.(*VMSSVirtualMachinesEntry)
+			if strings.EqualFold(vmEntry.ResourceGroup, resourceGroup) &&
+				strings.EqualFold(vmEntry.VMSSName, scaleSetName) &&
+				strings.EqualFold(vmEntry.InstanceID, instanceID) {
+				vm = vmEntry.VirtualMachine
 				found = true
 				return false
 			}
@@ -683,21 +683,21 @@ func (ss *ScaleSet) getNodeIdentityByNodeName(nodeName string, crt azcache.Azure
 
 		vmsses := cached.(*sync.Map)
 		vmsses.Range(func(key, value interface{}) bool {
-			v := value.(*vmssEntry)
-			if v.vmss.Name == nil {
+			v := value.(*VMSSEntry)
+			if v.VMSS.Name == nil {
 				return true
 			}
 
-			vmssPrefix := *v.vmss.Name
-			if v.vmss.VirtualMachineProfile != nil &&
-				v.vmss.VirtualMachineProfile.OsProfile != nil &&
-				v.vmss.VirtualMachineProfile.OsProfile.ComputerNamePrefix != nil {
-				vmssPrefix = *v.vmss.VirtualMachineProfile.OsProfile.ComputerNamePrefix
+			vmssPrefix := *v.VMSS.Name
+			if v.VMSS.VirtualMachineProfile != nil &&
+				v.VMSS.VirtualMachineProfile.OsProfile != nil &&
+				v.VMSS.VirtualMachineProfile.OsProfile.ComputerNamePrefix != nil {
+				vmssPrefix = *v.VMSS.VirtualMachineProfile.OsProfile.ComputerNamePrefix
 			}
 
 			if strings.EqualFold(vmssPrefix, nodeName[:len(nodeName)-6]) {
-				node.vmssName = *v.vmss.Name
-				node.resourceGroup = v.resourceGroup
+				node.vmssName = *v.VMSS.Name
+				node.resourceGroup = v.ResourceGroup
 				return false
 			}
 
@@ -1504,8 +1504,8 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVMSS(backendPoolID, vmSetName st
 		var errorList []error
 		walk := func(key, value interface{}) bool {
 			var vmss *compute.VirtualMachineScaleSet
-			if vmssEntry, ok := value.(*vmssEntry); ok {
-				vmss = vmssEntry.vmss
+			if vmssEntry, ok := value.(*VMSSEntry); ok {
+				vmss = vmssEntry.VMSS
 			} else if v, ok := value.(*compute.VirtualMachineScaleSet); ok {
 				vmss = v
 			}
@@ -1843,7 +1843,7 @@ func (ss *ScaleSet) GetAgentPoolVMSetNames(nodes []*v1.Node) (*[]string, error) 
 			if err != nil {
 				return nil, fmt.Errorf("GetAgentPoolVMSetNames: failed to get availabilitySetNodesCache")
 			}
-			vms := cached.(*availabilitySetNodeEntry).vms
+			vms := cached.(*AvailabilitySetNodeEntry).VMs
 			names, err = as.getAgentPoolAvailabilitySets(vms, []*v1.Node{node})
 			if err != nil {
 				return nil, fmt.Errorf("GetAgentPoolVMSetNames: failed to execute getAgentPoolAvailabilitySets: %w", err)

--- a/pkg/provider/azure_vmss_cache_test.go
+++ b/pkg/provider/azure_vmss_cache_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
@@ -122,15 +121,6 @@ func TestVMSSVMCache(t *testing.T) {
 	err = ss.DeleteCacheForNode(vmName)
 	assert.NoError(t, err)
 
-	// the VM should be removed from cache after DeleteCacheForNode().
-	cacheKey, cache, err := ss.getVMSSVMCache("rg", testVMSSName)
-	assert.NoError(t, err)
-	cached, err := cache.Get(cacheKey, azcache.CacheReadTypeDefault)
-	assert.NoError(t, err)
-	cachedVirtualMachines := cached.(*sync.Map)
-	_, ok := cachedVirtualMachines.Load(vmName)
-	assert.Equal(t, false, ok)
-
 	// the VM should be back after another cache refresh.
 	ssName, instanceID, realVM, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 	assert.NoError(t, err)
@@ -151,18 +141,20 @@ func TestDeleteCacheForAvailabilitySetNodeInVMSS(t *testing.T) {
 
 	mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]compute.VirtualMachine{
 		{Name: to.StringPtr("vm1")},
-	}, nil).AnyTimes()
+	}, nil)
+	mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]compute.VirtualMachine{}, nil).AnyTimes()
 	ss.cloud.nodeNames = sets.NewString("vm1")
 
 	err = ss.DeleteCacheForNode("vm1")
 	assert.NoError(t, err)
 
+	ss.cloud.nodeNames = sets.NewString()
 	cached, err := ss.availabilitySetNodesCache.Get(consts.AvailabilitySetNodesKey, azcache.CacheReadTypeUnsafe)
 	assert.NoError(t, err)
-	entry := cached.(*availabilitySetNodeEntry)
-	assert.Equal(t, 0, len(entry.nodeNames))
-	assert.Equal(t, 0, len(entry.vmNames))
-	assert.Equal(t, 0, len(entry.vms))
+	entry := cached.(*AvailabilitySetNodeEntry)
+	assert.Equal(t, 0, len(entry.NodeNames))
+	assert.Equal(t, 0, len(entry.VMNames))
+	assert.Equal(t, 0, len(entry.VMs))
 }
 
 func TestVMSSVMCacheWithDeletingNodes(t *testing.T) {

--- a/pkg/util/deepcopy/deepcopy.go
+++ b/pkg/util/deepcopy/deepcopy.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deepcopy
+
+import (
+	"reflect"
+	"sync"
+)
+
+type deepCopyInterface interface {
+	DeepCopy() interface{}
+}
+
+// Copy deepcopies from v.
+func Copy(src interface{}) interface{} {
+	if src == nil {
+		return nil
+	}
+
+	if fromSyncMap, ok := src.(*sync.Map); ok {
+		to := copySyncMap(fromSyncMap)
+		return to
+	}
+
+	return copyNormal(src)
+}
+
+// copySyncMap copies with sync.Map but not nested
+// Targets are vmssVMCache, vmssFlexVMCache, etc.
+func copySyncMap(from *sync.Map) *sync.Map {
+	to := &sync.Map{}
+
+	from.Range(func(k, v interface{}) bool {
+		vm, ok := v.(*sync.Map)
+		if ok {
+			to.Store(k, copySyncMap(vm))
+		} else {
+			to.Store(k, copyNormal(v))
+		}
+		return true
+	})
+
+	return to
+}
+
+func copyNormal(src interface{}) interface{} {
+	if src == nil {
+		return nil
+	}
+
+	from := reflect.ValueOf(src)
+
+	to := reflect.New(from.Type()).Elem()
+
+	copy(from, to)
+
+	return to.Interface()
+}
+
+func copy(from, to reflect.Value) {
+	// Check if DeepCopy() is already implemented for the interface
+	if from.CanInterface() {
+		if deepcopy, ok := from.Interface().(deepCopyInterface); ok {
+			to.Set(reflect.ValueOf(deepcopy.DeepCopy()))
+			return
+		}
+	}
+
+	switch from.Kind() {
+	case reflect.Ptr:
+		fromValue := from.Elem()
+		if !fromValue.IsValid() {
+			return
+		}
+
+		to.Set(reflect.New(fromValue.Type()))
+		copy(fromValue, to.Elem())
+
+	case reflect.Interface:
+		if from.IsNil() {
+			return
+		}
+
+		fromValue := from.Elem()
+		toValue := reflect.New(fromValue.Type()).Elem()
+		copy(fromValue, toValue)
+		to.Set(toValue)
+
+	case reflect.Struct:
+		for i := 0; i < from.NumField(); i++ {
+			if from.Type().Field(i).PkgPath != "" {
+				// It is an unexported field.
+				continue
+			}
+			copy(from.Field(i), to.Field(i))
+		}
+
+	case reflect.Slice:
+		if from.IsNil() {
+			return
+		}
+
+		to.Set(reflect.MakeSlice(from.Type(), from.Len(), from.Cap()))
+		for i := 0; i < from.Len(); i++ {
+			copy(from.Index(i), to.Index(i))
+		}
+
+	case reflect.Map:
+		if from.IsNil() {
+			return
+		}
+
+		to.Set(reflect.MakeMap(from.Type()))
+		for _, key := range from.MapKeys() {
+			fromValue := from.MapIndex(key)
+			toValue := reflect.New(fromValue.Type()).Elem()
+			copy(fromValue, toValue)
+			copiedKey := Copy(key.Interface())
+			to.SetMapIndex(reflect.ValueOf(copiedKey), toValue)
+		}
+
+	default:
+		to.Set(from)
+	}
+}

--- a/pkg/util/deepcopy/deepcopy_test.go
+++ b/pkg/util/deepcopy/deepcopy_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deepcopy
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeStruct struct {
+	Name string
+}
+
+type fakeIntf interface {
+	Get() string
+}
+
+func (f fakeStruct) Get() string {
+	return f.Name
+}
+
+// TestCopyBasic tests object with pointer, struct, map, slice, interface.
+func TestCopyBasic(t *testing.T) {
+	zones := []string{"zone0", "zone1"}
+	var vmOriginal *compute.VirtualMachine = &compute.VirtualMachine{
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			ProvisioningState: to.StringPtr("Failed"),
+		},
+		Name:  to.StringPtr("vmOriginal"),
+		Zones: &zones,
+		Tags: map[string]*string{
+			"tag0": to.StringPtr("tagVal0"),
+		},
+	}
+	vmCopied := Copy(vmOriginal).(*compute.VirtualMachine)
+
+	psOriginal := vmOriginal.VirtualMachineProperties.ProvisioningState
+	psCopied := vmCopied.VirtualMachineProperties.ProvisioningState
+	assert.Equal(t, psOriginal, psCopied)
+	assert.Equal(t, vmOriginal.Name, vmCopied.Name)
+	assert.Equal(t, vmOriginal.Zones, vmCopied.Zones)
+	assert.Equal(t, vmOriginal.Tags, vmCopied.Tags)
+
+	var fakeOriginal fakeIntf = fakeStruct{Name: "fakeOriginal"}
+	fakeCopied := Copy(fakeOriginal).(fakeIntf)
+	assert.Equal(t, fakeOriginal.Get(), fakeCopied.Get())
+}
+
+// TestCopyVMInSyncMap tests object like compute.VirtualMachine in a sync.Map.
+func TestCopyVMInSyncMap(t *testing.T) {
+	var vmOriginal *compute.VirtualMachine = &compute.VirtualMachine{
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			ProvisioningState: to.StringPtr("Failed"),
+		},
+		Name: to.StringPtr("vmOriginal"),
+	}
+	vmCacheOriginal := &sync.Map{}
+	vmCacheOriginal.Store("vmOriginal", vmOriginal)
+	vmCacheCopied := Copy(vmCacheOriginal).(*sync.Map)
+
+	psOriginal := vmOriginal.VirtualMachineProperties.ProvisioningState
+	vCopied, ok := vmCacheCopied.Load("vmOriginal")
+	assert.True(t, ok)
+	vmCopied := vCopied.(*compute.VirtualMachine)
+	psCopied := vmCopied.VirtualMachineProperties.ProvisioningState
+	assert.Equal(t, psOriginal, psCopied)
+	assert.Equal(t, vmOriginal.Name, vmCopied.Name)
+}
+
+type vmssEntry struct {
+	*compute.VirtualMachineScaleSet
+	Name *string
+}
+
+// TestCopyVMSSEntryInSyncMap tests object like vmssEntry in sync.Map.
+func TestCopyVMSSEntryInSyncMap(t *testing.T) {
+	vmssEntryOriginal := &vmssEntry{
+		Name: to.StringPtr("vmssEntryName"),
+		VirtualMachineScaleSet: &compute.VirtualMachineScaleSet{
+			Name: to.StringPtr("vmssOriginal"),
+		},
+	}
+	vmssCacheOriginal := &sync.Map{}
+	vmssCacheOriginal.Store("vmssEntry", vmssEntryOriginal)
+	vmssCacheCopied := Copy(vmssCacheOriginal)
+
+	vCopied, ok := vmssCacheCopied.(*sync.Map).Load("vmssEntry")
+	assert.True(t, ok)
+	vmssEntryCopied := vCopied.(*vmssEntry)
+	entryNameOriginal := vmssEntryOriginal.Name
+	entryNameCopied := vmssEntryCopied.Name
+	assert.Equal(t, entryNameOriginal, entryNameCopied)
+	vmNameOriginal := vmssEntryOriginal.VirtualMachineScaleSet.Name
+	vmNameCopied := vmssEntryCopied.VirtualMachineScaleSet.Name
+	assert.Equal(t, vmNameOriginal, vmNameCopied)
+}


### PR DESCRIPTION


Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[release-1.23] Deepcopy results of cache Get()
Considering thread safety, results of cache Get() should be deepcopied before used.
* Support deepcopy and add UT for all types
* Add TestGet UT
* Update current UT
* Make Entry structs exported to adjust for deepcopy
* Delete cacheKey for VMSS VM and VMSS deletion

#2445 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Considering thread safety, results of cache Get() should be deepcopied before used.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
