### PR TITLE
[e2e] Larger service timeout

### DIFF
--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -210,15 +210,32 @@ func WaitCreatePIP(azureTestClient *AzureTestClient, ipName, rgName string, ipPa
 	if err != nil {
 		return pip, err
 	}
+	// TODO: Because of latency at ARM side, List() instead of Get()
+	// is used here to ensure CCM is working properly.
 	err = wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
-		pip, err = pipClient.Get(context.Background(), rgName, ipName, "")
+		result, err := pipClient.List(context.Background(), rgName)
 		if err != nil {
 			if !IsRetryableAPIError(err) {
 				return false, err
 			}
 			return false, nil
 		}
-		return pip.IPAddress != nil, nil
+		if result.NotDone() {
+			for i := range result.Values() {
+				currentPIP := result.Values()[i]
+				if *currentPIP.Name == ipName {
+					if currentPIP.IPAddress == nil {
+						return false, nil
+					}
+					pip = currentPIP
+					return true, nil
+				}
+			}
+			if err := result.Next(); err != nil {
+				return false, fmt.Errorf("failed to get PIP result next page: %v", err)
+			}
+		}
+		return false, nil
 	})
 	return pip, err
 }

--- a/tests/e2e/utils/service_utils.go
+++ b/tests/e2e/utils/service_utils.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	serviceTimeout        = 5 * time.Minute
+	serviceTimeout        = 10 * time.Minute
 	serviceTimeoutBasicLB = 10 * time.Minute
 	pullInterval          = 10 * time.Second
 	pullTimeout           = 3 * time.Minute


### PR DESCRIPTION


Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Larger service timeout
* Use List() not Get() in WaitCreatePIP()
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
