### PR TITLE
[E2E][VMSS Flex] Modify E2E tests for VMSS Flex cluster

### DIFF
--- a/tests/e2e/autoscaling/autoscaler.go
+++ b/tests/e2e/autoscaling/autoscaler.go
@@ -331,7 +331,7 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 
 	It("should support scaling up or down Azure Spot VM", Label(utils.TestSuiteLabelVMSS, utils.TestSuiteLabelSpotVM), func() {
 		By("Checking the spot vms")
-		scaleSets, err := utils.ListVMSSes(tc)
+		scaleSets, err := utils.ListUniformVMSSes(tc)
 		Expect(err).NotTo(HaveOccurred())
 
 		if len(scaleSets) == 0 {

--- a/tests/e2e/network/node.go
+++ b/tests/e2e/network/node.go
@@ -87,12 +87,14 @@ var _ = Describe("Azure node resources", Label(utils.TestSuiteLabelNode), func()
 		if vms != nil && len(*vms) != 0 {
 			for _, vm := range *vms {
 				nodeName, err := utils.GetVMComputerName(vm)
+				utils.Logf("nodeName: %s", nodeName)
 				Expect(err).NotTo(HaveOccurred())
 
 				node, err := utils.GetNode(cs, strings.ToLower(nodeName))
 				Expect(err).NotTo(HaveOccurred())
 
 				providerID := node.Spec.ProviderID
+				utils.Logf("providerID: %s", providerID)
 				providerIDMatches := vmProviderIDRE.FindStringSubmatch(providerID)
 				Expect(len(providerIDMatches)).To(Equal(4))
 				Expect(strings.EqualFold(providerIDMatches[1], subscriptionID)).To(BeTrue())
@@ -102,7 +104,7 @@ var _ = Describe("Azure node resources", Label(utils.TestSuiteLabelNode), func()
 		}
 
 		utils.Logf("getting VMSS VMs")
-		vmsses, err := utils.ListVMSSes(tc)
+		vmsses, err := utils.ListUniformVMSSes(tc)
 		Expect(err).NotTo(HaveOccurred())
 
 		if len(vmsses) != 0 {
@@ -130,7 +132,7 @@ var _ = Describe("Azure node resources", Label(utils.TestSuiteLabelNode), func()
 	})
 
 	It("should set correct private IP address for every node", func() {
-		utils.Logf("getting all NICs of availabilitySet VMs")
+		utils.Logf("getting all NICs of availabilitySet VMs and vmssflex VMs")
 		vmasNICs, err := utils.ListNICs(tc, tc.GetResourceGroup())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -173,8 +175,8 @@ var _ = Describe("Azure node resources", Label(utils.TestSuiteLabelNode), func()
 			Expect(found).To(BeTrue())
 		}
 
-		utils.Logf("getting all scale sets")
-		vmsses, err := utils.ListVMSSes(tc)
+		utils.Logf("getting all uniform scale sets")
+		vmsses, err := utils.ListUniformVMSSes(tc)
 		Expect(err).NotTo(HaveOccurred())
 
 		utils.Logf("getting all NICs of VMSSes")

--- a/tests/e2e/network/standard_lb.go
+++ b/tests/e2e/network/standard_lb.go
@@ -114,7 +114,7 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 		utils.Logf("got BackendIPConfigurations IDs: %v", ipcIDs)
 
 		// Check if it is a cluster with VMSS
-		vmsses, err := utils.ListVMSSes(tc)
+		vmsses, err := utils.ListUniformVMSSes(tc)
 		Expect(err).NotTo(HaveOccurred())
 		if len(vmsses) != 0 {
 			allVMs := []azcompute.VirtualMachineScaleSetVM{}
@@ -140,6 +140,7 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 			}
 			utils.Logf("Validation succeeded for a VMSS cluster")
 		} else {
+			// AvSet VMs, standalone VMs, VMSS Flex VMs
 			vms, err := utils.ListVMs(tc)
 			Expect(err).NotTo(HaveOccurred())
 			for _, vm := range *vms {

--- a/tests/e2e/node/vmss.go
+++ b/tests/e2e/node/vmss.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -62,8 +63,8 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 		By("fetch VMSS")
 		vmss, err := utils.FindTestVMSS(azCli, azCli.GetResourceGroup())
 		Expect(err).NotTo(HaveOccurred())
-		if vmss == nil {
-			Skip("skip non-VMSS")
+		if vmss == nil || vmss.OrchestrationMode == compute.Flexible {
+			Skip("skip non-VMSS or VMSS Flex")
 		}
 		numInstance := *vmss.Sku.Capacity
 		utils.Logf("Current VMSS %q sku capacity: %d", *vmss.Name, numInstance)
@@ -106,8 +107,8 @@ var _ = Describe("Lifecycle of VMSS", Label(utils.TestSuiteLabelVMSS), func() {
 		By("fetch VMSS")
 		vmss, err := utils.FindTestVMSS(azCli, azCli.GetResourceGroup())
 		Expect(err).NotTo(HaveOccurred())
-		if vmss == nil {
-			Skip("skip non-VMSS")
+		if vmss == nil || vmss.OrchestrationMode == compute.Flexible {
+			Skip("skip non-VMSS or VMSS Flex")
 		}
 		numInstance := *vmss.Sku.Capacity
 		utils.Logf("Current VMSS %q sku capacity: %d", *vmss.Name, numInstance)

--- a/tests/e2e/utils/vmss_utils.go
+++ b/tests/e2e/utils/vmss_utils.go
@@ -193,7 +193,7 @@ func ValidateClusterNodesMatchVMSSInstances(tc *AzureTestClient, expectedCap map
 		}
 
 		// ignore error; check intersection of sets instead.
-		vmssList, _ := ListVMSSes(tc)
+		vmssList, _ := ListUniformVMSSes(tc)
 		capMatch := true
 		for _, vmss := range vmssList {
 			vms, err := ListVMSSVMs(tc, *vmss.Name)
@@ -280,8 +280,8 @@ func GetVMSS(tc *AzureTestClient, vmssName string) (azcompute.VirtualMachineScal
 	return vmssClient.Get(context.Background(), tc.GetResourceGroup(), vmssName, "")
 }
 
-// ListVMSSes returns the list of scale sets
-func ListVMSSes(tc *AzureTestClient) ([]azcompute.VirtualMachineScaleSet, error) {
+// ListUniformVMSSes returns the list of scale sets
+func ListUniformVMSSes(tc *AzureTestClient) ([]azcompute.VirtualMachineScaleSet, error) {
 	vmssClient := tc.createVMSSClient()
 
 	list, err := vmssClient.List(context.Background(), tc.GetResourceGroup())
@@ -290,7 +290,14 @@ func ListVMSSes(tc *AzureTestClient) ([]azcompute.VirtualMachineScaleSet, error)
 	}
 
 	res := list.Values()
-	return res, nil
+	vmssUniforms := make([]azcompute.VirtualMachineScaleSet, 0)
+	for i := range res {
+		vmssUniform := res[i]
+		if vmssUniform.OrchestrationMode == "" || vmssUniform.OrchestrationMode == azcompute.Uniform {
+			vmssUniforms = append(vmssUniforms, vmssUniform)
+		}
+	}
+	return vmssUniforms, nil
 }
 
 // GetVMSSVMComputerName returns the corresponding node name of the VMSS VM


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR modifies E2E tests for VMSS Flex cluster

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer to #2731 

#### Special notes for your reviewer:
Currently, 5 of 48 tests fails for VMSS Flex:
<img width="941" alt="image" src="https://user-images.githubusercontent.com/24629574/201029827-e24cda00-f4f3-4796-94be-77ddac8fc11c.png">
<img width="664" alt="image" src="https://user-images.githubusercontent.com/24629574/201029890-b8c65ff4-2cdb-4cec-aaf1-3c6da92ffca9.png">
This PR tries to resolve the failed tests:
- Lifecycle of VMSS should add node object when VMSS instance allocated [VMSS]: This test is skipped for VMSS Flex since the test logic only works for VMSS Uniform
- Lifecycle of VMSS should delete node object when VMSS instance deallocated [VMSS]: This test is skipped for VMSS Flex since the test logic only works for VMSS Uniform
- [StandardLoadBalancer] Standard load balancer should add all nodes in different agent pools to backends [Multi-Nodepool]: Modify this test to work with both VMSS Flex and Uniform
- Azure node resources should set correct private IP address for every node [Node]: Modify this test to work with both VMSS Flex and Uniform
- Azure node resources should set node provider id correctly [Node]: don't find the root cause why this test fails. Added some logs to help debug.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
