### PR TITLE
feat: add system assigned identity support for kubetest2-aks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 bin/
 obj/
 testResults/
-_artifacts
 _report
 _output/
 translations/
@@ -29,3 +28,8 @@ site/public/
 
 # helm chart verification
 chart_verify/
+
+# kubetest2
+_artifacts
+_kubeconfig
+_rundir

--- a/kubetest2-aks/README.md
+++ b/kubetest2-aks/README.md
@@ -1,31 +1,36 @@
-This is the kubetest2-aks repo to provision and delete aks clusters.
+# kubetest2-aks repo to provision and delete aks clusters
 
 ## Commands
-Make kubetest2-aks binary
-```
+
+Make kubetest2-aks binary under kubetest2-aks folder.
+
+```shell
 make install-deployer
 ```
 
 Build CCM images with target path or tags. Note: users should login the registry.
-```
+
+```shell
 export IMAGE_REGISTRY=<user-image-registry>
 
-kubetest2 aks --build --target cloud-provider-azure --targetPath ../cloud-provider-azure
-kubetest2 aks --build --target cloud-provider-azure --targetPath --targetTag v1.24.4
+kubetest2 aks --build --target ccm --targetPath ../cloud-provider-azure
+kubetest2 aks --build --target ccm --targetPath --targetTag v1.24.4
 ```
 
-Provision an aks cluster in a resource group
-```
+Provision an aks cluster in a resource group.
+
+```shell
 export AZURE_SUBSCRIPTION_ID=<subscription-id>
 export AZURE_TENANT_ID=<tenant-id>
+export IMAGE_REGISTRY=<user-image-registry>
+# Leaving `AZURE_CLIENT_SECRET` and `AZURE_CLIENT_ID` unset will use MSI by default.
 export AZURE_CLIENT_ID=<client-id>
 export AZURE_CLIENT_SECRET=<client-secret>
-export IMAGE_REGISTRY=<user-image-registry>
-
 kubetest2 aks --up --rgName aks-resource-group --location eastus --config cluster-templates/basic-lb.json --customConfig cluster-templates/customconfiguration.json  --clusterName aks-cluster --ccmImageTag abcdefg --k8sVersion 1.24.0
 ```
 
-Delete the resource group
-```
+Delete the resource group.
+
+```shell
 kubetest2 aks --down --rgName aks-resource-group --clusterName aks-cluster
 ```

--- a/kubetest2-aks/cluster-templates/autoscaling-multipool.json
+++ b/kubetest2-aks/cluster-templates/autoscaling-multipool.json
@@ -15,7 +15,7 @@
       {
         "name": "agentpool1",
         "count": 1,
-        "mode" : "System",
+        "mode": "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
         "availabilityProfile": "VirtualMachineScaleSets",
@@ -27,7 +27,7 @@
       {
         "name": "agentpool2",
         "count": 1,
-        "mode" : "System",
+        "mode": "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
         "availabilityProfile": "VirtualMachineScaleSets",
@@ -37,10 +37,6 @@
         "minCount": 1
       }
     ],
-    "servicePrincipalProfile": {
-        "clientId": "{AZURE_CLIENT_ID}",
-        "secret": "{AZURE_CLIENT_SECRET}"
-    },
     "encodedCustomConfiguration": "{CUSTOM_CONFIG}"
   }
 }

--- a/kubetest2-aks/cluster-templates/autoscaling.json
+++ b/kubetest2-aks/cluster-templates/autoscaling.json
@@ -15,7 +15,7 @@
       {
         "name": "agentpool1",
         "count": 1,
-        "mode" : "System",
+        "mode": "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
         "availabilityProfile": "VirtualMachineScaleSets",
@@ -25,10 +25,6 @@
         "minCount": 1
       }
     ],
-    "servicePrincipalProfile": {
-        "clientId": "{AZURE_CLIENT_ID}",
-        "secret": "{AZURE_CLIENT_SECRET}"
-    },
     "encodedCustomConfiguration": "{CUSTOM_CONFIG}"
   }
 }

--- a/kubetest2-aks/cluster-templates/basic-lb.json
+++ b/kubetest2-aks/cluster-templates/basic-lb.json
@@ -15,17 +15,13 @@
       {
         "name": "agentpool1",
         "count": 2,
-        "mode" : "System",
+        "mode": "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
         "availabilityProfile": "VirtualMachineScaleSets",
         "storageProfile": "ManagedDisks"
       }
     ],
-    "servicePrincipalProfile": {
-        "clientId": "{AZURE_CLIENT_ID}",
-        "secret": "{AZURE_CLIENT_SECRET}"
-    },
     "encodedCustomConfiguration": "{CUSTOM_CONFIG}",
     "networkProfile": {
       "loadBalancerSku": "Basic"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
MSI is preferable over service principal in consideration of future maintenance and has been the default credential in AKS to manage AKS resource groups for a while.
This PR add system-assigned identity support to kubetest2-aks and remove credentials in the log output, which is better to be sanitized.


The test has been done:
- When SP is specified, AKS cluster is created with SP:
```
➜  kubetest2-aks git:(kube-aks-msi) ✗ kubetest2 aks --up --rgName aks-resource-group4 --location eastus --config cluster-templates/basic-lb.json --customConfig cluster-templates/customconfiguration.json
--clusterName aks-cluster --ccmImageTag abcdefg --k8sVersion 1.24.6
I1206 02:02:06.670723 1027879 app.go:61] The files in RunDir shall not be part of Artifacts
I1206 02:02:06.670785 1027879 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I1206 02:02:06.670824 1027879 app.go:64] RunDir for this run: "/home/azureuser/go/src/sigs.k8s.io/cloud-provider-azure/kubetest2-aks/_rundir/bf16f39c-f039-4eee-bbdb-7d453838e324"
I1206 02:02:06.675565 1027879 app.go:128] ID for this run: "bf16f39c-f039-4eee-bbdb-7d453838e324"
I1206 02:02:08.400261 1027879 up.go:281] Resource group /subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aks-resource-group4 created
I1206 02:02:08.400301 1027879 up.go:179] Creating the AKS cluster with custom config
I1206 02:02:08.400391 1027879 up.go:141] AKS cluster config without credential: {
  "id": "/subscriptions/<my-sub>/resourcegroups/aks-resource-group4/providers/Microsoft.ContainerService/managedClusters/aks-cluster",
  "name": "aks-cluster",
  "location": "eastus",
  "type": "Microsoft.ContainerService/ManagedClusters",
  "properties": {
    "kubernetesVersion": "1.24.6",
    "dnsPrefix": "aks",
    "masterProfile": {
      "count": 3,
      "dnsPrefix": "{dnsPrefix}",
      "vmSize": "Standard_DS2_v2"
    },
    "agentPoolProfiles": [
      {
        "name": "agentpool1",
        "count": 2,
        "mode": "System",
        "vmSize": "Standard_DS2_v2",
        "osType": "Linux",
        "availabilityProfile": "VirtualMachineScaleSets",
        "storageProfile": "ManagedDisks"
      }
    ],
    "encodedCustomConfiguration": "ewogICJrdWJlcm5ldGVzQ29uZmlndXJhdGlvbnMiOiB7CiAgICAia3ViZS1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIiOiB7CiAgICAgICJpbWFnZSI6ICIvYXp1cmUtY2xvdWQtY29udHJvbGxlci1tYW5hZ2VyOmFiY2RlZmciLAogICAgICAiY29uZmlnIjogewogICAgICAgICAgIi0tbWluLXJlc3luYy1wZXJpb2QiOiAiMTBoMG0wcyIsCiAgICAgICAgICAiLS1wcm9maWxpbmciOiAiZmFsc2UiLAogICAgICAgICAgIi0tdiI6ICI2IgogICAgICB9CiAgICB9LAogICAgImt1YmUtY2xvdWQtbm9kZS1tYW5hZ2VyIjogewogICAgICAiaW1hZ2UiOiAiL2F6dXJlLWNsb3VkLW5vZGUtbWFuYWdlcjphYmNkZWZnLWxpbnV4LWFtZDY0IiwKICAgICAgImNvbmZpZyI6IHsKICAgICAgICAgICItLW5vZGUtbmFtZSI6ICIkKE5PREVfTkFNRSkiLAogICAgICAgICAgImt1YmUtYXBpLWJ1cnN0IjogIjUwIiwKICAgICAgICAgICJrdWJlLWFwaS1xcHMiOiAiNTAiCiAgICAgIH0KICAgIH0KICB9Cn0K",
    "networkProfile": {
      "loadBalancerSku": "Basic"
    }
  }
}
I1206 02:02:08.400616 1027879 up.go:154] Updating Azure credentials to manage cluster resource group
I1206 02:02:08.400639 1027879 up.go:157] Service principal is used to manage cluster resource group
I1206 02:05:18.090127 1027879 up.go:200] An AKS cluster "aks-cluster" in resource group "aks-resource-group4" is creating
I1206 02:05:18.090170 1027879 up.go:301] Waiting for AKS cluster to be up
I1206 02:05:18.838246 1027879 up.go:206] Retrieving AKS cluster's kubeconfig
I1206 02:05:19.347176 1027879 up.go:242] Succeeded in getting kubeconfig of cluster "aks-cluster" in resource group "aks-resource-group4"
```

- When SP is not set, system-assigned identity is used:
```
➜  kubetest2-aks git:(kube-aks-msi) unset AZURE_CLIENT_SECRET
➜  kubetest2-aks git:(kube-aks-msi) unset AZURE_CLIENT_ID
➜  kubetest2-aks git:(kube-aks-msi) kubetest2 aks --up --rgName aks-resource-group5 --location eastus --config cluster-templates/basic-lb.json --customConfig cluster-templates/customconfiguration.json  --clusterName aks-cluster --ccmImageTag abcdefg --k8sVersion 1.24.6
I1206 02:20:47.717344 1042905 app.go:61] The files in RunDir shall not be part of Artifacts
I1206 02:20:47.717403 1042905 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I1206 02:20:47.717440 1042905 app.go:64] RunDir for this run: "/home/azureuser/go/src/sigs.k8s.io/cloud-provider-azure/kubetest2-aks/_rundir/2d06180c-6d6f-4299-830e-79b37b9b47cd"
I1206 02:20:47.722936 1042905 app.go:128] ID for this run: "2d06180c-6d6f-4299-830e-79b37b9b47cd"
I1206 02:20:49.847278 1042905 up.go:281] Resource group /subscriptions/8ecadfc9-d1a3-4ea4-b844-0d9f87e4d7c8/resourceGroups/aks-resource-group5 created
I1206 02:20:49.847322 1042905 up.go:179] Creating the AKS cluster with custom config
I1206 02:20:49.847402 1042905 up.go:141] AKS cluster config without credential: {
  "id": "/subscriptions/<my-sub>/resourcegroups/aks-resource-group5/providers/Microsoft.ContainerService/managedClusters/aks-cluster",
  "name": "aks-cluster",
  "location": "eastus",
  "type": "Microsoft.ContainerService/ManagedClusters",
  "properties": {
    "kubernetesVersion": "1.24.6",
    "dnsPrefix": "aks",
    "masterProfile": {
      "count": 3,
      "dnsPrefix": "{dnsPrefix}",
      "vmSize": "Standard_DS2_v2"
    },
    "agentPoolProfiles": [
      {
        "name": "agentpool1",
        "count": 2,
        "mode": "System",
        "vmSize": "Standard_DS2_v2",
        "osType": "Linux",
        "availabilityProfile": "VirtualMachineScaleSets",
        "storageProfile": "ManagedDisks"
      }
    ],
    "encodedCustomConfiguration": "ewogICJrdWJlcm5ldGVzQ29uZmlndXJhdGlvbnMiOiB7CiAgICAia3ViZS1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIiOiB7CiAgICAgICJpbWFnZSI6ICIvYXp1cmUtY2xvdWQtY29udHJvbGxlci1tYW5hZ2VyOmFiY2RlZmciLAogICAgICAiY29uZmlnIjogewogICAgICAgICAgIi0tbWluLXJlc3luYy1wZXJpb2QiOiAiMTBoMG0wcyIsCiAgICAgICAgICAiLS1wcm9maWxpbmciOiAiZmFsc2UiLAogICAgICAgICAgIi0tdiI6ICI2IgogICAgICB9CiAgICB9LAogICAgImt1YmUtY2xvdWQtbm9kZS1tYW5hZ2VyIjogewogICAgICAiaW1hZ2UiOiAiL2F6dXJlLWNsb3VkLW5vZGUtbWFuYWdlcjphYmNkZWZnLWxpbnV4LWFtZDY0IiwKICAgICAgImNvbmZpZyI6IHsKICAgICAgICAgICItLW5vZGUtbmFtZSI6ICIkKE5PREVfTkFNRSkiLAogICAgICAgICAgImt1YmUtYXBpLWJ1cnN0IjogIjUwIiwKICAgICAgICAgICJrdWJlLWFwaS1xcHMiOiAiNTAiCiAgICAgIH0KICAgIH0KICB9Cn0K",
    "networkProfile": {
      "loadBalancerSku": "Basic"
    }
  }
}
I1206 02:20:49.847589 1042905 up.go:154] Updating Azure credentials to manage cluster resource group
I1206 02:20:49.847605 1042905 up.go:168] System assigned managed identity is used to manage cluster resource group
 I1206 02:25:02.409816 1042905 up.go:200] An AKS cluster "aks-cluster" in resource group "aks-resource-group5" is creating
I1206 02:25:02.409872 1042905 up.go:301] Waiting for AKS cluster to be up
I1206 02:25:03.656938 1042905 up.go:206] Retrieving AKS cluster's kubeconfig
I1206 02:25:04.900506 1042905 up.go:242] Succeeded in getting kubeconfig of cluster "aks-cluster" in resource group "aks-resource-group5"
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
