### PR TITLE
cleanup: remove unused controllerCommon fields

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -1006,20 +1006,9 @@ func initDiskControllers(az *Cloud) error {
 	klog.V(2).Infof("attach/detach disk operation rate limit QPS: %f, Bucket: %d", qps, bucket)
 
 	common := &controllerCommon{
-		location:              az.Location,
-		storageEndpointSuffix: az.Environment.StorageEndpointSuffix,
-		resourceGroup:         az.ResourceGroup,
-		subscriptionID:        az.SubscriptionID,
-		cloud:                 az,
-		lockMap:               newLockMap(),
-		diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(qps, bucket),
-	}
-
-	if az.HasExtendedLocation() {
-		common.extendedLocation = &ExtendedLocation{
-			Name: az.ExtendedLocationName,
-			Type: az.ExtendedLocationType,
-		}
+		cloud:             az,
+		lockMap:           newLockMap(),
+		diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(qps, bucket),
 	}
 
 	az.ManagedDiskController = &ManagedDiskController{common: common}

--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -91,14 +91,9 @@ var (
 )
 
 type controllerCommon struct {
-	subscriptionID        string
-	location              string
-	extendedLocation      *ExtendedLocation
-	storageEndpointSuffix string
-	resourceGroup         string
-	diskStateMap          sync.Map // <diskURI, attaching/detaching state>
-	lockMap               *lockMap
-	cloud                 *Cloud
+	diskStateMap sync.Map // <diskURI, attaching/detaching state>
+	lockMap      *lockMap
+	cloud        *Cloud
 	// disk queue that is waiting for attach or detach on specific node
 	// <nodeName, map<diskURI, *AttachDiskOptions/DetachDiskOptions>>
 	attachDiskMap sync.Map

--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -106,7 +106,7 @@ func TestCommonAttachDisk(t *testing.T) {
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMsClient.EXPECT().UpdateAsync(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(fakeUpdateAsync(statusCode)).MaxTimes(1)
 		mockVMsClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
-		mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(result).MaxTimes(1)
+		mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(result).MaxTimes(1)
 	}
 
 	maxShare := int32(1)
@@ -238,8 +238,8 @@ func TestCommonAttachDisk(t *testing.T) {
 				mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 				mockVMsClient.EXPECT().UpdateAsync(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(fakeUpdateAsync(200)).AnyTimes()
 				gomock.InOrder(
-					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(result),
-					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(nil),
+					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(result),
+					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(nil),
 				)
 			},
 		},
@@ -257,7 +257,7 @@ func TestCommonAttachDisk(t *testing.T) {
 				defaultSetup(testCloud, expectedVMs, statusCode, result)
 				mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 				mockVMsClient.EXPECT().UpdateAsync(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(fakeUpdateAsync(200)).AnyTimes()
-				mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(result).AnyTimes()
+				mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(result).AnyTimes()
 			},
 			contextDuration:      time.Second,
 			isContextDeadlineErr: true,
@@ -323,7 +323,7 @@ func TestWaitForUpdateResult(t *testing.T) {
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMsClient.EXPECT().UpdateAsync(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(fakeUpdateAsync(statusCode)).MaxTimes(1)
 		mockVMsClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
-		mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(result).MaxTimes(1)
+		mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(result).MaxTimes(1)
 	}
 
 	testCases := []struct {
@@ -371,8 +371,8 @@ func TestWaitForUpdateResult(t *testing.T) {
 				mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 				mockVMsClient.EXPECT().UpdateAsync(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(fakeUpdateAsync(200))
 				gomock.InOrder(
-					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(result),
-					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(nil),
+					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(result),
+					mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(nil),
 				)
 			},
 		},
@@ -387,7 +387,7 @@ func TestWaitForUpdateResult(t *testing.T) {
 				defaultSetup(testCloud, statusCode, result)
 				mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 				mockVMsClient.EXPECT().UpdateAsync(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(fakeUpdateAsync(200)).AnyTimes()
-				mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.resourceGroup, gomock.Any()).Return(result).AnyTimes()
+				mockVMsClient.EXPECT().WaitForUpdateResult(gomock.Any(), gomock.Any(), testCloud.ResourceGroup, gomock.Any()).Return(result).AnyTimes()
 			},
 			contextDuration:   time.Second,
 			expectedErrorType: context.DeadlineExceeded,
@@ -497,13 +497,9 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 		}
 
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
 			testCloud.SubscriptionID, testCloud.ResourceGroup, test.diskName)
@@ -563,13 +559,9 @@ func TestCommonDetachDisk(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
 			testCloud.SubscriptionID, testCloud.ResourceGroup)
@@ -634,13 +626,9 @@ func TestCommonUpdateVM(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, test.vmList, false)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -698,13 +686,9 @@ func TestGetDiskLun(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -761,13 +745,9 @@ func TestSetDiskLun(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, map[string]string{test.nodeName: "PowerState/Running"}, test.isDataDisksFull)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -811,13 +791,9 @@ func TestDisksAreAttached(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -1002,12 +978,8 @@ func TestCheckDiskExists(t *testing.T) {
 
 	testCloud := GetTestCloud(ctrl)
 	common := &controllerCommon{
-		location:              testCloud.Location,
-		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-		resourceGroup:         testCloud.ResourceGroup,
-		subscriptionID:        testCloud.SubscriptionID,
-		cloud:                 testCloud,
-		lockMap:               newLockMap(),
+		cloud:   testCloud,
+		lockMap: newLockMap(),
 	}
 	// create a new disk before running test
 	newDiskName := "newdisk"
@@ -1056,12 +1028,8 @@ func TestFilterNonExistingDisks(t *testing.T) {
 
 	testCloud := GetTestCloud(ctrl)
 	common := &controllerCommon{
-		location:              testCloud.Location,
-		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-		resourceGroup:         testCloud.ResourceGroup,
-		subscriptionID:        testCloud.SubscriptionID,
-		cloud:                 testCloud,
-		lockMap:               newLockMap(),
+		cloud:   testCloud,
+		lockMap: newLockMap(),
 	}
 	// create a new disk before running test
 	diskURIPrefix := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/",
@@ -1118,12 +1086,8 @@ func TestFilterNonExistingDisksWithSpecialHTTPStatusCode(t *testing.T) {
 
 	testCloud := GetTestCloud(ctrl)
 	common := &controllerCommon{
-		location:              testCloud.Location,
-		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-		resourceGroup:         testCloud.ResourceGroup,
-		subscriptionID:        testCloud.SubscriptionID,
-		cloud:                 testCloud,
-		lockMap:               newLockMap(),
+		cloud:   testCloud,
+		lockMap: newLockMap(),
 	}
 	// create a new disk before running test
 	diskURIPrefix := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/",
@@ -1228,13 +1192,9 @@ func TestAttachDiskRequestFuncs(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		for i := 1; i <= test.diskNum; i++ {
 			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)
@@ -1309,13 +1269,9 @@ func TestDetachDiskRequestFuncs(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			location:              testCloud.Location,
-			storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
-			resourceGroup:         testCloud.ResourceGroup,
-			subscriptionID:        testCloud.SubscriptionID,
-			cloud:                 testCloud,
-			lockMap:               newLockMap(),
-			diskOpRateLimiter:     flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:             testCloud,
+			lockMap:           newLockMap(),
+			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
 		}
 		for i := 1; i <= test.diskNum; i++ {
 			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)

--- a/pkg/provider/azure_fakes.go
+++ b/pkg/provider/azure_fakes.go
@@ -138,9 +138,5 @@ func GetTestCloudWithExtendedLocation(ctrl *gomock.Controller) (az *Cloud) {
 	az = GetTestCloud(ctrl)
 	az.Config.ExtendedLocationName = "microsoftlosangeles1"
 	az.Config.ExtendedLocationType = "EdgeZone"
-	az.controllerCommon.extendedLocation = &ExtendedLocation{
-		Name: az.Config.ExtendedLocationName,
-		Type: az.Config.ExtendedLocationType,
-	}
 	return az
 }

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -4592,7 +4592,7 @@ func TestEnsurePublicIPExistsWithExtendedLocation(t *testing.T) {
 	exLocName := "microsoftlosangeles1"
 	expectedPIP := &network.PublicIPAddress{
 		Name:     to.StringPtr("pip1"),
-		Location: &az.location,
+		Location: &az.Location,
 		ExtendedLocation: &network.ExtendedLocation{
 			Name: to.StringPtr("microsoftlosangeles1"),
 			Type: network.ExtendedLocationTypesEdgeZone,

--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -117,14 +117,14 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 	diskSizeGB := int32(options.SizeGB)
 	diskSku := options.StorageAccountType
 
-	rg := c.common.resourceGroup
+	rg := c.common.cloud.ResourceGroup
 	if options.ResourceGroup != "" {
 		rg = options.ResourceGroup
 	}
-	if options.SubscriptionID != "" && !strings.EqualFold(options.SubscriptionID, c.common.subscriptionID) && options.ResourceGroup == "" {
+	if options.SubscriptionID != "" && !strings.EqualFold(options.SubscriptionID, c.common.cloud.SubscriptionID) && options.ResourceGroup == "" {
 		return "", fmt.Errorf("resourceGroup must be specified when subscriptionID(%s) is not empty", options.SubscriptionID)
 	}
-	subsID := c.common.subscriptionID
+	subsID := c.common.cloud.SubscriptionID
 	if options.SubscriptionID != "" {
 		subsID = options.SubscriptionID
 	}
@@ -221,7 +221,7 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 		diskProperties.MaxShares = &options.MaxShares
 	}
 
-	location := c.common.location
+	location := c.common.cloud.Location
 	if options.Location != "" {
 		location = options.Location
 	}
@@ -234,10 +234,10 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 		DiskProperties: &diskProperties,
 	}
 
-	if el := c.common.extendedLocation; el != nil {
+	if c.common.cloud.HasExtendedLocation() {
 		model.ExtendedLocation = &compute.ExtendedLocation{
-			Name: to.StringPtr(el.Name),
-			Type: compute.ExtendedLocationTypes(el.Type),
+			Name: to.StringPtr(c.common.cloud.ExtendedLocationName),
+			Type: compute.ExtendedLocationTypes(c.common.cloud.ExtendedLocationType),
 		}
 	}
 

--- a/pkg/provider/azure_managedDiskController_test.go
+++ b/pkg/provider/azure_managedDiskController_test.go
@@ -326,13 +326,13 @@ func TestCreateManagedDiskWithExtendedLocation(t *testing.T) {
 	}
 
 	mockDisksClient := testCloud.DisksClient.(*mockdiskclient.MockInterface)
-	mockDisksClient.EXPECT().CreateOrUpdate(gomock.Any(), testCloud.subscriptionID, testCloud.ResourceGroup, diskName, gomock.Any()).
+	mockDisksClient.EXPECT().CreateOrUpdate(gomock.Any(), testCloud.SubscriptionID, testCloud.ResourceGroup, diskName, gomock.Any()).
 		Do(func(ctx interface{}, subsID, rg, dn string, disk compute.Disk) {
 			assert.Equal(t, el.Name, disk.ExtendedLocation.Name, "The extended location name should match.")
 			assert.Equal(t, el.Type, disk.ExtendedLocation.Type, "The extended location type should match.")
 		}).Return(nil)
 
-	mockDisksClient.EXPECT().Get(gomock.Any(), testCloud.subscriptionID, testCloud.ResourceGroup, diskName).Return(diskreturned, nil).AnyTimes()
+	mockDisksClient.EXPECT().Get(gomock.Any(), testCloud.SubscriptionID, testCloud.ResourceGroup, diskName).Return(diskreturned, nil).AnyTimes()
 
 	actualDiskID, err := managedDiskController.CreateManagedDisk(ctx, volumeOptions)
 	assert.Equal(t, expectedDiskID, actualDiskID, "Disk ID does not match.")
@@ -387,11 +387,11 @@ func TestDeleteManagedDisk(t *testing.T) {
 
 		mockDisksClient := testCloud.DisksClient.(*mockdiskclient.MockInterface)
 		if test.diskName == fakeGetDiskFailed {
-			mockDisksClient.EXPECT().Get(gomock.Any(), testCloud.subscriptionID, testCloud.ResourceGroup, test.diskName).Return(test.existedDisk, &retry.Error{RawError: fmt.Errorf("Get Disk failed")}).AnyTimes()
+			mockDisksClient.EXPECT().Get(gomock.Any(), testCloud.SubscriptionID, testCloud.ResourceGroup, test.diskName).Return(test.existedDisk, &retry.Error{RawError: fmt.Errorf("Get Disk failed")}).AnyTimes()
 		} else {
-			mockDisksClient.EXPECT().Get(gomock.Any(), testCloud.subscriptionID, testCloud.ResourceGroup, test.diskName).Return(test.existedDisk, nil).AnyTimes()
+			mockDisksClient.EXPECT().Get(gomock.Any(), testCloud.SubscriptionID, testCloud.ResourceGroup, test.diskName).Return(test.existedDisk, nil).AnyTimes()
 		}
-		mockDisksClient.EXPECT().Delete(gomock.Any(), testCloud.subscriptionID, testCloud.ResourceGroup, test.diskName).Return(nil).AnyTimes()
+		mockDisksClient.EXPECT().Delete(gomock.Any(), testCloud.SubscriptionID, testCloud.ResourceGroup, test.diskName).Return(nil).AnyTimes()
 
 		err := managedDiskController.DeleteManagedDisk(ctx, diskURI)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -1129,10 +1129,10 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 			nicUpdaters = append(nicUpdaters, func() error {
 				ctx, cancel := getContextWithCancel()
 				defer cancel()
-				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", as.resourceGroup, to.String(nic.Name), backendPoolID)
+				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", as.ResourceGroup, to.String(nic.Name), backendPoolID)
 				rerr := as.InterfacesClient.CreateOrUpdate(ctx, as.ResourceGroup, to.String(nic.Name), nic)
 				if rerr != nil {
-					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", as.resourceGroup, to.String(nic.Name), rerr.Error())
+					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", as.ResourceGroup, to.String(nic.Name), rerr.Error())
 					return rerr.Error()
 				}
 				nicUpdated = true

--- a/pkg/provider/azure_storage.go
+++ b/pkg/provider/azure_storage.go
@@ -38,10 +38,10 @@ func (az *Cloud) CreateFileShare(ctx context.Context, accountOptions *AccountOpt
 		return "", "", fmt.Errorf("share options is nil")
 	}
 	if accountOptions.ResourceGroup == "" {
-		accountOptions.ResourceGroup = az.resourceGroup
+		accountOptions.ResourceGroup = az.ResourceGroup
 	}
 	if accountOptions.SubscriptionID == "" {
-		accountOptions.SubscriptionID = az.subscriptionID
+		accountOptions.SubscriptionID = az.SubscriptionID
 	}
 
 	accountOptions.EnableHTTPSTrafficOnly = true

--- a/pkg/provider/azure_storage_test.go
+++ b/pkg/provider/azure_storage_test.go
@@ -35,7 +35,8 @@ func TestCreateFileShare(t *testing.T) {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	cloud := &Cloud{controllerCommon: &controllerCommon{resourceGroup: "rg"}}
+	cloud := &Cloud{controllerCommon: &controllerCommon{}}
+	cloud.ResourceGroup = "rg"
 	name := "baz"
 	sku := "sku"
 	kind := "StorageV2"

--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -1043,10 +1043,10 @@ func (fs *FlexScaleSet) ensureBackendPoolDeletedFromNode(vmssFlexVMNameMap map[s
 			nicUpdaters = append(nicUpdaters, func() error {
 				ctx, cancel := getContextWithCancel()
 				defer cancel()
-				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", fs.resourceGroup, to.String(nic.Name), backendPoolID)
+				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", fs.ResourceGroup, to.String(nic.Name), backendPoolID)
 				rerr := fs.InterfacesClient.CreateOrUpdate(ctx, fs.ResourceGroup, to.String(nic.Name), nic)
 				if rerr != nil {
-					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", fs.resourceGroup, to.String(nic.Name), rerr.Error())
+					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", fs.ResourceGroup, to.String(nic.Name), rerr.Error())
 					return rerr.Error()
 				}
 				nicUpdated = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
cleanup: remove unused controllerCommon fields
fileds in `controllerCommon` struct is copied from cloud struct, those are redundant fields, this PR removes those fields, make the logic simpler

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
