### PR TITLE
[WIP] fix: remove lb from vmss when the backend pool is empty

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -522,12 +522,10 @@ func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs
 
 // safeDeleteLoadBalancer deletes the load balancer after decoupling it from the vmSet
 func (az *Cloud) safeDeleteLoadBalancer(lb network.LoadBalancer, clusterName, vmSetName string, service *v1.Service) *retry.Error {
-	if isLBBackendPoolTypeIPConfig(service, &lb, clusterName) {
-		lbBackendPoolID := az.getBackendPoolID(to.String(lb.Name), az.getLoadBalancerResourceGroup(), getBackendPoolName(clusterName, service))
-		err := az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, lb.BackendAddressPools, true)
-		if err != nil {
-			return retry.NewError(false, fmt.Errorf("safeDeleteLoadBalancer: failed to EnsureBackendPoolDeleted: %w", err))
-		}
+	lbBackendPoolID := az.getBackendPoolID(to.String(lb.Name), az.getLoadBalancerResourceGroup(), getBackendPoolName(clusterName, service))
+	err := az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, lb.BackendAddressPools, true)
+	if err != nil {
+		return retry.NewError(false, fmt.Errorf("safeDeleteLoadBalancer: failed to EnsureBackendPoolDeleted: %w", err))
 	}
 
 	klog.V(2).Infof("safeDeleteLoadBalancer: deleting LB %s", to.String(lb.Name))

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -261,22 +261,6 @@ func getNodePrivateIPAddresses(node *v1.Node) []string {
 	return addresses
 }
 
-func isLBBackendPoolTypeIPConfig(service *v1.Service, lb *network.LoadBalancer, clusterName string) bool {
-	if lb == nil || lb.LoadBalancerPropertiesFormat == nil || lb.BackendAddressPools == nil {
-		klog.V(4).Infof("isLBBackendPoolTypeIPConfig: no backend pools in the LB %s", to.String(lb.Name))
-		return false
-	}
-	lbBackendPoolName := getBackendPoolName(clusterName, service)
-	for _, bp := range *lb.BackendAddressPools {
-		if strings.EqualFold(to.String(bp.Name), lbBackendPoolName) {
-			return bp.BackendAddressPoolPropertiesFormat != nil &&
-				bp.BackendIPConfigurations != nil &&
-				len(*bp.BackendIPConfigurations) != 0
-		}
-	}
-	return false
-}
-
 func getBoolValueFromServiceAnnotations(service *v1.Service, key string) bool {
 	if l, found := service.Annotations[key]; found {
 		return strings.EqualFold(strings.TrimSpace(l), consts.TrueAnnotationValue)

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1732,7 +1732,7 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVMSS(backendPoolID, vmSetName st
 	if err != nil {
 		return err
 	}
-	if !ss.DisableAvailabilitySetNodes || ss.EnableVmssFlexNodes {
+	if ss.EnableVmssFlexNodes {
 		flexScaleSet := ss.flexScaleSet.(*FlexScaleSet)
 		err = flexScaleSet.ensureBackendPoolDeletedFromVmssFlex(backendPoolID, vmSetName)
 	}

--- a/tests/e2e/node/vmss.go
+++ b/tests/e2e/node/vmss.go
@@ -68,8 +68,6 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 		numInstance := *vmss.Sku.Capacity
 		utils.Logf("Current VMSS %q sku capacity: %d", *vmss.Name, numInstance)
 		expectedCap := map[string]int64{*vmss.Name: numInstance}
-		originalNodes, err := utils.GetAgentNodes(k8sCli)
-		Expect(err).NotTo(HaveOccurred())
 
 		By("deallocate VMSS instance")
 		if strings.EqualFold(os.Getenv(utils.CAPZTestCCM), "true") {
@@ -90,7 +88,7 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 			Expect(err).NotTo(HaveOccurred())
 			expectedCap[*vmss.Name] = numInstance
 
-			err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap, originalNodes)
+			err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap)
 			Expect(err).NotTo(HaveOccurred())
 
 			vmssAfterTest, err := utils.GetVMSS(azCli, *vmss.Name)
@@ -98,7 +96,7 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 			utils.Logf("VMSS %q sku capacity after the test: %d", *vmssAfterTest.Name, *vmssAfterTest.Sku.Capacity)
 		}()
 
-		err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap, originalNodes)
+		err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -112,8 +110,6 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 		numInstance := *vmss.Sku.Capacity
 		utils.Logf("Current VMSS %q sku capacity: %d", *vmss.Name, numInstance)
 		expectedCap := map[string]int64{*vmss.Name: numInstance}
-		originalNodes, err := utils.GetAgentNodes(k8sCli)
-		Expect(err).NotTo(HaveOccurred())
 
 		By("allocate VMSS instance")
 		if strings.EqualFold(os.Getenv(utils.CAPZTestCCM), "true") {
@@ -134,7 +130,7 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 			Expect(err).NotTo(HaveOccurred())
 			expectedCap[*vmss.Name] = numInstance
 
-			err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap, originalNodes)
+			err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap)
 			Expect(err).NotTo(HaveOccurred())
 
 			vmssAfterTest, err := utils.GetVMSS(azCli, *vmss.Name)
@@ -142,7 +138,7 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 			utils.Logf("VMSS %q sku capacity after the test: %d", *vmssAfterTest.Name, *vmssAfterTest.Sku.Capacity)
 		}()
 
-		err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap, originalNodes)
+		err = utils.ValidateClusterNodesMatchVMSSInstances(azCli, expectedCap)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

`safeDeleteLoadBalancer` uses `isLBBackendPoolTypeIPConfig` to determine if we should call `vmSet. EnsureBackendPoolDeleted`, because for IP-based backend pools, we don't need to decouple the vmss from the lb before we delete the lb. But `isLBBackendPoolTypeIPConfig` cannot tell the backend pool type if it is empty. In this case, the lb cannot be deleted if the vmss (not the vmss vms) is still referencing the lb. This PR removes the check. If the backend pool is IP-based, `vmSet.EnsureBackendPoolDeleted` will be a no-op.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: remove lb from vmss when the backend pool is empty
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
