### PR TITLE
fix: kubetest2-aks is not passing custom configuration

### DIFF
--- a/kubetest2-aks/cluster-templates/autoscaling-multipool.json
+++ b/kubetest2-aks/cluster-templates/autoscaling-multipool.json
@@ -36,7 +36,6 @@
         "maxCount": 1000,
         "minCount": 1
       }
-    ],
-    "encodedCustomConfiguration": "{CUSTOM_CONFIG}"
+    ]
   }
 }

--- a/kubetest2-aks/cluster-templates/autoscaling.json
+++ b/kubetest2-aks/cluster-templates/autoscaling.json
@@ -24,7 +24,6 @@
         "maxCount": 1000,
         "minCount": 1
       }
-    ],
-    "encodedCustomConfiguration": "{CUSTOM_CONFIG}"
+    ]
   }
 }

--- a/kubetest2-aks/deployer/managedclustersclient.go
+++ b/kubetest2-aks/deployer/managedclustersclient.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	armcontainerservicev2 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
+)
+
+/*
+Background:
+AKS custom configuration feature is an internal feature used for testing only, and is not expected to be exposed to
+customers, thus custom configuration field is not defined in AKS API and SDK.
+
+Workaround:
+To leverage this feature while reusing as many code in SDK as possible, we wrap ManagedClustersClient struct and extend
+create functions with encodedCustomConfig variables. ManagedCluster parameter in SDK is not touched but transformed to
+a managable map structure before marshalled to request body by `insertCustomConfigToParameter`.
+*/
+
+const (
+	moduleName    = "armcontainerservice"
+	moduleVersion = "v2.2.0"
+	armAPIVersion = "2022-09-01"
+)
+
+// ManagedClustersClientWrapper is a wrapper of NewManagedClustersClient by supporting custom configuration.
+type ManagedClustersClientWrapper struct {
+	*armcontainerservicev2.ManagedClustersClient
+	host           string
+	subscriptionID string
+	pl             runtime.Pipeline
+}
+
+// NewManagedClustersClientWrapper returns a ManagedClustersClientWrapper.
+func NewManagedClustersClientWrapper(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagedClustersClientWrapper, error) {
+	if options == nil {
+		options = &arm.ClientOptions{}
+	}
+	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
+	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
+		ep = c.Endpoint
+	}
+	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+
+	managedClustersClient, err := armcontainerservicev2.NewManagedClustersClient(subscriptionID, credential, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ManagedClustersClientWrapper{
+		ManagedClustersClient: managedClustersClient,
+		subscriptionID:        subscriptionID,
+		host:                  ep,
+		pl:                    pl,
+	}, nil
+}
+
+// BeginCreateOrUpdate - Creates or updates a managed cluster.
+// If the operation fails it returns an *azcore.ResponseError type.
+// Generated from API version 2022-09-01
+// resourceGroupName - The name of the resource group. The name is case insensitive.
+// resourceName - The name of the managed cluster resource.
+// parameters - The managed cluster to create or update.
+// options - ManagedClustersClientBeginCreateOrUpdateOptions contains the optional parameters for the ManagedClustersClient.BeginCreateOrUpdate
+// method.
+func (client *ManagedClustersClientWrapper) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, resourceName string, parameters armcontainerservicev2.ManagedCluster, encodedCustomConfig string, options *armcontainerservicev2.ManagedClustersClientBeginCreateOrUpdateOptions) (*runtime.Poller[armcontainerservicev2.ManagedClustersClientCreateOrUpdateResponse], error) {
+	if options == nil || options.ResumeToken == "" {
+		resp, err := client.createOrUpdate(ctx, resourceGroupName, resourceName, parameters, encodedCustomConfig, options)
+		if err != nil {
+			return nil, err
+		}
+		return runtime.NewPoller[armcontainerservicev2.ManagedClustersClientCreateOrUpdateResponse](resp, client.pl, nil)
+	} else {
+		return runtime.NewPollerFromResumeToken[armcontainerservicev2.ManagedClustersClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+	}
+}
+
+// CreateOrUpdate - Creates or updates a managed cluster.
+// If the operation fails it returns an *azcore.ResponseError type.
+// Generated from API version 2022-09-01
+func (client *ManagedClustersClientWrapper) createOrUpdate(ctx context.Context, resourceGroupName string, resourceName string, parameters armcontainerservicev2.ManagedCluster, encodedCustomConfig string, options *armcontainerservicev2.ManagedClustersClientBeginCreateOrUpdateOptions) (*http.Response, error) {
+	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, resourceName, parameters, encodedCustomConfig, options)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated) {
+		return nil, runtime.NewResponseError(resp)
+	}
+	return resp, nil
+}
+
+// createOrUpdateCreateRequest creates the CreateOrUpdate request.
+func (client *ManagedClustersClientWrapper) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, resourceName string, parameters armcontainerservicev2.ManagedCluster, encodedCustomConfig string, options *armcontainerservicev2.ManagedClustersClientBeginCreateOrUpdateOptions) (*policy.Request, error) {
+	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter client.subscriptionID cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
+	if resourceGroupName == "" {
+		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	if resourceName == "" {
+		return nil, errors.New("parameter resourceName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceName}", url.PathEscape(resourceName))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", armAPIVersion)
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+
+	parametersWithCustomConfig, err := insertCustomConfigToParameter(parameters, encodedCustomConfig)
+	if err != nil {
+		return req, err
+	}
+
+	return req, runtime.MarshalAsJSON(req, parametersWithCustomConfig)
+}
+
+// insertCustomConfigToParameter inserts custom configuration into the managed cluster and returns a map to be Marshaled into request body.
+// To simply custom configuration insert, no new data structured is introduced on top of ManagedCluster, which contains no filed for
+// custom configuration by design, and reuse as many code as possible, we transform ManagedCluster object into a managable map struct
+// before being marshalled to request body. The idea is borrowed from the following link:
+// https://stackoverflow.com/questions/51795678/add-a-new-key-value-pair-to-a-json-object
+func insertCustomConfigToParameter(parameters armcontainerservicev2.ManagedCluster, encodedCustomConfiguration string) (map[string]interface{}, error) {
+	mcBytes, err := json.Marshal(parameters)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+
+	mcMap := map[string]interface{}{}
+	if err := json.Unmarshal(mcBytes, &mcMap); err != nil {
+		return map[string]interface{}{}, err
+	}
+	propertiesMap, ok := mcMap["properties"].(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}, errors.New("the properties is not a map type.")
+	}
+
+	propertiesMap["encodedCustomConfiguration"] = encodedCustomConfiguration
+	mcMap["properties"] = propertiesMap
+
+	return mcMap, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Background:
AKS custom configuration feature is an internal feature used for testing only, and is not expected to be exposed to
customers, thus custom configuration field is not defined in AKS API and SDK.

- Workaround:
To leverage this feature while reusing as many code in SDK as possible, we wrap ManagedClustersClient struct and extend
create functions with encodedCustomConfig variables. ManagedCluster parameter in SDK is not touched but transformed to
a managable map structure before marshalled to request body by `insertCustomConfigToParameter`.


- Tests:

```
➜  kubetest2-aks git:(kube-aks-msi) ✗ kubetest2 aks --up --rgName qinhao4 --location eastus --config cluster-templates/basic-lb.json --customConfig cluster-templates/customconfiguration.json  --clusterName aks-cluster --ccmImageTag v1.24.9 --k8sVersion 1.24.6
I1208 14:50:24.512430 3507486 app.go:61] The files in RunDir shall not be part of Artifacts
I1208 14:50:24.512523 3507486 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I1208 14:50:24.512561 3507486 app.go:64] RunDir for this run: "/home/azureuser/go/src/sigs.k8s.io/cloud-provider-azure/kubetest2-aks/_rundir/b1311b14-d090-4507-abe5-7feb5f53e402"
I1208 14:50:24.520151 3507486 app.go:128] ID for this run: "b1311b14-d090-4507-abe5-7feb5f53e402"
I1208 14:50:26.598781 3507486 up.go:294] Resource group /subscriptions/<my-sub>/resourceGroups/qinhao4 created
I1208 14:50:26.598820 3507486 up.go:183] Creating the AKS cluster with custom config
I1208 14:50:26.598885 3507486 up.go:125] AKS cluster config without credential: {
  "id": "/subscriptions/26fe00f8-9173-4872-9134-bb1d2e00343a/resourcegroups/qinhao4/providers/Microsoft.ContainerService/managedClusters/aks-cluster",
  "name": "aks-cluster",
  "location": "eastus",
  "type": "Microsoft.ContainerService/ManagedClusters",
  "properties": {
    "kubernetesVersion": "1.24.6",
    "dnsPrefix": "aks",
    "masterProfile": {
      "count": 3,
      "dnsPrefix": "{dnsPrefix}",
      "vmSize": "Standard_DS2_v2"
    },
    "agentPoolProfiles": [
      {
        "name": "agentpool1",
        "count": 2,
        "mode": "System",
        "vmSize": "Standard_DS2_v2",
        "osType": "Linux",
        "availabilityProfile": "VirtualMachineScaleSets",
        "storageProfile": "ManagedDisks"
      }
    ],
    "networkProfile": {
      "loadBalancerSku": "Basic"
    }
  }
}
I1208 14:50:26.599047 3507486 up.go:158] Updating Azure credentials to manage cluster resource group
I1208 14:50:26.599069 3507486 up.go:161] Service principal is used to manage cluster resource group
I1208 14:50:26.599138 3507486 up.go:151] AKS cluster custom configuration: {
  "kubernetesConfigurations": {
    "kube-cloud-controller-manager": {
      "image": "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.24.9",
      "config": {
          "--min-resync-period": "10h0m0s",
          "--profiling": "false",
          "--v": "6"
      }
    },
    "kube-cloud-node-manager": {
      "image": "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.24.9-linux-amd64",
      "config": {
          "--node-name": "$(NODE_NAME)",
          "kube-api-burst": "50",
          "kube-api-qps": "50"
      }
    }
  }
}
I1208 14:54:39.719005 3507486 up.go:213] An AKS cluster "aks-cluster" in resource group "qinhao4" is creating
```
From the AKS side, I can see the following log:
```
"msg": Decode custom configuration ewogICJrdWJlcm5ldGVzQ29uZmlndXJhdGlvbnMiOiB7CiAgICAia3ViZS1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXIiOiB7CiAgICAgICJpbWFnZSI6ICJtY3IubWljcm9zb2Z0LmNvbS9vc3Mva3ViZXJuZXRlcy9henVyZS1jbG91ZC1jb250cm9sbGVyLW1hbmFnZXI6djEuMjQuOSIsCiAgICAgICJjb25maWciOiB7CiAgICAgICAgICAiLS1taW4tcmVzeW5jLXBlcmlvZCI6ICIxMGgwbTBzIiwKICAgICAgICAgICItLXByb2ZpbGluZyI6ICJmYWxzZSIsCiAgICAgICAgICAiLS12IjogIjYiCiAgICAgIH0KICAgIH0sCiAgICAia3ViZS1jbG91ZC1ub2RlLW1hbmFnZXIiOiB7CiAgICAgICJpbWFnZSI6ICJtY3IubWljcm9zb2Z0LmNvbS9vc3Mva3ViZXJuZXRlcy9henVyZS1jbG91ZC1ub2RlLW1hbmFnZXI6djEuMjQuOS1saW51eC1hbWQ2NCIsCiAgICAgICJjb25maWciOiB7CiAgICAgICAgICAiLS1ub2RlLW5hbWUiOiAiJChOT0RFX05BTUUpIiwKICAgICAgICAgICJrdWJlLWFwaS1idXJzdCI6ICI1MCIsCiAgICAgICAgICAia3ViZS1hcGktcXBzIjogIjUwIgogICAgICB9CiAgICB9CiAgfQp9Cg==,
"resourceGroupName": qinhao4,
"resourceName": aks-cluster
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
