### PR TITLE
cleanup: Use k8s utils pointer instead of Azure autorest/to

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/adal v0.9.21
 	github.com/Azure/go-autorest/autorest/mocks v0.4.2
-	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/go-autorest/tracing v0.6.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fsnotify/fsnotify v1.6.0
@@ -39,6 +38,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect

--- a/kubetest2-aks/deployer/up.go
+++ b/kubetest2-aks/deployer/up.go
@@ -35,9 +35,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armcontainerservicev2 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
@@ -151,10 +151,10 @@ func (d *deployer) createResourceGroup(subscriptionID string) (armresources.Reso
 	now := time.Now()
 	timestamp := now.Unix()
 	param := armresources.ResourceGroup{
-		Location: to.StringPtr(d.Location),
+		Location: pointer.String(d.Location),
 		Tags: map[string]*string{
-			"creation_date": to.StringPtr(fmt.Sprintf("%d", timestamp)),
-			"usage":         to.StringPtr(usageTag),
+			"creation_date": pointer.String(fmt.Sprintf("%d", timestamp)),
+			"usage":         pointer.String(usageTag),
 		},
 	}
 

--- a/pkg/azureclients/armclient/azure_armclient_test.go
+++ b/pkg/azureclients/armclient/azure_armclient_test.go
@@ -26,13 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
-
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
@@ -85,19 +84,19 @@ func TestDoHackRegionalRetryForGET(t *testing.T) {
 			"RegionalRetry",
 			"{\"error\":{\"code\":\"ResourceGroupNotFound\"}}",
 			http.StatusInternalServerError,
-			to.StringPtr("100"),
+			pointer.String("100"),
 		},
 		{
 			"ReplicationLatency-Content-Length-0",
 			"{}",
 			http.StatusOK,
-			to.StringPtr("0"),
+			pointer.String("0"),
 		},
 		{
 			"ReplicationLatency-Content-Length-minus-1",
 			"{}",
 			http.StatusOK,
-			to.StringPtr("-1"),
+			pointer.String("-1"),
 		},
 	}
 

--- a/pkg/azureclients/containerserviceclient/azure_containerserviceclient.go
+++ b/pkg/azureclients/containerserviceclient/azure_containerserviceclient.go
@@ -24,10 +24,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-10-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -196,7 +196,7 @@ func (c *Client) listManagedCluster(ctx context.Context, resourceGroupName strin
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -222,12 +222,12 @@ func (c *Client) listResponder(resp *http.Response) (result containerservice.Man
 // managedClusterListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) managedClusterListResultPreparer(ctx context.Context, mclr containerservice.ManagedClusterListResult) (*http.Request, error) {
-	if mclr.NextLink == nil || len(to.String(mclr.NextLink)) < 1 {
+	if mclr.NextLink == nil || len(pointer.StringDeref(mclr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(mclr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(mclr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/containerserviceclient/azure_containerserviceclient_test.go
+++ b/pkg/azureclients/containerserviceclient/azure_containerserviceclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-10-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -86,9 +86,9 @@ func getTestManagedClusterClientWithRetryAfterReader(armClient armclient.Interfa
 
 func getTestManagedCluster(name string) containerservice.ManagedCluster {
 	return containerservice.ManagedCluster{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 
@@ -271,7 +271,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := containerservice.ManagedClusterListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -316,7 +316,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := containerservice.ManagedClusterListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -370,7 +370,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	mcList := []containerservice.ManagedCluster{getTestManagedCluster("cluster"), getTestManagedCluster("cluster1"), getTestManagedCluster("cluster2")}
-	responseBody, err := json.Marshal(containerservice.ManagedClusterListResult{Value: &mcList, NextLink: to.StringPtr("nextLink")})
+	responseBody, err := json.Marshal(containerservice.ManagedClusterListResult{Value: &mcList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	_, err = json.Marshal(containerservice.ManagedClusterListResult{Value: &mcList})
 	assert.NoError(t, err)
@@ -456,7 +456,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(mc.ID), mc, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(mc.ID, ""), mc, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	mcClient := getTestManagedClusterClient(armClient)
@@ -473,7 +473,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(mc.ID), mc, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(mc.ID, ""), mc, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	mcClient := getTestManagedClusterClient(armClient)
@@ -535,7 +535,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	mc := getTestManagedCluster("cluster")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(mc.ID), mc, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(mc.ID, ""), mc, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	mcClient := getTestManagedClusterClient(armClient)
@@ -550,7 +550,7 @@ func TestDelete(t *testing.T) {
 
 	mc := getTestManagedCluster("cluster")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(mc.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(mc.ID, "")).Return(nil).Times(1)
 
 	mcClient := getTestManagedClusterClient(armClient)
 	rerr := mcClient.Delete(context.TODO(), "rg", "cluster")
@@ -605,7 +605,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	mc := getTestManagedCluster("cluster")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(mc.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(mc.ID, "")).Return(throttleErr).Times(1)
 
 	mcClient := getTestManagedClusterClient(armClient)
 	rerr := mcClient.Delete(context.TODO(), "rg", "cluster")

--- a/pkg/azureclients/deploymentclient/azure_deploymentclient.go
+++ b/pkg/azureclients/deploymentclient/azure_deploymentclient.go
@@ -24,10 +24,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -196,7 +196,7 @@ func (c *Client) listDeployment(ctx context.Context, resourceGroupName string) (
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -222,12 +222,12 @@ func (c *Client) listResponder(resp *http.Response) (result resources.Deployment
 // deploymentListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) deploymentListResultPreparer(ctx context.Context, dplr resources.DeploymentListResult) (*http.Request, error) {
-	if dplr.NextLink == nil || len(to.String(dplr.NextLink)) < 1 {
+	if dplr.NextLink == nil || len(pointer.StringDeref(dplr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(dplr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(dplr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/deploymentclient/azure_deploymentclient_test.go
+++ b/pkg/azureclients/deploymentclient/azure_deploymentclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -86,8 +86,8 @@ func getTestDeploymentClientWithRetryAfterReader(armClient armclient.Interface) 
 
 func getTestDeploymentExtended(name string) resources.DeploymentExtended {
 	return resources.DeploymentExtended{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Resources/deployments/%s", name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Resources/deployments/%s", name)),
+		Name: pointer.String(name),
 	}
 }
 
@@ -269,7 +269,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := resources.DeploymentListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -314,7 +314,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := resources.DeploymentListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -368,7 +368,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	dpList := []resources.DeploymentExtended{getTestDeploymentExtended("dep"), getTestDeploymentExtended("dep1"), getTestDeploymentExtended("dep2")}
-	partialResponse, err := json.Marshal(resources.DeploymentListResult{Value: &dpList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(resources.DeploymentListResult{Value: &dpList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	_, err = json.Marshal(resources.DeploymentListResult{Value: &dpList})
 	assert.NoError(t, err)
@@ -455,7 +455,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(dpExtended.ID), dp, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(dpExtended.ID, ""), dp, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
@@ -474,7 +474,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(dpExtended.ID), dp, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(dpExtended.ID, ""), dp, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
@@ -537,7 +537,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 	dp := resources.Deployment{}
 	dpExtended := getTestDeploymentExtended("dep")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(dpExtended.ID), dp, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(dpExtended.ID, ""), dp, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
@@ -552,7 +552,7 @@ func TestDelete(t *testing.T) {
 
 	dp := getTestDeploymentExtended("dep")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(dp.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(dp.ID, "")).Return(nil).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
 	rerr := dpClient.Delete(context.TODO(), "rg", "dep")
@@ -607,7 +607,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	dp := getTestDeploymentExtended("dep")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(dp.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(dp.ID, "")).Return(throttleErr).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
 	rerr := dpClient.Delete(context.TODO(), "rg", "dep")

--- a/pkg/azureclients/diskclient/azure_diskclient.go
+++ b/pkg/azureclients/diskclient/azure_diskclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -370,7 +370,7 @@ func (c *Client) ListByResourceGroup(ctx context.Context, subsID, resourceGroupN
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -420,13 +420,13 @@ func (c *Client) listResponder(resp *http.Response) (result compute.DiskList, er
 }
 
 func (c *Client) diskListPreparer(ctx context.Context, lr compute.DiskList) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 	return autorest.Prepare((&http.Request{}).WithContext(ctx),
 		autorest.AsJSON(),
 		autorest.AsGet(),
-		autorest.WithBaseURL(to.String(lr.NextLink)))
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")))
 }
 
 // DiskListPage contains a page of Disk values.

--- a/pkg/azureclients/diskclient/azure_diskclient_test.go
+++ b/pkg/azureclients/diskclient/azure_diskclient_test.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -157,7 +157,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(disk.ID), disk).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(disk.ID, ""), disk).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	diskClient := getTestDiskClient(armClient)
@@ -175,7 +175,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		RetryAfter:     time.Unix(100, 0),
 	}
 
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(disk.ID), disk).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(disk.ID, ""), disk).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 	rerr = diskClient.CreateOrUpdate(context.TODO(), "", "rg", "disk1", disk)
 	assert.Equal(t, throttleErr, rerr)
@@ -218,7 +218,7 @@ func TestUpdate(t *testing.T) {
 func getTestDiskUpdate() compute.DiskUpdate {
 	return compute.DiskUpdate{
 		DiskUpdateProperties: &compute.DiskUpdateProperties{
-			DiskSizeGB: to.Int32Ptr(100),
+			DiskSizeGB: pointer.Int32(100),
 		},
 	}
 }
@@ -229,7 +229,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestDisk("disk1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	diskClient := getTestDiskClient(armClient)
 	rerr := diskClient.Delete(context.TODO(), "", "rg", "disk1")
@@ -241,16 +241,16 @@ func TestDelete(t *testing.T) {
 		Retriable:      true,
 		RetryAfter:     time.Unix(100, 0),
 	}
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(throttleErr).Times(1)
 	rerr = diskClient.Delete(context.TODO(), "", "rg", "disk1")
 	assert.Equal(t, throttleErr, rerr)
 }
 
 func getTestDisk(name string) compute.Disk {
 	return compute.Disk{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/disks/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/disks/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/fileclient/azure_fileclient.go
+++ b/pkg/azureclients/fileclient/azure_fileclient.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -219,7 +219,7 @@ func (c *Client) ListFileShare(ctx context.Context, resourceGroupName, accountNa
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 

--- a/pkg/azureclients/interfaceclient/azure_interfaceclient.go
+++ b/pkg/azureclients/interfaceclient/azure_interfaceclient.go
@@ -26,10 +26,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -261,8 +261,8 @@ func (c *Client) createOrUpdateInterface(ctx context.Context, resourceGroupName 
 		networkInterfaceName,
 	)
 	decorators := []autorest.PrepareDecorator{}
-	if to.String(parameters.Etag) != "" {
-		decorators = append(decorators, autorest.WithHeader("If-Match", autorest.String(to.String(parameters.Etag))))
+	if pointer.StringDeref(parameters.Etag, "") != "" {
+		decorators = append(decorators, autorest.WithHeader("If-Match", autorest.String(pointer.StringDeref(parameters.Etag, ""))))
 	}
 
 	response, rerr := c.armClient.PutResource(ctx, resourceID, parameters, decorators...)

--- a/pkg/azureclients/interfaceclient/azure_interfaceclient_test.go
+++ b/pkg/azureclients/interfaceclient/azure_interfaceclient_test.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -199,7 +199,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(testInterface.ID), testInterface, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(testInterface.ID, ""), testInterface, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nicClient := getTestInterfaceClient(armClient)
@@ -217,7 +217,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		RetryAfter:     time.Unix(100, 0),
 	}
 
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(testInterface.ID), testInterface, gomock.Any()).Return(response, noContentErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(testInterface.ID, ""), testInterface, gomock.Any()).Return(response, noContentErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 	rerr = nicClient.CreateOrUpdate(context.TODO(), "rg", "nic1", testInterface)
 	assert.Equal(t, noContentErr, rerr)
@@ -229,7 +229,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestInterface("interface1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	nicClient := getTestInterfaceClient(armClient)
 	rerr := nicClient.Delete(context.TODO(), "rg", "interface1")
@@ -241,7 +241,7 @@ func TestDelete(t *testing.T) {
 		Retriable:      true,
 		RetryAfter:     time.Unix(100, 0),
 	}
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(noContentErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(noContentErr).Times(1)
 
 	rerr = nicClient.Delete(context.TODO(), "rg", "interface1")
 	assert.Equal(t, noContentErr, rerr)
@@ -250,19 +250,19 @@ func TestDelete(t *testing.T) {
 func getTestInterface(name string) network.Interface {
 	resourceID := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/%s", name)
 	return network.Interface{
-		ID:       to.StringPtr(resourceID),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(resourceID),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 
 func getTestVMSSInterface(name string) network.Interface {
 	resourceID := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/%s", name)
 	return network.Interface{
-		ID:       to.StringPtr(resourceID),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(resourceID),
+		Location: pointer.String("eastus"),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-			EnableAcceleratedNetworking: to.BoolPtr(true),
+			EnableAcceleratedNetworking: pointer.Bool(true),
 		},
 	}
 }

--- a/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient.go
+++ b/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -203,7 +203,7 @@ func (c *Client) listLB(ctx context.Context, resourceGroupName string) ([]networ
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -344,12 +344,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.LoadBalancer
 // loadBalancerListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) loadBalancerListResultPreparer(ctx context.Context, lblr network.LoadBalancerListResult) (*http.Request, error) {
-	if lblr.NextLink == nil || len(to.String(lblr.NextLink)) < 1 {
+	if lblr.NextLink == nil || len(pointer.StringDeref(lblr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lblr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lblr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient_test.go
+++ b/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -191,7 +191,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	lbList := []network.LoadBalancer{getTestLoadBalancer("lb1"), getTestLoadBalancer("lb2"), getTestLoadBalancer("lb3")}
-	partialResponse, err := json.Marshal(network.LoadBalancerListResult{Value: &lbList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.LoadBalancerListResult{Value: &lbList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	_, err = json.Marshal(network.LoadBalancerListResult{Value: &lbList})
 	assert.NoError(t, err)
@@ -229,7 +229,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.LoadBalancerListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -271,7 +271,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(lb.ID), lb, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(lb.ID, ""), lb, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	lbClient := getTestLoadBalancerClient(armClient)
@@ -289,7 +289,7 @@ func TestCreateOrUpdateBackendPools(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(backendAddressPool.ID), backendAddressPool, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(backendAddressPool.ID, ""), backendAddressPool, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	lbClient := getTestLoadBalancerClient(armClient)
@@ -320,7 +320,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range tests {
 		armClient := mockarmclient.NewMockInterface(ctrl)
-		armClient.EXPECT().DeleteResource(gomock.Any(), to.String(lb.ID)).Return(test.armClientErr)
+		armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(lb.ID, "")).Return(test.armClientErr)
 
 		lbClient := getTestLoadBalancerClient(armClient)
 		rerr := lbClient.Delete(context.TODO(), "rg", "lb1")
@@ -330,18 +330,18 @@ func TestDelete(t *testing.T) {
 
 func getTestLoadBalancer(name string) network.LoadBalancer {
 	return network.LoadBalancer{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 
 func getTestBackendAddressPool(lbName, backendPoolName string) network.BackendAddressPool {
 	return network.BackendAddressPool{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s/backendAddressPools/%s", lbName, backendPoolName)),
-		Name: to.StringPtr(backendPoolName),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s/backendAddressPools/%s", lbName, backendPoolName)),
+		Name: pointer.String(backendPoolName),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
-			Location: to.StringPtr("eastus"),
+			Location: pointer.String("eastus"),
 		},
 	}
 }

--- a/pkg/azureclients/privatednsclient/azure_privatednsclient_test.go
+++ b/pkg/azureclients/privatednsclient/azure_privatednsclient_test.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -79,7 +79,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pz.ID), pz, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pz.ID, ""), pz, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzClient := getTestPrivateDNSZoneClient(armClient)
@@ -133,7 +133,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	pz := getTestPrivateDNSZone(pz0)
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pz.ID), pz, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pz.ID, ""), pz, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzClient := getTestPrivateDNSZoneClient(armClient)
@@ -152,7 +152,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pz.ID), pz, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pz.ID, ""), pz, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzClient := getTestPrivateDNSZoneClient(armClient)
@@ -162,9 +162,9 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 
 func getTestPrivateDNSZone(name string) privatedns.PrivateZone {
 	return privatedns.PrivateZone{
-		ID:       to.StringPtr(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/privatednszonegroupclient/azure_privatednszonegroupclient_test.go
+++ b/pkg/azureclients/privatednszonegroupclient/azure_privatednszonegroupclient_test.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -80,7 +80,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pzg.ID), pzg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pzg.ID, ""), pzg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzgClient := getTestPrivateDNSZoneGroupClient(armClient)
@@ -134,7 +134,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	pzg := getTestPrivateDNSZoneGroup(pzg0)
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pzg.ID), pzg, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pzg.ID, ""), pzg, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzgClient := getTestPrivateDNSZoneGroupClient(armClient)
@@ -153,7 +153,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pzg.ID), pzg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pzg.ID, ""), pzg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzgClient := getTestPrivateDNSZoneGroupClient(armClient)
@@ -163,8 +163,8 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 
 func getTestPrivateDNSZoneGroup(name string) network.PrivateDNSZoneGroup {
 	return network.PrivateDNSZoneGroup{
-		ID:   to.StringPtr(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/privateendpointclient/azure_privateendpointclient_test.go
+++ b/pkg/azureclients/privateendpointclient/azure_privateendpointclient_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -139,7 +139,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pe.ID), pe, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pe.ID, ""), pe, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	peClient := getTestPrivateEndpointClient(armClient)
@@ -153,7 +153,7 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 
 	pe := getTestPrivateEndpoint("pe1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceAsync(gomock.Any(), to.String(pe.ID), pe, gomock.Any()).Return(&azure.Future{}, nil).Times(1)
+	armClient.EXPECT().PutResourceAsync(gomock.Any(), pointer.StringDeref(pe.ID, ""), pe, gomock.Any()).Return(&azure.Future{}, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	peClient := getTestPrivateEndpointClient(armClient)
@@ -163,9 +163,9 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 
 func getTestPrivateEndpoint(name string) network.PrivateEndpoint {
 	return network.PrivateEndpoint{
-		ID:       to.StringPtr(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient.go
+++ b/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient.go
@@ -26,10 +26,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -270,7 +270,7 @@ func (c *Client) listPLS(ctx context.Context, resourceGroupName string) ([]netwo
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -382,12 +382,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.PrivateLinkS
 // privateLinkServiceListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) privateLinkServiceListResultPreparer(ctx context.Context, plslr network.PrivateLinkServiceListResult) (*http.Request, error) {
-	if plslr.NextLink == nil || len(to.String(plslr.NextLink)) < 1 {
+	if plslr.NextLink == nil || len(pointer.StringDeref(plslr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(plslr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(plslr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/publicipclient/azure_publicipclient.go
+++ b/pkg/azureclients/publicipclient/azure_publicipclient.go
@@ -26,10 +26,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -278,7 +278,7 @@ func (c *Client) listPublicIPAddress(ctx context.Context, resourceGroupName stri
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -415,12 +415,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.PublicIPAddr
 // publicIPAddressListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) publicIPAddressListResultPreparer(ctx context.Context, lr network.PublicIPAddressListResult) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }
@@ -543,7 +543,7 @@ func (c *Client) listAllPublicIPAddress(ctx context.Context) ([]network.PublicIP
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 

--- a/pkg/azureclients/publicipclient/azure_publicipclient_test.go
+++ b/pkg/azureclients/publicipclient/azure_publicipclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -214,7 +214,7 @@ func TestGetVMSSPublicIPAddress(t *testing.T) {
 
 	testPip := network.PublicIPAddress{
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("10.10.10.10"),
+			IPAddress: pointer.String("10.10.10.10"),
 		},
 	}
 	pip, err := testPip.MarshalJSON()
@@ -233,7 +233,7 @@ func TestGetVMSSPublicIPAddress(t *testing.T) {
 	expected := network.PublicIPAddress{
 		Response: autorest.Response{Response: response},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("10.10.10.10"),
+			IPAddress: pointer.String("10.10.10.10"),
 		},
 	}
 	result, rerr := pipClient.GetVirtualMachineScaleSetPublicIPAddress(context.TODO(), "rg", "vmss", "0", "nic", "ipConfig", "pip1", "")
@@ -455,7 +455,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	pipList := []network.PublicIPAddress{getTestPublicIPAddress("pip1"), getTestPublicIPAddress("pip2"), getTestPublicIPAddress("pip3")}
-	partialResponse, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList})
 	assert.NoError(t, err)
@@ -533,7 +533,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.PublicIPAddressListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -578,7 +578,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := network.PublicIPAddressListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -616,7 +616,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pip.ID), pip).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), pip).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
@@ -633,7 +633,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pip.ID), pip).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), pip).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
@@ -686,7 +686,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	pip := getTestPublicIPAddress("pip1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pip.ID), pip).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), pip).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
@@ -701,7 +701,7 @@ func TestDelete(t *testing.T) {
 
 	pip := getTestPublicIPAddress("pip1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(pip.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(pip.ID, "")).Return(nil).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
 	rerr := pipClient.Delete(context.TODO(), "rg", "pip1")
@@ -754,7 +754,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	pip := getTestPublicIPAddress("pip1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(pip.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(pip.ID, "")).Return(throttleErr).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
 	rerr := pipClient.Delete(context.TODO(), "rg", "pip1")
@@ -769,9 +769,9 @@ func getFutureTime() time.Time {
 
 func getTestPublicIPAddress(name string) network.PublicIPAddress {
 	return network.PublicIPAddress{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/routeclient/azure_routeclient_test.go
+++ b/pkg/azureclients/routeclient/azure_routeclient_test.go
@@ -26,11 +26,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -95,7 +95,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(r.ID), r, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(r.ID, ""), r, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
@@ -149,7 +149,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	r := getTestRoute("r1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(r.ID), r, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(r.ID, ""), r, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
@@ -168,7 +168,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(r.ID), r, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(r.ID, ""), r, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
@@ -182,7 +182,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestRoute("r1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
 	rerr := routeClient.Delete(context.TODO(), "rg", "rt", "r1")
@@ -235,7 +235,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	r := getTestRoute("r1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(throttleErr).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
 	rerr := routeClient.Delete(context.TODO(), "rg", "rt", "r1")
@@ -244,8 +244,8 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestRoute(name string) network.Route {
 	return network.Route{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/rt/routes/%s", name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/rt/routes/%s", name)),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/routetableclient/azure_routetableclient_test.go
+++ b/pkg/azureclients/routetableclient/azure_routetableclient_test.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -222,7 +222,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(rt1.ID), rt1, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(rt1.ID, ""), rt1, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	rtClient := getTestRouteTableClient(armClient)
@@ -276,7 +276,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	rt1 := getTestRouteTable("rt1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(rt1.ID), rt1, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(rt1.ID, ""), rt1, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routetableClient := getTestRouteTableClient(armClient)
@@ -295,7 +295,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(rt1.ID), rt1, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(rt1.ID, ""), rt1, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routetableClient := getTestRouteTableClient(armClient)
@@ -305,9 +305,9 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 
 func getTestRouteTable(name string) network.RouteTable {
 	return network.RouteTable{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/securitygroupclient/azure_securitygroupclient.go
+++ b/pkg/azureclients/securitygroupclient/azure_securitygroupclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -203,7 +203,7 @@ func (c *Client) listSecurityGroup(ctx context.Context, resourceGroupName string
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -344,12 +344,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.SecurityGrou
 // securityGroupListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) securityGroupListResultPreparer(ctx context.Context, sglr network.SecurityGroupListResult) (*http.Request, error) {
-	if sglr.NextLink == nil || len(to.String(sglr.NextLink)) < 1 {
+	if sglr.NextLink == nil || len(pointer.StringDeref(sglr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(sglr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(sglr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/securitygroupclient/azure_securitygroupclient_test.go
+++ b/pkg/azureclients/securitygroupclient/azure_securitygroupclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -257,7 +257,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.SecurityGroupListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -302,7 +302,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := network.SecurityGroupListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -356,7 +356,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	nsgList := []network.SecurityGroup{getTestSecurityGroup("nsg1"), getTestSecurityGroup("nsg2"), getTestSecurityGroup("nsg3")}
-	partialResponse, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList})
 	assert.NoError(t, err)
@@ -448,7 +448,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(nsg.ID), nsg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(nsg.ID, ""), nsg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
@@ -465,7 +465,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(nsg.ID), nsg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(nsg.ID, ""), nsg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
@@ -520,7 +520,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	nsg := getTestSecurityGroup("nsg1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(nsg.ID), nsg, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(nsg.ID, ""), nsg, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
@@ -535,7 +535,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestSecurityGroup("nsg1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	rtClient := getTestSecurityGroupClient(armClient)
 	rerr := rtClient.Delete(context.TODO(), "rg", "nsg1")
@@ -590,7 +590,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	nsg := getTestSecurityGroup("nsg1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(nsg.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(nsg.ID, "")).Return(throttleErr).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
 	rerr := nsgClient.Delete(context.TODO(), "rg", "nsg1")
@@ -600,9 +600,9 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestSecurityGroup(name string) network.SecurityGroup {
 	return network.SecurityGroup{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/snapshotclient/azure_snapshotclient.go
+++ b/pkg/azureclients/snapshotclient/azure_snapshotclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -329,7 +329,7 @@ func (c *Client) listSnapshotsByResourceGroup(ctx context.Context, subsID, resou
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -355,12 +355,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.SnapshotList
 // SnapshotListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) SnapshotListResultPreparer(ctx context.Context, lr compute.SnapshotList) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/snapshotclient/azure_snapshotclient_test.go
+++ b/pkg/azureclients/snapshotclient/azure_snapshotclient_test.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -316,7 +316,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	snList := []compute.Snapshot{getTestSnapshot("sn1"), getTestSnapshot("sn2"), getTestSnapshot("sn3")}
-	partialResponse, err := json.Marshal(compute.SnapshotList{Value: &snList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.SnapshotList{Value: &snList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.SnapshotList{Value: &snList})
 	assert.NoError(t, err)
@@ -394,7 +394,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := compute.SnapshotList{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -439,7 +439,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := compute.SnapshotList{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -477,7 +477,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(sn.ID), sn).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(sn.ID, ""), sn).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
@@ -494,7 +494,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(sn.ID), sn).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(sn.ID, ""), sn).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
@@ -547,7 +547,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	sn := getTestSnapshot("sn1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(sn.ID), sn).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(sn.ID, ""), sn).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
@@ -562,7 +562,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestSnapshot("sn1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	rtClient := getTestSnapshotClient(armClient)
 	rerr := rtClient.Delete(context.TODO(), "", "rg", "sn1")
@@ -615,7 +615,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	sn := getTestSnapshot("sn1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(sn.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(sn.ID, "")).Return(throttleErr).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
 	rerr := snClient.Delete(context.TODO(), "", "rg", "sn1")
@@ -625,9 +625,9 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestSnapshot(name string) compute.Snapshot {
 	return compute.Snapshot{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/snapshots/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/snapshots/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
+++ b/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -458,7 +458,7 @@ func (c *Client) ListStorageAccountByResourceGroup(ctx context.Context, subsID, 
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -484,12 +484,12 @@ func (c *Client) listResponder(resp *http.Response) (result storage.AccountListR
 // StorageAccountResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) StorageAccountResultPreparer(ctx context.Context, lr storage.AccountListResult) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/storageaccountclient/azure_storageaccountclient_test.go
+++ b/pkg/azureclients/storageaccountclient/azure_storageaccountclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -158,7 +158,7 @@ func TestAllNeverRateLimiter(t *testing.T) {
 	assert.Equal(t, saErr3, rerr3)
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 
 	rerr4 := saClient.Create(context.TODO(), "", "rg", "sa1", sa)
@@ -218,7 +218,7 @@ func TestAllRetryAfterReader(t *testing.T) {
 	assert.Equal(t, saErr3, rerr3)
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 
 	rerr4 := saClient.Create(context.TODO(), "", "rg", "sa1", sa)
@@ -244,7 +244,7 @@ func TestAllThrottle(t *testing.T) {
 	}
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 
 	r := getTestStorageAccount("sa1")
@@ -253,7 +253,7 @@ func TestAllThrottle(t *testing.T) {
 	armClient.EXPECT().PostResource(gomock.Any(), testResourceID, "listKeys", struct{}{}, map[string]interface{}{}).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().GetResource(gomock.Any(), testResourceID).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().PutResource(gomock.Any(), testResourceID, sa).Return(response, throttleErr).Times(1)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(3)
 
 	saClient := getTestStorageAccountClient(armClient)
@@ -379,7 +379,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := storage.AccountListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -424,7 +424,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := storage.AccountListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -498,7 +498,7 @@ func TestCreate(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -518,7 +518,7 @@ func TestCreateResponderError(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -538,7 +538,7 @@ func TestUpdate(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountUpdateParameters{
-		Tags: map[string]*string{"key": to.StringPtr("value")},
+		Tags: map[string]*string{"key": pointer.String("value")},
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -558,7 +558,7 @@ func TestUpdateResponderError(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountUpdateParameters{
-		Tags: map[string]*string{"key": to.StringPtr("value")},
+		Tags: map[string]*string{"key": pointer.String("value")},
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -579,7 +579,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestStorageAccount("sa1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	rtClient := getTestStorageAccountClient(armClient)
 	rerr := rtClient.Delete(context.TODO(), "", "rg", "sa1")
@@ -588,9 +588,9 @@ func TestDelete(t *testing.T) {
 
 func getTestStorageAccount(name string) storage.Account {
 	return storage.Account{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/subnetclient/azure_subnetclient.go
+++ b/pkg/azureclients/subnetclient/azure_subnetclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -211,7 +211,7 @@ func (c *Client) listSubnet(ctx context.Context, resourceGroupName string, virtu
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -350,12 +350,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.SubnetListRe
 // subnetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) subnetListResultPreparer(ctx context.Context, lblr network.SubnetListResult) (*http.Request, error) {
-	if lblr.NextLink == nil || len(to.String(lblr.NextLink)) < 1 {
+	if lblr.NextLink == nil || len(pointer.StringDeref(lblr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lblr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lblr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/subnetclient/azure_subnetclient_test.go
+++ b/pkg/azureclients/subnetclient/azure_subnetclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -92,7 +92,7 @@ func TestGet(t *testing.T) {
 	defer ctrl.Finish()
 
 	testSubnet := network.Subnet{
-		Name: to.StringPtr("subnet1"),
+		Name: pointer.String("subnet1"),
 	}
 	subnet, err := testSubnet.MarshalJSON()
 	assert.NoError(t, err)
@@ -107,7 +107,7 @@ func TestGet(t *testing.T) {
 
 	expected := network.Subnet{
 		Response: autorest.Response{Response: response},
-		Name:     to.StringPtr("subnet1"),
+		Name:     pointer.String("subnet1"),
 	}
 	subnetClient := getTestSubnetClient(armClient)
 	result, rerr := subnetClient.Get(context.TODO(), "rg", "vnet", "subnet1", "")
@@ -327,7 +327,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	subnetList := []network.Subnet{getTestSubnet("subnet1"), getTestSubnet("subnet2"), getTestSubnet("subnet3")}
-	partialResponse, err := json.Marshal(network.SubnetListResult{Value: &subnetList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.SubnetListResult{Value: &subnetList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(network.SubnetListResult{Value: &subnetList})
 	assert.NoError(t, err)
@@ -405,7 +405,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.SubnetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -450,7 +450,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := network.SubnetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -488,7 +488,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(subnet.ID), subnet).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(subnet.ID, ""), subnet).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
@@ -505,7 +505,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(subnet.ID), subnet).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(subnet.ID, ""), subnet).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
@@ -558,7 +558,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	subnet := getTestSubnet("subnet1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(subnet.ID), subnet).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(subnet.ID, ""), subnet).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
@@ -573,7 +573,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestSubnet("subnet1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
 	rerr := subnetClient.Delete(context.TODO(), "rg", "vnet", "subnet1")
@@ -626,7 +626,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	subnet := getTestSubnet("subnet1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(subnet.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(subnet.ID, "")).Return(throttleErr).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
 	rerr := subnetClient.Delete(context.TODO(), "rg", "vnet", "subnet1")
@@ -636,8 +636,8 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestSubnet(name string) network.Subnet {
 	return network.Subnet{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/%s", name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/%s", name)),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/virtualnetworklinksclient/azure_virtualnetworklinksclient_test.go
+++ b/pkg/azureclients/virtualnetworklinksclient/azure_virtualnetworklinksclient_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -139,7 +139,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(vnl.ID), vnl, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(vnl.ID, ""), vnl, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vnlClient := getTestVirtualNetworkLinkClient(armClient)
@@ -153,7 +153,7 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 
 	vnl := getTestVirtualNetworkLink("pz1", "vnl1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceAsync(gomock.Any(), to.String(vnl.ID), vnl, gomock.Any()).Return(&azure.Future{}, nil).Times(1)
+	armClient.EXPECT().PutResourceAsync(gomock.Any(), pointer.StringDeref(vnl.ID, ""), vnl, gomock.Any()).Return(&azure.Future{}, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vnlClient := getTestVirtualNetworkLinkClient(armClient)
@@ -163,9 +163,9 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 
 func getTestVirtualNetworkLink(privateZoneName, virtualNetworkLinkName string) privatedns.VirtualNetworkLink {
 	return privatedns.VirtualNetworkLink{
-		ID:       to.StringPtr(fmt.Sprintf(testResourceIDFormat, privateZoneName, virtualNetworkLinkName)),
-		Name:     to.StringPtr(virtualNetworkLinkName),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf(testResourceIDFormat, privateZoneName, virtualNetworkLinkName)),
+		Name:     pointer.String(virtualNetworkLinkName),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/vmasclient/azure_vmasclient.go
+++ b/pkg/azureclients/vmasclient/azure_vmasclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -203,7 +203,7 @@ func (c *Client) listVMAS(ctx context.Context, resourceGroupName string) ([]comp
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -229,12 +229,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.Availability
 // availabilitySetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) availabilitySetListResultPreparer(ctx context.Context, vmaslr compute.AvailabilitySetListResult) (*http.Request, error) {
-	if vmaslr.NextLink == nil || len(to.String(vmaslr.NextLink)) < 1 {
+	if vmaslr.NextLink == nil || len(pointer.StringDeref(vmaslr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmaslr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmaslr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmasclient/azure_vmasclient_test.go
+++ b/pkg/azureclients/vmasclient/azure_vmasclient_test.go
@@ -29,11 +29,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -318,7 +318,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmasList := []compute.AvailabilitySet{getTestVMAS("vmas1"), getTestVMAS("vmas2"), getTestVMAS("vmas3")}
-	partialResponse, err := json.Marshal(compute.AvailabilitySetListResult{Value: &vmasList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.AvailabilitySetListResult{Value: &vmasList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.AvailabilitySetListResult{Value: &vmasList})
 	assert.NoError(t, err)
@@ -403,7 +403,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := compute.AvailabilitySetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -459,7 +459,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := compute.AvailabilitySetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -495,12 +495,12 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 
 func getTestVMAS(name string) compute.AvailabilitySet {
 	return compute.AvailabilitySet{
-		ID:       to.StringPtr("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/vmas1"),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/vmas1"),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 		Sku: &compute.Sku{
-			Name:     to.StringPtr("Standard"),
-			Capacity: to.Int64Ptr(3),
+			Name:     pointer.String("Standard"),
+			Capacity: pointer.Int64(3),
 		},
 	}
 }

--- a/pkg/azureclients/vmclient/azure_vmclient.go
+++ b/pkg/azureclients/vmclient/azure_vmclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -204,7 +204,7 @@ func (c *Client) listVM(ctx context.Context, resourceGroupName string) ([]comput
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -310,7 +310,7 @@ func (c *Client) listVmssFlexVMs(ctx context.Context, vmssFlexID string, statusO
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -474,12 +474,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.VirtualMachi
 // vmListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) vmListResultPreparer(ctx context.Context, vmlr compute.VirtualMachineListResult) (*http.Request, error) {
-	if vmlr.NextLink == nil || len(to.String(vmlr.NextLink)) < 1 {
+	if vmlr.NextLink == nil || len(pointer.StringDeref(vmlr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmlr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmlr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmclient/azure_vmclient_test.go
+++ b/pkg/azureclients/vmclient/azure_vmclient_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -320,7 +320,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmList := []compute.VirtualMachine{getTestVM("vm1"), getTestVM("vm2"), getTestVM("vm3")}
-	partialResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList})
 	assert.NoError(t, err)
@@ -405,7 +405,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := compute.VirtualMachineListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -461,7 +461,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := compute.VirtualMachineListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -606,7 +606,7 @@ func TestListVmssFlexVMsWithoutInstanceViewWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmList := []compute.VirtualMachine{getTestVM("vm1"), getTestVM("vm2"), getTestVM("vm3")}
-	partialResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList})
 	assert.NoError(t, err)
@@ -774,7 +774,7 @@ func TestListVmssFlexVMsWithOnlyInstanceViewWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmList := []compute.VirtualMachine{getTestVM("vm1"), getTestVM("vm2"), getTestVM("vm3")}
-	partialResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.VirtualMachineListResult{Value: &vmList})
 	assert.NoError(t, err)
@@ -1005,7 +1005,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(testVM.ID), testVM).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(testVM.ID, ""), testVM).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vmClient := getTestVMClient(armClient)
@@ -1022,7 +1022,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(testVM.ID), testVM).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(testVM.ID, ""), testVM).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vmClient := getTestVMClient(armClient)
@@ -1075,7 +1075,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	testVM := getTestVM("vm1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(testVM.ID), testVM).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(testVM.ID, ""), testVM).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vmClient := getTestVMClient(armClient)
@@ -1090,7 +1090,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestVM("vm1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID)).Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, "")).Return(nil).Times(1)
 
 	client := getTestVMClient(armClient)
 	rerr := client.Delete(context.TODO(), "rg", "vm1")
@@ -1143,7 +1143,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	testVM := getTestVM("vm1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(testVM.ID)).Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(testVM.ID, "")).Return(throttleErr).Times(1)
 
 	vmClient := getTestVMClient(armClient)
 	rerr := vmClient.Delete(context.TODO(), "rg", "vm1")
@@ -1154,9 +1154,9 @@ func TestDeleteThrottle(t *testing.T) {
 func getTestVM(vmName string) compute.VirtualMachine {
 	resourceID := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/%s", vmName)
 	return compute.VirtualMachine{
-		ID:       to.StringPtr(resourceID),
-		Name:     to.StringPtr(vmName),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(resourceID),
+		Name:     pointer.String(vmName),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/vmsizeclient/azure_vmsizeclient_test.go
+++ b/pkg/azureclients/vmsizeclient/azure_vmsizeclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -220,7 +220,7 @@ func getTestVMSizeClient(armClient armclient.Interface) *Client {
 
 func getTestVMSize(name string) compute.VirtualMachineSize {
 	return compute.VirtualMachineSize{
-		Name: to.StringPtr(name),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/vmssclient/azure_vmssclient.go
+++ b/pkg/azureclients/vmssclient/azure_vmssclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -207,7 +207,7 @@ func (c *Client) listVMSS(ctx context.Context, resourceGroupName string) ([]comp
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -366,12 +366,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.VirtualMachi
 // virtualMachineScaleSetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) virtualMachineScaleSetListResultPreparer(ctx context.Context, vmsslr compute.VirtualMachineScaleSetListResult) (*http.Request, error) {
-	if vmsslr.NextLink == nil || len(to.String(vmsslr.NextLink)) < 1 {
+	if vmsslr.NextLink == nil || len(pointer.StringDeref(vmsslr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmsslr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmsslr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmssvmclient/azure_vmssvmclient.go
+++ b/pkg/azureclients/vmssvmclient/azure_vmssvmclient.go
@@ -25,11 +25,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -217,7 +217,7 @@ func (c *Client) listVMSSVM(ctx context.Context, resourceGroupName string, virtu
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -383,12 +383,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.VirtualMachi
 // virtualMachineScaleSetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) virtualMachineScaleSetVMListResultPreparer(ctx context.Context, vmssvmlr compute.VirtualMachineScaleSetVMListResult) (*http.Request, error) {
-	if vmssvmlr.NextLink == nil || len(to.String(vmssvmlr.NextLink)) < 1 {
+	if vmssvmlr.NextLink == nil || len(pointer.StringDeref(vmssvmlr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmssvmlr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmssvmlr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmssvmclient/azure_vmssvmclient_test.go
+++ b/pkg/azureclients/vmssvmclient/azure_vmssvmclient_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -321,7 +321,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmssvmList := []compute.VirtualMachineScaleSetVM{getTestVMSSVM("vmss1", "1"), getTestVMSSVM("vmss1", "2"), getTestVMSSVM("vmss1", "3")}
-	partialResponse, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssvmList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssvmList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssvmList})
 	assert.NoError(t, err)
@@ -406,7 +406,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := compute.VirtualMachineScaleSetVMListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -462,7 +462,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := compute.VirtualMachineScaleSetVMListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -506,7 +506,7 @@ func TestUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	expected := &compute.VirtualMachineScaleSetVM{}
@@ -524,7 +524,7 @@ func TestUpdateAsync(t *testing.T) {
 
 	vmssVM := getTestVMSSVM("vmss1", "0")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceAsync(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(nil, nil).Times(1)
+	armClient.EXPECT().PutResourceAsync(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(nil, nil).Times(1)
 
 	vmssClient := getTestVMSSVMClient(armClient)
 	future, rerr := vmssClient.UpdateAsync(context.TODO(), "rg", "vmss1", "0", vmssVM, "test")
@@ -601,7 +601,7 @@ func TestUpdateWithUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 	expected := &compute.VirtualMachineScaleSetVM{}
 	expected.Response = autorest.Response{Response: response}
@@ -668,7 +668,7 @@ func TestUpdateThrottle(t *testing.T) {
 
 	vmssVM := getTestVMSSVM("vmss1", "0")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vmssvmClient := getTestVMSSVMClient(armClient)
@@ -690,18 +690,18 @@ func TestUpdateVMs(t *testing.T) {
 		"2": vmssVM2,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM1.ID): vmssVM1,
-		to.String(vmssVM2.ID): vmssVM2,
+		pointer.StringDeref(vmssVM1.ID, ""): vmssVM1,
+		pointer.StringDeref(vmssVM2.ID, ""): vmssVM2,
 	}
 	response := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM1.ID): {
+		pointer.StringDeref(vmssVM1.ID, ""): {
 			Response: response,
 		},
-		to.String(vmssVM2.ID): {
+		pointer.StringDeref(vmssVM2.ID, ""): {
 			Response: response,
 		},
 	}
@@ -724,14 +724,14 @@ func TestUpdateVMsWithUpdateVMsResponderError(t *testing.T) {
 		"1": vmssVM,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM.ID): vmssVM,
+		pointer.StringDeref(vmssVM.ID, ""): vmssVM,
 	}
 	response := &http.Response{
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM.ID): {
+		pointer.StringDeref(vmssVM.ID, ""): {
 			Response: response,
 		},
 	}
@@ -788,7 +788,7 @@ func TestUpdateVMsThrottle(t *testing.T) {
 		"1": vmssVM,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM.ID): vmssVM,
+		pointer.StringDeref(vmssVM.ID, ""): vmssVM,
 	}
 	throttleErr := retry.Error{
 		HTTPStatusCode: http.StatusTooManyRequests,
@@ -797,7 +797,7 @@ func TestUpdateVMsThrottle(t *testing.T) {
 		RetryAfter:     time.Unix(100, 0),
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM.ID): {
+		pointer.StringDeref(vmssVM.ID, ""): {
 			Response: &http.Response{
 				StatusCode: http.StatusTooManyRequests,
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
@@ -831,10 +831,10 @@ func TestUpdateVMsIgnoreError(t *testing.T) {
 		"4": vmssVM4,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM.ID):  vmssVM,
-		to.String(vmssVM2.ID): vmssVM2,
-		to.String(vmssVM3.ID): vmssVM3,
-		to.String(vmssVM4.ID): vmssVM4,
+		pointer.StringDeref(vmssVM.ID, ""):  vmssVM,
+		pointer.StringDeref(vmssVM2.ID, ""): vmssVM2,
+		pointer.StringDeref(vmssVM3.ID, ""): vmssVM3,
+		pointer.StringDeref(vmssVM4.ID, ""): vmssVM4,
 	}
 	notActiveError := retry.Error{
 		RawError:  fmt.Errorf(consts.VmssVMNotActiveErrorMessage),
@@ -853,16 +853,16 @@ func TestUpdateVMsIgnoreError(t *testing.T) {
 		Retriable: false,
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM.ID): {
+		pointer.StringDeref(vmssVM.ID, ""): {
 			Error: &notActiveError,
 		},
-		to.String(vmssVM2.ID): {
+		pointer.StringDeref(vmssVM2.ID, ""): {
 			Error: &parentResourceNotFoundError,
 		},
-		to.String(vmssVM3.ID): {
+		pointer.StringDeref(vmssVM3.ID, ""): {
 			Error: &concurrentRequestConflictError,
 		},
-		to.String(vmssVM4.ID): {
+		pointer.StringDeref(vmssVM4.ID, ""): {
 			Error: &beingDeletedError,
 		},
 	}
@@ -880,9 +880,9 @@ func TestUpdateVMsIgnoreError(t *testing.T) {
 func getTestVMSSVM(vmssName, instanceID string) compute.VirtualMachineScaleSetVM {
 	resourceID := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s", vmssName, instanceID)
 	return compute.VirtualMachineScaleSetVM{
-		ID:         to.StringPtr(resourceID),
-		InstanceID: to.StringPtr(instanceID),
-		Location:   to.StringPtr("eastus"),
+		ID:         pointer.String(resourceID),
+		InstanceID: pointer.String(instanceID),
+		Location:   pointer.String("eastus"),
 	}
 }
 

--- a/pkg/consts/helpers_test.go
+++ b/pkg/consts/helpers_test.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestIsK8sServiceHasHAModeEnabled(t *testing.T) {
@@ -184,13 +184,13 @@ func Test_extractInt32FromString(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "value is not a number", args: args{val: "cookies"}, wantErr: true},
-		{name: "value is zero", args: args{val: "0"}, wantErr: false, want: to.Int32Ptr(0)},
+		{name: "value is zero", args: args{val: "0"}, wantErr: false, want: pointer.Int32(0)},
 		{name: "value is a float number", args: args{val: "0.1"}, wantErr: true},
-		{name: "value is a positive integer", args: args{val: "24"}, want: to.Int32Ptr(24), wantErr: false},
-		{name: "value negative integer", args: args{val: "-6"}, want: to.Int32Ptr(-6), wantErr: false},
+		{name: "value is a positive integer", args: args{val: "24"}, want: pointer.Int32(24), wantErr: false},
+		{name: "value negative integer", args: args{val: "-6"}, want: pointer.Int32(-6), wantErr: false},
 		{name: "validator is nil", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
 			nil,
-		}}, want: to.Int32Ptr(-6), wantErr: false},
+		}}, want: pointer.Int32(-6), wantErr: false},
 		{name: "validation failed", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
 			func(i *int32) error {
 				return fmt.Errorf("validator failed")
@@ -349,7 +349,7 @@ func TestGetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(t *testing.T) {
 				port:        80,
 				key:         HealthProbeParamsNumOfProbe,
 			},
-			want:    to.Int32Ptr(2),
+			want:    pointer.Int32(2),
 			wantErr: false,
 		},
 		{

--- a/pkg/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -31,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -191,8 +191,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should put the correct mask sizes on the map",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("25"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("65"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("25"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("65"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{"vmss-0": {25, 65}},
 		},
@@ -200,8 +200,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should put the default mask sizes on the map if the providerID is invalid",
 			providerID:  "invalid",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{"vmss-0": {24, 64}},
 		},
@@ -209,8 +209,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should report an error if the ipv4 mask is smaller than the cluster mask",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("15"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("65"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("15"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("65"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{},
 			expectedErr:                        fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv4 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", 15, "vmss-0", 16),
@@ -219,8 +219,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should report an error if the ipv6 mask is smaller than the cluster mask",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("25"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("45"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("25"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("45"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{},
 			expectedErr:                        fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv6 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", 45, "vmss-0", 48),
@@ -232,7 +232,7 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedVMSS := compute.VirtualMachineScaleSet{
-				Name: to.StringPtr("vmss"),
+				Name: pointer.String("vmss"),
 				Tags: tc.tags,
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 					OrchestrationMode: compute.Uniform,

--- a/pkg/provider/azure_backoff_test.go
+++ b/pkg/provider/azure_backoff_test.go
@@ -25,10 +25,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -102,14 +102,14 @@ func TestGetPrivateIPsForMachine(t *testing.T) {
 
 	expectedVM := compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			AvailabilitySet: &compute.SubResource{ID: to.StringPtr("availability-set")},
+			AvailabilitySet: &compute.SubResource{ID: pointer.String("availability-set")},
 			NetworkProfile: &compute.NetworkProfile{
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
 						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-							Primary: to.BoolPtr(true),
+							Primary: pointer.Bool(true),
 						},
-						ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
+						ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -121,7 +121,7 @@ func TestGetPrivateIPsForMachine(t *testing.T) {
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("1.2.3.4"),
+						PrivateIPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -164,14 +164,14 @@ func TestGetIPForMachineWithRetry(t *testing.T) {
 
 	expectedVM := compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			AvailabilitySet: &compute.SubResource{ID: to.StringPtr("availability-set")},
+			AvailabilitySet: &compute.SubResource{ID: pointer.String("availability-set")},
 			NetworkProfile: &compute.NetworkProfile{
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
 						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-							Primary: to.BoolPtr(true),
+							Primary: pointer.Bool(true),
 						},
-						ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
+						ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -183,9 +183,9 @@ func TestGetIPForMachineWithRetry(t *testing.T) {
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("1.2.3.4"),
+						PrivateIPAddress: pointer.String("1.2.3.4"),
 						PublicIPAddress: &network.PublicIPAddress{
-							ID: to.StringPtr("test/pip"),
+							ID: pointer.String("test/pip"),
 						},
 					},
 				},
@@ -195,7 +195,7 @@ func TestGetIPForMachineWithRetry(t *testing.T) {
 
 	expectedPIP := network.PublicIPAddress{
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("5.6.7.8"),
+			IPAddress: pointer.String("5.6.7.8"),
 		},
 	}
 
@@ -230,7 +230,7 @@ func TestCreateOrUpdateSecurityGroupCanceled(t *testing.T) {
 	})
 	mockSGClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "sg", gomock.Any()).Return(network.SecurityGroup{}, nil)
 
-	err := az.CreateOrUpdateSecurityGroup(network.SecurityGroup{Name: to.StringPtr("sg")})
+	err := az.CreateOrUpdateSecurityGroup(network.SecurityGroup{Name: pointer.String("sg")})
 	assert.EqualError(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: %w", fmt.Errorf("canceledandsupersededduetoanotheroperation")), err.Error())
 
 	// security group should be removed from cache if the operation is canceled
@@ -274,15 +274,15 @@ func TestCreateOrUpdateLB(t *testing.T) {
 		mockPIPClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
 		mockPIPClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, "pip", gomock.Any()).Return(nil).AnyTimes()
 		mockPIPClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "pip", gomock.Any()).Return(network.PublicIPAddress{
-			Name: to.StringPtr("pip"),
+			Name: pointer.String("pip"),
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 				ProvisioningState: network.ProvisioningStateSucceeded,
 			},
 		}, nil).AnyTimes()
 
 		err := az.CreateOrUpdateLB(&v1.Service{}, network.LoadBalancer{
-			Name: to.StringPtr("lb"),
-			Etag: to.StringPtr("etag"),
+			Name: pointer.String("lb"),
+			Etag: pointer.String("etag"),
 		})
 		assert.EqualError(t, test.expectedErr, err.Error())
 
@@ -318,18 +318,18 @@ func TestListAgentPoolLBs(t *testing.T) {
 		},
 		{
 			existingLBs: []network.LoadBalancer{
-				{Name: to.StringPtr("kubernetes")},
-				{Name: to.StringPtr("kubernetes-internal")},
-				{Name: to.StringPtr("vmas-1")},
-				{Name: to.StringPtr("vmas-1-internal")},
-				{Name: to.StringPtr("unmanaged")},
-				{Name: to.StringPtr("unmanaged-internal")},
+				{Name: pointer.String("kubernetes")},
+				{Name: pointer.String("kubernetes-internal")},
+				{Name: pointer.String("vmas-1")},
+				{Name: pointer.String("vmas-1-internal")},
+				{Name: pointer.String("unmanaged")},
+				{Name: pointer.String("unmanaged-internal")},
 			},
 			expectedLBs: []network.LoadBalancer{
-				{Name: to.StringPtr("kubernetes")},
-				{Name: to.StringPtr("kubernetes-internal")},
-				{Name: to.StringPtr("vmas-1")},
-				{Name: to.StringPtr("vmas-1-internal")},
+				{Name: pointer.String("kubernetes")},
+				{Name: pointer.String("kubernetes-internal")},
+				{Name: pointer.String("vmas-1")},
+				{Name: pointer.String("vmas-1-internal")},
 			},
 			callTimes: 1,
 		},
@@ -414,7 +414,7 @@ func TestCreateOrUpdatePIP(t *testing.T) {
 			mockPIPClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "nic", gomock.Any()).Return(network.PublicIPAddress{}, nil)
 		}
 
-		err := az.CreateOrUpdatePIP(&v1.Service{}, az.ResourceGroup, network.PublicIPAddress{Name: to.StringPtr("nic")})
+		err := az.CreateOrUpdatePIP(&v1.Service{}, az.ResourceGroup, network.PublicIPAddress{Name: pointer.String("nic")})
 		assert.EqualError(t, test.expectedErr, err.Error())
 
 		cachedPIP, err := az.pipCache.GetWithDeepCopy(az.getPIPCacheKey(az.ResourceGroup, "nic"), cache.CacheReadTypeDefault)
@@ -435,7 +435,7 @@ func TestCreateOrUpdateInterface(t *testing.T) {
 	mockInterfaceClient := az.InterfacesClient.(*mockinterfaceclient.MockInterface)
 	mockInterfaceClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, "nic", gomock.Any()).Return(&retry.Error{HTTPStatusCode: http.StatusInternalServerError})
 
-	err := az.CreateOrUpdateInterface(&v1.Service{}, network.Interface{Name: to.StringPtr("nic")})
+	err := az.CreateOrUpdateInterface(&v1.Service{}, network.Interface{Name: pointer.String("nic")})
 	assert.EqualError(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: %w", error(nil)), err.Error())
 }
 
@@ -490,8 +490,8 @@ func TestCreateOrUpdateRouteTable(t *testing.T) {
 		mockRTClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "rt", gomock.Any()).Return(network.RouteTable{}, nil)
 
 		err := az.CreateOrUpdateRouteTable(network.RouteTable{
-			Name: to.StringPtr("rt"),
-			Etag: to.StringPtr("etag"),
+			Name: pointer.String("rt"),
+			Etag: pointer.String("etag"),
 		})
 		assert.EqualError(t, test.expectedErr, err.Error())
 
@@ -535,8 +535,8 @@ func TestCreateOrUpdateRoute(t *testing.T) {
 		mockRTableClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "rt", gomock.Any()).Return(network.RouteTable{}, nil)
 
 		err := az.CreateOrUpdateRoute(network.Route{
-			Name: to.StringPtr("rt"),
-			Etag: to.StringPtr("etag"),
+			Name: pointer.String("rt"),
+			Etag: pointer.String("etag"),
 		})
 		if test.expectedErr != nil {
 			assert.EqualError(t, test.expectedErr, err.Error())
@@ -603,7 +603,7 @@ func TestCreateOrUpdateVMSS(t *testing.T) {
 		{
 			vmss: compute.VirtualMachineScaleSet{
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-					ProvisioningState: to.StringPtr(consts.VirtualMachineScaleSetsDeallocating),
+					ProvisioningState: pointer.String(consts.VirtualMachineScaleSetsDeallocating),
 				},
 			},
 		},

--- a/pkg/provider/azure_config_test.go
+++ b/pkg/provider/azure_config_test.go
@@ -28,12 +28,12 @@ import (
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/zoneclient/mockzoneclient"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/yaml"
 )
@@ -55,7 +55,7 @@ func getTestConfig() *Config {
 		PrimaryAvailabilitySetName:  "PrimaryAvailabilitySetName",
 		PrimaryScaleSetName:         "PrimaryScaleSetName",
 		LoadBalancerSku:             "LoadBalancerSku",
-		ExcludeMasterFromStandardLB: to.BoolPtr(true),
+		ExcludeMasterFromStandardLB: pointer.Bool(true),
 	}
 }
 

--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
 	autorestmocks "github.com/Azure/go-autorest/autorest/mocks"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -113,7 +112,7 @@ func TestCommonAttachDisk(t *testing.T) {
 	goodInstanceID := fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/%s", "vm1")
 	diskEncryptionSetID := fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/%s", "diskEncryptionSet-name")
 	testTags := make(map[string]*string)
-	testTags[WriteAcceleratorEnabled] = to.StringPtr("true")
+	testTags[WriteAcceleratorEnabled] = pointer.String("true")
 	testCases := []struct {
 		desc                 string
 		diskName             string
@@ -146,7 +145,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			desc:        "LUN -1 and error shall be returned if there's no such instance corresponding to given nodeName",
 			nodeName:    "vm1",
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun: -1,
 			expectErr:   true,
 		},
@@ -156,7 +155,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			nodeName:        "vm1",
 			isDataDisksFull: true,
 			diskName:        "disk-name",
-			existedDisk:     &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk:     &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun:     -1,
 			expectErr:       true,
 		},
@@ -165,10 +164,10 @@ func TestCommonAttachDisk(t *testing.T) {
 			vmList:   map[string]string{"vm1": "PowerState/Running"},
 			nodeName: "vm1",
 			diskName: "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name"),
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name"),
 				DiskProperties: &compute.DiskProperties{
 					Encryption: &compute.Encryption{DiskEncryptionSetID: &diskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey},
-					DiskSizeGB: to.Int32Ptr(4096),
+					DiskSizeGB: pointer.Int32(4096),
 					DiskState:  compute.Unattached,
 				},
 				Tags: testTags},
@@ -181,10 +180,10 @@ func TestCommonAttachDisk(t *testing.T) {
 			vmList:   map[string]string{"vm1": "PowerState/Running"},
 			nodeName: "vm1",
 			diskName: "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name"),
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name"),
 				DiskProperties: &compute.DiskProperties{
 					Encryption: &compute.Encryption{DiskEncryptionSetID: &diskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey},
-					DiskSizeGB: to.Int32Ptr(4096),
+					DiskSizeGB: pointer.Int32(4096),
 					DiskState:  compute.Attached,
 				},
 				Tags: testTags},
@@ -196,7 +195,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			vmList:      map[string]string{"vm1": "PowerState/Running"},
 			nodeName:    "vm1",
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name"), ManagedBy: to.StringPtr(goodInstanceID), DiskProperties: &compute.DiskProperties{MaxShares: &maxShare}},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name"), ManagedBy: pointer.String(goodInstanceID), DiskProperties: &compute.DiskProperties{MaxShares: &maxShare}},
 			expectedLun: -1,
 			expectErr:   true,
 		},
@@ -455,7 +454,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 			isVMSS:      false,
 			isManagedBy: false,
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -466,7 +465,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 			isVMSS:      true,
 			isManagedBy: false,
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -478,7 +477,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 		if test.isVMSS {
 			if test.isManagedBy {
 				testCloud.DisableAvailabilitySetNodes = false
-				expectedVMSS := compute.VirtualMachineScaleSet{Name: to.StringPtr(testVMSSName)}
+				expectedVMSS := compute.VirtualMachineScaleSet{Name: pointer.String(testVMSSName)}
 				mockVMSSClient := testCloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
 				mockVMSSClient.EXPECT().List(gomock.Any(), testCloud.ResourceGroup).Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 

--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -89,7 +89,7 @@ func (as *availabilitySet) AttachDisk(ctx context.Context, nodeName types.NodeNa
 				Caching:                 opt.cachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: to.BoolPtr(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
 			})
 	}
 
@@ -178,7 +178,7 @@ func (as *availabilitySet) DetachDisk(ctx context.Context, nodeName types.NodeNa
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diskURI)
-				disks[i].ToBeDetached = to.BoolPtr(true)
+				disks[i].ToBeDetached = pointer.Bool(true)
 				bFoundDisk = true
 			}
 		}
@@ -192,7 +192,7 @@ func (as *availabilitySet) DetachDisk(ctx context.Context, nodeName types.NodeNa
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			newDisks := []compute.DataDisk{}
 			for _, disk := range disks {
-				if !to.Bool(disk.ToBeDetached) {
+				if !pointer.BoolDeref(disk.ToBeDetached, false) {
 					newDisks = append(newDisks, disk)
 				}
 			}

--- a/pkg/provider/azure_controller_standard_test.go
+++ b/pkg/provider/azure_controller_standard_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
 	autorestmocks "github.com/Azure/go-autorest/autorest/mocks"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
@@ -91,11 +91,11 @@ func TestStandardAttachDisk(t *testing.T) {
 		for _, vm := range expectedVMs {
 			vm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
@@ -105,7 +105,7 @@ func TestStandardAttachDisk(t *testing.T) {
 				diskName := "disk-name2"
 				diskURI := "uri"
 				vm.StorageProfile.DataDisks = &[]compute.DataDisk{
-					{Lun: to.Int32Ptr(0), Name: &diskName, ManagedDisk: &compute.ManagedDiskParameters{ID: &diskURI}},
+					{Lun: pointer.Int32(0), Name: &diskName, ManagedDisk: &compute.ManagedDiskParameters{ID: &diskURI}},
 				}
 			}
 			mockVMsClient.EXPECT().Get(gomock.Any(), testCloud.ResourceGroup, *vm.Name, gomock.Any()).Return(vm, nil).AnyTimes()
@@ -306,16 +306,16 @@ func TestGetDataDisks(t *testing.T) {
 			nodeName: "vm1",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 				{
-					Lun:  to.Int32Ptr(1),
-					Name: to.StringPtr("disk2"),
+					Lun:  pointer.Int32(1),
+					Name: pointer.String("disk2"),
 				},
 				{
-					Lun:  to.Int32Ptr(2),
-					Name: to.StringPtr("disk3"),
+					Lun:  pointer.Int32(2),
+					Name: pointer.String("disk3"),
 				},
 			},
 			expectedError: false,
@@ -326,16 +326,16 @@ func TestGetDataDisks(t *testing.T) {
 			nodeName: "vm1",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 				{
-					Lun:  to.Int32Ptr(1),
-					Name: to.StringPtr("disk2"),
+					Lun:  pointer.Int32(1),
+					Name: pointer.String("disk2"),
 				},
 				{
-					Lun:  to.Int32Ptr(2),
-					Name: to.StringPtr("disk3"),
+					Lun:  pointer.Int32(2),
+					Name: pointer.String("disk3"),
 				},
 			},
 			expectedError: false,

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -95,7 +95,7 @@ func (ss *ScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName, dis
 				Caching:                 opt.cachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: to.BoolPtr(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
 			})
 	}
 
@@ -191,7 +191,7 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diskURI)
-				disks[i].ToBeDetached = to.BoolPtr(true)
+				disks[i].ToBeDetached = pointer.Bool(true)
 				bFoundDisk = true
 			}
 		}
@@ -205,7 +205,7 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			var newDisks []compute.DataDisk
 			for _, disk := range disks {
-				if !to.Bool(disk.ToBeDetached) {
+				if !pointer.BoolDeref(disk.ToBeDetached, false) {
 					newDisks = append(newDisks, disk)
 				}
 			}

--- a/pkg/provider/azure_controller_vmss_test.go
+++ b/pkg/provider/azure_controller_vmss_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
 	autorestmocks "github.com/Azure/go-autorest/autorest/mocks"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -109,11 +109,11 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 		for _, vmssvm := range expectedVMSSVMs {
 			vmssvm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
@@ -123,7 +123,7 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 				diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
 					testCloud.SubscriptionID, testCloud.ResourceGroup, diskname)
 				vmssvm.StorageProfile.DataDisks = &[]compute.DataDisk{
-					{Lun: to.Int32Ptr(0), Name: &diskname, ManagedDisk: &compute.ManagedDiskParameters{ID: &diskURI}},
+					{Lun: pointer.Int32(0), Name: &diskname, ManagedDisk: &compute.ManagedDiskParameters{ID: &diskURI}},
 				}
 			}
 		}
@@ -237,26 +237,26 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 		for itr, vmssvm := range expectedVMSSVMs {
 			vmssvm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
 				DataDisks: &[]compute.DataDisk{
 					{
-						Lun:  to.Int32Ptr(0),
-						Name: to.StringPtr(diskName),
+						Lun:  pointer.Int32(0),
+						Name: pointer.String(diskName),
 					},
 					{
-						Lun:  to.Int32Ptr(1),
-						Name: to.StringPtr("disk2"),
+						Lun:  pointer.Int32(1),
+						Name: pointer.String("disk2"),
 					},
 					{
-						Lun:  to.Int32Ptr(2),
-						Name: to.StringPtr("disk3"),
+						Lun:  pointer.Int32(2),
+						Name: pointer.String("disk3"),
 					},
 				},
 			}
@@ -319,7 +319,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:     []string{"vmss-vm-000001"},
 			vmssName:       "vm1",
 			vmssvmName:     "vm1",
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("not a vmss instance"),
 		},
@@ -328,7 +328,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:  []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:    "vmss00",
 			vmssvmName:  "vmss00-vm-000000",
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName)},
+			existedDisk: compute.Disk{Name: pointer.String(diskName)},
 			expectedErr: false,
 		},
 		{
@@ -336,7 +336,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:     []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:       fakeStatusNotFoundVMSSName,
 			vmssvmName:     "vmss00-vm-000000",
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: %w", fmt.Errorf("instance not found")),
 		},
@@ -345,7 +345,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:  []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:    "vmss00",
 			vmssvmName:  "vmss00-vm-000000",
-			existedDisk: compute.Disk{Name: to.StringPtr("disk-name-err")},
+			existedDisk: compute.Disk{Name: pointer.String("disk-name-err")},
 			expectedErr: false,
 		},
 	}
@@ -368,17 +368,17 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 		for itr, vmssvm := range expectedVMSSVMs {
 			vmssvm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
 				DataDisks: &[]compute.DataDisk{{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr(diskName),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String(diskName),
 				}},
 			}
 
@@ -444,8 +444,8 @@ func TestGetDataDisksWithVMSS(t *testing.T) {
 			nodeName: "vmss00-vm-000000",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 			},
 			expectedErr: false,
@@ -456,8 +456,8 @@ func TestGetDataDisksWithVMSS(t *testing.T) {
 			nodeName: "vmss00-vm-000000",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 			},
 			expectedErr: false,
@@ -489,8 +489,8 @@ func TestGetDataDisksWithVMSS(t *testing.T) {
 			for _, vmssvm := range expectedVMSSVMs {
 				vmssvm.StorageProfile = &compute.StorageProfile{
 					DataDisks: &[]compute.DataDisk{{
-						Lun:  to.Int32Ptr(0),
-						Name: to.StringPtr("disk1"),
+						Lun:  pointer.Int32(0),
+						Name: pointer.String("disk1"),
 					}},
 				}
 			}

--- a/pkg/provider/azure_controller_vmssflex.go
+++ b/pkg/provider/azure_controller_vmssflex.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -89,7 +89,7 @@ func (fs *FlexScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName,
 				Caching:                 opt.cachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: to.BoolPtr(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
 			})
 	}
 
@@ -147,7 +147,7 @@ func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName,
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diskURI)
-				disks[i].ToBeDetached = to.BoolPtr(true)
+				disks[i].ToBeDetached = pointer.Bool(true)
 				bFoundDisk = true
 			}
 		}
@@ -161,7 +161,7 @@ func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName,
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			newDisks := []compute.DataDisk{}
 			for _, disk := range disks {
-				if !to.Bool(disk.ToBeDetached) {
+				if !pointer.BoolDeref(disk.ToBeDetached, false) {
 					newDisks = append(newDisks, disk)
 				}
 			}

--- a/pkg/provider/azure_controller_vmssflex_test.go
+++ b/pkg/provider/azure_controller_vmssflex_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
 	autorestmocks "github.com/Azure/go-autorest/autorest/mocks"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -307,9 +307,9 @@ func TestGetDataDisksWithVmssFlex(t *testing.T) {
 			vmListErr:                      nil,
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:         to.Int32Ptr(1),
-					Name:        to.StringPtr("dataDisktestvm1"),
-					ManagedDisk: &compute.ManagedDiskParameters{ID: to.StringPtr("uri")},
+					Lun:         pointer.Int32(1),
+					Name:        pointer.String("dataDisktestvm1"),
+					ManagedDisk: &compute.ManagedDiskParameters{ID: pointer.String("uri")},
 				},
 			},
 			expectedErr: nil,
@@ -366,14 +366,14 @@ func TestVMSSFlexUpdateCache(t *testing.T) {
 		{
 			description: "vm.VirtualMachineProperties is nil",
 			nodeName:    "vmssflex1000001",
-			vm:          &compute.VirtualMachine{Name: to.StringPtr("vmssflex1000001")},
+			vm:          &compute.VirtualMachine{Name: pointer.String("vmssflex1000001")},
 			expectedErr: fmt.Errorf("vm.VirtualMachineProperties is nil"),
 		},
 		{
 			description: "vm.OsProfile.ComputerName is nil",
 			nodeName:    "vmssflex1000001",
 			vm: &compute.VirtualMachine{
-				Name:                     to.StringPtr("vmssflex1000001"),
+				Name:                     pointer.String("vmssflex1000001"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{},
 			},
 			expectedErr: fmt.Errorf("vm.OsProfile.ComputerName is nil"),
@@ -382,7 +382,7 @@ func TestVMSSFlexUpdateCache(t *testing.T) {
 			description: "vm.OsProfile.ComputerName is nil",
 			nodeName:    "vmssflex1000001",
 			vm: &compute.VirtualMachine{
-				Name: to.StringPtr("vmssflex1000001"),
+				Name: pointer.String("vmssflex1000001"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					OsProfile: &compute.OSProfile{},
 				},

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -34,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
@@ -58,14 +58,14 @@ func setTestVirtualMachines(c *Cloud, vmList map[string]string, isDataDisksFull 
 		}
 		status := []compute.InstanceViewStatus{
 			{
-				Code: to.StringPtr(powerState),
+				Code: pointer.String(powerState),
 			},
 			{
-				Code: to.StringPtr("ProvisioningState/succeeded"),
+				Code: pointer.String("ProvisioningState/succeeded"),
 			},
 		}
 		vm.VirtualMachineProperties = &compute.VirtualMachineProperties{
-			ProvisioningState: to.StringPtr(string(compute.ProvisioningStateSucceeded)),
+			ProvisioningState: pointer.String(string(compute.ProvisioningStateSucceeded)),
 			HardwareProfile: &compute.HardwareProfile{
 				VMSize: compute.StandardA0,
 			},
@@ -79,22 +79,22 @@ func setTestVirtualMachines(c *Cloud, vmList map[string]string, isDataDisksFull 
 		if !isDataDisksFull {
 			vm.StorageProfile.DataDisks = &[]compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 				{
-					Lun:  to.Int32Ptr(1),
-					Name: to.StringPtr("disk2"),
+					Lun:  pointer.Int32(1),
+					Name: pointer.String("disk2"),
 				},
 				{
-					Lun:  to.Int32Ptr(2),
-					Name: to.StringPtr("disk3"),
+					Lun:  pointer.Int32(2),
+					Name: pointer.String("disk3"),
 				},
 			}
 		} else {
 			dataDisks := make([]compute.DataDisk, maxLUN)
 			for i := 0; i < maxLUN; i++ {
-				dataDisks[i] = compute.DataDisk{Lun: to.Int32Ptr(int32(i))}
+				dataDisks[i] = compute.DataDisk{Lun: pointer.Int32(int32(i))}
 			}
 			vm.StorageProfile.DataDisks = &dataDisks
 		}
@@ -361,7 +361,7 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 		cloud := GetTestCloud(ctrl)
 		expectedVMs := setTestVirtualMachines(cloud, test.vmList, false)
 		if test.provisioningState != "" {
-			expectedVMs[0].ProvisioningState = to.StringPtr(test.provisioningState)
+			expectedVMs[0].ProvisioningState = pointer.String(test.provisioningState)
 		}
 		mockVMsClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		for _, vm := range expectedVMs {
@@ -395,9 +395,9 @@ func TestNodeAddresses(t *testing.T) {
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
 						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-							Primary: to.BoolPtr(true),
+							Primary: pointer.Bool(true),
 						},
-						ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
+						ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -405,9 +405,9 @@ func TestNodeAddresses(t *testing.T) {
 	}
 
 	expectedPIP := network.PublicIPAddress{
-		ID: to.StringPtr("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+		ID: pointer.String("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("192.168.1.12"),
+			IPAddress: pointer.String("192.168.1.12"),
 		},
 	}
 
@@ -416,7 +416,7 @@ func TestNodeAddresses(t *testing.T) {
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("172.1.0.3"),
+						PrivateIPAddress: pointer.String("172.1.0.3"),
 						PublicIPAddress:  &expectedPIP,
 					},
 				},
@@ -882,24 +882,24 @@ func TestInstanceMetadata(t *testing.T) {
 		expectedVM.HardwareProfile = &compute.HardwareProfile{
 			VMSize: compute.BasicA0,
 		}
-		expectedVM.Location = to.StringPtr("westus2")
+		expectedVM.Location = pointer.String("westus2")
 		expectedVM.Zones = &[]string{"1"}
-		expectedVM.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/VirtualMachines/vm")
+		expectedVM.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/VirtualMachines/vm")
 		mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, "vm", gomock.Any()).Return(expectedVM, nil)
 		expectedNIC := buildDefaultTestInterface(true, []string{})
-		(*expectedNIC.IPConfigurations)[0].PrivateIPAddress = to.StringPtr("1.2.3.4")
+		(*expectedNIC.IPConfigurations)[0].PrivateIPAddress = pointer.String("1.2.3.4")
 		(*expectedNIC.IPConfigurations)[0].PublicIPAddress = &network.PublicIPAddress{
-			ID: to.StringPtr("pip"),
+			ID: pointer.String("pip"),
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-				IPAddress: to.StringPtr("5.6.7.8"),
+				IPAddress: pointer.String("5.6.7.8"),
 			},
 		}
 		mockNICClient := cloud.InterfacesClient.(*mockinterfaceclient.MockInterface)
 		mockNICClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, "k8s-agentpool1-00000000-nic-1", gomock.Any()).Return(expectedNIC, nil)
 		expectedPIP := network.PublicIPAddress{
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-				IPAddress: to.StringPtr("5.6.7.8"),
+				IPAddress: pointer.String("5.6.7.8"),
 			},
 		}
 		mockPIPClient := cloud.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)

--- a/pkg/provider/azure_loadbalancer_backendpool_test.go
+++ b/pkg/provider/azure_loadbalancer_backendpool_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -48,31 +48,31 @@ func TestEnsureHostsInPoolNodeIP(t *testing.T) {
 	bi := newBackendPoolTypeNodeIP(az)
 
 	backendPool := network.BackendAddressPool{
-		Name: to.StringPtr("kubernetes"),
+		Name: pointer.String("kubernetes"),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("10.0.0.1"),
+						IPAddress: pointer.String("10.0.0.1"),
 					},
 				},
 			},
 		},
 	}
 	expectedBackendPool := network.BackendAddressPool{
-		Name: to.StringPtr("kubernetes"),
+		Name: pointer.String("kubernetes"),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("10.0.0.1"),
+						IPAddress: pointer.String("10.0.0.1"),
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-0"),
+					Name: pointer.String("vmss-0"),
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress:      to.StringPtr("10.0.0.2"),
-						VirtualNetwork: &network.SubResource{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
+						IPAddress:      pointer.String("10.0.0.2"),
+						VirtualNetwork: &network.SubResource{ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
 					},
 				},
 			},
@@ -136,15 +136,15 @@ func TestCleanupVMSetFromBackendPoolByConditionNodeIPConfig(t *testing.T) {
 	cloud.VMSet = mockVMSet
 
 	expectedLB := network.LoadBalancer{
-		Name: to.StringPtr("testCluster"),
+		Name: pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
+								ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
 							},
 						},
 					},
@@ -229,15 +229,15 @@ func TestCleanupVMSetFromBackendPoolForInstanceNotFound(t *testing.T) {
 	cloud.VMSet = mockVMSet
 
 	expectedLB := network.LoadBalancer{
-		Name: to.StringPtr("testCluster"),
+		Name: pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
+								ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
 							},
 						},
 					},
@@ -286,7 +286,7 @@ func TestReconcileBackendPoolsNodeIPConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	lb = network.LoadBalancer{
-		Name:                         to.StringPtr(testClusterName),
+		Name:                         pointer.String(testClusterName),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 	}
 	az = GetTestCloud(ctrl)
@@ -433,7 +433,7 @@ func TestReconcileBackendPoolsNodeIP(t *testing.T) {
 	assert.NoError(t, err)
 
 	lb = &network.LoadBalancer{
-		Name:                         to.StringPtr(testClusterName),
+		Name:                         pointer.String(testClusterName),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 	}
 	az = GetTestCloud(ctrl)
@@ -524,22 +524,22 @@ func TestReconcileBackendPoolsNodeIPConfigToIP(t *testing.T) {
 func TestRemoveNodeIPAddressFromBackendPool(t *testing.T) {
 	nodeIPAddresses := []string{"1.2.3.4", "4.3.2.1"}
 	backendPool := network.BackendAddressPool{
-		Name: to.StringPtr("kubernetes"),
+		Name: pointer.String("kubernetes"),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("5.6.7.8"),
+						IPAddress: pointer.String("5.6.7.8"),
 					},
 				},
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 				{
@@ -549,12 +549,12 @@ func TestRemoveNodeIPAddressFromBackendPool(t *testing.T) {
 		},
 	}
 	expectedBackendPool := network.BackendAddressPool{
-		Name: to.StringPtr("kubernetes"),
+		Name: pointer.String("kubernetes"),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("5.6.7.8"),
+						IPAddress: pointer.String("5.6.7.8"),
 					},
 				},
 				{

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/cases"
@@ -38,6 +37,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient"
@@ -61,30 +61,30 @@ const LBInUseRawError = `{
 
 func TestGetLoadBalancer(t *testing.T) {
 	lb1 := network.LoadBalancer{
-		Name:                         to.StringPtr("testCluster"),
+		Name:                         pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 	}
 	lb2 := network.LoadBalancer{
-		Name: to.StringPtr("testCluster"),
+		Name: pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("aservice"),
+					Name: pointer.String("aservice"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice")},
+						PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice")},
 					},
 				},
 			},
 		},
 	}
 	lb3 := network.LoadBalancer{
-		Name: to.StringPtr("testCluster-internal"),
+		Name: pointer.String("testCluster-internal"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("aservice"),
+					Name: pointer.String("aservice"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("10.0.0.6"),
+						PrivateIPAddress: pointer.String("10.0.0.6"),
 					},
 				},
 			},
@@ -170,7 +170,7 @@ func TestGetLoadBalancer(t *testing.T) {
 		if c.pipExists {
 			mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", gomock.Any(), gomock.Any()).Return(network.PublicIPAddress{
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				}}, nil)
 		} else {
 			mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", gomock.Any(), gomock.Any()).Return(network.PublicIPAddress{}, &retry.Error{HTTPStatusCode: http.StatusNotFound})
@@ -200,16 +200,16 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe names match while ports don't should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("httpProbe"),
+					Name: pointer.String("httpProbe"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port: to.Int32Ptr(1),
+						Port: pointer.Int32(1),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("httpProbe"),
+				Name: pointer.String("httpProbe"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(2),
+					Port: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -218,16 +218,16 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe ports match while names don't should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port: to.Int32Ptr(1),
+						Port: pointer.Int32(1),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe2"),
+				Name: pointer.String("probe2"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(1),
+					Port: pointer.Int32(1),
 				},
 			},
 			expected: false,
@@ -236,17 +236,17 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe protocol don't match should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:     to.Int32Ptr(1),
+						Port:     pointer.Int32(1),
 						Protocol: network.ProbeProtocolHTTP,
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port:     to.Int32Ptr(1),
+					Port:     pointer.Int32(1),
 					Protocol: network.ProbeProtocolTCP,
 				},
 			},
@@ -256,18 +256,18 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe path don't match should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:        to.Int32Ptr(1),
-						RequestPath: to.StringPtr("/path1"),
+						Port:        pointer.Int32(1),
+						RequestPath: pointer.String("/path1"),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port:        to.Int32Ptr(1),
-					RequestPath: to.StringPtr("/path2"),
+					Port:        pointer.Int32(1),
+					RequestPath: pointer.String("/path2"),
 				},
 			},
 			expected: false,
@@ -276,20 +276,20 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe interval don't match should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:              to.Int32Ptr(1),
-						RequestPath:       to.StringPtr("/path"),
-						IntervalInSeconds: to.Int32Ptr(5),
+						Port:              pointer.Int32(1),
+						RequestPath:       pointer.String("/path"),
+						IntervalInSeconds: pointer.Int32(5),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port:              to.Int32Ptr(1),
-					RequestPath:       to.StringPtr("/path"),
-					IntervalInSeconds: to.Int32Ptr(10),
+					Port:              pointer.Int32(1),
+					RequestPath:       pointer.String("/path"),
+					IntervalInSeconds: pointer.Int32(10),
 				},
 			},
 			expected: false,
@@ -298,16 +298,16 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe match should return true",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port: to.Int32Ptr(1),
+						Port: pointer.Int32(1),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(1),
+					Port: pointer.Int32(1),
 				},
 			},
 			expected: true,
@@ -335,16 +335,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names don't match should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpProbe1"),
+					Name: pointer.String("httpProbe1"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendPort: to.Int32Ptr(1),
+						FrontendPort: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpProbe2"),
+				Name: pointer.String("httpProbe2"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendPort: to.Int32Ptr(1),
+					FrontendPort: pointer.Int32(1),
 				},
 			},
 			expected: false,
@@ -353,14 +353,14 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while protocols don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Protocol: network.TransportProtocolTCP,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					Protocol: network.TransportProtocolUDP,
 				},
@@ -371,18 +371,18 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while EnableTCPResets don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Protocol:       network.TransportProtocolTCP,
-						EnableTCPReset: to.BoolPtr(true),
+						EnableTCPReset: pointer.Bool(true),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					Protocol:       network.TransportProtocolTCP,
-					EnableTCPReset: to.BoolPtr(false),
+					EnableTCPReset: pointer.Bool(false),
 				},
 			},
 			expected: false,
@@ -391,16 +391,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while frontend ports don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpProbe"),
+					Name: pointer.String("httpProbe"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendPort: to.Int32Ptr(1),
+						FrontendPort: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpProbe"),
+				Name: pointer.String("httpProbe"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendPort: to.Int32Ptr(2),
+					FrontendPort: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -409,16 +409,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while backend ports don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpProbe"),
+					Name: pointer.String("httpProbe"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						BackendPort: to.Int32Ptr(1),
+						BackendPort: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpProbe"),
+				Name: pointer.String("httpProbe"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					BackendPort: to.Int32Ptr(2),
+					BackendPort: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -427,16 +427,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while idletimeout don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						IdleTimeoutInMinutes: to.Int32Ptr(1),
+						IdleTimeoutInMinutes: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					IdleTimeoutInMinutes: to.Int32Ptr(2),
+					IdleTimeoutInMinutes: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -445,14 +445,14 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while idletimeout nil should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name:                              to.StringPtr("httpRule"),
+					Name:                              pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					IdleTimeoutInMinutes: to.Int32Ptr(2),
+					IdleTimeoutInMinutes: pointer.Int32(2),
 				},
 			},
 			expected: true,
@@ -461,14 +461,14 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while LoadDistribution don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						LoadDistribution: network.LoadDistributionSourceIP,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					LoadDistribution: network.LoadDistributionDefault,
 				},
@@ -479,16 +479,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and probe names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						Probe: &network.SubResource{ID: to.StringPtr("probe")},
+						Probe: &network.SubResource{ID: pointer.String("probe")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					Probe: &network.SubResource{ID: to.StringPtr("probe")},
+					Probe: &network.SubResource{ID: pointer.String("probe")},
 				},
 			},
 			expected: true,
@@ -497,16 +497,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while probe don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Probe: nil,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					Probe: &network.SubResource{ID: to.StringPtr("probe")},
+					Probe: &network.SubResource{ID: pointer.String("probe")},
 				},
 			},
 			expected: false,
@@ -515,19 +515,19 @@ func TestFindRule(t *testing.T) {
 			msg: "both rule names and LoadBalancingRulePropertiesFormats match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						BackendPort:      to.Int32Ptr(2),
-						FrontendPort:     to.Int32Ptr(2),
+						BackendPort:      pointer.Int32(2),
+						FrontendPort:     pointer.Int32(2),
 						LoadDistribution: network.LoadDistributionSourceIP,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					BackendPort:      to.Int32Ptr(2),
-					FrontendPort:     to.Int32Ptr(2),
+					BackendPort:      pointer.Int32(2),
+					FrontendPort:     pointer.Int32(2),
 					LoadDistribution: network.LoadDistributionSourceIP,
 				},
 			},
@@ -537,16 +537,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and FrontendIPConfiguration names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("FrontendIPConfiguration")},
+						FrontendIPConfiguration: &network.SubResource{ID: pointer.String("FrontendIPConfiguration")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("frontendipconfiguration")},
+					FrontendIPConfiguration: &network.SubResource{ID: pointer.String("frontendipconfiguration")},
 				},
 			},
 			expected: true,
@@ -555,16 +555,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while FrontendIPConfiguration don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("FrontendIPConfiguration")},
+						FrontendIPConfiguration: &network.SubResource{ID: pointer.String("FrontendIPConfiguration")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("frontendipconifguration")},
+					FrontendIPConfiguration: &network.SubResource{ID: pointer.String("frontendipconifguration")},
 				},
 			},
 			expected: false,
@@ -573,16 +573,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and BackendAddressPool names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						BackendAddressPool: &network.SubResource{ID: to.StringPtr("BackendAddressPool")},
+						BackendAddressPool: &network.SubResource{ID: pointer.String("BackendAddressPool")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					BackendAddressPool: &network.SubResource{ID: to.StringPtr("backendaddresspool")},
+					BackendAddressPool: &network.SubResource{ID: pointer.String("backendaddresspool")},
 				},
 			},
 			expected: true,
@@ -591,16 +591,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and Probe names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						Probe: &network.SubResource{ID: to.StringPtr("Probe")},
+						Probe: &network.SubResource{ID: pointer.String("Probe")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					Probe: &network.SubResource{ID: to.StringPtr("probe")},
+					Probe: &network.SubResource{ID: pointer.String("probe")},
 				},
 			},
 			expected: true,
@@ -669,7 +669,7 @@ func TestSubnet(t *testing.T) {
 					},
 				},
 			},
-			expected: to.StringPtr("subnet"),
+			expected: pointer.String("subnet"),
 		},
 	} {
 		real := subnet(c.service)
@@ -808,10 +808,10 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when service name tag doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey: to.StringPtr("default/nginx"),
+					consts.ServiceTagKey: pointer.String("default/nginx"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			serviceName:  "web",
@@ -821,10 +821,10 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned when service name tag matches and cluster name tag is not set",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey: to.StringPtr("default/nginx"),
+					consts.ServiceTagKey: pointer.String("default/nginx"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -835,11 +835,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when cluster name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "k8s",
@@ -850,11 +850,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when cluster name matches while service name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/web"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/web"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -865,11 +865,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned when both service name tag and cluster name match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -880,11 +880,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when the tag is empty and load balancer IP does not match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr(""),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String(""),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:             "kubernetes",
@@ -896,11 +896,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned if there is a match among a multi-service tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx1,default/nginx2"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -911,11 +911,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned if there is not a match among a multi-service tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx1,default/nginx2"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -926,11 +926,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned if the load balancer IP is matched even if the svc name is not included in the tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr(""),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String(""),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:             "kubernetes",
@@ -943,11 +943,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned if the load balancer IP is not matched but the svc name is included in the tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx1,default/nginx2"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -1006,24 +1006,24 @@ func TestGetPublicIPAddressResourceGroup(t *testing.T) {
 
 func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 	existingPipWithTag := network.PublicIPAddress{
-		ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-		Name: to.StringPtr("testPIP"),
+		ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+		Name: pointer.String("testPIP"),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   network.IPVersionIPv4,
 			PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 			IPTags: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 			},
 		},
 	}
 
 	existingPipWithNoPublicIPAddressFormatProperties := network.PublicIPAddress{
-		ID:                              to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-		Name:                            to.StringPtr("testPIP"),
-		Tags:                            map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test2")},
+		ID:                              pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+		Name:                            pointer.String("testPIP"),
+		Tags:                            map[string]*string{consts.ServiceTagKey: pointer.String("default/test2")},
 		PublicIPAddressPropertiesFormat: nil,
 	}
 
@@ -1120,8 +1120,8 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 				IPTagsRequestedByAnnotation: true,
 				IPTags: &[]network.IPTag{
 					{
-						IPTagType: to.StringPtr("tag2"),
-						Tag:       to.StringPtr("tag2value"),
+						IPTagType: pointer.String("tag2"),
+						Tag:       pointer.String("tag2value"),
 					},
 				},
 			},
@@ -1133,7 +1133,7 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbShouldExist:  false,
 			lbIsInternal:   false,
 			desiredPipName: *existingPipWithTag.Name,
-			tags:           map[string]*string{consts.ServiceTagKey: to.StringPtr("")},
+			tags:           map[string]*string{consts.ServiceTagKey: pointer.String("")},
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
@@ -1146,7 +1146,7 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbShouldExist:  false,
 			lbIsInternal:   false,
 			desiredPipName: *existingPipWithTag.Name,
-			tags:           map[string]*string{consts.ServiceTagKey: to.StringPtr("svc1")},
+			tags:           map[string]*string{consts.ServiceTagKey: pointer.String("svc1")},
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
@@ -1158,7 +1158,7 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbShouldExist:  false,
 			lbIsInternal:   false,
 			desiredPipName: *existingPipWithTag.Name,
-			tags:           map[string]*string{consts.ServiceTagKey: to.StringPtr("")},
+			tags:           map[string]*string{consts.ServiceTagKey: pointer.String("")},
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
@@ -1273,8 +1273,8 @@ func TestConvertIPTagMapToSlice(t *testing.T) {
 			},
 			expected: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 			},
 		},
@@ -1286,12 +1286,12 @@ func TestConvertIPTagMapToSlice(t *testing.T) {
 			},
 			expected: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 		},
@@ -1305,13 +1305,13 @@ func TestConvertIPTagMapToSlice(t *testing.T) {
 		if actual != nil {
 			sort.Slice(*actual, func(i, j int) bool {
 				ipTagSlice := *actual
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 		}
 		if c.expected != nil {
 			sort.Slice(*c.expected, func(i, j int) bool {
 				ipTagSlice := *c.expected
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 
 		}
@@ -1373,12 +1373,12 @@ func TestGetserviceIPTagRequestForPublicIP(t *testing.T) {
 				IPTagsRequestedByAnnotation: true,
 				IPTags: &[]network.IPTag{
 					{
-						IPTagType: to.StringPtr("tag1"),
-						Tag:       to.StringPtr("tag1value"),
+						IPTagType: pointer.String("tag1"),
+						Tag:       pointer.String("tag1value"),
 					},
 					{
-						IPTagType: to.StringPtr("tag2"),
-						Tag:       to.StringPtr("tag2value"),
+						IPTagType: pointer.String("tag2"),
+						Tag:       pointer.String("tag2value"),
 					},
 				},
 			},
@@ -1392,13 +1392,13 @@ func TestGetserviceIPTagRequestForPublicIP(t *testing.T) {
 		if actual.IPTags != nil {
 			sort.Slice(*actual.IPTags, func(i, j int) bool {
 				ipTagSlice := *actual.IPTags
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 		}
 		if c.expected.IPTags != nil {
 			sort.Slice(*c.expected.IPTags, func(i, j int) bool {
 				ipTagSlice := *c.expected.IPTags
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 
 		}
@@ -1436,12 +1436,12 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "nil should not be considered equal to anything (case 1)",
 			input1: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input2:   nil,
@@ -1451,12 +1451,12 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "nil should not be considered equal to anything (case 2)",
 			input2: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input1:   nil,
@@ -1466,22 +1466,22 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "exactly equal should be treated as equal",
 			input1: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input2: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			expected: true,
@@ -1490,22 +1490,22 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "equal but out of order should be treated as equal",
 			input1: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input2: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 			},
 			expected: true,
@@ -1591,13 +1591,13 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			desc: "getServiceLoadBalancer shall return corresponding lb, status, exists if there are existed lbs",
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 							{
-								Name: to.StringPtr("aservice1"),
+								Name: pointer.String("aservice1"),
 								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-									PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+									PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 								},
 							},
 						},
@@ -1607,13 +1607,13 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			service: getTestService("service1", v1.ProtocolTCP, nil, false, 80),
 			wantLB:  false,
 			expectedLB: &network.LoadBalancer{
-				Name: to.StringPtr("testCluster"),
+				Name: pointer.String("testCluster"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 						{
-							Name: to.StringPtr("aservice1"),
+							Name: pointer.String("aservice1"),
 							FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-								PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+								PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 							},
 						},
 					},
@@ -1628,29 +1628,29 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 				"not standard and there are existing lbs already",
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						LoadBalancingRules: &[]network.LoadBalancingRule{
-							{Name: to.StringPtr("rule1")},
+							{Name: pointer.String("rule1")},
 						},
 					},
 				},
 				{
-					Name: to.StringPtr("as-1"),
+					Name: pointer.String("as-1"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						LoadBalancingRules: &[]network.LoadBalancingRule{
-							{Name: to.StringPtr("rule1")},
-							{Name: to.StringPtr("rule2")},
+							{Name: pointer.String("rule1")},
+							{Name: pointer.String("rule2")},
 						},
 					},
 				},
 				{
-					Name: to.StringPtr("as-2"),
+					Name: pointer.String("as-2"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						LoadBalancingRules: &[]network.LoadBalancingRule{
-							{Name: to.StringPtr("rule1")},
-							{Name: to.StringPtr("rule2")},
-							{Name: to.StringPtr("rule3")},
+							{Name: pointer.String("rule1")},
+							{Name: pointer.String("rule2")},
+							{Name: pointer.String("rule3")},
 						},
 					},
 				},
@@ -1659,10 +1659,10 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "__auto__"},
 			wantLB:      true,
 			expectedLB: &network.LoadBalancer{
-				Name: to.StringPtr("testCluster"),
+				Name: pointer.String("testCluster"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
-						{Name: to.StringPtr("rule1")},
+						{Name: pointer.String("rule1")},
 					},
 				},
 			},
@@ -1673,8 +1673,8 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			desc:    "getServiceLoadBalancer shall create a new lb otherwise",
 			service: getTestService("service1", v1.ProtocolTCP, nil, false, 80),
 			expectedLB: &network.LoadBalancer{
-				Name:                         to.StringPtr("testCluster"),
-				Location:                     to.StringPtr("westus"),
+				Name:                         pointer.String("testCluster"),
+				Location:                     pointer.String("westus"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 			},
 			expectedExists: false,
@@ -1687,15 +1687,15 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			service: getTestService("service1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationLoadBalancerMode: "as", consts.ServiceAnnotationLoadBalancerInternal: consts.TrueAnnotationValue}, false, 80),
 			existingLBs: []network.LoadBalancer{
 				{
-					Name:     to.StringPtr("as-internal"),
-					Location: to.StringPtr("westus"),
+					Name:     pointer.String("as-internal"),
+					Location: pointer.String("westus"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 							{
-								Name: to.StringPtr("aservice1"),
-								ID:   to.StringPtr("as-internal-aservice1"),
+								Name: pointer.String("aservice1"),
+								ID:   pointer.String("as-internal-aservice1"),
 								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-									PrivateIPAddress: to.StringPtr("1.2.3.4"),
+									PrivateIPAddress: pointer.String("1.2.3.4"),
 								},
 							},
 						},
@@ -1703,8 +1703,8 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 				},
 			},
 			expectedLB: &network.LoadBalancer{
-				Name:     to.StringPtr("testCluster-internal"),
-				Location: to.StringPtr("westus"),
+				Name:     pointer.String("testCluster-internal"),
+				Location: pointer.String("westus"),
 				Sku: &network.LoadBalancerSku{
 					Name: network.LoadBalancerSkuNameBasic,
 				},
@@ -1762,10 +1762,10 @@ func TestGetServiceLoadBalancerWithExtendedLocation(t *testing.T) {
 
 	// Test with wantLB=false
 	expectedLB := &network.LoadBalancer{
-		Name:     to.StringPtr("testCluster"),
-		Location: to.StringPtr("westus"),
+		Name:     pointer.String("testCluster"),
+		Location: pointer.String("westus"),
 		ExtendedLocation: &network.ExtendedLocation{
-			Name: to.StringPtr("microsoftlosangeles1"),
+			Name: pointer.String("microsoftlosangeles1"),
 			Type: network.ExtendedLocationTypesEdgeZone,
 		},
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
@@ -1783,10 +1783,10 @@ func TestGetServiceLoadBalancerWithExtendedLocation(t *testing.T) {
 
 	// Test with wantLB=true
 	expectedLB = &network.LoadBalancer{
-		Name:     to.StringPtr("testCluster"),
-		Location: to.StringPtr("westus"),
+		Name:     pointer.String("testCluster"),
+		Location: pointer.String("westus"),
 		ExtendedLocation: &network.ExtendedLocation{
-			Name: to.StringPtr("microsoftlosangeles1"),
+			Name: pointer.String("microsoftlosangeles1"),
 			Type: network.ExtendedLocationTypesEdgeZone,
 		},
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
@@ -1826,7 +1826,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return true if config.Name has a prefix of lb's name and " +
 				"config.Name != lbFrontendIPConfigName",
-			config:                 network.FrontendIPConfiguration{Name: to.StringPtr("atest1-name")},
+			config:                 network.FrontendIPConfiguration{Name: pointer.String("atest1-name")},
 			service:                getInternalTestService("test1", 80),
 			lbFrontendIPConfigName: "configName",
 			expectedFlag:           true,
@@ -1835,7 +1835,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return false if config.Name doesn't have a prefix of lb's name " +
 				"and config.Name != lbFrontendIPConfigName",
-			config:                 network.FrontendIPConfiguration{Name: to.StringPtr("btest1-name")},
+			config:                 network.FrontendIPConfiguration{Name: pointer.String("btest1-name")},
 			service:                getInternalTestService("test1", 80),
 			lbFrontendIPConfigName: "configName",
 			expectedFlag:           false,
@@ -1845,7 +1845,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, no loadBalancerIP is given, " +
 				"subnetName == nil and config.PrivateIPAllocationMethod == network.Static",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
 				},
@@ -1859,7 +1859,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, no loadBalancerIP is given, " +
 				"subnetName == nil and config.PrivateIPAllocationMethod != network.Static",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
 				},
@@ -1873,15 +1873,15 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return true if the service is internal and " +
 				"config.Subnet.ID != subnet.ID",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					Subnet: &network.Subnet{ID: to.StringPtr("testSubnet")},
+					Subnet: &network.Subnet{ID: pointer.String("testSubnet")},
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
 			service:                getInternalTestService("test1", 80),
 			annotations:            "testSubnet",
-			existingSubnet:         network.Subnet{ID: to.StringPtr("testSubnet1")},
+			existingSubnet:         network.Subnet{ID: pointer.String("testSubnet1")},
 			expectedFlag:           true,
 			expectedError:          false,
 		},
@@ -1889,10 +1889,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, subnet == nil, " +
 				"loadBalancerIP == config.PrivateIPAddress and config.PrivateIPAllocationMethod != 'static'",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-					PrivateIPAddress:          to.StringPtr("1.1.1.1"),
+					PrivateIPAddress:          pointer.String("1.1.1.1"),
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1905,10 +1905,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, subnet == nil, " +
 				"loadBalancerIP == config.PrivateIPAddress and config.PrivateIPAllocationMethod == 'static'",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-					PrivateIPAddress:          to.StringPtr("1.1.1.1"),
+					PrivateIPAddress:          pointer.String("1.1.1.1"),
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1921,10 +1921,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return true if the service is internal, subnet == nil and " +
 				"loadBalancerIP != config.PrivateIPAddress",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-					PrivateIPAddress:          to.StringPtr("1.1.1.2"),
+					PrivateIPAddress:          pointer.String("1.1.1.2"),
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1936,7 +1936,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return false if config.PublicIPAddress == nil",
 			config: network.FrontendIPConfiguration{
-				Name:                                    to.StringPtr("btest1-name"),
+				Name:                                    pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1944,10 +1944,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			loadBalancerIP:         "1.1.1.1",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
-					ID:   to.StringPtr("pip"),
+					Name: pointer.String("pipName"),
+					ID:   pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.1.1.1"),
+						IPAddress: pointer.String("1.1.1.1"),
 					},
 				},
 			},
@@ -1957,9 +1957,9 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return false if pip.ID == config.PublicIPAddress.ID",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription" +
+					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("/subscriptions/subscription" +
 						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName")},
 				},
 			},
@@ -1968,11 +1968,11 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			loadBalancerIP:         "1.1.1.1",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
+					Name: pointer.String("pipName"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.1.1.1"),
+						IPAddress: pointer.String("1.1.1.1"),
 					},
-					ID: to.StringPtr("/subscriptions/subscription" +
+					ID: pointer.String("/subscriptions/subscription" +
 						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName"),
 				},
 			},
@@ -1982,10 +1982,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return true if pip.ID != config.PublicIPAddress.ID",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/subscription" +
+						ID: pointer.String("/subscriptions/subscription" +
 							"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName1"),
 					},
 				},
@@ -1995,11 +1995,11 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			loadBalancerIP:         "1.1.1.1",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
-					ID: to.StringPtr("/subscriptions/subscription" +
+					Name: pointer.String("pipName"),
+					ID: pointer.String("/subscriptions/subscription" +
 						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName2"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.1.1.1"),
+						IPAddress: pointer.String("1.1.1.1"),
 					},
 				},
 			},
@@ -2046,9 +2046,9 @@ func TestFindMatchedPIPByLoadBalancerIP(t *testing.T) {
 	defer ctrl.Finish()
 
 	testPIP := network.PublicIPAddress{
-		Name: to.StringPtr("pipName"),
+		Name: pointer.String("pipName"),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("1.2.3.4"),
+			IPAddress: pointer.String("1.2.3.4"),
 		},
 	}
 	var nilPIPs []network.PublicIPAddress
@@ -2127,9 +2127,9 @@ func TestDeterminePublicIPName(t *testing.T) {
 			loadBalancerIP: "1.2.3.4",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
+					Name: pointer.String("pipName"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -2376,7 +2376,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			loadBalancerSku: "standard",
 			probeProtocol:   "Https",
 			probePath:       "/healthy1",
-			expectedProbes:  getTestProbes("Https", "/healthy1", to.Int32Ptr(20), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedProbes:  getTestProbes("Https", "/healthy1", pointer.Int32(20), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(5)),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -2387,7 +2387,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			}, false, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Http",
-			expectedProbes:  getTestProbes("Http", "/", to.Int32Ptr(20), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedProbes:  getTestProbes("Http", "/", pointer.Int32(20), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(5)),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -2398,7 +2398,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			}, false, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
-			expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(20), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedProbes:  getTestProbes("Tcp", "", pointer.Int32(20), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(5)),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -2497,8 +2497,8 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 				getTestRule(false, 8000),
 			},
 			expectedProbes: []network.Probe{
-				getTestProbe("Tcp", "/", to.Int32Ptr(5), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(2)),
-				getTestProbe("Tcp", "/", to.Int32Ptr(5), to.Int32Ptr(8000), to.Int32Ptr(10080), to.Int32Ptr(2)),
+				getTestProbe("Tcp", "/", pointer.Int32(5), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(2)),
+				getTestProbe("Tcp", "/", pointer.Int32(5), pointer.Int32(8000), pointer.Int32(10080), pointer.Int32(2)),
 			},
 		},
 		{
@@ -2511,8 +2511,8 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 				getTestRule(false, 8000),
 			},
 			expectedProbes: []network.Probe{
-				getTestProbe("Tcp", "/", to.Int32Ptr(5), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(2)),
-				getTestProbe("Tcp", "/", to.Int32Ptr(5), to.Int32Ptr(8000), to.Int32Ptr(10080), to.Int32Ptr(2)),
+				getTestProbe("Tcp", "/", pointer.Int32(5), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(2)),
+				getTestProbe("Tcp", "/", pointer.Int32(5), pointer.Int32(8000), pointer.Int32(10080), pointer.Int32(2)),
 			},
 		},
 		{
@@ -2529,7 +2529,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 				}(),
 			},
 			expectedProbes: []network.Probe{
-				getTestProbe("Tcp", "/", to.Int32Ptr(5), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(2)),
+				getTestProbe("Tcp", "/", pointer.Int32(5), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(2)),
 			},
 		},
 		{
@@ -2541,12 +2541,12 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 				getTestRule(false, 80),
 			},
 			expectedProbes: []network.Probe{
-				getTestProbe("Tcp", "/", to.Int32Ptr(5), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(2)),
+				getTestProbe("Tcp", "/", pointer.Int32(5), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(2)),
 			},
 		},
 	}
 	rules := getDefaultTestRules(true)
-	rules[0].IdleTimeoutInMinutes = to.Int32Ptr(5)
+	rules[0].IdleTimeoutInMinutes = pointer.Int32(5)
 	testCases = append(testCases, struct {
 		desc            string
 		service         v1.Service
@@ -2565,7 +2565,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		}, false, 80),
 		loadBalancerSku: "standard",
 		probeProtocol:   "Tcp",
-		expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(10), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(10)),
+		expectedProbes:  getTestProbes("Tcp", "", pointer.Int32(10), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(10)),
 		expectedRules:   rules,
 	})
 	rules1 := []network.LoadBalancingRule{
@@ -2573,9 +2573,9 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		getTestRule(true, 443),
 		getTestRule(true, 421),
 	}
-	rules1[0].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
-	rules1[1].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
-	rules1[2].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[0].Probe.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[1].Probe.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[2].Probe.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
 
 	// When the service spec externalTrafficPolicy is Local all of these annotations should be ignored
 	svc := getTestService("test1", v1.ProtocolTCP, map[string]string{
@@ -2588,7 +2588,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 	}, false, 80, 443, 421)
 	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 	svc.Spec.HealthCheckNodePort = 34567
-	probes := getTestProbes("Http", "/healthz", to.Int32Ptr(5), to.Int32Ptr(34567), to.Int32Ptr(34567), to.Int32Ptr(2))
+	probes := getTestProbes("Http", "/healthz", pointer.Int32(5), pointer.Int32(34567), pointer.Int32(34567), pointer.Int32(2))
 	testCases = append(testCases, struct {
 		desc            string
 		service         v1.Service
@@ -2640,7 +2640,7 @@ func getTestProbes(protocol, path string, interval, servicePort, probePort, numO
 
 func getTestProbe(protocol, path string, interval, servicePort, probePort, numOfProbe *int32) network.Probe {
 	expectedProbes := network.Probe{
-		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", *servicePort)),
+		Name: pointer.String(fmt.Sprintf("atest1-TCP-%d", *servicePort)),
 		ProbePropertiesFormat: &network.ProbePropertiesFormat{
 			Protocol:          network.ProbeProtocol(protocol),
 			Port:              probePort,
@@ -2649,12 +2649,12 @@ func getTestProbe(protocol, path string, interval, servicePort, probePort, numOf
 		},
 	}
 	if (strings.EqualFold(protocol, "Http") || strings.EqualFold(protocol, "Https")) && len(strings.TrimSpace(path)) > 0 {
-		expectedProbes.RequestPath = to.StringPtr(path)
+		expectedProbes.RequestPath = pointer.String(path)
 	}
 	return expectedProbes
 }
 func getDefaultTestProbes(protocol, path string) []network.Probe {
-	return getTestProbes(protocol, path, to.Int32Ptr(5), to.Int32Ptr(80), to.Int32Ptr(10080), to.Int32Ptr(2))
+	return getTestProbes(protocol, path, pointer.Int32(5), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(2))
 }
 
 func getDefaultTestRules(enableTCPReset bool) []network.LoadBalancingRule {
@@ -2666,37 +2666,37 @@ func getDefaultTestRules(enableTCPReset bool) []network.LoadBalancingRule {
 func getDefaultInternalIPv6Rules(enableTCPReset bool) []network.LoadBalancingRule {
 	rules := getDefaultTestRules(true)
 	for _, rule := range rules {
-		rule.EnableFloatingIP = to.BoolPtr(false)
-		rule.BackendPort = to.Int32Ptr(getBackendPort(*rule.FrontendPort))
+		rule.EnableFloatingIP = pointer.Bool(false)
+		rule.BackendPort = pointer.Int32(getBackendPort(*rule.FrontendPort))
 	}
 	return rules
 }
 
 func getTestRule(enableTCPReset bool, port int32) network.LoadBalancingRule {
 	expectedRules := network.LoadBalancingRule{
-		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", port)),
+		Name: pointer.String(fmt.Sprintf("atest1-TCP-%d", port)),
 		LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 			Protocol: network.TransportProtocol("Tcp"),
 			FrontendIPConfiguration: &network.SubResource{
-				ID: to.StringPtr("frontendIPConfigID"),
+				ID: pointer.String("frontendIPConfigID"),
 			},
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("backendPoolID"),
+				ID: pointer.String("backendPoolID"),
 			},
 			LoadDistribution:     "Default",
-			FrontendPort:         to.Int32Ptr(port),
-			BackendPort:          to.Int32Ptr(port),
-			EnableFloatingIP:     to.BoolPtr(true),
-			DisableOutboundSnat:  to.BoolPtr(false),
-			IdleTimeoutInMinutes: to.Int32Ptr(4),
+			FrontendPort:         pointer.Int32(port),
+			BackendPort:          pointer.Int32(port),
+			EnableFloatingIP:     pointer.Bool(true),
+			DisableOutboundSnat:  pointer.Bool(false),
+			IdleTimeoutInMinutes: pointer.Int32(4),
 			Probe: &network.SubResource{
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/" +
 					fmt.Sprintf("Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-%d", port)),
 			},
 		},
 	}
 	if enableTCPReset {
-		expectedRules.EnableTCPReset = to.BoolPtr(true)
+		expectedRules.EnableTCPReset = pointer.Bool(true)
 	}
 	return expectedRules
 }
@@ -2704,28 +2704,28 @@ func getTestRule(enableTCPReset bool, port int32) network.LoadBalancingRule {
 func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol) []network.LoadBalancingRule {
 	expectedRules := []network.LoadBalancingRule{
 		{
-			Name: to.StringPtr(fmt.Sprintf("atest1-%s-80", string(protocol))),
+			Name: pointer.String(fmt.Sprintf("atest1-%s-80", string(protocol))),
 			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 				Protocol: network.TransportProtocol("All"),
 				FrontendIPConfiguration: &network.SubResource{
-					ID: to.StringPtr("frontendIPConfigID"),
+					ID: pointer.String("frontendIPConfigID"),
 				},
 				BackendAddressPool: &network.SubResource{
-					ID: to.StringPtr("backendPoolID"),
+					ID: pointer.String("backendPoolID"),
 				},
 				LoadDistribution:     "Default",
-				FrontendPort:         to.Int32Ptr(0),
-				BackendPort:          to.Int32Ptr(0),
-				EnableFloatingIP:     to.BoolPtr(true),
-				DisableOutboundSnat:  to.BoolPtr(false),
-				IdleTimeoutInMinutes: to.Int32Ptr(4),
-				EnableTCPReset:       to.BoolPtr(true),
+				FrontendPort:         pointer.Int32(0),
+				BackendPort:          pointer.Int32(0),
+				EnableFloatingIP:     pointer.Bool(true),
+				DisableOutboundSnat:  pointer.Bool(false),
+				IdleTimeoutInMinutes: pointer.Int32(4),
+				EnableTCPReset:       pointer.Bool(true),
 			},
 		},
 	}
 	if hasProbe {
 		expectedRules[0].Probe = &network.SubResource{
-			ID: to.StringPtr(fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/"+
+			ID: pointer.String(fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/"+
 				"Microsoft.Network/loadBalancers/lbname/probes/atest1-%s-80", string(protocol))),
 		}
 	}
@@ -2734,29 +2734,29 @@ func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol) []netwo
 
 func getFloatingIPTestRule(enableTCPReset, enableFloatingIP bool, port int32) network.LoadBalancingRule {
 	expectedRules := network.LoadBalancingRule{
-		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", port)),
+		Name: pointer.String(fmt.Sprintf("atest1-TCP-%d", port)),
 		LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 			Protocol: network.TransportProtocol("Tcp"),
 			FrontendIPConfiguration: &network.SubResource{
-				ID: to.StringPtr("frontendIPConfigID"),
+				ID: pointer.String("frontendIPConfigID"),
 			},
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("backendPoolID"),
+				ID: pointer.String("backendPoolID"),
 			},
 			LoadDistribution:     "Default",
-			FrontendPort:         to.Int32Ptr(port),
-			BackendPort:          to.Int32Ptr(getBackendPort(port)),
-			EnableFloatingIP:     to.BoolPtr(enableFloatingIP),
-			DisableOutboundSnat:  to.BoolPtr(false),
-			IdleTimeoutInMinutes: to.Int32Ptr(4),
+			FrontendPort:         pointer.Int32(port),
+			BackendPort:          pointer.Int32(getBackendPort(port)),
+			EnableFloatingIP:     pointer.Bool(enableFloatingIP),
+			DisableOutboundSnat:  pointer.Bool(false),
+			IdleTimeoutInMinutes: pointer.Int32(4),
 			Probe: &network.SubResource{
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/" +
 					fmt.Sprintf("Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-%d", port)),
 			},
 		},
 	}
 	if enableTCPReset {
-		expectedRules.EnableTCPReset = to.BoolPtr(true)
+		expectedRules.EnableTCPReset = pointer.Bool(true)
 	}
 	return expectedRules
 }
@@ -2772,10 +2772,10 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
 					Name: identifier,
-					ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
+					ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 						"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/" + *identifier),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+						PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 					},
 				},
 			},
@@ -2784,39 +2784,39 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 			},
 			Probes: &[]network.Probe{
 				{
-					Name: to.StringPtr(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
+					Name: pointer.String(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
 						"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:              to.Int32Ptr(10080),
+						Port:              pointer.Int32(10080),
 						Protocol:          network.ProbeProtocolTCP,
-						IntervalInSeconds: to.Int32Ptr(5),
-						NumberOfProbes:    to.Int32Ptr(2),
+						IntervalInSeconds: pointer.Int32(5),
+						NumberOfProbes:    pointer.Int32(2),
 					},
 				},
 			},
 			LoadBalancingRules: &[]network.LoadBalancingRule{
 				{
-					Name: to.StringPtr(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
+					Name: pointer.String(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
 						"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Protocol: network.TransportProtocol(caser.String((strings.ToLower(string(service.Spec.Ports[0].Protocol))))),
 						FrontendIPConfiguration: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
+							ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 								"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/aservice1"),
 						},
 						BackendAddressPool: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
+							ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 								"Microsoft.Network/loadBalancers/" + *name + "/backendAddressPools/" + *clusterName),
 						},
 						LoadDistribution:     network.LoadDistribution("Default"),
-						FrontendPort:         to.Int32Ptr(service.Spec.Ports[0].Port),
-						BackendPort:          to.Int32Ptr(service.Spec.Ports[0].Port),
-						EnableFloatingIP:     to.BoolPtr(true),
-						EnableTCPReset:       to.BoolPtr(strings.EqualFold(lbSku, "standard")),
-						DisableOutboundSnat:  to.BoolPtr(false),
-						IdleTimeoutInMinutes: to.Int32Ptr(4),
+						FrontendPort:         pointer.Int32(service.Spec.Ports[0].Port),
+						BackendPort:          pointer.Int32(service.Spec.Ports[0].Port),
+						EnableFloatingIP:     pointer.Bool(true),
+						EnableTCPReset:       pointer.Bool(strings.EqualFold(lbSku, "standard")),
+						DisableOutboundSnat:  pointer.Bool(false),
+						IdleTimeoutInMinutes: pointer.Int32(4),
 						Probe: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-80"),
+							ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-80"),
 						},
 					},
 				},
@@ -2831,17 +2831,17 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	defer ctrl.Finish()
 
 	service1 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
-	basicLb1 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service1, "Basic")
+	basicLb1 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service1, "Basic")
 
 	service2 := getTestService("test1", v1.ProtocolTCP, nil, false, 80)
-	basicLb2 := getTestLoadBalancer(to.StringPtr("lb1"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("bservice1"), service2, "Basic")
-	basicLb2.Name = to.StringPtr("testCluster")
+	basicLb2 := getTestLoadBalancer(pointer.String("lb1"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("bservice1"), service2, "Basic")
+	basicLb2.Name = pointer.String("testCluster")
 	basicLb2.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
@@ -2849,186 +2849,186 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	service3 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
 	modifiedLbs := make([]network.LoadBalancer, 2)
 	for i := range modifiedLbs {
-		modifiedLbs[i] = getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service3, "Basic")
+		modifiedLbs[i] = getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service3, "Basic")
 		modifiedLbs[i].FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 			{
-				Name: to.StringPtr("aservice1"),
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+				Name: pointer.String("aservice1"),
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 				},
 			},
 			{
-				Name: to.StringPtr("bservice1"),
-				ID:   to.StringPtr("bservice1"),
+				Name: pointer.String("bservice1"),
+				ID:   pointer.String("bservice1"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 				},
 			},
 		}
 		modifiedLbs[i].Probes = &[]network.Probe{
 			{
-				Name: to.StringPtr("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
+				Name: pointer.String("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
 					"-" + strconv.Itoa(int(service3.Spec.Ports[0].Port))),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(10080),
+					Port: pointer.Int32(10080),
 				},
 			},
 			{
-				Name: to.StringPtr("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
+				Name: pointer.String("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
 					"-" + strconv.Itoa(int(service3.Spec.Ports[0].Port))),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(10081),
+					Port: pointer.Int32(10081),
 				},
 			},
 		}
 	}
-	expectedLb1 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service3, "Basic")
+	expectedLb1 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service3, "Basic")
 	expectedLb1.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 
 	service4 := getTestService("service1", v1.ProtocolTCP, map[string]string{}, false, 80)
-	existingSLB := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service4, "Standard")
+	existingSLB := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service4, "Standard")
 	existingSLB.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 	existingSLB.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10080),
+				Port: pointer.Int32(10080),
 			},
 		},
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10081),
+				Port: pointer.Int32(10081),
 			},
 		},
 	}
 
-	expectedSLb := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service4, "Standard")
-	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
-	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = to.BoolPtr(true)
-	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = to.Int32Ptr(4)
+	expectedSLb := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service4, "Standard")
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(true)
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = pointer.Bool(true)
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = pointer.Int32(4)
 	expectedSLb.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 
 	service5 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
-	slb5 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service5, "Standard")
+	slb5 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service5, "Standard")
 	slb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 	slb5.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10080),
+				Port: pointer.Int32(10080),
 			},
 		},
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10081),
+				Port: pointer.Int32(10081),
 			},
 		},
 	}
 
 	//change to false to test that reconciliation will fix it (despite the fact that disable-tcp-reset was removed in 1.20)
-	(*slb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = to.BoolPtr(false)
+	(*slb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = pointer.Bool(false)
 
-	expectedSLb5 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service5, "Standard")
-	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
-	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = to.Int32Ptr(4)
+	expectedSLb5 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service5, "Standard")
+	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(true)
+	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = pointer.Int32(4)
 	expectedSLb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 
 	service6 := getTestService("service1", v1.ProtocolUDP, nil, false, 80)
-	lb6 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service6, "basic")
+	lb6 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service6, "basic")
 	lb6.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	lb6.Probes = &[]network.Probe{}
-	expectedLB6 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service6, "basic")
+	expectedLB6 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service6, "basic")
 	expectedLB6.Probes = &[]network.Probe{}
 	(*expectedLB6.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].Probe = nil
 	(*expectedLB6.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = nil
 	expectedLB6.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 	}
@@ -3036,62 +3036,62 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	service7 := getTestService("service1", v1.ProtocolUDP, nil, false, 80)
 	service7.Spec.HealthCheckNodePort = 10081
 	service7.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
-	lb7 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service7, "basic")
+	lb7 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service7, "basic")
 	lb7.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	lb7.Probes = &[]network.Probe{}
-	expectedLB7 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service7, "basic")
+	expectedLB7 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service7, "basic")
 	(*expectedLB7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].Probe = &network.SubResource{
-		ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-10081"),
+		ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-10081"),
 	}
 	(*expectedLB7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = nil
-	(*lb7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
+	(*lb7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(true)
 	expectedLB7.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 	}
 	expectedLB7.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(v1.ProtocolTCP) +
+			Name: pointer.String("aservice1-" + string(v1.ProtocolTCP) +
 				"-" + strconv.Itoa(int(service7.Spec.HealthCheckNodePort))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port:              to.Int32Ptr(10081),
-				RequestPath:       to.StringPtr("/healthz"),
+				Port:              pointer.Int32(10081),
+				RequestPath:       pointer.String("/healthz"),
 				Protocol:          network.ProbeProtocolHTTP,
-				IntervalInSeconds: to.Int32Ptr(5),
-				NumberOfProbes:    to.Int32Ptr(2),
+				IntervalInSeconds: pointer.Int32(5),
+				NumberOfProbes:    pointer.Int32(2),
 			},
 		},
 	}
 
 	service8 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
-	lb8 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("anotherRG"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service8, "Standard")
+	lb8 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("anotherRG"), pointer.String("testCluster"), pointer.String("aservice1"), service8, "Standard")
 	lb8.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	lb8.Probes = &[]network.Probe{}
-	expectedLB8 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("anotherRG"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service8, "Standard")
-	(*expectedLB8.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(false)
+	expectedLB8 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("anotherRG"), pointer.String("testCluster"), pointer.String("aservice1"), service8, "Standard")
+	(*expectedLB8.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(false)
 	expectedLB8.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 	}
 	expectedLB8.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(service8.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service8.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service7.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port:              to.Int32Ptr(10080),
+				Port:              pointer.Int32(10080),
 				Protocol:          network.ProbeProtocolTCP,
-				IntervalInSeconds: to.Int32Ptr(5),
-				NumberOfProbes:    to.Int32Ptr(2),
+				IntervalInSeconds: pointer.Int32(5),
+				NumberOfProbes:    pointer.Int32(2),
 			},
 		},
 	}
@@ -3154,7 +3154,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			desc:                "reconcileLoadBalancer shall remove and reconstruct the corresponding field of lb and set enableTcpReset to true in lbRule",
 			loadBalancerSku:     "standard",
 			service:             service4,
-			disableOutboundSnat: to.BoolPtr(true),
+			disableOutboundSnat: pointer.Bool(true),
 			existingLB:          existingSLB,
 			wantLb:              true,
 			expectedLB:          expectedSLb,
@@ -3165,7 +3165,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			desc:                "reconcileLoadBalancer shall remove and reconstruct the corresponding field of lb and set enableTcpReset (false => true) in lbRule",
 			loadBalancerSku:     "standard",
 			service:             service5,
-			disableOutboundSnat: to.BoolPtr(true),
+			disableOutboundSnat: pointer.Bool(true),
 			existingLB:          slb5,
 			wantLb:              true,
 			expectedLB:          expectedSLb5,
@@ -3221,9 +3221,9 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			setServiceLoadBalancerIP(&test.service, "1.2.3.4")
 
 			err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "pipName", network.PublicIPAddress{
-				Name: to.StringPtr("pipName"),
+				Name: pointer.String("pipName"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			})
 			assert.NoError(t, err.Error())
@@ -3265,61 +3265,61 @@ func TestGetServiceLoadBalancerStatus(t *testing.T) {
 
 	setMockPublicIPs(az, ctrl, 1)
 
-	lb1 := getTestLoadBalancer(to.StringPtr("lb1"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), internalService, "Basic")
+	lb1 := getTestLoadBalancer(pointer.String("lb1"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), internalService, "Basic")
 	lb1.FrontendIPConfigurations = nil
-	lb2 := getTestLoadBalancer(to.StringPtr("lb2"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), internalService, "Basic")
+	lb2 := getTestLoadBalancer(pointer.String("lb2"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), internalService, "Basic")
 	lb2.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
-				PrivateIPAddress: to.StringPtr("private"),
+				PublicIPAddress:  &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb3 := getTestLoadBalancer(to.StringPtr("lb3"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("test1"), internalService, "Basic")
+	lb3 := getTestLoadBalancer(pointer.String("lb3"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("test1"), internalService, "Basic")
 	lb3.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
-				PrivateIPAddress: to.StringPtr("private"),
+				PublicIPAddress:  &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb4 := getTestLoadBalancer(to.StringPtr("lb4"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), service, "Basic")
+	lb4 := getTestLoadBalancer(pointer.String("lb4"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), service, "Basic")
 	lb4.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PublicIPAddress:  &network.PublicIPAddress{ID: nil},
-				PrivateIPAddress: to.StringPtr("private"),
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb5 := getTestLoadBalancer(to.StringPtr("lb5"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), service, "Basic")
+	lb5 := getTestLoadBalancer(pointer.String("lb5"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), service, "Basic")
 	lb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PublicIPAddress:  nil,
-				PrivateIPAddress: to.StringPtr("private"),
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb6 := getTestLoadBalancer(to.StringPtr("lb6"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), service, "Basic")
+	lb6 := getTestLoadBalancer(pointer.String("lb6"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), service, "Basic")
 	lb6.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("illegal/id/")},
-				PrivateIPAddress: to.StringPtr("private"),
+				PublicIPAddress:  &network.PublicIPAddress{ID: pointer.String("illegal/id/")},
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
@@ -3437,16 +3437,16 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall delete unwanted sg if wantLb is false and lbIP is nil",
 			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-toBeDeleted"),
+							Name: pointer.String("atest1-toBeDeleted"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-								SourceAddressPrefix:      to.StringPtr("prefix"),
-								SourcePortRange:          to.StringPtr("range"),
-								DestinationAddressPrefix: to.StringPtr("desPrefix"),
-								DestinationPortRange:     to.StringPtr("desRange"),
+								SourceAddressPrefix:      pointer.String("prefix"),
+								SourcePortRange:          pointer.String("range"),
+								DestinationAddressPrefix: pointer.String("desPrefix"),
+								DestinationPortRange:     pointer.String("desRange"),
 							},
 						},
 					},
@@ -3454,7 +3454,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			}},
 			wantLb: false,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{},
 				},
@@ -3464,37 +3464,37 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall delete unwanted sgs and create needed ones",
 			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-toBeDeleted"),
+							Name: pointer.String("atest1-toBeDeleted"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-								SourceAddressPrefix:      to.StringPtr("prefix"),
-								SourcePortRange:          to.StringPtr("range"),
-								DestinationAddressPrefix: to.StringPtr("desPrefix"),
-								DestinationPortRange:     to.StringPtr("desRange"),
+								SourceAddressPrefix:      pointer.String("prefix"),
+								SourcePortRange:          pointer.String("range"),
+								DestinationAddressPrefix: pointer.String("desPrefix"),
+								DestinationPortRange:     pointer.String("desRange"),
 							},
 						},
 					},
 				},
 			}},
-			lbIP:   to.StringPtr("1.1.1.1"),
+			lbIP:   pointer.String("1.1.1.1"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("80"),
-								SourceAddressPrefix:      to.StringPtr("Internet"),
-								DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("Internet"),
+								DestinationAddressPrefix: pointer.String("1.1.1.1"),
 								Access:                   network.SecurityRuleAccess("Allow"),
-								Priority:                 to.Int32Ptr(500),
+								Priority:                 pointer.Int32(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3506,25 +3506,25 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix for IPv6",
 			service: getTestService("test1", v1.ProtocolTCP, nil, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("fd00::eef0"),
+			lbIP:   pointer.String("fd00::eef0"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("80"),
-								SourceAddressPrefix:      to.StringPtr("Internet"),
-								DestinationAddressPrefix: to.StringPtr("fd00::eef0"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("Internet"),
+								DestinationAddressPrefix: pointer.String("fd00::eef0"),
 								Access:                   network.SecurityRuleAccess("Allow"),
-								Priority:                 to.Int32Ptr(500),
+								Priority:                 pointer.Int32(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3536,25 +3536,25 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix with additional public IPs",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAdditionalPublicIPs: "2.3.4.5"}, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1.2.3.4"),
+			lbIP:   pointer.String("1.2.3.4"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr("80"),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"1.2.3.4", "2.3.4.5"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String("80"),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"1.2.3.4", "2.3.4.5"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3566,37 +3566,37 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall not create unwanted security rules if there is service tags",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAllowedServiceTag: "tag"}, true, 80),
 			wantLb:  true,
-			lbIP:    to.StringPtr("1.1.1.1"),
+			lbIP:    pointer.String("1.1.1.1"),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-toBeDeleted"),
+							Name: pointer.String("atest1-toBeDeleted"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-								SourceAddressPrefix:      to.StringPtr("prefix"),
-								SourcePortRange:          to.StringPtr("range"),
-								DestinationAddressPrefix: to.StringPtr("destPrefix"),
-								DestinationPortRange:     to.StringPtr("desRange"),
+								SourceAddressPrefix:      pointer.String("prefix"),
+								SourcePortRange:          pointer.String("range"),
+								DestinationAddressPrefix: pointer.String("destPrefix"),
+								DestinationPortRange:     pointer.String("desRange"),
 							},
 						},
 					},
 				},
 			}},
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-tag"),
+							Name: pointer.String("atest1-TCP-80-tag"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("80"),
-								SourceAddressPrefix:      to.StringPtr("tag"),
-								DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("tag"),
+								DestinationAddressPrefix: pointer.String("1.1.1.1"),
 								Access:                   network.SecurityRuleAccess("Allow"),
-								Priority:                 to.Int32Ptr(500),
+								Priority:                 pointer.Int32(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3608,25 +3608,25 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create shared sgs for service with azure-shared-securityrule annotations",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1.2.3.4"),
+			lbIP:   pointer.String("1.2.3.4"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("shared-TCP-80-Internet"),
+							Name: pointer.String("shared-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr("80"),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"1.2.3.4"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String("80"),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"1.2.3.4"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3638,26 +3638,26 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with floating IP disabled",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1.2.3.4"),
-			lbName: to.StringPtr("lb"),
+			lbIP:   pointer.String("1.2.3.4"),
+			lbName: pointer.String("lb"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr(strconv.Itoa(int(getBackendPort(80)))),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"1.2.3.4", "5.6.7.8"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String(strconv.Itoa(int(getBackendPort(80)))),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"1.2.3.4", "5.6.7.8"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3669,26 +3669,26 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with only IPv6 destination addresses for IPv6 services with floating IP disabled",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1234::5"),
-			lbName: to.StringPtr("lb"),
+			lbIP:   pointer.String("1234::5"),
+			lbName: pointer.String("lb"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr(strconv.Itoa(int(getBackendPort(80)))),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"fc00::1", "fc00::2"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String(strconv.Itoa(int(getBackendPort(80)))),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"fc00::1", "fc00::2"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3732,39 +3732,39 @@ func TestReconcileSecurityGroupLoadBalancerSourceRanges(t *testing.T) {
 	service := getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true"}, false, 80)
 	service.Spec.LoadBalancerSourceRanges = []string{"1.2.3.4/32"}
 	existingSg := network.SecurityGroup{
-		Name: to.StringPtr("nsg"),
+		Name: pointer.String("nsg"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &[]network.SecurityRule{},
 		},
 	}
-	lbIP := to.StringPtr("1.1.1.1")
+	lbIP := pointer.String("1.1.1.1")
 	expectedSg := network.SecurityGroup{
-		Name: to.StringPtr("nsg"),
+		Name: pointer.String("nsg"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &[]network.SecurityRule{
 				{
-					Name: to.StringPtr("atest1-TCP-80-1.2.3.4_32"),
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:                 network.SecurityRuleProtocol("Tcp"),
-						SourcePortRange:          to.StringPtr("*"),
-						SourceAddressPrefix:      to.StringPtr("1.2.3.4/32"),
-						DestinationPortRange:     to.StringPtr("80"),
-						DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
 						Access:                   network.SecurityRuleAccess("Allow"),
-						Priority:                 to.Int32Ptr(500),
+						Priority:                 pointer.Int32(500),
 						Direction:                network.SecurityRuleDirection("Inbound"),
 					},
 				},
 				{
-					Name: to.StringPtr("atest1-TCP-80-deny_all"),
+					Name: pointer.String("atest1-TCP-80-deny_all"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:                 network.SecurityRuleProtocol("Tcp"),
-						SourcePortRange:          to.StringPtr("*"),
-						SourceAddressPrefix:      to.StringPtr("*"),
-						DestinationPortRange:     to.StringPtr("80"),
-						DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
 						Access:                   network.SecurityRuleAccess("Deny"),
-						Priority:                 to.Int32Ptr(501),
+						Priority:                 pointer.Int32(501),
 						Direction:                network.SecurityRuleDirection("Inbound"),
 					},
 				},
@@ -3792,25 +3792,25 @@ func TestSafeDeletePublicIP(t *testing.T) {
 		{
 			desc: "safeDeletePublicIP shall delete corresponding ip configurations and lb rules",
 			pip: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					IPConfiguration: &network.IPConfiguration{
-						ID: to.StringPtr("id1"),
+						ID: pointer.String("id1"),
 					},
 				},
 			},
 			lb: &network.LoadBalancer{
-				Name: to.StringPtr("lb1"),
+				Name: pointer.String("lb1"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 						{
-							ID: to.StringPtr("id1"),
+							ID: pointer.String("id1"),
 							FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]network.SubResource{{ID: to.StringPtr("rules1")}},
+								LoadBalancingRules: &[]network.SubResource{{ID: pointer.String("rules1")}},
 							},
 						},
 					},
-					LoadBalancingRules: &[]network.LoadBalancingRule{{ID: to.StringPtr("rules1")}},
+					LoadBalancingRules: &[]network.LoadBalancingRule{{ID: pointer.String("rules1")}},
 				},
 			},
 		},
@@ -3823,10 +3823,10 @@ func TestSafeDeletePublicIP(t *testing.T) {
 			mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "pip1", gomock.Any()).Return(nil).AnyTimes()
 			mockPIPsClient.EXPECT().Delete(gomock.Any(), "rg", "pip1").Return(nil).AnyTimes()
 			err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "pip1", network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					IPConfiguration: &network.IPConfiguration{
-						ID: to.StringPtr("id1"),
+						ID: pointer.String("id1"),
 					},
 				},
 			})
@@ -3849,7 +3849,7 @@ func TestReconcilePublicIP(t *testing.T) {
 
 	deleteUnwantedPIPsAndCreateANewOneclientGet := func(client *mockpublicipclient.MockInterface) {
 		client.EXPECT().Get(gomock.Any(), "rg", "testCluster-atest1", gomock.Any()).Return(network.PublicIPAddress{}, &retry.Error{HTTPStatusCode: http.StatusNotFound}).Times(1)
-		client.EXPECT().Get(gomock.Any(), "rg", "testCluster-atest1", gomock.Any()).Return(network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1")}, nil).Times(1)
+		client.EXPECT().Get(gomock.Any(), "rg", "testCluster-atest1", gomock.Any()).Return(network.PublicIPAddress{ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1")}, nil).Times(1)
 	}
 
 	testCases := []struct {
@@ -3875,7 +3875,7 @@ func TestReconcilePublicIP(t *testing.T) {
 			wantLb: false,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
+					Name: pointer.String("pip1"),
 				},
 			},
 			expectedCreateOrUpdateCount: 0,
@@ -3886,10 +3886,10 @@ func TestReconcilePublicIP(t *testing.T) {
 			wantLb: true,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -3905,12 +3905,12 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				},
 			},
 			expectedError:               true,
@@ -3923,34 +3923,34 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion: network.IPVersionIPv4,
-					IPAddress:              to.StringPtr("1.2.3.4"),
+					IPAddress:              pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -3962,34 +3962,34 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1,default/test2")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion: network.IPVersionIPv4,
-					IPAddress:              to.StringPtr("1.2.3.4"),
+					IPAddress:              pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -4004,38 +4004,38 @@ func TestReconcilePublicIP(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPVersionIPv4,
 					PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 					IPTags: &[]network.IPTag{
 						{
-							IPTagType: to.StringPtr("tag1"),
-							Tag:       to.StringPtr("tag1value"),
+							IPTagType: pointer.String("tag1"),
+							Tag:       pointer.String("tag1value"),
 						},
 					},
 				},
@@ -4052,35 +4052,35 @@ func TestReconcilePublicIP(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPVersionIPv4,
 						PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 						IPTags: &[]network.IPTag{
 							{
-								IPTagType: to.StringPtr("tag1"),
-								Tag:       to.StringPtr("tag1value"),
+								IPTagType: pointer.String("tag1"),
+								Tag:       pointer.String("tag1value"),
 							},
 						},
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPVersionIPv4,
 					PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 					IPTags: &[]network.IPTag{
 						{
-							IPTagType: to.StringPtr("tag1"),
-							Tag:       to.StringPtr("tag1value"),
+							IPTagType: pointer.String("tag1"),
+							Tag:       pointer.String("tag1value"),
 						},
 					},
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 0,
@@ -4092,31 +4092,31 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
+					Name: pointer.String("pip1"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
+					Name: pointer.String("testPIP"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion: network.IPVersionIPv4,
-					IPAddress:              to.StringPtr("1.2.3.4"),
+					IPAddress:              pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -4127,10 +4127,10 @@ func TestReconcilePublicIP(t *testing.T) {
 			wantLb: false,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1,default/test2")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -4186,7 +4186,7 @@ func TestReconcilePublicIP(t *testing.T) {
 					return nil
 				})
 
-				err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", to.String(pip.Name), pip)
+				err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", pointer.StringDeref(pip.Name, ""), pip)
 				assert.NoError(t, err.Error())
 
 				// Clear create or update count to prepare for main execution
@@ -4197,7 +4197,7 @@ func TestReconcilePublicIP(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			if test.expectedID != "" {
-				assert.Equal(t, test.expectedID, to.String(pip.ID))
+				assert.Equal(t, test.expectedID, pointer.StringDeref(pip.ID, ""))
 			} else if test.expectedPIP != nil && test.expectedPIP.Name != nil {
 				assert.Equal(t, *test.expectedPIP.Name, *pip.Name)
 
@@ -4245,10 +4245,10 @@ func TestEnsurePublicIPExists(t *testing.T) {
 	}{
 		{
 			desc:         "shall return existed PIP if there is any",
-			existingPIPs: []network.PublicIPAddress{{Name: to.StringPtr("pip1")}},
+			existingPIPs: []network.PublicIPAddress{{Name: pointer.String("pip1")}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPVersionIPv4,
@@ -4269,20 +4269,20 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			inputDNSLabel:           "newdns",
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name:                            to.StringPtr("pip1"),
+				Name:                            pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("newdns"),
+						DomainNameLabel: pointer.String("newdns"),
 					},
 					PublicIPAddressVersion: network.IPVersionIPv4,
 				},
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("default/test1")},
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("default/test1")},
 			},
 			shouldPutPIP: true,
 		},
@@ -4290,16 +4290,16 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			desc:                    "shall delete DNS from PIP if DNS label is set empty",
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings:            nil,
@@ -4313,20 +4313,20 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			desc:                    "shall not delete DNS from PIP if DNS label annotation is not set",
 			foundDNSLabelAnnotation: false,
 			existingPIPs: []network.PublicIPAddress{{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 					PublicIPAddressVersion: network.IPVersionIPv4,
 				},
@@ -4338,21 +4338,21 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			foundDNSLabelAnnotation: true,
 			isIPv6:                  true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name:                            to.StringPtr("pip1"),
+				Name:                            pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("newdns"),
+						DomainNameLabel: pointer.String("newdns"),
 					},
 					PublicIPAllocationMethod: network.IPAllocationMethodDynamic,
 					PublicIPAddressVersion:   network.IPVersionIPv6,
 				},
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("default/test1")},
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("default/test1")},
 			},
 			shouldPutPIP: true,
 		},
@@ -4362,26 +4362,26 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			foundDNSLabelAnnotation: true,
 			isIPv6:                  true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("newdns"),
+						DomainNameLabel: pointer.String("newdns"),
 					},
 					PublicIPAllocationMethod: network.IPAllocationMethodDynamic,
 					PublicIPAddressVersion:   network.IPVersionIPv6,
 				},
 				Tags: map[string]*string{
-					"k8s-azure-dns-label-service": to.StringPtr("default/test1"),
+					"k8s-azure-dns-label-service": pointer.String("default/test1"),
 				},
 			},
 			shouldPutPIP: true,
@@ -4393,28 +4393,28 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			isIPv6:                  false,
 			existingPIPs: []network.PublicIPAddress{{
 
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 					PublicIPAllocationMethod: network.IPAllocationMethodDynamic,
 					PublicIPAddressVersion:   network.IPVersionIPv4,
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("newdns"),
+						DomainNameLabel: pointer.String("newdns"),
 					},
 					PublicIPAllocationMethod: network.IPAllocationMethodDynamic,
 					PublicIPAddressVersion:   network.IPVersionIPv4,
 				},
 				Tags: map[string]*string{
-					"k8s-azure-dns-label-service": to.StringPtr("default/test1"),
+					"k8s-azure-dns-label-service": pointer.String("default/test1"),
 				},
 			},
 			shouldPutPIP: true,
@@ -4424,11 +4424,11 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			inputDNSLabel:           "test",
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name: to.StringPtr("pip1"),
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("test1")},
+				Name: pointer.String("pip1"),
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 				},
 			}},
@@ -4439,16 +4439,16 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			inputDNSLabel: "test",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+					Name: pointer.String("pip1"),
+					ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 						"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{
-						consts.ServiceUsingDNSKey: to.StringPtr("default/test1"),
-						consts.ServiceTagKey:      to.StringPtr("default/test1"),
+						consts.ServiceUsingDNSKey: pointer.String("default/test1"),
+						consts.ServiceTagKey:      pointer.String("default/test1"),
 					},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						DNSSettings: &network.PublicIPAddressDNSSettings{
-							DomainNameLabel: to.StringPtr("test"),
+							DomainNameLabel: pointer.String("test"),
 						},
 						PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 						PublicIPAddressVersion:   network.IPVersionIPv4,
@@ -4456,16 +4456,16 @@ func TestEnsurePublicIPExists(t *testing.T) {
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				Tags: map[string]*string{
-					consts.ServiceUsingDNSKey: to.StringPtr("default/test1"),
-					consts.ServiceTagKey:      to.StringPtr("default/test1"),
+					consts.ServiceUsingDNSKey: pointer.String("default/test1"),
+					consts.ServiceTagKey:      pointer.String("default/test1"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("test"),
+						DomainNameLabel: pointer.String("test"),
 					},
 					PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 					PublicIPAddressVersion:   network.IPVersionIPv4,
@@ -4475,11 +4475,11 @@ func TestEnsurePublicIPExists(t *testing.T) {
 		{
 			desc: "shall tag the service name to the pip correctly",
 			existingPIPs: []network.PublicIPAddress{
-				{Name: to.StringPtr("pip1")},
+				{Name: pointer.String("pip1")},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPVersionIPv4,
@@ -4495,7 +4495,7 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			useSLB: true,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
+					Name: pointer.String("pip1"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPVersionIPv6,
 						PublicIPAllocationMethod: network.IPAllocationMethodStatic,
@@ -4503,8 +4503,8 @@ func TestEnsurePublicIPExists(t *testing.T) {
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPVersionIPv6,
@@ -4516,11 +4516,11 @@ func TestEnsurePublicIPExists(t *testing.T) {
 		},
 		{
 			desc:         "shall update pip tags if there is any change",
-			existingPIPs: []network.PublicIPAddress{{Name: to.StringPtr("pip1"), Tags: map[string]*string{"a": to.StringPtr("b")}}},
+			existingPIPs: []network.PublicIPAddress{{Name: pointer.String("pip1"), Tags: map[string]*string{"a": pointer.String("b")}}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				Tags: map[string]*string{"a": to.StringPtr("c")},
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				Tags: map[string]*string{"a": pointer.String("c")},
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPVersionIPv4,
@@ -4556,13 +4556,13 @@ func TestEnsurePublicIPExists(t *testing.T) {
 				var basicPIP network.PublicIPAddress
 				if len(test.existingPIPs) == 0 {
 					basicPIP = network.PublicIPAddress{
-						Name: to.StringPtr("pip1"),
+						Name: pointer.String("pip1"),
 					}
 				} else {
 					basicPIP = test.existingPIPs[0]
 				}
 
-				basicPIP.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				basicPIP.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1")
 
 				if basicPIP.PublicIPAddressPropertiesFormat == nil {
@@ -4582,7 +4582,7 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			pip, err := az.ensurePublicIPExists(&service, "pip1", test.inputDNSLabel, "", false, test.foundDNSLabelAnnotation)
 			assert.Equal(t, test.expectedError, err != nil, "unexpectedly encountered (or not) error: %v", err)
 			if test.expectedID != "" {
-				assert.Equal(t, test.expectedID, to.String(pip.ID))
+				assert.Equal(t, test.expectedID, pointer.StringDeref(pip.ID, ""))
 			} else {
 				assert.Equal(t, test.expectedPIP, pip)
 			}
@@ -4599,10 +4599,10 @@ func TestEnsurePublicIPExistsWithExtendedLocation(t *testing.T) {
 
 	exLocName := "microsoftlosangeles1"
 	expectedPIP := &network.PublicIPAddress{
-		Name:     to.StringPtr("pip1"),
+		Name:     pointer.String("pip1"),
 		Location: &az.Location,
 		ExtendedLocation: &network.ExtendedLocation{
-			Name: to.StringPtr("microsoftlosangeles1"),
+			Name: pointer.String("microsoftlosangeles1"),
 			Type: network.ExtendedLocationTypesEdgeZone,
 		},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
@@ -4611,8 +4611,8 @@ func TestEnsurePublicIPExistsWithExtendedLocation(t *testing.T) {
 			ProvisioningState:        "",
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("default/test1"),
-			consts.ClusterNameKey: to.StringPtr(""),
+			consts.ServiceTagKey:  pointer.String("default/test1"),
+			consts.ClusterNameKey: pointer.String(""),
 		},
 	}
 	mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
@@ -4701,13 +4701,13 @@ func TestShouldUpdateLoadBalancer(t *testing.T) {
 			}
 			if test.existsLb {
 				lb := network.LoadBalancer{
-					Name: to.StringPtr("vmas"),
+					Name: pointer.String("vmas"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 							{
-								Name: to.StringPtr("atest1"),
+								Name: pointer.String("atest1"),
 								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-									PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+									PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 								},
 							},
 						},
@@ -4823,10 +4823,10 @@ func TestIsBackendPoolPreConfigured(t *testing.T) {
 
 func TestParsePIPServiceTag(t *testing.T) {
 	tags := []*string{
-		to.StringPtr("ns1/svc1,ns2/svc2"),
-		to.StringPtr(" ns1/svc1, ns2/svc2 "),
-		to.StringPtr("ns1/svc1,"),
-		to.StringPtr(""),
+		pointer.String("ns1/svc1,ns2/svc2"),
+		pointer.String(" ns1/svc1, ns2/svc2 "),
+		pointer.String("ns1/svc1,"),
+		pointer.String(""),
 		nil,
 	}
 	expectedNames := [][]string{
@@ -4847,17 +4847,17 @@ func TestBindServicesToPIP(t *testing.T) {
 	pips := []*network.PublicIPAddress{
 		{Tags: nil},
 		{Tags: map[string]*string{}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")}},
 	}
 	serviceNames := []string{"ns2/svc2", "ns3/svc3"}
 	expectedTags := []map[string]*string{
-		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")},
 	}
 
 	flags := []bool{true, true, true, true, false}
@@ -4872,18 +4872,18 @@ func TestBindServicesToPIP(t *testing.T) {
 func TestUnbindServiceFromPIP(t *testing.T) {
 	pips := []*network.PublicIPAddress{
 		{Tags: nil},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2")}},
 	}
 	serviceName := "ns2/svc2"
 	service := getTestService(serviceName, v1.ProtocolTCP, nil, false, 80)
 	setServiceLoadBalancerIP(&service, "1.2.3.4")
 	expectedTags := []map[string]*string{
 		nil,
-		{consts.ServiceTagKey: to.StringPtr("")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1")},
+		{consts.ServiceTagKey: pointer.String("")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1")},
 	}
 
 	for i, pip := range pips {
@@ -4898,7 +4898,7 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 
 	service := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
 	az := GetTestCloud(ctrl)
-	fipID := to.StringPtr("fip")
+	fipID := pointer.String("fip")
 
 	testCases := []struct {
 		desc       string
@@ -4909,13 +4909,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return true if there is a " +
 				"loadBalancing rule from other service referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -4927,14 +4927,14 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return true if there is a " +
 				"outbound rule referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					OutboundRules: &[]network.OutboundRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							OutboundRulePropertiesFormat: &network.OutboundRulePropertiesFormat{
 								FrontendIPConfigurations: &[]network.SubResource{
-									{ID: to.StringPtr("fip")},
+									{ID: pointer.String("fip")},
 								},
 							},
 						},
@@ -4947,13 +4947,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return false if there is a " +
 				"loadBalancing rule from this service referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -4964,13 +4964,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return true if there is a " +
 				"inbound NAT rule referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatRules: &[]network.InboundNatRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -4982,13 +4982,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return true if there is a " +
 				"inbound NAT pool referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatPools: &[]network.InboundNatPool{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							InboundNatPoolPropertiesFormat: &network.InboundNatPoolPropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -5021,14 +5021,14 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted loadBalancing rule",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(80),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(80),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -5041,14 +5041,14 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted inbound NAT rule",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatRules: &[]network.InboundNatRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(80),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(80),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -5061,15 +5061,15 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted inbound NAT pool",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatPools: &[]network.InboundNatPool{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatPoolPropertiesFormat: &network.InboundNatPoolPropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPortRangeStart:  to.Int32Ptr(80),
-								FrontendPortRangeEnd:    to.Int32Ptr(90),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPortRangeStart:  pointer.Int32(80),
+								FrontendPortRangeEnd:    pointer.Int32(90),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -5082,35 +5082,35 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should not report the conflict error if there " +
 				"is no conflicted loadBalancer resources",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(90),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(90),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
 					},
 					InboundNatRules: &[]network.InboundNatRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(90),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(90),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
 					},
 					InboundNatPools: &[]network.InboundNatPool{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatPoolPropertiesFormat: &network.InboundNatPoolPropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPortRangeStart:  to.Int32Ptr(800),
-								FrontendPortRangeEnd:    to.Int32Ptr(900),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPortRangeStart:  pointer.Int32(800),
+								FrontendPortRangeEnd:    pointer.Int32(900),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -5128,11 +5128,11 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 
 func buildLBWithVMIPs(clusterName string, vmIPs []string) *network.LoadBalancer {
 	lb := network.LoadBalancer{
-		Name: to.StringPtr(clusterName),
+		Name: pointer.String(clusterName),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr(clusterName),
+					Name: pointer.String(clusterName),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{},
 					},
@@ -5155,11 +5155,11 @@ func buildLBWithVMIPs(clusterName string, vmIPs []string) *network.LoadBalancer 
 
 func buildDefaultTestLB(name string, backendIPConfigs []string) network.LoadBalancer {
 	expectedLB := network.LoadBalancer{
-		Name: to.StringPtr(name),
+		Name: pointer.String(name),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr(name),
+					Name: pointer.String(name),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{},
 					},
@@ -5169,7 +5169,7 @@ func buildDefaultTestLB(name string, backendIPConfigs []string) network.LoadBala
 	}
 	backendIPConfigurations := make([]network.InterfaceIPConfiguration, 0)
 	for _, ipConfig := range backendIPConfigs {
-		backendIPConfigurations = append(backendIPConfigurations, network.InterfaceIPConfiguration{ID: to.StringPtr(ipConfig)})
+		backendIPConfigurations = append(backendIPConfigurations, network.InterfaceIPConfiguration{ID: pointer.String(ipConfig)})
 	}
 	(*expectedLB.BackendAddressPools)[0].BackendIPConfigurations = &backendIPConfigurations
 	return expectedLB
@@ -5191,25 +5191,25 @@ func TestEnsurePIPTagged(t *testing.T) {
 	}
 	pip := network.PublicIPAddress{
 		Tags: map[string]*string{
-			consts.ClusterNameKey: to.StringPtr("testCluster"),
-			consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-			"foo":                 to.StringPtr("bar"),
-			"a":                   to.StringPtr("j"),
-			"m":                   to.StringPtr("n"),
+			consts.ClusterNameKey: pointer.String("testCluster"),
+			consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+			"foo":                 pointer.String("bar"),
+			"a":                   pointer.String("j"),
+			"m":                   pointer.String("n"),
 		},
 	}
 
 	t.Run("ensurePIPTagged should ensure the pip is tagged as configured", func(t *testing.T) {
 		expectedPIP := network.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey: to.StringPtr("testCluster"),
-				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":                 to.StringPtr("bar"),
-				"a":                   to.StringPtr("b"),
-				"c":                   to.StringPtr("d"),
-				"y":                   to.StringPtr("z"),
-				"m":                   to.StringPtr("n"),
-				"e":                   to.StringPtr(""),
+				consts.ClusterNameKey: pointer.String("testCluster"),
+				consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+				"foo":                 pointer.String("bar"),
+				"a":                   pointer.String("b"),
+				"c":                   pointer.String("d"),
+				"y":                   pointer.String("z"),
+				"m":                   pointer.String("n"),
+				"e":                   pointer.String(""),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -5221,13 +5221,13 @@ func TestEnsurePIPTagged(t *testing.T) {
 		cloud.SystemTags = "a,foo"
 		expectedPIP := network.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey: to.StringPtr("testCluster"),
-				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":                 to.StringPtr("bar"),
-				"a":                   to.StringPtr("b"),
-				"c":                   to.StringPtr("d"),
-				"y":                   to.StringPtr("z"),
-				"e":                   to.StringPtr(""),
+				consts.ClusterNameKey: pointer.String("testCluster"),
+				consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+				"foo":                 pointer.String("bar"),
+				"a":                   pointer.String("b"),
+				"c":                   pointer.String("d"),
+				"y":                   pointer.String("z"),
+				"e":                   pointer.String(""),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -5240,13 +5240,13 @@ func TestEnsurePIPTagged(t *testing.T) {
 		cloud.TagsMap = map[string]string{"a": "c", "a=b": "c=d", "Y": "zz"}
 		expectedPIP := network.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey: to.StringPtr("testCluster"),
-				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":                 to.StringPtr("bar"),
-				"a":                   to.StringPtr("b"),
-				"c":                   to.StringPtr("d"),
-				"a=b":                 to.StringPtr("c=d"),
-				"e":                   to.StringPtr(""),
+				consts.ClusterNameKey: pointer.String("testCluster"),
+				consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+				"foo":                 pointer.String("bar"),
+				"a":                   pointer.String("b"),
+				"c":                   pointer.String("d"),
+				"a=b":                 pointer.String("c=d"),
+				"e":                   pointer.String(""),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -5267,17 +5267,17 @@ func TestEnsureLoadBalancerTagged(t *testing.T) {
 	}{
 		{
 			description:     "ensureLoadBalancerTagged should not delete the old tags if SystemTags is not specified",
-			existedTags:     map[string]*string{"a": to.StringPtr("b")},
+			existedTags:     map[string]*string{"a": pointer.String("b")},
 			newTags:         "c=d",
-			expectedTags:    map[string]*string{"a": to.StringPtr("b"), "c": to.StringPtr("d")},
+			expectedTags:    map[string]*string{"a": pointer.String("b"), "c": pointer.String("d")},
 			expectedChanged: true,
 		},
 		{
 			description:     "ensureLoadBalancerTagged should delete the old tags if SystemTags is specified",
-			existedTags:     map[string]*string{"a": to.StringPtr("b"), "c": to.StringPtr("d"), "h": to.StringPtr("i")},
+			existedTags:     map[string]*string{"a": pointer.String("b"), "c": pointer.String("d"), "h": pointer.String("i")},
 			newTags:         "c=e,f=g",
 			systemTags:      "a,x,y,z",
-			expectedTags:    map[string]*string{"a": to.StringPtr("b"), "c": to.StringPtr("e"), "f": to.StringPtr("g")},
+			expectedTags:    map[string]*string{"a": pointer.String("b"), "c": pointer.String("e"), "f": pointer.String("g")},
 			expectedChanged: true,
 		},
 	} {
@@ -5340,18 +5340,18 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerDelete(t *testing.T) {
 	defer ctrl.Finish()
 	t.Run("removeFrontendIPConfigurationFromLoadBalancer should remove the unwanted frontend IP configuration and delete the orphaned LB", func(t *testing.T) {
 		fip := &network.FrontendIPConfiguration{
-			Name: to.StringPtr("testCluster"),
-			ID:   to.StringPtr("testCluster-fip"),
+			Name: pointer.String("testCluster"),
+			ID:   pointer.String("testCluster-fip"),
 		}
 		service := getTestService("svc1", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("lb"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("testCluster"), service, "standard")
+		lb := getTestLoadBalancer(pointer.String("lb"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("testCluster"), service, "standard")
 		bid := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-0/ipConfigurations/ipconfig1"
 		lb.BackendAddressPools = &[]network.BackendAddressPool{
 			{
-				Name: to.StringPtr("testCluster"),
+				Name: pointer.String("testCluster"),
 				BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 					BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
-						{ID: to.StringPtr(bid)},
+						{ID: pointer.String(bid)},
 					},
 				},
 			},
@@ -5362,7 +5362,7 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerDelete(t *testing.T) {
 		expectedPLS := make([]network.PrivateLinkService, 0)
 		mockPLSClient := cloud.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
 		mockPLSClient.EXPECT().List(gomock.Any(), "rg").Return(expectedPLS, nil).MaxTimes(1)
-		existingLBs := []network.LoadBalancer{{Name: to.StringPtr("lb")}}
+		existingLBs := []network.LoadBalancer{{Name: pointer.String("lb")}}
 		err := cloud.removeFrontendIPConfigurationFromLoadBalancer(&lb, existingLBs, fip, "testCluster", &service)
 		assert.NoError(t, err)
 	})
@@ -5373,12 +5373,12 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerUpdate(t *testing.T) {
 	defer ctrl.Finish()
 	t.Run("removeFrontendIPConfigurationFromLoadBalancer should remove the unwanted frontend IP configuration and update the LB if there are remaining frontend IP configurations", func(t *testing.T) {
 		fip := &network.FrontendIPConfiguration{
-			Name: to.StringPtr("testCluster"),
-			ID:   to.StringPtr("testCluster-fip"),
+			Name: pointer.String("testCluster"),
+			ID:   pointer.String("testCluster-fip"),
 		}
 		service := getTestService("svc1", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("lb"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("testCluster"), service, "standard")
-		*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, network.FrontendIPConfiguration{Name: to.StringPtr("fip1")})
+		lb := getTestLoadBalancer(pointer.String("lb"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("testCluster"), service, "standard")
+		*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, network.FrontendIPConfiguration{Name: pointer.String("fip1")})
 		cloud := GetTestCloud(ctrl)
 		mockLBClient := cloud.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 		mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "lb", gomock.Any(), gomock.Any()).Return(nil)
@@ -5410,10 +5410,10 @@ func TestCleanOrphanedLoadBalancerLBInUseByVMSS(t *testing.T) {
 		mockVMSSClient.EXPECT().List(gomock.Any(), "rg").Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil)
 
 		service := getTestService("test", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("test"), to.StringPtr("rg"), to.StringPtr("test"), to.StringPtr("test"), service, consts.LoadBalancerSkuStandard)
-		(*lb.BackendAddressPools)[0].ID = to.StringPtr(testLBBackendpoolID0)
+		lb := getTestLoadBalancer(pointer.String("test"), pointer.String("rg"), pointer.String("test"), pointer.String("test"), service, consts.LoadBalancerSkuStandard)
+		(*lb.BackendAddressPools)[0].ID = pointer.String(testLBBackendpoolID0)
 
-		existingLBs := []network.LoadBalancer{{Name: to.StringPtr("test")}}
+		existingLBs := []network.LoadBalancer{{Name: pointer.String("test")}}
 
 		err = cloud.cleanOrphanedLoadBalancer(&lb, existingLBs, &service, "test")
 		assert.NoError(t, err)
@@ -5427,8 +5427,8 @@ func TestCleanOrphanedLoadBalancerLBInUseByVMSS(t *testing.T) {
 		cloud.LoadBalancerSku = consts.LoadBalancerSkuStandard
 
 		service := getTestService("test", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("test"), to.StringPtr("rg"), to.StringPtr("test"), to.StringPtr("test"), service, consts.LoadBalancerSkuStandard)
-		(*lb.BackendAddressPools)[0].ID = to.StringPtr(testLBBackendpoolID0)
+		lb := getTestLoadBalancer(pointer.String("test"), pointer.String("rg"), pointer.String("test"), pointer.String("test"), service, consts.LoadBalancerSkuStandard)
+		(*lb.BackendAddressPools)[0].ID = pointer.String(testLBBackendpoolID0)
 
 		existingLBs := []network.LoadBalancer{}
 
@@ -5459,7 +5459,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 			description:               "reconcileFrontendIPConfigs should reconcile the zones for the new fip config",
 			service:                   getTestService("test", v1.ProtocolTCP, nil, false, 80),
 			existingFrontendIPConfigs: []network.FrontendIPConfiguration{},
-			existingPIP:               network.PublicIPAddress{Location: to.StringPtr("eastus")},
+			existingPIP:               network.PublicIPAddress{Location: pointer.String("eastus")},
 			getPIPError:               &retry.Error{HTTPStatusCode: http.StatusNotFound},
 			regionZonesMap:            map[string][]string{"westus": {"1", "2", "3"}, "eastus": {"1", "2"}},
 			expectedDirty:             true,
@@ -5468,7 +5468,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 			description:               "reconcileFrontendIPConfigs should reconcile the zones for the new internal fip config",
 			service:                   getInternalTestService("test", 80),
 			existingFrontendIPConfigs: []network.FrontendIPConfiguration{},
-			existingPIP:               network.PublicIPAddress{Location: to.StringPtr("eastus")},
+			existingPIP:               network.PublicIPAddress{Location: pointer.String("eastus")},
 			getPIPError:               &retry.Error{HTTPStatusCode: http.StatusNotFound},
 			regionZonesMap:            map[string][]string{"westus": {"1", "2", "3"}, "eastus": {"1", "2"}},
 			expectedZones:             &[]string{"1", "2", "3"},
@@ -5487,10 +5487,10 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 				consts.ServiceAnnotationLoadBalancerInternal:       consts.TrueAnnotationValue}, 80),
 			existingFrontendIPConfigs: []network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("atest1"),
+					Name: pointer.String("atest1"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 						Subnet: &network.Subnet{
-							Name: to.StringPtr("subnet-1"),
+							Name: pointer.String("subnet-1"),
 						},
 					},
 				},
@@ -5504,19 +5504,19 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 				consts.ServiceAnnotationLoadBalancerInternal:       consts.TrueAnnotationValue}, 80),
 			existingFrontendIPConfigs: []network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("not-this-one"),
+					Name: pointer.String("not-this-one"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 						Subnet: &network.Subnet{
-							Name: to.StringPtr("subnet-1"),
+							Name: pointer.String("subnet-1"),
 						},
 					},
 					Zones: &[]string{"2"},
 				},
 				{
-					Name: to.StringPtr("atest1"),
+					Name: pointer.String("atest1"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 						Subnet: &network.Subnet{
-							Name: to.StringPtr("subnet-1"),
+							Name: pointer.String("subnet-1"),
 						},
 					},
 					Zones: &[]string{"1"},
@@ -5533,7 +5533,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 					{IP: "1.2.3.4"},
 				},
 			},
-			expectedIP:    to.StringPtr("1.2.3.4"),
+			expectedIP:    pointer.String("1.2.3.4"),
 			expectedDirty: true,
 		},
 		{
@@ -5544,7 +5544,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 					{IP: "1.2.3.6"},
 				},
 			},
-			expectedIP:    to.StringPtr(""),
+			expectedIP:    pointer.String(""),
 			expectedDirty: true,
 		},
 	} {
@@ -5553,7 +5553,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 			cloud.regionZonesMap = tc.regionZonesMap
 			cloud.LoadBalancerSku = string(network.LoadBalancerSkuNameStandard)
 
-			lb := getTestLoadBalancer(to.StringPtr("lb"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("testCluster"), tc.service, "standard")
+			lb := getTestLoadBalancer(pointer.String("lb"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("testCluster"), tc.service, "standard")
 			lb.FrontendIPConfigurations = &tc.existingFrontendIPConfigs
 
 			mockPIPClient := cloud.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
@@ -5563,7 +5563,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 
 			subnetClient := cloud.SubnetsClient.(*mocksubnetclient.MockInterface)
 			subnetClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", gomock.Any()).Return(
-				network.Subnet{SubnetPropertiesFormat: &network.SubnetPropertiesFormat{AddressPrefix: to.StringPtr("1.2.3.4/31")}}, nil).MaxTimes(1)
+				network.Subnet{SubnetPropertiesFormat: &network.SubnetPropertiesFormat{AddressPrefix: pointer.String("1.2.3.4/31")}}, nil).MaxTimes(1)
 
 			zoneClient := mockzoneclient.NewMockInterface(ctrl)
 			zoneClient.EXPECT().GetZones(gomock.Any(), gomock.Any()).Return(map[string][]string{}, tc.getZoneError).MaxTimes(1)
@@ -5579,13 +5579,13 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 			assert.Equal(t, tc.expectedDirty, dirty)
 
 			for _, fip := range *lb.FrontendIPConfigurations {
-				if strings.EqualFold(to.String(fip.Name), defaultLBFrontendIPConfigName) {
+				if strings.EqualFold(pointer.StringDeref(fip.Name, ""), defaultLBFrontendIPConfigName) {
 					assert.Equal(t, tc.expectedZones, fip.Zones)
 				}
 			}
 
 			if tc.expectedIP != nil {
-				assert.Equal(t, *tc.expectedIP, to.String((*lb.FrontendIPConfigurations)[0].PrivateIPAddress))
+				assert.Equal(t, *tc.expectedIP, pointer.StringDeref((*lb.FrontendIPConfigurations)[0].PrivateIPAddress, ""))
 				if *tc.expectedIP != "" {
 					assert.Equal(t, network.IPAllocationMethodStatic, (*lb.FrontendIPConfigurations)[0].PrivateIPAllocationMethod)
 				} else {
@@ -5620,15 +5620,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 									},
 								},
@@ -5637,15 +5637,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("kubernetes-internal"),
+					Name: pointer.String("kubernetes-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 									},
 								},
@@ -5654,15 +5654,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss1-nic-1"),
+											ID: pointer.String("vmss1-nic-1"),
 										},
 									},
 								},
@@ -5671,15 +5671,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("vmss1-internal"),
+					Name: pointer.String("vmss1-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss1-nic-1"),
+											ID: pointer.String("vmss1-nic-1"),
 										},
 									},
 								},
@@ -5690,15 +5690,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			expectedLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 									},
 								},
@@ -5707,15 +5707,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("kubernetes-internal"),
+					Name: pointer.String("kubernetes-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 									},
 								},
@@ -5746,18 +5746,18 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 				},
 				{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 				},
 			},
 			expectedLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 				},
 				{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 				},
 			},
 			expectedListCount:     1,
@@ -5827,12 +5827,12 @@ func TestGetServiceFromPIPDNSTags(t *testing.T) {
 		},
 		{
 			desc:     "Expected service should be returned when tags contain dns label tag",
-			tags:     map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.ServiceUsingDNSKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 		{
 			desc:     "Expected service should be returned when tags contain legacy dns label tag",
-			tags:     map[string]*string{consts.LegacyServiceUsingDNSKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.LegacyServiceUsingDNSKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 	}
@@ -5856,12 +5856,12 @@ func TestGetServiceFromPIPServiceTags(t *testing.T) {
 		},
 		{
 			desc:     "Expected service should be returned when tags contain service tag",
-			tags:     map[string]*string{consts.ServiceTagKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.ServiceTagKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 		{
 			desc:     "Expected service should be returned when tags contain legacy service tag",
-			tags:     map[string]*string{consts.LegacyServiceTagKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.LegacyServiceTagKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 	}
@@ -5885,12 +5885,12 @@ func TestGetClusterFromPIPClusterTags(t *testing.T) {
 		},
 		{
 			desc:     "Expected service should be returned when tags contain cluster name tag",
-			tags:     map[string]*string{consts.ClusterNameKey: to.StringPtr("test-cluster")},
+			tags:     map[string]*string{consts.ClusterNameKey: pointer.String("test-cluster")},
 			expected: "test-cluster",
 		},
 		{
 			desc:     "Expected service should be returned when tags contain legacy cluster name tag",
-			tags:     map[string]*string{consts.LegacyClusterNameKey: to.StringPtr("test-cluster")},
+			tags:     map[string]*string{consts.LegacyClusterNameKey: pointer.String("test-cluster")},
 			expected: "test-cluster",
 		},
 	}
@@ -5946,7 +5946,7 @@ func TestSafeDeleteLoadBalancer(t *testing.T) {
 			cloud.LoadBalancerClient = mockLBClient
 			svc := getTestService("svc", v1.ProtocolTCP, nil, false, 80)
 			lb := network.LoadBalancer{
-				Name: to.StringPtr("test"),
+				Name: pointer.String("test"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					BackendAddressPools: &[]network.BackendAddressPool{},
 				},

--- a/pkg/provider/azure_managedDiskController_test.go
+++ b/pkg/provider/azure_managedDiskController_test.go
@@ -23,13 +23,13 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	cloudvolume "k8s.io/cloud-provider/volume"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/diskclient/mockdiskclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -53,7 +53,7 @@ func TestCreateManagedDisk(t *testing.T) {
 	goodDiskEncryptionSetID := fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/%s", "diskEncryptionSet-name")
 	badDiskEncryptionSetID := "badDiskEncryptionSetID"
 	testTags := make(map[string]*string)
-	testTags[WriteAcceleratorEnabled] = to.StringPtr("true")
+	testTags[WriteAcceleratorEnabled] = pointer.String("true")
 	testCases := []struct {
 		desc                string
 		diskID              string
@@ -81,7 +81,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -93,7 +93,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -105,7 +105,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -117,7 +117,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -129,7 +129,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - failed to parse DiskIOPSReadWrite: strconv.Atoi: parsing \"invalid\": invalid syntax"),
 		},
@@ -142,7 +142,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "invalid",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - failed to parse DiskMBpsReadWrite: strconv.Atoi: parsing \"invalid\": invalid syntax"),
 		},
@@ -155,7 +155,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: badDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - format of DiskEncryptionSetID(%s) is incorrect, correct format: %s", badDiskEncryptionSetID, consts.DiskEncryptionSetIDFormat),
 		},
@@ -167,7 +167,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskEncryptionSetID: "",
 			diskEncryptionType:  "EncryptionAtRestWithCustomerKey",
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - DiskEncryptionType(EncryptionAtRestWithCustomerKey) should be empty when DiskEncryptionSetID is not set"),
 		},
@@ -180,7 +180,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - DiskIOPSReadWrite parameter is only applicable in UltraSSD_LRS disk type"),
 		},
@@ -193,7 +193,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - DiskMBpsReadWrite parameter is only applicable in UltraSSD_LRS disk type"),
 		},
@@ -205,7 +205,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			networkAccessPolicy: compute.DenyAll,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -217,7 +217,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskEncryptionType:  "EncryptionAtRestWithCustomerKey",
 			networkAccessPolicy: compute.AllowAll,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -228,7 +228,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			networkAccessPolicy: compute.AllowPrivate,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("DiskAccessID should not be empty when NetworkAccessPolicy is AllowPrivate"),
 		},
@@ -239,9 +239,9 @@ func TestCreateManagedDisk(t *testing.T) {
 			storageAccountType:  compute.StandardLRS,
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			networkAccessPolicy: compute.AllowAll,
-			diskAccessID:        to.StringPtr("diskAccessID"),
+			diskAccessID:        pointer.String("diskAccessID"),
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("DiskAccessID(diskAccessID) must be empty when NetworkAccessPolicy(AllowAll) is not AllowPrivate"),
 		},
@@ -252,7 +252,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			subscriptionID: "abc",
 			resouceGroup:   "",
 			expectedDiskID: "",
-			existedDisk:    compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:    compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("resourceGroup must be specified when subscriptionID(abc) is not empty"),
 		},
@@ -303,16 +303,16 @@ func TestCreateManagedDiskWithExtendedLocation(t *testing.T) {
 	diskName := disk1Name
 	expectedDiskID := disk1ID
 	el := &compute.ExtendedLocation{
-		Name: to.StringPtr("microsoftlosangeles1"),
+		Name: pointer.String("microsoftlosangeles1"),
 		Type: compute.ExtendedLocationTypesEdgeZone,
 	}
 
 	diskreturned := compute.Disk{
-		ID:               to.StringPtr(expectedDiskID),
-		Name:             to.StringPtr(diskName),
+		ID:               pointer.String(expectedDiskID),
+		Name:             pointer.String(diskName),
 		ExtendedLocation: el,
 		DiskProperties: &compute.DiskProperties{
-			ProvisioningState: to.StringPtr("Succeeded"),
+			ProvisioningState: pointer.String("Succeeded"),
 		},
 	}
 
@@ -355,20 +355,20 @@ func TestDeleteManagedDisk(t *testing.T) {
 			desc:           "an error shall be returned if delete an attaching disk",
 			diskName:       disk1Name,
 			diskState:      "attaching",
-			existedDisk:    compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk:    compute.Disk{Name: pointer.String(disk1Name)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("failed to delete disk(/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/disks/disk1) since it's in attaching or detaching state"),
 		},
 		{
 			desc:        "no error shall be returned if everything is good",
 			diskName:    disk1Name,
-			existedDisk: compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk: compute.Disk{Name: pointer.String(disk1Name)},
 			expectedErr: false,
 		},
 		{
 			desc:           "an error shall be returned if get disk failed",
 			diskName:       fakeGetDiskFailed,
-			existedDisk:    compute.Disk{Name: to.StringPtr(fakeGetDiskFailed)},
+			existedDisk:    compute.Disk{Name: pointer.String(fakeGetDiskFailed)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
 		},
@@ -420,7 +420,7 @@ func TestGetDisk(t *testing.T) {
 		{
 			desc:                      "no error shall be returned if get a normal disk without DiskProperties",
 			diskName:                  disk1Name,
-			existedDisk:               compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk:               compute.Disk{Name: pointer.String(disk1Name)},
 			expectedErr:               false,
 			expectedProvisioningState: "",
 			expectedDiskID:            "",
@@ -428,7 +428,7 @@ func TestGetDisk(t *testing.T) {
 		{
 			desc:                      "an error shall be returned if get disk failed",
 			diskName:                  fakeGetDiskFailed,
-			existedDisk:               compute.Disk{Name: to.StringPtr(fakeGetDiskFailed)},
+			existedDisk:               compute.Disk{Name: pointer.String(fakeGetDiskFailed)},
 			expectedErr:               true,
 			expectedErrMsg:            fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
 			expectedProvisioningState: "",
@@ -482,7 +482,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         diskName,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      false,
 		},
@@ -491,7 +491,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         diskName,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk:      compute.Disk{Name: pointer.String(disk1Name)},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("DiskProperties of disk(%s) is nil", diskName),
@@ -501,7 +501,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         diskName,
 			oldSize:          *resource.NewQuantity(1*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      false,
 		},
@@ -510,7 +510,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         fakeGetDiskFailed,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
@@ -520,7 +520,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         fakeCreateDiskFailed,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Create Disk failed"),
@@ -530,7 +530,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         fakeCreateDiskFailed,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Attached}},
+			existedDisk:      compute.Disk{Name: pointer.String(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Attached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("azureDisk - disk resize is only supported on Unattached disk, current disk state: Attached, already attached to "),
@@ -597,7 +597,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expected: map[string]string{
 				consts.LabelFailureDomainBetaRegion: testCloud0.Location,
 				consts.LabelFailureDomainBetaZone:   testCloud0.makeZone(testCloud0.Location, 1),
@@ -617,7 +617,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"invalid"}},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"invalid"}},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("failed to parse zone [invalid] for AzureDisk %v: %v", diskName, "strconv.Atoi: parsing \"invalid\": invalid syntax"),
 		},
@@ -634,7 +634,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected: map[string]string{
 				consts.LabelFailureDomainBetaRegion: testCloud0.Location,
 			},
@@ -654,7 +654,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk:    compute.Disk{Name: to.StringPtr(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
+			existedDisk:    compute.Disk{Name: pointer.String(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
 		},
@@ -671,7 +671,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("invalid disk URI: invalidDiskURI"),
 		},
@@ -688,7 +688,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected:    nil,
 			expectedErr: false,
 		},
@@ -700,7 +700,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					PersistentVolumeSource: v1.PersistentVolumeSource{},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected:    nil,
 			expectedErr: false,
 		},

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -43,7 +43,7 @@ func (az *Cloud) reconcilePrivateLinkService(
 	createPLS := wantPLS && serviceRequiresPLS(service)
 	serviceName := getServiceName(service)
 	fipConfigID := fipConfig.ID
-	klog.V(2).Infof("reconcilePrivateLinkService for service(%s) - LB fipConfigID(%s) - wantPLS(%t) - createPLS(%t)", serviceName, to.String(fipConfig.Name), wantPLS, createPLS)
+	klog.V(2).Infof("reconcilePrivateLinkService for service(%s) - LB fipConfigID(%s) - wantPLS(%t) - createPLS(%t)", serviceName, pointer.StringDeref(fipConfig.Name, ""), wantPLS, createPLS)
 
 	if createPLS {
 		// Firstly, make sure it's internal service
@@ -54,19 +54,19 @@ func (az *Cloud) reconcilePrivateLinkService(
 		// Secondly, check if there is a private link service already created
 		existingPLS, err := az.getPrivateLinkService(fipConfigID, azcache.CacheReadTypeDefault)
 		if err != nil {
-			klog.Errorf("reconcilePrivateLinkService for service(%s): getPrivateLinkService(%s) failed: %v", serviceName, to.String(fipConfigID), err)
+			klog.Errorf("reconcilePrivateLinkService for service(%s): getPrivateLinkService(%s) failed: %v", serviceName, pointer.StringDeref(fipConfigID, ""), err)
 			return err
 		}
 
-		exists := !strings.EqualFold(to.String(existingPLS.ID), consts.PrivateLinkServiceNotExistID)
+		exists := !strings.EqualFold(pointer.StringDeref(existingPLS.ID, ""), consts.PrivateLinkServiceNotExistID)
 		if exists {
-			klog.V(4).Infof("reconcilePrivateLinkService for service(%s): found existing private link service attached(%s)", serviceName, to.String(existingPLS.Name))
+			klog.V(4).Infof("reconcilePrivateLinkService for service(%s): found existing private link service attached(%s)", serviceName, pointer.StringDeref(existingPLS.Name, ""))
 			if !isManagedPrivateLinkSerivce(&existingPLS, clusterName) {
 				return fmt.Errorf(
 					"reconcilePrivateLinkService for service(%s) failed: LB frontend(%s) already has unmanaged private link service(%s)",
 					serviceName,
-					to.String(fipConfigID),
-					to.String(existingPLS.ID),
+					pointer.StringDeref(fipConfigID, ""),
+					pointer.StringDeref(existingPLS.ID, ""),
 				)
 			}
 			// If there is an existing private link service, only owner service can update its properties
@@ -76,15 +76,15 @@ func (az *Cloud) reconcilePrivateLinkService(
 					return fmt.Errorf(
 						"reconcilePrivateLinkService for service(%s) failed: LB frontend(%s) already has existing private link service(%s) owned by service(%s)",
 						serviceName,
-						to.String(fipConfigID),
-						to.String(existingPLS.Name),
+						pointer.StringDeref(fipConfigID, ""),
+						pointer.StringDeref(existingPLS.Name, ""),
 						ownerService,
 					)
 				}
 				klog.V(2).Infof(
 					"reconcilePrivateLinkService for service(%s): automatically share private link service(%s) owned by service(%s)",
 					serviceName,
-					to.String(existingPLS.Name),
+					pointer.StringDeref(existingPLS.Name, ""),
 					ownerService,
 				)
 				return nil
@@ -118,7 +118,7 @@ func (az *Cloud) reconcilePrivateLinkService(
 				klog.Errorf("reconcilePrivateLinkService for service(%s) disable PLS network policy failed for pls(%s): %v", serviceName, plsName, err.Error())
 				return err
 			}
-			existingPLS.Etag = to.StringPtr("")
+			existingPLS.Etag = pointer.String("")
 			err = az.CreateOrUpdatePLS(service, existingPLS)
 			if err != nil {
 				klog.Errorf("reconcilePrivateLinkService for service(%s) abort backoff: pls(%s) - updating: %s", serviceName, plsName, err.Error())
@@ -128,15 +128,15 @@ func (az *Cloud) reconcilePrivateLinkService(
 	} else if !wantPLS {
 		existingPLS, err := az.getPrivateLinkService(fipConfigID, azcache.CacheReadTypeDefault)
 		if err != nil {
-			klog.Errorf("reconcilePrivateLinkService for service(%s): getPrivateLinkService(%s) failed: %v", serviceName, to.String(fipConfigID), err)
+			klog.Errorf("reconcilePrivateLinkService for service(%s): getPrivateLinkService(%s) failed: %v", serviceName, pointer.StringDeref(fipConfigID, ""), err)
 			return err
 		}
 
-		exists := !strings.EqualFold(to.String(existingPLS.ID), consts.PrivateLinkServiceNotExistID)
+		exists := !strings.EqualFold(pointer.StringDeref(existingPLS.ID, ""), consts.PrivateLinkServiceNotExistID)
 		if exists {
 			deleteErr := az.safeDeletePLS(&existingPLS, service)
 			if deleteErr != nil {
-				klog.Errorf("reconcilePrivateLinkService for service(%s): deletePLS for frontEnd(%s) failed: %v", serviceName, to.String(fipConfigID), err)
+				klog.Errorf("reconcilePrivateLinkService for service(%s): deletePLS for frontEnd(%s) failed: %v", serviceName, pointer.StringDeref(fipConfigID, ""), err)
 				return deleteErr.Error()
 			}
 		}
@@ -182,19 +182,19 @@ func (az *Cloud) safeDeletePLS(pls *network.PrivateLinkService, service *v1.Serv
 	peConns := pls.PrivateEndpointConnections
 	if peConns != nil {
 		for _, peConn := range *peConns {
-			klog.V(2).Infof("deletePLS: deleting PEConnection %s", to.String(peConn.Name))
-			rerr := az.DeletePEConn(service, to.String(pls.Name), to.String(peConn.Name))
+			klog.V(2).Infof("deletePLS: deleting PEConnection %s", pointer.StringDeref(peConn.Name, ""))
+			rerr := az.DeletePEConn(service, pointer.StringDeref(pls.Name, ""), pointer.StringDeref(peConn.Name, ""))
 			if rerr != nil {
 				return rerr
 			}
 		}
 	}
 
-	rerr := az.DeletePLS(service, to.String(pls.Name), to.String((*pls.LoadBalancerFrontendIPConfigurations)[0].ID))
+	rerr := az.DeletePLS(service, pointer.StringDeref(pls.Name, ""), pointer.StringDeref((*pls.LoadBalancerFrontendIPConfigurations)[0].ID, ""))
 	if rerr != nil {
 		return rerr
 	}
-	klog.V(2).Infof("safeDeletePLS(%s) finished", to.String(pls.Name))
+	klog.V(2).Infof("safeDeletePLS(%s) finished", pointer.StringDeref(pls.Name, ""))
 	return nil
 }
 
@@ -209,11 +209,11 @@ func (az *Cloud) getPrivateLinkServiceName(
 
 	if nameFromService, found := service.Annotations[consts.ServiceAnnotationPLSName]; found {
 		nameFromService = strings.TrimSpace(nameFromService)
-		if existingName != nil && !strings.EqualFold(to.String(existingName), nameFromService) {
+		if existingName != nil && !strings.EqualFold(pointer.StringDeref(existingName, ""), nameFromService) {
 			return "", fmt.Errorf(
 				"getPrivateLinkServiceName(%s) failed: cannot change existing private link service name (%s) to (%s)",
 				serviceName,
-				to.String(existingName),
+				pointer.StringDeref(existingName, ""),
 				nameFromService,
 			)
 		}
@@ -221,7 +221,7 @@ func (az *Cloud) getPrivateLinkServiceName(
 	}
 
 	if existingName != nil {
-		return to.String(existingName), nil
+		return pointer.StringDeref(existingName, ""), nil
 	}
 
 	// default PLS name: pls-<frontendIPConfigName>
@@ -339,19 +339,19 @@ func (az *Cloud) reconcilePLSIpConfigs(
 
 	existingStaticIps := make([]string, 0)
 	for _, ipConfig := range *existingPLS.IPConfigurations {
-		if !strings.EqualFold(to.String(subnet.ID), to.String(ipConfig.Subnet.ID)) {
+		if !strings.EqualFold(pointer.StringDeref(subnet.ID, ""), pointer.StringDeref(ipConfig.Subnet.ID, "")) {
 			changed = true
 		}
 		if strings.EqualFold(string(ipConfig.PrivateIPAllocationMethod), string(network.IPAllocationMethodStatic)) {
-			klog.V(10).Infof("Found static IP: %s", to.String(ipConfig.PrivateIPAddress))
-			if _, found := staticIps[to.String(ipConfig.PrivateIPAddress)]; !found {
+			klog.V(10).Infof("Found static IP: %s", pointer.StringDeref(ipConfig.PrivateIPAddress, ""))
+			if _, found := staticIps[pointer.StringDeref(ipConfig.PrivateIPAddress, "")]; !found {
 				changed = true
 			}
-			existingStaticIps = append(existingStaticIps, to.String(ipConfig.PrivateIPAddress))
+			existingStaticIps = append(existingStaticIps, pointer.StringDeref(ipConfig.PrivateIPAddress, ""))
 		}
 		if *ipConfig.Primary {
 			if strings.EqualFold(string(ipConfig.PrivateIPAllocationMethod), string(network.IPAllocationMethodStatic)) {
-				if !strings.EqualFold(primaryIP, to.String(ipConfig.PrivateIPAddress)) {
+				if !strings.EqualFold(primaryIP, pointer.StringDeref(ipConfig.PrivateIPAddress, "")) {
 					changed = true
 				}
 			} else {
@@ -371,7 +371,7 @@ func (az *Cloud) reconcilePLSIpConfigs(
 		for k := range staticIps {
 			ip := k
 			isPrimary := strings.EqualFold(ip, primaryIP)
-			configName := fmt.Sprintf("%s-%s-static-%s", to.String(subnet.Name), to.String(existingPLS.Name), ip)
+			configName := fmt.Sprintf("%s-%s-static-%s", pointer.StringDeref(subnet.Name, ""), pointer.StringDeref(existingPLS.Name, ""), ip)
 			ipConfigs = append(ipConfigs, network.PrivateLinkServiceIPConfiguration{
 				Name: &configName,
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
@@ -387,7 +387,7 @@ func (az *Cloud) reconcilePLSIpConfigs(
 		}
 		for i := 0; i < int(ipConfigCount)-len(staticIps); i++ {
 			isPrimary := primaryIP == "" && i == 0
-			configName := fmt.Sprintf("%s-%s-dynamic-%d", to.String(subnet.Name), to.String(existingPLS.Name), i)
+			configName := fmt.Sprintf("%s-%s-dynamic-%d", pointer.StringDeref(subnet.Name, ""), pointer.StringDeref(existingPLS.Name, ""), i)
 			ipConfigs = append(ipConfigs, network.PrivateLinkServiceIPConfiguration{
 				Name: &configName,
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{

--- a/pkg/provider/azure_privatelinkservice_test.go
+++ b/pkg/provider/azure_privatelinkservice_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
@@ -72,8 +72,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -81,7 +81,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList:   true,
 			existingPLSList:   []network.PrivateLinkService{},
 			expectedPLSCreate: true,
-			expectedPLS:       &network.PrivateLinkService{Name: to.StringPtr("pls-fipConfig")},
+			expectedPLS:       &network.PrivateLinkService{Name: pointer.String("pls-fipConfig")},
 		},
 		{
 			desc: "reconcilePrivateLinkService should create a new PLS if no existing PLS attached to the LB frontend",
@@ -93,8 +93,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -102,7 +102,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList:   true,
 			existingPLSList:   []network.PrivateLinkService{},
 			expectedPLSCreate: true,
-			expectedPLS:       &network.PrivateLinkService{Name: to.StringPtr("testpls")},
+			expectedPLS:       &network.PrivateLinkService{Name: pointer.String("testpls")},
 		},
 		{
 			desc: "reconcilePrivateLinkService should report error if existing PLS attached to LB frontEnd is unmanaged",
@@ -115,15 +115,15 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPVersionIPv4,
 								},
 							},
@@ -144,23 +144,23 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPVersionIPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test1"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test1"),
 					},
 				},
 			},
@@ -176,24 +176,24 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-									PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									PrivateIPAddress:          pointer.String("10.2.0.4"),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPVersionIPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test1"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test1"),
 					},
 				},
 			},
@@ -208,8 +208,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -217,23 +217,23 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPVersionIPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test"),
 					},
 				},
 			},
@@ -249,8 +249,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -258,28 +258,28 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPVersionIPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test"),
 					},
 				},
 			},
 			expectedPLSCreate: true,
-			expectedPLS:       &network.PrivateLinkService{Name: to.StringPtr("testpls")},
+			expectedPLS:       &network.PrivateLinkService{Name: pointer.String("testpls")},
 		},
 		{
 			desc: "reconcilePrivateLinkService should not do anything if no existing PLS attached to the LB frontend when deleting",
@@ -291,9 +291,9 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID2")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID2")}},
 					},
 				},
 			},
@@ -308,9 +308,9 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 					},
 				},
 			},
@@ -321,8 +321,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 		az := GetTestCloud(ctrl)
 		service := getTestServiceWithAnnotation("test", test.annotations, 80)
 		fipConfig := &network.FrontendIPConfiguration{
-			Name: to.StringPtr("fipConfig"),
-			ID:   to.StringPtr("fipConfigID"),
+			Name: pointer.String("fipConfig"),
+			ID:   pointer.String("fipConfigID"),
 		}
 		clusterName := testClusterName
 
@@ -335,7 +335,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			mockPLSsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPLSList, nil).MaxTimes(1)
 		}
 		if test.expectedPLSCreate {
-			mockPLSsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", to.String(test.expectedPLS.Name), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockPLSsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", pointer.StringDeref(test.expectedPLS.Name, ""), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		}
 		if test.expectedPLSDelete {
 			mockPLSsClient.EXPECT().Delete(gomock.Any(), "rg", "testpls").Return(nil).Times(1)
@@ -358,7 +358,7 @@ func TestDisablePLSNetworkPolicy(t *testing.T) {
 		{
 			desc: "disablePLSNetworkPolicy shall not update subnet if pls-network-policy is disabled",
 			subnet: network.Subnet{
-				Name: to.StringPtr("plsSubnet"),
+				Name: pointer.String("plsSubnet"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -368,7 +368,7 @@ func TestDisablePLSNetworkPolicy(t *testing.T) {
 		{
 			desc: "disablePLSNetworkPolicy shall update subnet if pls-network-policy is enabled",
 			subnet: network.Subnet{
-				Name: to.StringPtr("plsSubnet"),
+				Name: pointer.String("plsSubnet"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
 				},
@@ -387,7 +387,7 @@ func TestDisablePLSNetworkPolicy(t *testing.T) {
 		mockSubnetsClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "plsSubnet", "").Return(test.subnet, nil).Times(1)
 		if test.expectedSubnetUpdate {
 			mockSubnetsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "vnet", "plsSubnet", network.Subnet{
-				Name: to.StringPtr("plsSubnet"),
+				Name: pointer.String("plsSubnet"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -410,12 +410,12 @@ func TestSafeDeletePLS(t *testing.T) {
 		{
 			desc: "safeDeletePLS shall delete all PE connections and pls itself",
 			pls: &network.PrivateLinkService{
-				Name: to.StringPtr("testpls"),
+				Name: pointer.String("testpls"),
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("FipConfigID")}},
+					LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("FipConfigID")}},
 					PrivateEndpointConnections: &[]network.PrivateEndpointConnection{
-						{Name: to.StringPtr("pe1")},
-						{Name: to.StringPtr("pe2")},
+						{Name: pointer.String("pe1")},
+						{Name: pointer.String("pe2")},
 					},
 				},
 			},
@@ -459,14 +459,14 @@ func TestGetPrivateLinkServiceName(t *testing.T) {
 			desc: "If pls name does not set, and service does not configure, sets it as default(pls-fipConfigName)",
 			pls:  &network.PrivateLinkService{},
 			fipConfig: &network.FrontendIPConfiguration{
-				Name: to.StringPtr("fipname"),
+				Name: pointer.String("fipname"),
 			},
 			expectedName: "pls-fipname",
 		},
 		{
 			desc: "If pls name is not equal to service configuration, error should be reported",
 			pls: &network.PrivateLinkService{
-				Name: to.StringPtr("testpls"),
+				Name: pointer.String("testpls"),
 			},
 			annotations: map[string]string{
 				consts.ServiceAnnotationPLSName: "testpls1",
@@ -476,7 +476,7 @@ func TestGetPrivateLinkServiceName(t *testing.T) {
 		{
 			desc: "If pls name is same as service configuration, simply return it",
 			pls: &network.PrivateLinkService{
-				Name: to.StringPtr("testpls"),
+				Name: pointer.String("testpls"),
 			},
 			annotations: map[string]string{
 				consts.ServiceAnnotationPLSName: "testpls",
@@ -520,13 +520,13 @@ func TestGetExpectedPrivateLinkService(t *testing.T) {
 		}
 		plsName := "testPLS"
 		clusterName := testClusterName
-		fipConfig := &network.FrontendIPConfiguration{ID: to.StringPtr("fipConfigID")}
+		fipConfig := &network.FrontendIPConfiguration{ID: pointer.String("fipConfigID")}
 		pls := &network.PrivateLinkService{PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{}}
 		subnetClient := cloud.SubnetsClient.(*mocksubnetclient.MockInterface)
 		subnetClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", gomock.Any()).Return(
 			network.Subnet{
-				ID:   to.StringPtr("subnetID"),
-				Name: to.StringPtr("subnet"),
+				ID:   pointer.String("subnetID"),
+				Name: pointer.String("subnet"),
 			}, nil).MaxTimes(1)
 
 		dirtyPLS, err := cloud.getExpectedPrivateLinkService(pls, &plsName, &clusterName, service, fipConfig)
@@ -540,31 +540,31 @@ func TestGetExpectedPrivateLinkService(t *testing.T) {
 
 		expectedConfigs := []network.PrivateLinkServiceIPConfiguration{
 			{
-				Name: to.StringPtr("subnet-testPLS-static-10.2.0.4"),
+				Name: pointer.String("subnet-testPLS-static-10.2.0.4"),
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 					PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-					PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-					Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-					Primary:                   to.BoolPtr(true),
+					PrivateIPAddress:          pointer.String("10.2.0.4"),
+					Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+					Primary:                   pointer.Bool(true),
 					PrivateIPAddressVersion:   network.IPVersionIPv4,
 				},
 			},
 			{
-				Name: to.StringPtr("subnet-testPLS-static-10.2.0.5"),
+				Name: pointer.String("subnet-testPLS-static-10.2.0.5"),
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 					PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-					PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-					Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-					Primary:                   to.BoolPtr(false),
+					PrivateIPAddress:          pointer.String("10.2.0.5"),
+					Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+					Primary:                   pointer.Bool(false),
 					PrivateIPAddressVersion:   network.IPVersionIPv4,
 				},
 			},
 			{
-				Name: to.StringPtr("subnet-testPLS-dynamic-0"),
+				Name: pointer.String("subnet-testPLS-dynamic-0"),
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 					PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-					Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-					Primary:                   to.BoolPtr(false),
+					Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+					Primary:                   pointer.Bool(false),
 					PrivateIPAddressVersion:   network.IPVersionIPv4,
 				},
 			},
@@ -619,11 +619,11 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should change existingPLS if its ipConfig is nil",
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -637,31 +637,31 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-1"),
+					Name: pointer.String("subnet-testpls-dynamic-1"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(false),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(false),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -672,22 +672,22 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should change existingPLS if its subnetID is different",
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID1")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID1")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -702,32 +702,32 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.4"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.4"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-						PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.4"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(false),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(false),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -738,23 +738,23 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should change existingPLS if ip allocation type is changed from static to dynamic",
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.4"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.4"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-						PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.4"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -768,24 +768,24 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.4"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.4"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-						PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.4"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.5"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.5"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-						PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.5"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -796,22 +796,22 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should not change existingPLS if ip allocation type is dynamic only",
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodDynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -824,24 +824,24 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.5"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.5"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-						PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.5"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.5"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.5"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.IPAllocationMethodStatic,
-						PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.5"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPVersionIPv4,
 					},
 				},
@@ -857,7 +857,7 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 		}
 		pls := &network.PrivateLinkService{
-			Name: to.StringPtr("testpls"),
+			Name: pointer.String("testpls"),
 			PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
 				IPConfigurations: test.existingIPConfigs,
 			},
@@ -865,8 +865,8 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 		subnetClient := cloud.SubnetsClient.(*mocksubnetclient.MockInterface)
 		subnetClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", gomock.Any()).Return(
 			network.Subnet{
-				ID:   to.StringPtr("subnetID"),
-				Name: to.StringPtr("subnet"),
+				ID:   pointer.String("subnetID"),
+				Name: pointer.String("subnet"),
 			}, test.getSubnetError).MaxTimes(1)
 
 		changed, err := cloud.reconcilePLSIpConfigs(pls, service)
@@ -883,10 +883,10 @@ func testSamePLSIpConfigs(t *testing.T, actual []network.PrivateLinkServiceIPCon
 	actualIPConfigs := make(map[string]network.PrivateLinkServiceIPConfiguration)
 	expectedIPConfigs := make(map[string]network.PrivateLinkServiceIPConfiguration)
 	for _, ipConfig := range actual {
-		actualIPConfigs[to.String(ipConfig.Name)] = ipConfig
+		actualIPConfigs[pointer.StringDeref(ipConfig.Name, "")] = ipConfig
 	}
 	for _, ipConfig := range expected {
-		expectedIPConfigs[to.String(ipConfig.Name)] = ipConfig
+		expectedIPConfigs[pointer.StringDeref(ipConfig.Name, "")] = ipConfig
 	}
 	assert.Equal(t, actualIPConfigs, expectedIPConfigs)
 }
@@ -957,10 +957,10 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			},
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					EnableProxyProtocol: to.BoolPtr(false),
+					EnableProxyProtocol: pointer.Bool(false),
 				},
 			},
-			expectedEnabled: to.BoolPtr(false),
+			expectedEnabled: pointer.Bool(false),
 		},
 		{
 			desc: "true service enableProxyProto and true pls enableProxyProto should not trigger any change",
@@ -969,10 +969,10 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			},
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					EnableProxyProtocol: to.BoolPtr(true),
+					EnableProxyProtocol: pointer.Bool(true),
 				},
 			},
-			expectedEnabled: to.BoolPtr(true),
+			expectedEnabled: pointer.Bool(true),
 		},
 		{
 			desc: "true service enableProxyProto and empty pls enableProxyProto should trigger update",
@@ -982,7 +982,7 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{},
 			},
-			expectedEnabled: to.BoolPtr(true),
+			expectedEnabled: pointer.Bool(true),
 			expectedChanged: true,
 		},
 		{
@@ -992,10 +992,10 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			},
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					EnableProxyProtocol: to.BoolPtr(true),
+					EnableProxyProtocol: pointer.Bool(true),
 				},
 			},
-			expectedEnabled: to.BoolPtr(false),
+			expectedEnabled: pointer.Bool(false),
 			expectedChanged: true,
 		},
 	}
@@ -1254,9 +1254,9 @@ func TestReconcilePLSTags(t *testing.T) {
 	}
 	pls := network.PrivateLinkService{
 		Tags: map[string]*string{
-			"foo": to.StringPtr("bar"),
-			"a":   to.StringPtr("j"),
-			"m":   to.StringPtr("n"),
+			"foo": pointer.String("bar"),
+			"a":   pointer.String("j"),
+			"m":   pointer.String("n"),
 		},
 	}
 	clusterName := testClusterName
@@ -1264,12 +1264,12 @@ func TestReconcilePLSTags(t *testing.T) {
 	t.Run("reconcilePLSTags should ensure the pls is tagged as configured", func(t *testing.T) {
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-				consts.OwnerServiceTagKey: to.StringPtr("test-ns/test-svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("x"),
-				"y":                       to.StringPtr("z"),
-				"m":                       to.StringPtr("n"),
+				consts.ClusterNameTagKey:  pointer.String(testClusterName),
+				consts.OwnerServiceTagKey: pointer.String("test-ns/test-svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("x"),
+				"y":                       pointer.String("z"),
+				"m":                       pointer.String("n"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1281,11 +1281,11 @@ func TestReconcilePLSTags(t *testing.T) {
 		cloud.SystemTags = "a,foo,b"
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-				consts.OwnerServiceTagKey: to.StringPtr("test-ns/test-svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("x"),
-				"y":                       to.StringPtr("z"),
+				consts.ClusterNameTagKey:  pointer.String(testClusterName),
+				consts.OwnerServiceTagKey: pointer.String("test-ns/test-svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("x"),
+				"y":                       pointer.String("z"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1298,11 +1298,11 @@ func TestReconcilePLSTags(t *testing.T) {
 		cloud.TagsMap = map[string]string{"a": "c", "a=b": "c=d", "Y": "zz"}
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-				consts.OwnerServiceTagKey: to.StringPtr("test-ns/test-svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("c"),
-				"a=b":                     to.StringPtr("c=d"),
+				consts.ClusterNameTagKey:  pointer.String(testClusterName),
+				consts.OwnerServiceTagKey: pointer.String("test-ns/test-svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("c"),
+				"a=b":                     pointer.String("c=d"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1310,18 +1310,18 @@ func TestReconcilePLSTags(t *testing.T) {
 		assert.Equal(t, expectedPLS, pls)
 	})
 
-	pls.Tags[consts.ClusterNameTagKey] = to.StringPtr("testCluster1")
-	pls.Tags[consts.OwnerServiceTagKey] = to.StringPtr("default/svc")
+	pls.Tags[consts.ClusterNameTagKey] = pointer.String("testCluster1")
+	pls.Tags[consts.OwnerServiceTagKey] = pointer.String("default/svc")
 
 	t.Run("reconcilePLSTags should respect cluster and owner service tag keys", func(t *testing.T) {
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr("testCluster1"),
-				consts.OwnerServiceTagKey: to.StringPtr("default/svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("c"),
-				"a=b":                     to.StringPtr("c=d"),
-				"Y":                       to.StringPtr("zz"),
+				consts.ClusterNameTagKey:  pointer.String("testCluster1"),
+				consts.OwnerServiceTagKey: pointer.String("default/svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("c"),
+				"a=b":                     pointer.String("c=d"),
+				"Y":                       pointer.String("zz"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1347,7 +1347,7 @@ func TestGetPLSSubnetName(t *testing.T) {
 			annotations: map[string]string{
 				consts.ServiceAnnotationPLSIpConfigurationSubnet: "pls-subnet",
 			},
-			expectedSubnet: to.StringPtr("pls-subnet"),
+			expectedSubnet: pointer.String("pls-subnet"),
 		},
 		{
 			desc: "Service with empty private link subnet specified but LB subnet specified should return LB subnet",
@@ -1356,7 +1356,7 @@ func TestGetPLSSubnetName(t *testing.T) {
 				consts.ServiceAnnotationPLSIpConfigurationSubnet:   "",
 				consts.ServiceAnnotationLoadBalancerInternalSubnet: "lb-subnet",
 			},
-			expectedSubnet: to.StringPtr("lb-subnet"),
+			expectedSubnet: pointer.String("lb-subnet"),
 		},
 		{
 			desc: "Service with LB subnet specified should return it",
@@ -1364,7 +1364,7 @@ func TestGetPLSSubnetName(t *testing.T) {
 				consts.ServiceAnnotationLoadBalancerInternal:       "true",
 				consts.ServiceAnnotationLoadBalancerInternalSubnet: "lb-subnet",
 			},
-			expectedSubnet: to.StringPtr("lb-subnet"),
+			expectedSubnet: pointer.String("lb-subnet"),
 		},
 		{
 			desc: "Service with both empty subnets specified should return nil",
@@ -1702,7 +1702,7 @@ func TestIsManagedPrivateLinkSerivce(t *testing.T) {
 			desc: "Private link service with different cluster name should return false",
 			pls: &network.PrivateLinkService{
 				Tags: map[string]*string{
-					"k8s-azure-cluster-name": to.StringPtr("test-cluster1"),
+					"k8s-azure-cluster-name": pointer.String("test-cluster1"),
 				},
 			},
 			clusterName: "test-cluster",
@@ -1711,7 +1711,7 @@ func TestIsManagedPrivateLinkSerivce(t *testing.T) {
 			desc: "Private link service with same cluster name should return true",
 			pls: &network.PrivateLinkService{
 				Tags: map[string]*string{
-					"k8s-azure-cluster-name": to.StringPtr("test-cluster"),
+					"k8s-azure-cluster-name": pointer.String("test-cluster"),
 				},
 			},
 			clusterName: "test-cluster",
@@ -1743,7 +1743,7 @@ func TestGetPrivateLinkServiceOwner(t *testing.T) {
 		{
 			desc: "Private link service with service owner tag should return service owner",
 			pls: &network.PrivateLinkService{
-				Tags: map[string]*string{"k8s-azure-owner-service": to.StringPtr("test-service")},
+				Tags: map[string]*string{"k8s-azure-owner-service": pointer.String("test-service")},
 			},
 			expected: "test-service",
 		},

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -24,13 +24,13 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -168,13 +168,13 @@ func (d *delayedRouteUpdater) updateRoutes() {
 		routeMatch := false
 		onlyUpdateTags = false
 		for i, existingRoute := range routes {
-			if strings.EqualFold(to.String(existingRoute.Name), to.String(rt.route.Name)) {
+			if strings.EqualFold(pointer.StringDeref(existingRoute.Name, ""), pointer.StringDeref(rt.route.Name, "")) {
 				// delete the name-matched routes here (missing routes would be added later if the operation is add).
 				routes = append(routes[:i], routes[i+1:]...)
 				if existingRoute.RoutePropertiesFormat != nil &&
 					rt.route.RoutePropertiesFormat != nil &&
-					strings.EqualFold(to.String(existingRoute.AddressPrefix), to.String(rt.route.AddressPrefix)) &&
-					strings.EqualFold(to.String(existingRoute.NextHopIPAddress), to.String(rt.route.NextHopIPAddress)) {
+					strings.EqualFold(pointer.StringDeref(existingRoute.AddressPrefix, ""), pointer.StringDeref(rt.route.AddressPrefix, "")) &&
+					strings.EqualFold(pointer.StringDeref(existingRoute.NextHopIPAddress, ""), pointer.StringDeref(rt.route.NextHopIPAddress, "")) {
 					routeMatch = true
 				}
 				if rt.operation == routeOperationDelete {
@@ -184,7 +184,7 @@ func (d *delayedRouteUpdater) updateRoutes() {
 			}
 		}
 		if rt.operation == routeOperationDelete && !dirty {
-			klog.Warningf("updateRoutes: route to be deleted %s does not match any of the existing route", to.String(rt.route.Name))
+			klog.Warningf("updateRoutes: route to be deleted %s does not match any of the existing route", pointer.StringDeref(rt.route.Name, ""))
 		}
 
 		// Add missing routes if the operation is add.
@@ -217,7 +217,7 @@ func (d *delayedRouteUpdater) updateRoutes() {
 // and deletes all dualstack routes when dualstack is not enabled.
 func (d *delayedRouteUpdater) cleanupOutdatedRoutes(existingRoutes []network.Route) (routes []network.Route, changed bool) {
 	for i := len(existingRoutes) - 1; i >= 0; i-- {
-		existingRouteName := to.String(existingRoutes[i].Name)
+		existingRouteName := pointer.StringDeref(existingRoutes[i].Name, "")
 		split := strings.Split(existingRouteName, consts.RouteNameSeparator)
 
 		klog.V(4).Infof("cleanupOutdatedRoutes: checking route %s", existingRouteName)
@@ -300,7 +300,7 @@ func (az *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpr
 	// ensure the route table is tagged as configured
 	tags, changed := az.ensureRouteTableTagged(&routeTable)
 	if changed {
-		klog.V(2).Infof("ListRoutes: updating tags on route table %s", to.String(routeTable.Name))
+		klog.V(2).Infof("ListRoutes: updating tags on route table %s", pointer.StringDeref(routeTable.Name, ""))
 		op, err := az.routeUpdater.addUpdateRouteTableTagsOperation(routeTableOperationUpdateTags, tags)
 		if err != nil {
 			klog.Errorf("ListRoutes: failed to add route table operation with error: %v", err)
@@ -349,8 +349,8 @@ func processRoutes(ipv6DualStackEnabled bool, routeTable network.RouteTable, exi
 
 func (az *Cloud) createRouteTable() error {
 	routeTable := network.RouteTable{
-		Name:                       to.StringPtr(az.RouteTableName),
-		Location:                   to.StringPtr(az.Location),
+		Name:                       pointer.String(az.RouteTableName),
+		Location:                   pointer.String(az.Location),
 		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{},
 	}
 
@@ -417,11 +417,11 @@ func (az *Cloud) CreateRoute(ctx context.Context, clusterName string, nameHint s
 	}
 	routeName := mapNodeNameToRouteName(az.ipv6DualStackEnabled, kubeRoute.TargetNode, kubeRoute.DestinationCIDR)
 	route := network.Route{
-		Name: to.StringPtr(routeName),
+		Name: pointer.String(routeName),
 		RoutePropertiesFormat: &network.RoutePropertiesFormat{
-			AddressPrefix:    to.StringPtr(kubeRoute.DestinationCIDR),
+			AddressPrefix:    pointer.String(kubeRoute.DestinationCIDR),
 			NextHopType:      network.RouteNextHopTypeVirtualAppliance,
-			NextHopIPAddress: to.StringPtr(targetIP),
+			NextHopIPAddress: pointer.String(targetIP),
 		},
 	}
 
@@ -471,7 +471,7 @@ func (az *Cloud) DeleteRoute(ctx context.Context, clusterName string, kubeRoute 
 	routeName := mapNodeNameToRouteName(az.ipv6DualStackEnabled, kubeRoute.TargetNode, kubeRoute.DestinationCIDR)
 	klog.V(2).Infof("DeleteRoute: deleting route. clusterName=%q instance=%q cidr=%q routeName=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR, routeName)
 	route := network.Route{
-		Name:                  to.StringPtr(routeName),
+		Name:                  pointer.String(routeName),
 		RoutePropertiesFormat: &network.RoutePropertiesFormat{},
 	}
 	op, err := az.routeUpdater.addRouteOperation(routeOperationDelete, route)
@@ -492,7 +492,7 @@ func (az *Cloud) DeleteRoute(ctx context.Context, clusterName string, kubeRoute 
 		routeNameWithoutIPV6Suffix := strings.Split(routeName, consts.RouteNameSeparator)[0]
 		klog.V(2).Infof("DeleteRoute: deleting route. clusterName=%q instance=%q cidr=%q routeName=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR, routeNameWithoutIPV6Suffix)
 		route := network.Route{
-			Name:                  to.StringPtr(routeNameWithoutIPV6Suffix),
+			Name:                  pointer.String(routeNameWithoutIPV6Suffix),
 			RoutePropertiesFormat: &network.RoutePropertiesFormat{},
 		}
 		op, err := az.routeUpdater.addRouteOperation(routeOperationDelete, route)

--- a/pkg/provider/azure_routes_test.go
+++ b/pkg/provider/azure_routes_test.go
@@ -25,13 +25,13 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/routetableclient/mockroutetableclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -206,9 +206,9 @@ func TestCreateRoute(t *testing.T) {
 	nodePrivateIP := "2.4.6.8"
 	networkRoute := &[]network.Route{
 		{
-			Name: to.StringPtr("node"),
+			Name: pointer.String("node"),
 			RoutePropertiesFormat: &network.RoutePropertiesFormat{
-				AddressPrefix:    to.StringPtr("1.2.3.4/24"),
+				AddressPrefix:    pointer.String("1.2.3.4/24"),
 				NextHopIPAddress: &nodePrivateIP,
 				NextHopType:      network.RouteNextHopTypeVirtualAppliance,
 			},
@@ -314,9 +314,9 @@ func TestCreateRoute(t *testing.T) {
 			routeTableName: "rt9",
 			updatedRoute: &[]network.Route{
 				{
-					Name: to.StringPtr("node____123424"),
+					Name: pointer.String("node____123424"),
 					RoutePropertiesFormat: &network.RoutePropertiesFormat{
-						AddressPrefix:    to.StringPtr("1.2.3.4/24"),
+						AddressPrefix:    pointer.String("1.2.3.4/24"),
 						NextHopIPAddress: &nodePrivateIP,
 						NextHopType:      network.RouteNextHopTypeVirtualAppliance,
 					},
@@ -333,14 +333,14 @@ func TestCreateRoute(t *testing.T) {
 
 	for _, test := range testCases {
 		initialTable := network.RouteTable{
-			Name:     to.StringPtr(test.routeTableName),
+			Name:     pointer.String(test.routeTableName),
 			Location: &cloud.Location,
 			RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 				Routes: test.initialRoute,
 			},
 		}
 		updatedTable := network.RouteTable{
-			Name:     to.StringPtr(test.routeTableName),
+			Name:     pointer.String(test.routeTableName),
 			Location: &cloud.Location,
 			RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 				Routes: test.updatedRoute,
@@ -443,9 +443,9 @@ func TestProcessRoutes(t *testing.T) {
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("name"),
+							Name: pointer.String("name"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/16"),
+								AddressPrefix: pointer.String("1.2.3.4/16"),
 							},
 						},
 					},
@@ -466,15 +466,15 @@ func TestProcessRoutes(t *testing.T) {
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("name"),
+							Name: pointer.String("name"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/16"),
+								AddressPrefix: pointer.String("1.2.3.4/16"),
 							},
 						},
 						{
-							Name: to.StringPtr("name2"),
+							Name: pointer.String("name2"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("5.6.7.8/16"),
+								AddressPrefix: pointer.String("5.6.7.8/16"),
 							},
 						},
 					},
@@ -625,14 +625,14 @@ func TestListRoutes(t *testing.T) {
 			name:           "ListRoutes should return correct routes",
 			routeTableName: "rt1",
 			routeTable: network.RouteTable{
-				Name:     to.StringPtr("rt1"),
+				Name:     pointer.String("rt1"),
 				Location: &cloud.Location,
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("node"),
+							Name: pointer.String("node"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/24"),
+								AddressPrefix: pointer.String("1.2.3.4/24"),
 							},
 						},
 					},
@@ -653,14 +653,14 @@ func TestListRoutes(t *testing.T) {
 			unmanagedNodeName: "unmanaged-node",
 			routeCIDRs:        map[string]string{"unmanaged-node": "2.2.3.4/24"},
 			routeTable: network.RouteTable{
-				Name:     to.StringPtr("rt2"),
+				Name:     pointer.String("rt2"),
 				Location: &cloud.Location,
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("node"),
+							Name: pointer.String("node"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/24"),
+								AddressPrefix: pointer.String("1.2.3.4/24"),
 							},
 						},
 					},
@@ -747,11 +747,11 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should delete outdated non-dualstack routes when dualstack is enabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
 			},
 			existingNodeNames:   sets.NewString("aks-node1-vmss000000"),
 			enableIPV6DualStack: true,
@@ -760,11 +760,11 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should delete outdated dualstack routes when dualstack is disabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			existingNodeNames: sets.NewString("aks-node1-vmss000000"),
 			expectedChanged:   true,
@@ -772,12 +772,12 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should not delete unmanaged routes when dualstack is enabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			existingNodeNames:   sets.NewString("aks-node1-vmss000001"),
 			enableIPV6DualStack: true,
@@ -785,12 +785,12 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should not delete unmanaged routes when dualstack is disabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			existingNodeNames: sets.NewString("aks-node1-vmss000001"),
 		},

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,6 +40,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -201,7 +201,7 @@ func getPrimaryInterfaceID(machine compute.VirtualMachine) (string, error) {
 	}
 
 	for _, ref := range *machine.NetworkProfile.NetworkInterfaces {
-		if to.Bool(ref.Primary) {
+		if pointer.BoolDeref(ref.Primary, false) {
 			return *ref.ID, nil
 		}
 	}
@@ -244,7 +244,7 @@ func getIPConfigByIPFamily(nic network.Interface, IPv6 bool) (*network.Interface
 			return &ref, nil
 		}
 	}
-	return nil, fmt.Errorf("failed to determine the ipconfig(IPv6=%v). nicname=%q", IPv6, to.String(nic.Name))
+	return nil, fmt.Errorf("failed to determine the ipconfig(IPv6=%v). nicname=%q", IPv6, pointer.StringDeref(nic.Name, ""))
 }
 
 func isInternalLoadBalancer(lb *network.LoadBalancer) bool {
@@ -337,7 +337,7 @@ func (az *Cloud) serviceOwnsRule(service *v1.Service, rule string) bool {
 func (az *Cloud) serviceOwnsFrontendIP(fip network.FrontendIPConfiguration, service *v1.Service, pips *[]network.PublicIPAddress) (bool, bool, error) {
 	var isPrimaryService bool
 	baseName := az.GetLoadBalancerName(context.TODO(), "", service)
-	if strings.HasPrefix(to.String(fip.Name), baseName) {
+	if strings.HasPrefix(pointer.StringDeref(fip.Name, ""), baseName) {
 		klog.V(6).Infof("serviceOwnsFrontendIP: found primary service %s of the frontend IP config %s", service.Name, *fip.Name)
 		isPrimaryService = true
 		return true, isPrimaryService, nil
@@ -364,7 +364,7 @@ func (az *Cloud) serviceOwnsFrontendIP(fip network.FrontendIPConfiguration, serv
 			pip.IPAddress != nil &&
 			fip.FrontendIPConfigurationPropertiesFormat != nil &&
 			fip.FrontendIPConfigurationPropertiesFormat.PublicIPAddress != nil {
-			if strings.EqualFold(to.String(pip.ID), to.String(fip.PublicIPAddress.ID)) {
+			if strings.EqualFold(pointer.StringDeref(pip.ID, ""), pointer.StringDeref(fip.PublicIPAddress.ID, "")) {
 				klog.V(4).Infof("serviceOwnsFrontendIP: found secondary service %s of the frontend IP config %s", service.Name, *fip.Name)
 
 				return true, isPrimaryService, nil
@@ -463,11 +463,11 @@ func (as *availabilitySet) newVMASCache() (*azcache.TimedCache, error) {
 
 			for i := range allAvailabilitySets {
 				vmas := allAvailabilitySets[i]
-				if strings.EqualFold(to.String(vmas.Name), "") {
+				if strings.EqualFold(pointer.StringDeref(vmas.Name, ""), "") {
 					klog.Warning("failed to get the name of the VMAS")
 					continue
 				}
-				localCache.Store(to.String(vmas.Name), &AvailabilitySetEntry{
+				localCache.Store(pointer.StringDeref(vmas.Name, ""), &AvailabilitySetEntry{
 					VMAS:          &vmas,
 					ResourceGroup: resourceGroup,
 				})
@@ -543,7 +543,7 @@ func (as *availabilitySet) GetPowerStatusByNodeName(name string) (powerState str
 	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
 		statuses := *vm.InstanceView.Statuses
 		for _, status := range statuses {
-			state := to.String(status.Code)
+			state := pointer.StringDeref(status.Code, "")
 			if strings.HasPrefix(state, vmPowerStatePrefix) {
 				return strings.TrimPrefix(state, vmPowerStatePrefix), nil
 			}
@@ -566,7 +566,7 @@ func (as *availabilitySet) GetProvisioningStateByNodeName(name string) (provisio
 		return provisioningState, nil
 	}
 
-	return to.String(vm.VirtualMachineProperties.ProvisioningState), nil
+	return pointer.StringDeref(vm.VirtualMachineProperties.ProvisioningState, ""), nil
 }
 
 // GetNodeNameByProviderID gets the node name by provider ID.
@@ -612,15 +612,15 @@ func (as *availabilitySet) GetZoneByNodeName(name string) (cloudprovider.Zone, e
 			return cloudprovider.Zone{}, fmt.Errorf("failed to parse zone %q: %w", zones, err)
 		}
 
-		failureDomain = as.makeZone(to.String(vm.Location), zoneID)
+		failureDomain = as.makeZone(pointer.StringDeref(vm.Location, ""), zoneID)
 	} else {
 		// Availability zone is not used for the node, falling back to fault domain.
-		failureDomain = strconv.Itoa(int(to.Int32(vm.VirtualMachineProperties.InstanceView.PlatformFaultDomain)))
+		failureDomain = strconv.Itoa(int(pointer.Int32Deref(vm.VirtualMachineProperties.InstanceView.PlatformFaultDomain, 0)))
 	}
 
 	zone := cloudprovider.Zone{
 		FailureDomain: strings.ToLower(failureDomain),
-		Region:        strings.ToLower(to.String(vm.Location)),
+		Region:        strings.ToLower(pointer.StringDeref(vm.Location, "")),
 	}
 	return zone, nil
 }
@@ -795,13 +795,13 @@ func (as *availabilitySet) GetNodeVMSetName(node *v1.Node) (string, error) {
 
 	var asName string
 	for _, vm := range vms {
-		if strings.EqualFold(to.String(vm.Name), hostName) {
-			if vm.AvailabilitySet != nil && to.String(vm.AvailabilitySet.ID) != "" {
+		if strings.EqualFold(pointer.StringDeref(vm.Name, ""), hostName) {
+			if vm.AvailabilitySet != nil && pointer.StringDeref(vm.AvailabilitySet.ID, "") != "" {
 				klog.V(4).Infof("as.GetNodeVMSetName: found vm %s", hostName)
 
-				asName, err = getLastSegment(to.String(vm.AvailabilitySet.ID), "/")
+				asName, err = getLastSegment(pointer.StringDeref(vm.AvailabilitySet.ID, ""), "/")
 				if err != nil {
-					klog.Errorf("as.GetNodeVMSetName: failed to get last segment of ID %s: %s", to.String(vm.AvailabilitySet.ID), err)
+					klog.Errorf("as.GetNodeVMSetName: failed to get last segment of ID %s: %s", pointer.StringDeref(vm.AvailabilitySet.ID, ""), err)
 					return "", err
 				}
 			}
@@ -871,7 +871,7 @@ func (as *availabilitySet) getPrimaryInterfaceWithVMSet(nodeName, vmSetName stri
 
 		// ensure the vm that is supposed to share the primary SLB in the backendpool of the primary SLB
 		if machine.AvailabilitySet != nil {
-			vmasName, _ := getLastSegment(to.String(machine.AvailabilitySet.ID), "/")
+			vmasName, _ := getLastSegment(pointer.StringDeref(machine.AvailabilitySet.ID, ""), "/")
 			if strings.EqualFold(as.GetPrimaryVMSetName(), vmSetName) &&
 				as.getVMSetNamesSharingPrimarySLB().Has(strings.ToLower(vmasName)) {
 				klog.V(4).Infof("getPrimaryInterfaceWithVMSet: the vm %s in the vmSet %s is supposed to share the primary SLB", nodeName, vmasName)
@@ -902,7 +902,7 @@ func (as *availabilitySet) getPrimaryInterfaceWithVMSet(nodeName, vmSetName stri
 
 	var availabilitySetID string
 	if machine.VirtualMachineProperties != nil && machine.AvailabilitySet != nil {
-		availabilitySetID = to.String(machine.AvailabilitySet.ID)
+		availabilitySetID = pointer.StringDeref(machine.AvailabilitySet.ID, "")
 	}
 	return nic, availabilitySetID, nil
 }
@@ -977,7 +977,7 @@ func (as *availabilitySet) EnsureHostInPool(service *v1.Service, nodeName types.
 
 		newBackendPools = append(newBackendPools,
 			network.BackendAddressPool{
-				ID: to.StringPtr(backendPoolID),
+				ID: pointer.String(backendPoolID),
 			})
 
 		primaryIPConfig.LoadBalancerBackendAddressPools = &newBackendPools
@@ -1053,7 +1053,7 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 
 	ipConfigurationIDs := []string{}
 	for _, backendPool := range *backendAddressPools {
-		if strings.EqualFold(to.String(backendPool.ID), backendPoolID) &&
+		if strings.EqualFold(pointer.StringDeref(backendPool.ID, ""), backendPoolID) &&
 			backendPool.BackendAddressPoolPropertiesFormat != nil &&
 			backendPool.BackendIPConfigurations != nil {
 			for _, ipConf := range *backendPool.BackendIPConfigurations {
@@ -1109,7 +1109,7 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 		if nic.InterfacePropertiesFormat != nil && nic.InterfacePropertiesFormat.IPConfigurations != nil {
 			newIPConfigs := *nic.IPConfigurations
 			for j, ipConf := range newIPConfigs {
-				if !to.Bool(ipConf.Primary) {
+				if !pointer.BoolDeref(ipConf.Primary, false) {
 					continue
 				}
 				// found primary ip configuration
@@ -1117,7 +1117,7 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 					newLBAddressPools := *ipConf.LoadBalancerBackendAddressPools
 					for k := len(newLBAddressPools) - 1; k >= 0; k-- {
 						pool := newLBAddressPools[k]
-						if strings.EqualFold(to.String(pool.ID), backendPoolID) {
+						if strings.EqualFold(pointer.StringDeref(pool.ID, ""), backendPoolID) {
 							newLBAddressPools = append(newLBAddressPools[:k], newLBAddressPools[k+1:]...)
 							break
 						}
@@ -1129,10 +1129,10 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 			nicUpdaters = append(nicUpdaters, func() error {
 				ctx, cancel := getContextWithCancel()
 				defer cancel()
-				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", as.ResourceGroup, to.String(nic.Name), backendPoolID)
-				rerr := as.InterfacesClient.CreateOrUpdate(ctx, as.ResourceGroup, to.String(nic.Name), nic)
+				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", as.ResourceGroup, pointer.StringDeref(nic.Name, ""), backendPoolID)
+				rerr := as.InterfacesClient.CreateOrUpdate(ctx, as.ResourceGroup, pointer.StringDeref(nic.Name, ""), nic)
 				if rerr != nil {
-					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", as.ResourceGroup, to.String(nic.Name), rerr.Error())
+					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", as.ResourceGroup, pointer.StringDeref(nic.Name, ""), rerr.Error())
 					return rerr.Error()
 				}
 				nicUpdated = true
@@ -1195,7 +1195,7 @@ func (as *availabilitySet) GetNodeNameByIPConfigurationID(ipConfigurationID stri
 	}
 	vmID := ""
 	if nic.InterfacePropertiesFormat != nil && nic.VirtualMachine != nil {
-		vmID = to.String(nic.VirtualMachine.ID)
+		vmID = pointer.StringDeref(nic.VirtualMachine.ID, "")
 	}
 	if vmID == "" {
 		klog.V(2).Infof("GetNodeNameByIPConfigurationID(%s): empty vmID", ipConfigurationID)
@@ -1215,7 +1215,7 @@ func (as *availabilitySet) GetNodeNameByIPConfigurationID(ipConfigurationID stri
 	}
 	asID := ""
 	if vm.VirtualMachineProperties != nil && vm.AvailabilitySet != nil {
-		asID = to.String(vm.AvailabilitySet.ID)
+		asID = pointer.StringDeref(vm.AvailabilitySet.ID, "")
 	}
 	if asID == "" {
 		return vmName, "", nil
@@ -1247,9 +1247,9 @@ func (as *availabilitySet) getAvailabilitySetByNodeName(nodeName string, crt azc
 		if vmas != nil && vmas.AvailabilitySetProperties != nil && vmas.VirtualMachines != nil {
 			for _, vmIDRef := range *vmas.VirtualMachines {
 				if vmIDRef.ID != nil {
-					matches := vmIDRE.FindStringSubmatch(to.String(vmIDRef.ID))
+					matches := vmIDRE.FindStringSubmatch(pointer.StringDeref(vmIDRef.ID, ""))
 					if len(matches) != 2 {
-						err = fmt.Errorf("invalid vm ID %s", to.String(vmIDRef.ID))
+						err = fmt.Errorf("invalid vm ID %s", pointer.StringDeref(vmIDRef.ID, ""))
 						return false
 					}
 
@@ -1294,15 +1294,15 @@ func (as *availabilitySet) GetNodeCIDRMasksByProviderID(providerID string) (int,
 
 	var ipv4Mask, ipv6Mask int
 	if v4, ok := vmas.Tags[consts.VMSetCIDRIPV4TagKey]; ok && v4 != nil {
-		ipv4Mask, err = strconv.Atoi(to.String(v4))
+		ipv4Mask, err = strconv.Atoi(pointer.StringDeref(v4, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", to.String(v4), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", pointer.StringDeref(v4, ""), err)
 		}
 	}
 	if v6, ok := vmas.Tags[consts.VMSetCIDRIPV6TagKey]; ok && v6 != nil {
-		ipv6Mask, err = strconv.Atoi(to.String(v6))
+		ipv6Mask, err = strconv.Atoi(pointer.StringDeref(v6, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", to.String(v6), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", pointer.StringDeref(v6, ""), err)
 		}
 	}
 

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmasclient/mockvmasclient"
@@ -664,21 +664,21 @@ func TestGetStandardVMPrimaryInterfaceID(t *testing.T) {
 		{
 			name: "GetPrimaryInterfaceID should get primary NIC ID",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm2"),
+				Name: pointer.String("vm2"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(true),
+									Primary: pointer.Bool(true),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
 							},
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(false),
+									Primary: pointer.Bool(false),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
 							},
 						},
 					},
@@ -689,21 +689,21 @@ func TestGetStandardVMPrimaryInterfaceID(t *testing.T) {
 		{
 			name: "GetPrimaryInterfaceID should report error if node don't have primary NIC",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm3"),
+				Name: pointer.String("vm3"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(false),
+									Primary: pointer.Bool(false),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
 							},
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(false),
+									Primary: pointer.Bool(false),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
 							},
 						},
 					},
@@ -731,51 +731,51 @@ func TestGetPrimaryIPConfig(t *testing.T) {
 		{
 			name: "GetPrimaryIPConfig should get the only IP configuration",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 						},
 					},
 				},
 			},
 			expectedIPConfig: &network.InterfaceIPConfiguration{
-				Name: to.StringPtr("ipconfig1"),
+				Name: pointer.String("ipconfig1"),
 			},
 		},
 		{
 			name: "GetPrimaryIPConfig should get the primary IP configuration",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(true),
+								Primary: pointer.Bool(true),
 							},
 						},
 						{
-							Name: to.StringPtr("ipconfig2"),
+							Name: pointer.String("ipconfig2"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(false),
+								Primary: pointer.Bool(false),
 							},
 						},
 					},
 				},
 			},
 			expectedIPConfig: &network.InterfaceIPConfiguration{
-				Name: to.StringPtr("ipconfig1"),
+				Name: pointer.String("ipconfig1"),
 				InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-					Primary: to.BoolPtr(true),
+					Primary: pointer.Bool(true),
 				},
 			},
 		},
 		{
 			name: "GetPrimaryIPConfig should report error if nic don't have IP configuration",
 			nic: network.Interface{
-				Name:                      to.StringPtr("nic"),
+				Name:                      pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{},
 			},
 			expectedErrMsg: fmt.Errorf("nic.IPConfigurations for nic (nicname=%q) is nil", "nic"),
@@ -783,19 +783,19 @@ func TestGetPrimaryIPConfig(t *testing.T) {
 		{
 			name: "GetPrimaryIPConfig should report error if node has more than one IP configuration and don't have primary IP configuration",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(false),
+								Primary: pointer.Bool(false),
 							},
 						},
 						{
-							Name: to.StringPtr("ipconfig2"),
+							Name: pointer.String("ipconfig2"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(false),
+								Primary: pointer.Bool(false),
 							},
 						},
 					},
@@ -814,21 +814,21 @@ func TestGetPrimaryIPConfig(t *testing.T) {
 
 func TestGetIPConfigByIPFamily(t *testing.T) {
 	ipv4IPconfig := network.InterfaceIPConfiguration{
-		Name: to.StringPtr("ipconfig1"),
+		Name: pointer.String("ipconfig1"),
 		InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 			PrivateIPAddressVersion: network.IPVersionIPv4,
-			PrivateIPAddress:        to.StringPtr("10.10.0.12"),
+			PrivateIPAddress:        pointer.String("10.10.0.12"),
 		},
 	}
 	ipv6IPconfig := network.InterfaceIPConfiguration{
-		Name: to.StringPtr("ipconfig2"),
+		Name: pointer.String("ipconfig2"),
 		InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 			PrivateIPAddressVersion: network.IPVersionIPv6,
-			PrivateIPAddress:        to.StringPtr("1111:11111:00:00:1111:1111:000:111"),
+			PrivateIPAddress:        pointer.String("1111:11111:00:00:1111:1111:000:111"),
 		},
 	}
 	testNic := network.Interface{
-		Name: to.StringPtr("nic"),
+		Name: pointer.String("nic"),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 			IPConfigurations: &[]network.InterfaceIPConfiguration{ipv4IPconfig, ipv6IPconfig},
 		},
@@ -854,7 +854,7 @@ func TestGetIPConfigByIPFamily(t *testing.T) {
 		{
 			name: "GetIPConfigByIPFamily should report error if nic don't have IP configuration",
 			nic: network.Interface{
-				Name:                      to.StringPtr("nic"),
+				Name:                      pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{},
 			},
 			expectedErrMsg: fmt.Errorf("nic.IPConfigurations for nic (nicname=%q) is nil", "nic"),
@@ -862,7 +862,7 @@ func TestGetIPConfigByIPFamily(t *testing.T) {
 		{
 			name: "GetIPConfigByIPFamily should report error if nic don't have IPv6 configuration when IPv6 is true",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{ipv4IPconfig},
 				},
@@ -873,11 +873,11 @@ func TestGetIPConfigByIPFamily(t *testing.T) {
 		{
 			name: "GetIPConfigByIPFamily should report error if nic don't have PrivateIPAddress",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 								PrivateIPAddressVersion: network.IPVersionIPv4,
 							},
@@ -928,8 +928,8 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 	cloud := GetTestCloud(ctrl)
 
 	expectedVM := compute.VirtualMachine{
-		Name: to.StringPtr("vm1"),
-		ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"),
+		Name: pointer.String("vm1"),
+		ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"),
 	}
 	invalidResouceID := "/subscriptions/subscription/resourceGroups/rg/Microsoft.Compute/virtualMachines/vm4"
 	testcases := []struct {
@@ -968,8 +968,8 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 			RawError:       fmt.Errorf("VMGet error"),
 		}).AnyTimes()
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, "vm4", gomock.Any()).Return(compute.VirtualMachine{
-			Name: to.StringPtr("vm4"),
-			ID:   to.StringPtr(invalidResouceID),
+			Name: pointer.String("vm4"),
+			ID:   pointer.String(invalidResouceID),
 		}, nil).AnyTimes()
 
 		instanceID, err := cloud.VMSet.GetInstanceIDByNodeName(test.nodeName)
@@ -1007,13 +1007,13 @@ func TestGetStandardVMPowerStatusByNodeName(t *testing.T) {
 			name:     "GetPowerStatusByNodeName should get power status as expected",
 			nodeName: "vm2",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm2"),
+				Name: pointer.String("vm2"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 					InstanceView: &compute.VirtualMachineInstanceView{
 						Statuses: &[]compute.InstanceViewStatus{
 							{
-								Code: to.StringPtr("PowerState/Running"),
+								Code: pointer.String("PowerState/Running"),
 							},
 						},
 					},
@@ -1025,9 +1025,9 @@ func TestGetStandardVMPowerStatusByNodeName(t *testing.T) {
 			name:     "GetPowerStatusByNodeName should get vmPowerStateStopped if vm.InstanceView is nil",
 			nodeName: "vm3",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm3"),
+				Name: pointer.String("vm3"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 				},
 			},
 			expectedStatus: vmPowerStateStopped,
@@ -1036,9 +1036,9 @@ func TestGetStandardVMPowerStatusByNodeName(t *testing.T) {
 			name:     "GetPowerStatusByNodeName should get vmPowerStateStopped if vm.InstanceView.statuses is nil",
 			nodeName: "vm4",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm4"),
+				Name: pointer.String("vm4"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 					InstanceView:      &compute.VirtualMachineInstanceView{},
 				},
 			},
@@ -1082,13 +1082,13 @@ func TestGetStandardVMProvisioningStateByNodeName(t *testing.T) {
 			name:     "GetProvisioningStateByNodeName should return Succeeded for running VM",
 			nodeName: "vm2",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm2"),
+				Name: pointer.String("vm2"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 					InstanceView: &compute.VirtualMachineInstanceView{
 						Statuses: &[]compute.InstanceViewStatus{
 							{
-								Code: to.StringPtr("PowerState/Running"),
+								Code: pointer.String("PowerState/Running"),
 							},
 						},
 					},
@@ -1100,7 +1100,7 @@ func TestGetStandardVMProvisioningStateByNodeName(t *testing.T) {
 			name:     "GetProvisioningStateByNodeName should return empty string when vm.ProvisioningState is nil",
 			nodeName: "vm3",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm3"),
+				Name: pointer.String("vm3"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					ProvisioningState: nil,
 				},
@@ -1146,8 +1146,8 @@ func TestGetStandardVMZoneByNodeName(t *testing.T) {
 			name:     "GetZoneByNodeName should get zone as expected",
 			nodeName: "vm2",
 			vm: compute.VirtualMachine{
-				Name:     to.StringPtr("vm2"),
-				Location: to.StringPtr("EASTUS"),
+				Name:     pointer.String("vm2"),
+				Location: pointer.String("EASTUS"),
 				Zones:    &[]string{"2"},
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
@@ -1164,8 +1164,8 @@ func TestGetStandardVMZoneByNodeName(t *testing.T) {
 			name:     "GetZoneByNodeName should get FailureDomain as zone if zone is not used for node",
 			nodeName: "vm3",
 			vm: compute.VirtualMachine{
-				Name:     to.StringPtr("vm3"),
-				Location: to.StringPtr("EASTUS"),
+				Name:     pointer.String("vm3"),
+				Location: pointer.String("EASTUS"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
 						PlatformFaultDomain: &faultDomain,
@@ -1181,8 +1181,8 @@ func TestGetStandardVMZoneByNodeName(t *testing.T) {
 			name:     "GetZoneByNodeName should report error if zones is invalid",
 			nodeName: "vm4",
 			vm: compute.VirtualMachine{
-				Name:     to.StringPtr("vm4"),
-				Location: to.StringPtr("EASTUS"),
+				Name:     pointer.String("vm4"),
+				Location: pointer.String("EASTUS"),
 				Zones:    &[]string{"a"},
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
@@ -1210,13 +1210,13 @@ func TestGetStandardVMSetNames(t *testing.T) {
 	defer ctrl.Finish()
 
 	testVM := compute.VirtualMachine{
-		Name: to.StringPtr("vm1"),
+		Name: pointer.String("vm1"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			AvailabilitySet: &compute.SubResource{ID: to.StringPtr(asID)},
+			AvailabilitySet: &compute.SubResource{ID: pointer.String(asID)},
 		},
 	}
 	testVMWithoutAS := compute.VirtualMachine{
-		Name:                     to.StringPtr("vm2"),
+		Name:                     pointer.String("vm2"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{},
 	}
 	testCases := []struct {
@@ -1463,10 +1463,10 @@ func TestStandardEnsureHostInPool(t *testing.T) {
 		}
 
 		testVM := buildDefaultTestVirtualMachine(availabilitySetID, []string{test.nicID})
-		testVM.Name = to.StringPtr(string(test.nodeName))
+		testVM.Name = pointer.String(string(test.nodeName))
 		testNIC := buildDefaultTestInterface(false, []string{backendAddressPoolID})
-		testNIC.Name = to.StringPtr(test.nicName)
-		testNIC.ID = to.StringPtr(test.nicID)
+		testNIC.Name = pointer.String(test.nicName)
+		testNIC.ID = pointer.String(test.nicID)
 		testNIC.ProvisioningState = test.nicProvisionState
 
 		mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -1601,13 +1601,13 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 
 	for _, test := range testCases {
 		cloud.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
-		cloud.Config.ExcludeMasterFromStandardLB = to.BoolPtr(true)
+		cloud.Config.ExcludeMasterFromStandardLB = pointer.Bool(true)
 		cloud.excludeLoadBalancerNodes = sets.NewString(test.excludeLBNodes...)
 
 		testVM := buildDefaultTestVirtualMachine(availabilitySetID, []string{test.nicID})
 		testNIC := buildDefaultTestInterface(false, []string{backendAddressPoolID})
-		testNIC.Name = to.StringPtr(test.nicName)
-		testNIC.ID = to.StringPtr(test.nicID)
+		testNIC.Name = pointer.String(test.nicName)
+		testNIC.ID = pointer.String(test.nicID)
 
 		mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, test.nodeName, gomock.Any()).Return(testVM, nil).AnyTimes()
@@ -1642,7 +1642,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 		{
 			desc: "serviceOwnsFrontendIP should detect the primary service",
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 			},
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
@@ -1655,7 +1655,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 		{
 			desc: "serviceOwnsFrontendIP should return false if the secondary external service doesn't set it's loadBalancer IP",
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 			},
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
@@ -1668,17 +1668,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 				"found according to the external service's loadBalancer IP but do not return the error",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("pip"),
+						ID: pointer.String("pip"),
 					},
 				},
 			},
@@ -1694,17 +1694,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 				"the counterpart on the frontend IP config",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("pip1"),
+						ID: pointer.String("pip1"),
 					},
 				},
 			},
@@ -1719,17 +1719,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			desc: "serviceOwnsFrontendIP should return false if there is no public IP address in the frontend IP config",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPPrefix: &network.SubResource{
-						ID: to.StringPtr("pip1"),
+						ID: pointer.String("pip1"),
 					},
 				},
 			},
@@ -1744,17 +1744,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			desc: "serviceOwnsFrontendIP should detect the secondary external service",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("pip"),
+						ID: pointer.String("pip"),
 					},
 				},
 			},
@@ -1769,9 +1769,9 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 		{
 			desc: "serviceOwnsFrontendIP should detect the secondary internal service",
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PrivateIPAddress: to.StringPtr("4.3.2.1"),
+					PrivateIPAddress: pointer.String("4.3.2.1"),
 				},
 			},
 			service: &v1.Service{
@@ -1814,11 +1814,11 @@ func TestStandardEnsureBackendPoolDeleted(t *testing.T) {
 			desc: "EnsureBackendPoolDeleted should decouple the nic and the load balancer properly",
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(backendPoolID),
+					ID: pointer.String(backendPoolID),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
+								ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
 							},
 						},
 					},
@@ -1838,7 +1838,7 @@ func TestStandardEnsureBackendPoolDeleted(t *testing.T) {
 		cloud.VirtualMachinesClient = mockVMClient
 		mockNICClient := mockinterfaceclient.NewMockInterface(ctrl)
 		test.existingNIC.VirtualMachine = &network.SubResource{
-			ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-1"),
+			ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-1"),
 		}
 		mockNICClient.EXPECT().Get(gomock.Any(), "rg", "k8s-agentpool1-00000000-nic-1", gomock.Any()).Return(test.existingNIC, nil).Times(2)
 		mockNICClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -1857,7 +1857,7 @@ func buildDefaultTestInterface(isPrimary bool, lbBackendpoolIDs []string) networ
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						Primary: to.BoolPtr(isPrimary),
+						Primary: pointer.Bool(isPrimary),
 					},
 				},
 			},
@@ -1866,7 +1866,7 @@ func buildDefaultTestInterface(isPrimary bool, lbBackendpoolIDs []string) networ
 	backendAddressPool := make([]network.BackendAddressPool, 0)
 	for _, id := range lbBackendpoolIDs {
 		backendAddressPool = append(backendAddressPool, network.BackendAddressPool{
-			ID: to.StringPtr(id),
+			ID: pointer.String(id),
 		})
 	}
 	(*expectedNIC.IPConfigurations)[0].LoadBalancerBackendAddressPools = &backendAddressPool
@@ -1877,7 +1877,7 @@ func buildDefaultTestVirtualMachine(asID string, nicIDs []string) compute.Virtua
 	expectedVM := compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			AvailabilitySet: &compute.SubResource{
-				ID: to.StringPtr(asID),
+				ID: pointer.String(asID),
 			},
 			NetworkProfile: &compute.NetworkProfile{},
 		},
@@ -1885,7 +1885,7 @@ func buildDefaultTestVirtualMachine(asID string, nicIDs []string) compute.Virtua
 	networkInterfaces := make([]compute.NetworkInterfaceReference, 0)
 	for _, nicID := range nicIDs {
 		networkInterfaces = append(networkInterfaces, compute.NetworkInterfaceReference{
-			ID: to.StringPtr(nicID),
+			ID: pointer.String(nicID),
 		})
 	}
 	expectedVM.VirtualMachineProperties.NetworkProfile.NetworkInterfaces = &networkInterfaces
@@ -1897,12 +1897,12 @@ func TestStandardGetNodeNameByIPConfigurationID(t *testing.T) {
 	defer ctrl.Finish()
 	cloud := GetTestCloud(ctrl)
 	expectedVM := buildDefaultTestVirtualMachine("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL1-AVAILABILITYSET-00000000", []string{})
-	expectedVM.Name = to.StringPtr("name")
+	expectedVM.Name = pointer.String("name")
 	mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 	mockVMClient.EXPECT().Get(gomock.Any(), "rg", "k8s-agentpool1-00000000-0", gomock.Any()).Return(expectedVM, nil)
 	expectedNIC := buildDefaultTestInterface(true, []string{})
 	expectedNIC.VirtualMachine = &network.SubResource{
-		ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-0"),
+		ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-0"),
 	}
 	mockNICClient := cloud.InterfacesClient.(*mockinterfaceclient.MockInterface)
 	mockNICClient.EXPECT().Get(gomock.Any(), "rg", "k8s-agentpool1-00000000-nic-0", gomock.Any()).Return(expectedNIC, nil)
@@ -1962,11 +1962,11 @@ func TestGetAvailabilitySetByNodeName(t *testing.T) {
 		subResources := make([]compute.SubResource, 0)
 		for _, vmID := range test.vmasVMIDs {
 			subResources = append(subResources, compute.SubResource{
-				ID: to.StringPtr(vmID),
+				ID: pointer.String(vmID),
 			})
 		}
 		expected := compute.AvailabilitySet{
-			Name: to.StringPtr("vmas-1"),
+			Name: pointer.String("vmas-1"),
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 				VirtualMachines: &subResources,
 			},
@@ -2002,8 +2002,8 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV4MaskSize: 24,
 			expectedIPV6MaskSize: 64,
@@ -2018,7 +2018,7 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes even if some of the tags are not specified",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
 			},
 			expectedIPV4MaskSize: 24,
 		},
@@ -2026,8 +2026,8 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should not fail even if some of the tag is invalid",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("abc"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("abc"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV6MaskSize: 64,
 		},
@@ -2042,10 +2042,10 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			cloud.AvailabilitySetsClient = mockVMASClient
 
 			expected := compute.AvailabilitySet{
-				Name: to.StringPtr("vmas-1"),
+				Name: pointer.String("vmas-1"),
 				AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 					VirtualMachines: &[]compute.SubResource{
-						{ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0")},
+						{ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0")},
 					},
 				},
 				Tags: tc.tags,
@@ -2129,10 +2129,10 @@ func TestGetNodeVMSetName(t *testing.T) {
 			},
 			expectedVMs: []compute.VirtualMachine{
 				{
-					Name: to.StringPtr("vm"),
+					Name: pointer.String("vm"),
 					VirtualMachineProperties: &compute.VirtualMachineProperties{
 						AvailabilitySet: &compute.SubResource{
-							ID: to.StringPtr("/"),
+							ID: pointer.String("/"),
 						},
 					},
 				},
@@ -2154,10 +2154,10 @@ func TestGetNodeVMSetName(t *testing.T) {
 			},
 			expectedVMs: []compute.VirtualMachine{
 				{
-					Name: to.StringPtr("vm"),
+					Name: pointer.String("vm"),
 					VirtualMachineProperties: &compute.VirtualMachineProperties{
 						AvailabilitySet: &compute.SubResource{
-							ID: to.StringPtr("as"),
+							ID: pointer.String("as"),
 						},
 					},
 				},

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatednsclient/mockprivatednsclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatednszonegroupclient/mockprivatednszonegroupclient"
@@ -392,8 +392,8 @@ func TestEnsureStorageAccount(t *testing.T) {
 			mockStorageAccountsClient:       true,
 			setAccountOptions:               true,
 			storageType:                     StorageTypeBlob,
-			requireInfrastructureEncryption: to.BoolPtr(true),
-			keyVaultURL:                     to.StringPtr("keyVaultURL"),
+			requireInfrastructureEncryption: pointer.Bool(true),
+			keyVaultURL:                     pointer.String("keyVaultURL"),
 			resourceGroup:                   "rg",
 			accessTier:                      "AccessTierHot",
 			accountName:                     "",
@@ -405,8 +405,8 @@ func TestEnsureStorageAccount(t *testing.T) {
 			createPrivateEndpoint:           true,
 			mockStorageAccountsClient:       true,
 			setAccountOptions:               true,
-			requireInfrastructureEncryption: to.BoolPtr(true),
-			keyVaultURL:                     to.StringPtr("keyVaultURL"),
+			requireInfrastructureEncryption: pointer.Bool(true),
+			keyVaultURL:                     pointer.String("keyVaultURL"),
 			resourceGroup:                   "rg",
 			accessTier:                      "AccessTierHot",
 			accountName:                     "",
@@ -597,7 +597,7 @@ func TestIsTagsEqual(t *testing.T) {
 			desc: "identitical tags",
 			account: storage.Account{
 				Tags: map[string]*string{
-					"key":  to.StringPtr("value"),
+					"key":  pointer.String("value"),
 					"key2": nil,
 				},
 			},
@@ -613,8 +613,8 @@ func TestIsTagsEqual(t *testing.T) {
 			desc: "identitical tags",
 			account: storage.Account{
 				Tags: map[string]*string{
-					"key":  to.StringPtr("value"),
-					"key2": to.StringPtr("value2"),
+					"key":  pointer.String("value"),
+					"key2": pointer.String("value2"),
 				},
 			},
 			accountOptions: &AccountOptions{
@@ -629,7 +629,7 @@ func TestIsTagsEqual(t *testing.T) {
 			desc: "non-identitical tags while MatchTags is false",
 			account: storage.Account{
 				Tags: map[string]*string{
-					"key": to.StringPtr("value2"),
+					"key": pointer.String("value2"),
 				},
 			},
 			accountOptions: &AccountOptions{
@@ -644,7 +644,7 @@ func TestIsTagsEqual(t *testing.T) {
 			desc: "non-identitical tags",
 			account: storage.Account{
 				Tags: map[string]*string{
-					"key": to.StringPtr("value2"),
+					"key": pointer.String("value2"),
 				},
 			},
 			accountOptions: &AccountOptions{

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -40,6 +39,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
@@ -166,21 +166,21 @@ func setMockEnv(az *Cloud, ctrl *gomock.Controller, expectedInterfaces []network
 func setMockPublicIPs(az *Cloud, ctrl *gomock.Controller, serviceCount int) {
 	expectedPIPs := []network.PublicIPAddress{
 		{
-			Name:     to.StringPtr("testCluster-aservicea"),
+			Name:     pointer.String("testCluster-aservicea"),
 			Location: &az.Location,
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 				PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 				PublicIPAddressVersion:   network.IPVersionIPv4,
-				IPAddress:                to.StringPtr("1.2.3.4"),
+				IPAddress:                pointer.String("1.2.3.4"),
 			},
 			Tags: map[string]*string{
-				consts.ServiceTagKey:  to.StringPtr("default/servicea"),
-				consts.ClusterNameKey: to.StringPtr(testClusterName),
+				consts.ServiceTagKey:  pointer.String("default/servicea"),
+				consts.ClusterNameKey: pointer.String(testClusterName),
 			},
 			Sku: &network.PublicIPAddressSku{
 				Name: network.PublicIPAddressSkuNameStandard,
 			},
-			ID: to.StringPtr("testCluster-aservice1"),
+			ID: pointer.String("testCluster-aservice1"),
 		},
 	}
 
@@ -193,12 +193,12 @@ func setMockPublicIPs(az *Cloud, ctrl *gomock.Controller, serviceCount int) {
 
 	a := 'a'
 	for i := 1; i <= serviceCount; i++ {
-		expectedPIPs[0].Name = to.StringPtr(fmt.Sprintf("testCluster-aservice%d", i))
-		expectedPIPs[0].Tags[consts.ServiceTagKey] = to.StringPtr(fmt.Sprintf("default/service%d", i))
+		expectedPIPs[0].Name = pointer.String(fmt.Sprintf("testCluster-aservice%d", i))
+		expectedPIPs[0].Tags[consts.ServiceTagKey] = pointer.String(fmt.Sprintf("default/service%d", i))
 		mockPIPsClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%d", i), gomock.Any()).Return(expectedPIPs[0], nil).AnyTimes()
 		mockPIPsClient.EXPECT().Delete(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%d", i)).Return(nil).AnyTimes()
-		expectedPIPs[0].Name = to.StringPtr(fmt.Sprintf("testCluster-aservice%c", a))
-		expectedPIPs[0].Tags[consts.ServiceTagKey] = to.StringPtr(fmt.Sprintf("default/service%c", a))
+		expectedPIPs[0].Name = pointer.String(fmt.Sprintf("testCluster-aservice%c", a))
+		expectedPIPs[0].Tags[consts.ServiceTagKey] = pointer.String(fmt.Sprintf("default/service%c", a))
 		mockPIPsClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%c", a), gomock.Any()).Return(expectedPIPs[0], nil).AnyTimes()
 		mockPIPsClient.EXPECT().Delete(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%c", a)).Return(nil).AnyTimes()
 		a++
@@ -234,7 +234,7 @@ func setMockLBs(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadB
 			LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 				BackendAddressPools: &[]network.BackendAddressPool{
 					{
-						Name: to.StringPtr("testCluster"),
+						Name: pointer.String("testCluster"),
 					},
 				},
 			},
@@ -242,39 +242,39 @@ func setMockLBs(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadB
 		lb.Name = &expectedLBName
 		lb.LoadBalancingRules = &[]network.LoadBalancingRule{
 			{
-				Name: to.StringPtr(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
+				Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
 			},
 		}
 		fips := []network.FrontendIPConfiguration{
 			{
-				Name: to.StringPtr(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
-				ID:   to.StringPtr("fip"),
+				Name: pointer.String(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
+				ID:   pointer.String("fip"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: "Dynamic",
-					PublicIPAddress:           &network.PublicIPAddress{ID: to.StringPtr(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+					PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
 				},
 			},
 		}
 		if isInternal {
-			fips[0].Subnet = &network.Subnet{Name: to.StringPtr("subnet")}
+			fips[0].Subnet = &network.Subnet{Name: pointer.String("subnet")}
 		}
 		lb.FrontendIPConfigurations = &fips
 
 		*expectedLBs = append(*expectedLBs, lb)
 	} else {
 		*(*expectedLBs)[lbIndex].LoadBalancingRules = append(*(*expectedLBs)[lbIndex].LoadBalancingRules, network.LoadBalancingRule{
-			Name: to.StringPtr(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
+			Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
 		})
 		fip := network.FrontendIPConfiguration{
-			Name: to.StringPtr(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
-			ID:   to.StringPtr("fip"),
+			Name: pointer.String(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
+			ID:   pointer.String("fip"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PrivateIPAllocationMethod: "Dynamic",
-				PublicIPAddress:           &network.PublicIPAddress{ID: to.StringPtr(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+				PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
 			},
 		}
 		if isInternal {
-			fip.Subnet = &network.Subnet{Name: to.StringPtr("subnet")}
+			fip.Subnet = &network.Subnet{Name: pointer.String("subnet")}
 		}
 		*(*expectedLBs)[lbIndex].FrontendIPConfigurations = append(*(*expectedLBs)[lbIndex].FrontendIPConfigurations, fip)
 	}
@@ -722,11 +722,11 @@ func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t
 	setMockSecurityGroup(az, ctrl, sg)
 
 	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(""), nil, true)
+	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(""), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -745,7 +745,7 @@ func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 	setMockSecurityGroup(az, ctrl, sg)
 
 	dynamicallyAssignedIP := "192.168.0.0"
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(dynamicallyAssignedIP), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(dynamicallyAssignedIP), nil, true)
 	if err != nil {
 		t.Errorf("unexpected error: %q", err)
 	}
@@ -1068,20 +1068,20 @@ func TestServiceDefaultsToNoSessionPersistence(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service-sa-omitted", 1, 1, false)
 
 	expectedPIP := network.PublicIPAddress{
-		Name:     to.StringPtr("testCluster-aservicesaomitted1"),
+		Name:     pointer.String("testCluster-aservicesaomitted1"),
 		Location: &az.Location,
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 			PublicIPAddressVersion:   network.IPVersionIPv4,
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("aservicesaomitted1"),
-			consts.ClusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  pointer.String("aservicesaomitted1"),
+			consts.ClusterNameKey: pointer.String(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
 		},
-		ID: to.StringPtr("testCluster-aservicesaomitted1"),
+		ID: pointer.String("testCluster-aservicesaomitted1"),
 	}
 
 	mockPIPsClient := mockpublicipclient.NewMockInterface(ctrl)
@@ -1122,20 +1122,20 @@ func TestServiceRespectsNoSessionAffinity(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service-sa-none", 1, 1, false)
 
 	expectedPIP := network.PublicIPAddress{
-		Name:     to.StringPtr("testCluster-aservicesanone"),
+		Name:     pointer.String("testCluster-aservicesanone"),
 		Location: &az.Location,
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 			PublicIPAddressVersion:   network.IPVersionIPv4,
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("aservicesanone"),
-			consts.ClusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  pointer.String("aservicesanone"),
+			consts.ClusterNameKey: pointer.String(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
 		},
-		ID: to.StringPtr("testCluster-aservicesanone"),
+		ID: pointer.String("testCluster-aservicesanone"),
 	}
 
 	mockPIPsClient := mockpublicipclient.NewMockInterface(ctrl)
@@ -1182,20 +1182,20 @@ func TestServiceRespectsClientIPSessionAffinity(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service-sa-clientip", 1, 1, false)
 
 	expectedPIP := network.PublicIPAddress{
-		Name:     to.StringPtr("testCluster-aservicesaclientip"),
+		Name:     pointer.String("testCluster-aservicesaclientip"),
 		Location: &az.Location,
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 			PublicIPAddressVersion:   network.IPVersionIPv4,
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("aservicesaclientip"),
-			consts.ClusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  pointer.String("aservicesaclientip"),
+			consts.ClusterNameKey: pointer.String(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
 		},
-		ID: to.StringPtr("testCluster-aservicesaclientip"),
+		ID: pointer.String("testCluster-aservicesaclientip"),
 	}
 
 	mockPIPsClient := mockpublicipclient.NewMockInterface(ctrl)
@@ -1295,10 +1295,10 @@ func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(to.StringPtr(testClusterName),
-			to.StringPtr(az.ResourceGroup),
-			to.StringPtr(testClusterName),
-			to.StringPtr("aservice1"),
+		getTestLoadBalancer(pointer.String(testClusterName),
+			pointer.String(az.ResourceGroup),
+			pointer.String(testClusterName),
+			pointer.String("aservice1"),
 			service1,
 			"Standard"), nil).AnyTimes()
 
@@ -1341,10 +1341,10 @@ func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(to.StringPtr(testClusterName),
-			to.StringPtr(az.ResourceGroup),
-			to.StringPtr(testClusterName),
-			to.StringPtr("aservice1"),
+		getTestLoadBalancer(pointer.String(testClusterName),
+			pointer.String(az.ResourceGroup),
+			pointer.String(testClusterName),
+			pointer.String("aservice1"),
 			svc,
 			"Standard"), nil).AnyTimes()
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true)
@@ -1396,8 +1396,8 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 
 	sg := getTestSecurityGroup(az)
 	cachedSG := *sg
-	cachedSG.Etag = to.StringPtr("1111111-0000-0000-0000-000000000000")
-	az.nsgCache.Set(to.String(sg.Name), &cachedSG)
+	cachedSG.Etag = pointer.String("1111111-0000-0000-0000-000000000000")
+	az.nsgCache.Set(pointer.StringDeref(sg.Name, ""), &cachedSG)
 
 	svc1 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
@@ -1415,10 +1415,10 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(to.StringPtr(testClusterName),
-			to.StringPtr(az.ResourceGroup),
-			to.StringPtr(testClusterName),
-			to.StringPtr("aservice1"),
+		getTestLoadBalancer(pointer.String(testClusterName),
+			pointer.String(az.ResourceGroup),
+			pointer.String(testClusterName),
+			pointer.String("aservice1"),
 			svc1,
 			"Standard"), nil).AnyTimes()
 
@@ -1739,10 +1739,10 @@ func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGr
 			for _, src := range sources {
 				ruleName := az.getSecurityRuleName(&services[i], port, src)
 				rules = append(rules, network.SecurityRule{
-					Name: to.StringPtr(ruleName),
+					Name: pointer.String(ruleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						SourceAddressPrefix:  to.StringPtr(src),
-						DestinationPortRange: to.StringPtr(fmt.Sprintf("%d", port.Port)),
+						SourceAddressPrefix:  pointer.String(src),
+						DestinationPortRange: pointer.String(fmt.Sprintf("%d", port.Port)),
 					},
 				})
 			}
@@ -1751,7 +1751,7 @@ func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGr
 
 	sg := network.SecurityGroup{
 		Name: &az.SecurityGroupName,
-		Etag: to.StringPtr("0000000-0000-0000-0000-000000000000"),
+		Etag: pointer.String("0000000-0000-0000-0000-000000000000"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &rules,
 		},
@@ -1781,7 +1781,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 			}
 			expectedFrontendIP := ExpectedFrontendIPInfo{
 				Name:   az.getDefaultFrontendIPConfigName(&services[i]),
-				Subnet: to.StringPtr(expectedSubnetName),
+				Subnet: pointer.String(expectedSubnetName),
 			}
 			expectedFrontendIPs = append(expectedFrontendIPs, expectedFrontendIP)
 		}
@@ -1846,7 +1846,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 	frontendIPs := *loadBalancer.FrontendIPConfigurations
 	for _, expectedFrontendIP := range expectedFrontendIPs {
 		if !expectedFrontendIP.existsIn(frontendIPs) {
-			t.Errorf("Expected the loadbalancer to have frontend IP %s/%s. Found %s", expectedFrontendIP.Name, to.String(expectedFrontendIP.Subnet), describeFIPs(frontendIPs))
+			t.Errorf("Expected the loadbalancer to have frontend IP %s/%s. Found %s", expectedFrontendIP.Name, pointer.StringDeref(expectedFrontendIP.Subnet, ""), describeFIPs(frontendIPs))
 		}
 	}
 
@@ -1867,7 +1867,7 @@ type ExpectedFrontendIPInfo struct {
 }
 
 func (expected ExpectedFrontendIPInfo) matches(frontendIP network.FrontendIPConfiguration) bool {
-	return strings.EqualFold(expected.Name, to.String(frontendIP.Name)) && strings.EqualFold(to.String(expected.Subnet), to.String(subnetName(frontendIP)))
+	return strings.EqualFold(expected.Name, pointer.StringDeref(frontendIP.Name, "")) && strings.EqualFold(pointer.StringDeref(expected.Subnet, ""), pointer.StringDeref(subnetName(frontendIP), ""))
 }
 
 func (expected ExpectedFrontendIPInfo) existsIn(frontendIPs []network.FrontendIPConfiguration) bool {
@@ -1891,9 +1891,9 @@ func describeFIPs(frontendIPs []network.FrontendIPConfiguration) string {
 	for _, actualFIP := range frontendIPs {
 		actualSubnetName := ""
 		if actualFIP.Subnet != nil {
-			actualSubnetName = to.String(actualFIP.Subnet.Name)
+			actualSubnetName = pointer.StringDeref(actualFIP.Subnet.Name, "")
 		}
-		actualFIPText := fmt.Sprintf("%s/%s ", to.String(actualFIP.Name), actualSubnetName)
+		actualFIPText := fmt.Sprintf("%s/%s ", pointer.StringDeref(actualFIP.Name, ""), actualSubnetName)
 		description = description + actualFIPText
 	}
 	return description
@@ -2034,7 +2034,7 @@ func TestSecurityRulePriorityPicksNextAvailablePriority(t *testing.T) {
 	for i = consts.LoadBalancerMinimumPriority; i < expectedPriority; i++ {
 		rules = append(rules, network.SecurityRule{
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-				Priority: to.Int32Ptr(i),
+				Priority: pointer.Int32(i),
 			},
 		})
 	}
@@ -2056,7 +2056,7 @@ func TestSecurityRulePriorityFailsIfExhausted(t *testing.T) {
 	for i = consts.LoadBalancerMinimumPriority; i < consts.LoadBalancerMaximumPriority; i++ {
 		rules = append(rules, network.SecurityRule{
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-				Priority: to.Int32Ptr(i),
+				Priority: pointer.Int32(i),
 			},
 		})
 	}
@@ -2449,7 +2449,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T
 	sg := getTestSecurityGroup(az)
 	setMockSecurityGroup(az, ctrl, sg)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -2497,10 +2497,10 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 			Name: &expectedRuleName,
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				Protocol:                 network.SecurityRuleProtocolTCP,
-				SourcePortRange:          to.StringPtr("*"),
-				SourceAddressPrefix:      to.StringPtr("Internet"),
-				DestinationPortRange:     to.StringPtr("80"),
-				DestinationAddressPrefix: to.StringPtr(testIP2),
+				SourcePortRange:          pointer.String("*"),
+				SourceAddressPrefix:      pointer.String("Internet"),
+				DestinationPortRange:     pointer.String("80"),
+				DestinationAddressPrefix: pointer.String(testIP2),
 				Access:                   network.SecurityRuleAccessAllow,
 				Direction:                network.SecurityRuleDirectionInbound,
 			},
@@ -2508,7 +2508,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 	}
 	setMockSecurityGroup(az, ctrl, sg)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -2552,13 +2552,13 @@ func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2625,13 +2625,13 @@ func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCre
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2698,13 +2698,13 @@ func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRules
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2773,19 +2773,19 @@ func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSepara
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
 	}
@@ -2873,13 +2873,13 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2887,7 +2887,7 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 	validateSecurityGroup(t, sg, svc1, svc2)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
@@ -2936,19 +2936,19 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
 	}
@@ -2956,7 +2956,7 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 	validateSecurityGroup(t, sg, svc1, svc2, svc3)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
@@ -3047,19 +3047,19 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
 	}
@@ -3067,13 +3067,13 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 	validateSecurityGroup(t, sg, svc1, svc2, svc3)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc3: %q", err)
 	}
@@ -3148,7 +3148,7 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	for i, svc := range testServices {
 		svc := svc
 		setMockSecurityGroup(az, ctrl, sg)
-		sg, err = az.reconcileSecurityGroup(testClusterName, &testServices[i], to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
+		sg, err = az.reconcileSecurityGroup(testClusterName, &testServices[i], pointer.String(getServiceLoadBalancerIP(&svc)), nil, true)
 		if err != nil {
 			t.Errorf("Unexpected error adding svc%d: %q", i+1, err)
 		}
@@ -3241,13 +3241,13 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc5, to.StringPtr(getServiceLoadBalancerIP(&svc5)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc5, pointer.String(getServiceLoadBalancerIP(&svc5)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc5: %q", err)
 	}
@@ -3643,14 +3643,14 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 
 func TestFindSecurityRule(t *testing.T) {
 	sg := network.SecurityRule{
-		Name: to.StringPtr(testRuleName4),
+		Name: pointer.String(testRuleName4),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 			Protocol:                   network.SecurityRuleProtocolTCP,
-			SourcePortRange:            to.StringPtr("*"),
-			SourceAddressPrefix:        to.StringPtr("Internet"),
-			DestinationPortRange:       to.StringPtr("80"),
-			DestinationAddressPrefix:   to.StringPtr(testIP1),
-			DestinationAddressPrefixes: to.StringSlicePtr([]string{}),
+			SourcePortRange:            pointer.String("*"),
+			SourceAddressPrefix:        pointer.String("Internet"),
+			DestinationPortRange:       pointer.String("80"),
+			DestinationAddressPrefix:   pointer.String(testIP1),
+			DestinationAddressPrefixes: &([]string{}),
 			Access:                     network.SecurityRuleAccessAllow,
 			Direction:                  network.SecurityRuleDirectionInbound,
 		},
@@ -3668,14 +3668,14 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when rule name doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr("not-the-right-name"),
+				Name: pointer.String("not-the-right-name"),
 			},
 			expected: false,
 		},
 		{
 			desc: "false should be returned when protocol doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol: network.SecurityRuleProtocolUDP,
 				},
@@ -3685,10 +3685,10 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourcePortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:        network.SecurityRuleProtocolUDP,
-					SourcePortRange: to.StringPtr("1.2.3.4/32"),
+					SourcePortRange: pointer.String("1.2.3.4/32"),
 				},
 			},
 			expected: false,
@@ -3696,11 +3696,11 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourceAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:            network.SecurityRuleProtocolUDP,
-					SourcePortRange:     to.StringPtr("*"),
-					SourceAddressPrefix: to.StringPtr("2.3.4.0/24"),
+					SourcePortRange:     pointer.String("*"),
+					SourceAddressPrefix: pointer.String("2.3.4.0/24"),
 				},
 			},
 			expected: false,
@@ -3708,12 +3708,12 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationPortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:             network.SecurityRuleProtocolUDP,
-					SourcePortRange:      to.StringPtr("*"),
-					SourceAddressPrefix:  to.StringPtr("Internet"),
-					DestinationPortRange: to.StringPtr("443"),
+					SourcePortRange:      pointer.String("*"),
+					SourceAddressPrefix:  pointer.String("Internet"),
+					DestinationPortRange: pointer.String("443"),
 				},
 			},
 			expected: false,
@@ -3721,13 +3721,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP2),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP2),
 				},
 			},
 			expected: false,
@@ -3735,13 +3735,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Access doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP1),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP1),
 					Access:                   network.SecurityRuleAccessDeny,
 					// Direction:                network.SecurityRuleDirectionInbound,
 				},
@@ -3751,13 +3751,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Direction doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP1),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP1),
 					Access:                   network.SecurityRuleAccessAllow,
 					Direction:                network.SecurityRuleDirectionOutbound,
 				},
@@ -3767,13 +3767,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "true should be returned when everything matches but protocol is in different case",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocol("TCP"),
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP1),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP1),
 					Access:                   network.SecurityRuleAccessAllow,
 					Direction:                network.SecurityRuleDirectionInbound,
 				},
@@ -3783,13 +3783,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "true should be returned when everything matches but DestinationAddressPrefixes is nil",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                   network.SecurityRuleProtocolTCP,
-					SourcePortRange:            to.StringPtr("*"),
-					SourceAddressPrefix:        to.StringPtr("Internet"),
-					DestinationPortRange:       to.StringPtr("80"),
-					DestinationAddressPrefix:   to.StringPtr(testIP1),
+					SourcePortRange:            pointer.String("*"),
+					SourceAddressPrefix:        pointer.String("Internet"),
+					DestinationPortRange:       pointer.String("80"),
+					DestinationAddressPrefix:   pointer.String(testIP1),
 					DestinationAddressPrefixes: nil,
 					Access:                     network.SecurityRuleAccessAllow,
 					Direction:                  network.SecurityRuleDirectionInbound,

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -103,75 +103,75 @@ func TestReconcileTags(t *testing.T) {
 		{
 			description: "reconcileTags should add missing tags and update existing tags",
 			currentTagsOnResource: map[string]*string{
-				"a": to.StringPtr("b"),
+				"a": pointer.String("b"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("c"),
-				"b": to.StringPtr("d"),
+				"a": pointer.String("c"),
+				"b": pointer.String("d"),
 			},
 			expectedTags: map[string]*string{
-				"a": to.StringPtr("c"),
-				"b": to.StringPtr("d"),
+				"a": pointer.String("c"),
+				"b": pointer.String("d"),
 			},
 			expectedChanged: true,
 		},
 		{
 			description: "reconcileTags should remove the tags that are not included in systemTags",
 			currentTagsOnResource: map[string]*string{
-				"a": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			systemTags: "a, b",
 			expectedTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			expectedChanged: true,
 		},
 		{
 			description: "reconcileTags should ignore the case of keys when comparing",
 			currentTagsOnResource: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("b"),
-				"C": to.StringPtr("d"),
+				"a": pointer.String("b"),
+				"C": pointer.String("d"),
 			},
 			expectedTags: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 		},
 		{
 			description: "reconcileTags should ignore the case of values when comparing",
 			currentTagsOnResource: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("B"),
-				"C": to.StringPtr("D"),
+				"a": pointer.String("B"),
+				"C": pointer.String("D"),
 			},
 			expectedTags: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 		},
 		{
 			description: "reconcileTags should ignore the case of keys when checking systemTags",
 			currentTagsOnResource: map[string]*string{
-				"a": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			systemTags: "A, b",
 			expectedTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			expectedChanged: true,
 		},
@@ -271,18 +271,18 @@ func TestRemoveDuplicatedSecurityRules(t *testing.T) {
 			description: "no duplicated rules",
 			rules: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 			},
 			expected: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 			},
 		},
@@ -290,21 +290,21 @@ func TestRemoveDuplicatedSecurityRules(t *testing.T) {
 			description: "duplicated rules",
 			rules: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 			},
 			expected: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 			},
 		},

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +34,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -284,7 +284,7 @@ func (ss *ScaleSet) GetPowerStatusByNodeName(name string) (powerState string, er
 		if v.InstanceView != nil && v.InstanceView.Statuses != nil {
 			statuses := *v.InstanceView.Statuses
 			for _, status := range statuses {
-				state := to.String(status.Code)
+				state := pointer.StringDeref(status.Code, "")
 				if strings.HasPrefix(state, vmPowerStatePrefix) {
 					return strings.TrimPrefix(state, vmPowerStatePrefix), nil
 				}
@@ -323,7 +323,7 @@ func (ss *ScaleSet) GetProvisioningStateByNodeName(name string) (provisioningSta
 		return provisioningState, nil
 	}
 
-	return to.String(vm.VirtualMachineScaleSetVMProperties.ProvisioningState), nil
+	return pointer.StringDeref(vm.VirtualMachineScaleSetVMProperties.ProvisioningState, ""), nil
 }
 
 // getCachedVirtualMachineByInstanceID gets scaleSetVMInfo from cache.
@@ -687,7 +687,7 @@ func (ss *ScaleSet) GetPrivateIPsByNodeName(nodeName string) ([]string, error) {
 func (ss *ScaleSet) getPrimaryInterfaceID(vm *virtualmachine.VirtualMachine) (string, error) {
 	machine := vm.AsVirtualMachineScaleSetVM()
 	if machine.NetworkProfile == nil || machine.NetworkProfile.NetworkInterfaces == nil {
-		return "", fmt.Errorf("failed to find the network interfaces for vm %s", to.String(machine.Name))
+		return "", fmt.Errorf("failed to find the network interfaces for vm %s", pointer.StringDeref(machine.Name, ""))
 	}
 
 	if len(*machine.NetworkProfile.NetworkInterfaces) == 1 {
@@ -695,12 +695,12 @@ func (ss *ScaleSet) getPrimaryInterfaceID(vm *virtualmachine.VirtualMachine) (st
 	}
 
 	for _, ref := range *machine.NetworkProfile.NetworkInterfaces {
-		if to.Bool(ref.Primary) {
+		if pointer.BoolDeref(ref.Primary, false) {
 			return *ref.ID, nil
 		}
 	}
 
-	return "", fmt.Errorf("failed to find a primary nic for the vm. vmname=%q", to.String(machine.Name))
+	return "", fmt.Errorf("failed to find a primary nic for the vm. vmname=%q", pointer.StringDeref(machine.Name, ""))
 }
 
 // getVmssMachineID returns the full identifier of a vmss virtual machine.
@@ -764,7 +764,7 @@ func (ss *ScaleSet) listScaleSets(resourceGroup string) ([]string, error) {
 	ssNames := make([]string, 0)
 	for _, vmss := range allScaleSets {
 		name := *vmss.Name
-		if vmss.Sku != nil && to.Int64(vmss.Sku.Capacity) == 0 {
+		if vmss.Sku != nil && pointer.Int64Deref(vmss.Sku.Capacity, 0) == 0 {
 			klog.V(3).Infof("Capacity of VMSS %q is 0, skipping", name)
 			continue
 		}
@@ -1203,7 +1203,7 @@ func (ss *ScaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeNam
 	// Compose a new vmssVM with added backendPoolID.
 	newBackendPools = append(newBackendPools,
 		compute.SubResource{
-			ID: to.StringPtr(backendPoolID),
+			ID: pointer.String(backendPoolID),
 		})
 	primaryIPConfiguration.LoadBalancerBackendAddressPools = &newBackendPools
 	newVM := &compute.VirtualMachineScaleSetVM{
@@ -1372,7 +1372,7 @@ func (ss *ScaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 		// Compose a new vmss with added backendPoolID.
 		loadBalancerBackendAddressPools = append(loadBalancerBackendAddressPools,
 			compute.SubResource{
-				ID: to.StringPtr(backendPoolID),
+				ID: pointer.String(backendPoolID),
 			})
 		primaryIPConfig.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
 		newVMSS := compute.VirtualMachineScaleSet{
@@ -1717,7 +1717,7 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVMSS(backendPoolID, vmSetName st
 
 		vmssUniformMap.Range(func(key, value interface{}) bool {
 			vmssEntry := value.(*VMSSEntry)
-			if to.String(vmssEntry.VMSS.Name) == vmSetName {
+			if pointer.StringDeref(vmssEntry.VMSS.Name, "") == vmSetName {
 				found = true
 				return false
 			}
@@ -1736,7 +1736,7 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVMSS(backendPoolID, vmSetName st
 		vmssFlexMap := cachedFlex.(*sync.Map)
 		vmssFlexMap.Range(func(key, value interface{}) bool {
 			vmssFlex := value.(*compute.VirtualMachineScaleSet)
-			if to.String(vmssFlex.Name) == vmSetName {
+			if pointer.StringDeref(vmssFlex.Name, "") == vmSetName {
 				found = true
 				return false
 			}
@@ -1783,32 +1783,32 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVmssUniform(backendPoolID, vmSet
 			} else if v, ok := value.(*compute.VirtualMachineScaleSet); ok {
 				vmss = v
 			}
-			klog.V(2).Infof("ensureBackendPoolDeletedFromVmssUniform: vmss (%s)", to.String(vmss.Name))
+			klog.V(2).Infof("ensureBackendPoolDeletedFromVmssUniform: vmss (%s)", pointer.StringDeref(vmss.Name, ""))
 
 			// When vmss is being deleted, CreateOrUpdate API would report "the vmss is being deleted" error.
 			// Since it is being deleted, we shouldn't send more CreateOrUpdate requests for it.
 			if vmss.ProvisioningState != nil && strings.EqualFold(*vmss.ProvisioningState, consts.VirtualMachineScaleSetsDeallocating) {
-				klog.V(3).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s being deleted, skipping", to.String(vmss.Name))
+				klog.V(3).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s being deleted, skipping", pointer.StringDeref(vmss.Name, ""))
 				return true
 			}
 			if vmss.VirtualMachineProfile == nil {
-				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: vmss %s has no VirtualMachineProfile, skipping", to.String(vmss.Name))
+				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: vmss %s has no VirtualMachineProfile, skipping", pointer.StringDeref(vmss.Name, ""))
 				return true
 			}
 			if vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations == nil {
-				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: cannot obtain the primary network interface configuration, of vmss %s", to.String(vmss.Name))
+				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: cannot obtain the primary network interface configuration, of vmss %s", pointer.StringDeref(vmss.Name, ""))
 				return true
 			}
 			vmssNIC := *vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-			primaryNIC, err := getPrimaryNetworkInterfaceConfigurationForScaleSet(vmssNIC, to.String(vmss.Name))
+			primaryNIC, err := getPrimaryNetworkInterfaceConfigurationForScaleSet(vmssNIC, pointer.StringDeref(vmss.Name, ""))
 			if err != nil {
-				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to get the primary network interface config of the VMSS %s: %v", to.String(vmss.Name), err)
+				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to get the primary network interface config of the VMSS %s: %v", pointer.StringDeref(vmss.Name, ""), err)
 				errorList = append(errorList, err)
 				return true
 			}
 			primaryIPConfig, err := getPrimaryIPConfigFromVMSSNetworkConfig(primaryNIC)
 			if err != nil {
-				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to the primary IP config from the VMSS %s's network config : %v", to.String(vmss.Name), err)
+				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to the primary IP config from the VMSS %s's network config : %v", pointer.StringDeref(vmss.Name, ""), err)
 				errorList = append(errorList, err)
 				return true
 			}
@@ -1817,10 +1817,10 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVmssUniform(backendPoolID, vmSet
 				loadBalancerBackendAddressPools = *primaryIPConfig.LoadBalancerBackendAddressPools
 			}
 			for _, loadBalancerBackendAddressPool := range loadBalancerBackendAddressPools {
-				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: loadBalancerBackendAddressPool (%s) on vmss (%s)", to.String(loadBalancerBackendAddressPool.ID), to.String(vmss.Name))
-				if strings.EqualFold(to.String(loadBalancerBackendAddressPool.ID), backendPoolID) {
-					klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s with backend pool %s, removing it", to.String(vmss.Name), backendPoolID)
-					vmssNamesMap[to.String(vmss.Name)] = true
+				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: loadBalancerBackendAddressPool (%s) on vmss (%s)", pointer.StringDeref(loadBalancerBackendAddressPool.ID, ""), pointer.StringDeref(vmss.Name, ""))
+				if strings.EqualFold(pointer.StringDeref(loadBalancerBackendAddressPool.ID, ""), backendPoolID) {
+					klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s with backend pool %s, removing it", pointer.StringDeref(vmss.Name, ""), backendPoolID)
+					vmssNamesMap[pointer.StringDeref(vmss.Name, "")] = true
 				}
 			}
 
@@ -2025,7 +2025,7 @@ func (ss *ScaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID,
 	if len(vmssUniformBackendIPConfigurations) > 0 {
 		vmssUniformBackendPools := &[]network.BackendAddressPool{
 			{
-				ID: to.StringPtr(backendPoolID),
+				ID: pointer.String(backendPoolID),
 				BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 					BackendIPConfigurations: &vmssUniformBackendIPConfigurations,
 				},
@@ -2043,7 +2043,7 @@ func (ss *ScaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID,
 	if len(vmssFlexBackendIPConfigurations) > 0 {
 		vmssFlexBackendPools := &[]network.BackendAddressPool{
 			{
-				ID: to.StringPtr(backendPoolID),
+				ID: pointer.String(backendPoolID),
 				BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 					BackendIPConfigurations: &vmssFlexBackendIPConfigurations,
 				},
@@ -2061,7 +2061,7 @@ func (ss *ScaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID,
 	if len(avSetBackendIPConfigurations) > 0 {
 		avSetBackendPools := &[]network.BackendAddressPool{
 			{
-				ID: to.StringPtr(backendPoolID),
+				ID: pointer.String(backendPoolID),
 				BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 					BackendIPConfigurations: &avSetBackendIPConfigurations,
 				},
@@ -2109,15 +2109,15 @@ func (ss *ScaleSet) GetNodeCIDRMasksByProviderID(providerID string) (int, int, e
 
 	var ipv4Mask, ipv6Mask int
 	if v4, ok := vmss.Tags[consts.VMSetCIDRIPV4TagKey]; ok && v4 != nil {
-		ipv4Mask, err = strconv.Atoi(to.String(v4))
+		ipv4Mask, err = strconv.Atoi(pointer.StringDeref(v4, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", to.String(v4), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", pointer.StringDeref(v4, ""), err)
 		}
 	}
 	if v6, ok := vmss.Tags[consts.VMSetCIDRIPV6TagKey]; ok && v6 != nil {
-		ipv6Mask, err = strconv.Atoi(to.String(v6))
+		ipv6Mask, err = strconv.Atoi(pointer.StringDeref(v6, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", to.String(v6), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", pointer.StringDeref(v6, ""), err)
 		}
 	}
 

--- a/pkg/provider/azure_vmss_cache_test.go
+++ b/pkg/provider/azure_vmss_cache_test.go
@@ -23,11 +23,11 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -61,18 +61,18 @@ func TestVMSSVMCache(t *testing.T) {
 	// validate getting VMSS VM via cache.
 	for i := range expectedVMs {
 		vm := expectedVMs[i]
-		vmName := to.String(vm.OsProfile.ComputerName)
+		vmName := pointer.StringDeref(vm.OsProfile.ComputerName, "")
 		realVM, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 		assert.NoError(t, err)
 		assert.NotNil(t, realVM)
 		assert.Equal(t, "vmss", realVM.VMSSName)
-		assert.Equal(t, to.String(vm.InstanceID), realVM.InstanceID)
+		assert.Equal(t, pointer.StringDeref(vm.InstanceID, ""), realVM.InstanceID)
 		assert.Equal(t, &vm, realVM.AsVirtualMachineScaleSetVM())
 	}
 
 	// validate DeleteCacheForNode().
 	vm := expectedVMs[0]
-	vmName := to.String(vm.OsProfile.ComputerName)
+	vmName := pointer.StringDeref(vm.OsProfile.ComputerName, "")
 	err = ss.DeleteCacheForNode(vmName)
 	assert.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestVMSSVMCache(t *testing.T) {
 	realVM, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 	assert.NoError(t, err)
 	assert.Equal(t, "vmss", realVM.VMSSName)
-	assert.Equal(t, to.String(vm.InstanceID), realVM.InstanceID)
+	assert.Equal(t, pointer.StringDeref(vm.InstanceID, ""), realVM.InstanceID)
 	assert.Equal(t, &vm, realVM.AsVirtualMachineScaleSetVM())
 }
 
@@ -98,7 +98,7 @@ func TestVMSSVMCacheWithDeletingNodes(t *testing.T) {
 	ss.cloud.VirtualMachineScaleSetVMsClient = mockVMSSVMClient
 
 	expectedScaleSet := compute.VirtualMachineScaleSet{
-		Name:                             to.StringPtr(testVMSSName),
+		Name:                             pointer.String(testVMSSName),
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{},
 	}
 	mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]compute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
@@ -108,8 +108,8 @@ func TestVMSSVMCacheWithDeletingNodes(t *testing.T) {
 
 	for i := range expectedVMs {
 		vm := expectedVMs[i]
-		vmName := to.String(vm.OsProfile.ComputerName)
-		assert.Equal(t, vm.ProvisioningState, to.StringPtr(string(compute.ProvisioningStateDeleting)))
+		vmName := pointer.StringDeref(vm.OsProfile.ComputerName, "")
+		assert.Equal(t, vm.ProvisioningState, pointer.String(string(compute.ProvisioningStateDeleting)))
 
 		realVM, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 		assert.Nil(t, realVM)
@@ -138,11 +138,11 @@ func TestVMSSVMCacheClearedWhenRGDeleted(t *testing.T) {
 
 	// validate getting VMSS VM via cache.
 	vm := expectedVMs[0]
-	vmName := to.String(vm.OsProfile.ComputerName)
+	vmName := pointer.StringDeref(vm.OsProfile.ComputerName, "")
 	realVM, err := ss.getVmssVM(vmName, azcache.CacheReadTypeDefault)
 	assert.NoError(t, err)
 	assert.Equal(t, "vmss", realVM.VMSSName)
-	assert.Equal(t, to.String(vm.InstanceID), realVM.InstanceID)
+	assert.Equal(t, pointer.StringDeref(vm.InstanceID, ""), realVM.InstanceID)
 	assert.Equal(t, &vm, realVM.AsVirtualMachineScaleSetVM())
 
 	// verify cache has test vmss.
@@ -329,7 +329,7 @@ func TestGetVMManagementTypeByIPConfigurationID(t *testing.T) {
 	testVM1 := generateVmssFlexTestVMWithoutInstanceView(testVM1Spec)
 	testVM2 := generateVmssFlexTestVMWithoutInstanceView(testVM2Spec)
 	testVM2.VirtualMachineScaleSet = nil
-	testVM2.VirtualMachineProperties.OsProfile.ComputerName = to.StringPtr("testvm2")
+	testVM2.VirtualMachineProperties.OsProfile.ComputerName = pointer.String("testvm2")
 
 	testVMList := []compute.VirtualMachine{
 		testVM1,

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -34,6 +33,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
@@ -59,7 +59,7 @@ const (
 func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv6 bool) compute.VirtualMachineScaleSet {
 	lbBackendpools := make([]compute.SubResource, 0)
 	for _, id := range lbBackendpoolIDs {
-		lbBackendpools = append(lbBackendpools, compute.SubResource{ID: to.StringPtr(id)})
+		lbBackendpools = append(lbBackendpools, compute.SubResource{ID: pointer.String(id)})
 	}
 	ipConfig := []compute.VirtualMachineScaleSetIPConfiguration{
 		{
@@ -81,7 +81,7 @@ func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv
 		Name: &name,
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 			OrchestrationMode: compute.Uniform,
-			ProvisioningState: to.StringPtr("Running"),
+			ProvisioningState: pointer.String("Running"),
 			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
 				OsProfile: &compute.VirtualMachineScaleSetOSProfile{
 					ComputerNamePrefix: &namePrefix,
@@ -90,7 +90,7 @@ func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv
 					NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 						{
 							VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-								Primary:          to.BoolPtr(true),
+								Primary:          pointer.Bool(true),
 								IPConfigurations: &ipConfig,
 							},
 						},
@@ -135,23 +135,23 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 			{
 				ID: &interfaceID,
 				NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-					Primary: to.BoolPtr(true),
+					Primary: pointer.Bool(true),
 				},
 			},
 		}
 		ipConfigurations := []compute.VirtualMachineScaleSetIPConfiguration{
 			{
-				Name: to.StringPtr("ipconfig1"),
+				Name: pointer.String("ipconfig1"),
 				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-					Primary:                         to.BoolPtr(true),
-					LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: to.StringPtr(testLBBackendpoolID0)}},
+					Primary:                         pointer.Bool(true),
+					LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: pointer.String(testLBBackendpoolID0)}},
 				},
 			},
 		}
 		networkConfigurations := []compute.VirtualMachineScaleSetNetworkConfiguration{
 			{
-				Name: to.StringPtr("ipconfig1"),
-				ID:   to.StringPtr("fakeNetworkConfiguration"),
+				Name: pointer.String("ipconfig1"),
+				ID:   pointer.String("fakeNetworkConfiguration"),
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					IPConfigurations: &ipConfigurations,
 				},
@@ -159,15 +159,15 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 		}
 		if isIPv6 {
 			networkConfigurations = append(networkConfigurations, compute.VirtualMachineScaleSetNetworkConfiguration{
-				Name: to.StringPtr("ipconfig1v6"),
-				ID:   to.StringPtr("fakeNetworkConfigurationIPv6"),
+				Name: pointer.String("ipconfig1v6"),
+				ID:   pointer.String("fakeNetworkConfigurationIPv6"),
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-								Primary:                         to.BoolPtr(false),
-								LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: to.StringPtr(testLBBackendpoolID0)}},
+								Primary:                         pointer.Bool(false),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: pointer.String(testLBBackendpoolID0)}},
 								PrivateIPAddressVersion:         compute.IPv6,
 							},
 						},
@@ -178,7 +178,7 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 
 		vmssVM := compute.VirtualMachineScaleSetVM{
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-				ProvisioningState: to.StringPtr(state),
+				ProvisioningState: pointer.String(state),
 				OsProfile: &compute.OSProfile{
 					ComputerName: &nodeName,
 				},
@@ -191,7 +191,7 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 				InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
 					PlatformFaultDomain: &faultDomain,
 					Statuses: &[]compute.InstanceViewStatus{
-						{Code: to.StringPtr(testVMPowerState)},
+						{Code: pointer.String(testVMPowerState)},
 					},
 				},
 			},
@@ -199,7 +199,7 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 			InstanceID: &instanceID,
 			Name:       &vmName,
 			Location:   &ss.Location,
-			Sku:        &compute.Sku{Name: to.StringPtr("sku")},
+			Sku:        &compute.Sku{Name: pointer.String("sku")},
 		}
 		if zone != "" {
 			zones := []string{zone}
@@ -208,16 +208,16 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 
 		// set interfaces.
 		expectedInterface = network.Interface{
-			Name: to.StringPtr("nic"),
+			Name: pointer.String("nic"),
 			ID:   &interfaceID,
 			InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 				IPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
 						InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-							Primary:          to.BoolPtr(true),
-							PrivateIPAddress: to.StringPtr(fakePrivateIP),
+							Primary:          pointer.Bool(true),
+							PrivateIPAddress: pointer.String(fakePrivateIP),
 							PublicIPAddress: &network.PublicIPAddress{
-								ID: to.StringPtr(publicAddressID),
+								ID: pointer.String(publicAddressID),
 							},
 						},
 					},
@@ -227,9 +227,9 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 
 		// set public IPs.
 		expectedPIP = network.PublicIPAddress{
-			ID: to.StringPtr(publicAddressID),
+			ID: pointer.String(publicAddressID),
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-				IPAddress: to.StringPtr(fakePublicIP),
+				IPAddress: pointer.String(fakePublicIP),
 			},
 		}
 
@@ -703,7 +703,7 @@ func TestGetVMSS(t *testing.T) {
 		ss.cloud.VirtualMachineScaleSetsClient = mockVMSSClient
 
 		expected := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr(test.existedVMSSName),
+			Name: pointer.String(test.existedVMSSName),
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 			},
@@ -857,7 +857,7 @@ func TestGetProvisioningStateByNodeName(t *testing.T) {
 		expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, test.vmList, "", false)
 		mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
 		if test.provisioningState != "" {
-			expectedVMSSVMs[0].ProvisioningState = to.StringPtr(test.provisioningState)
+			expectedVMSSVMs[0].ProvisioningState = pointer.String(test.provisioningState)
 		} else {
 			expectedVMSSVMs[0].ProvisioningState = nil
 		}
@@ -894,7 +894,7 @@ func TestGetVmssVMByInstanceID(t *testing.T) {
 		assert.NoError(t, err, "unexpected error when creating test VMSS")
 
 		expectedVMSS := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr(testVMSSName),
+			Name: pointer.String(testVMSSName),
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 			},
@@ -943,7 +943,7 @@ func TestGetVmssVMByNodeIdentity(t *testing.T) {
 			assert.NoError(t, err, "unexpected error when creating test VMSS")
 
 			expectedVMSS := compute.VirtualMachineScaleSet{
-				Name: to.StringPtr(testVMSSName),
+				Name: pointer.String(testVMSSName),
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 					VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 				},
@@ -1052,12 +1052,12 @@ func TestGetPrimaryInterfaceID(t *testing.T) {
 			description: "GetPrimaryInterfaceID should return the ID of the primary NIC on the VMSS VM",
 			existedInterfaces: []compute.NetworkInterfaceReference{
 				{
-					ID: to.StringPtr("1"),
+					ID: pointer.String("1"),
 					NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-						Primary: to.BoolPtr(true),
+						Primary: pointer.Bool(true),
 					},
 				},
-				{ID: to.StringPtr("2")},
+				{ID: pointer.String("2")},
 			},
 			expectedID: "1",
 		},
@@ -1065,15 +1065,15 @@ func TestGetPrimaryInterfaceID(t *testing.T) {
 			description: "GetPrimaryInterfaceID should report an error if there's no primary NIC on the VMSS VM",
 			existedInterfaces: []compute.NetworkInterfaceReference{
 				{
-					ID: to.StringPtr("1"),
+					ID: pointer.String("1"),
 					NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 				{
-					ID: to.StringPtr("2"),
+					ID: pointer.String("2"),
 					NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 			},
@@ -1091,7 +1091,7 @@ func TestGetPrimaryInterfaceID(t *testing.T) {
 		assert.NoError(t, err, "unexpected error when creating test VMSS")
 
 		vm := compute.VirtualMachineScaleSetVM{
-			Name: to.StringPtr("vm"),
+			Name: pointer.String("vm"),
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 				NetworkProfile: &compute.NetworkProfile{
 					NetworkInterfaces: &test.existedInterfaces,
@@ -1189,15 +1189,15 @@ func TestGetPrimaryInterface(t *testing.T) {
 		expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, test.vmList, "", false)
 		if !test.hasPrimaryInterface {
 			networkInterfaces := *expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces
-			networkInterfaces[0].Primary = to.BoolPtr(false)
+			networkInterfaces[0].Primary = pointer.Bool(false)
 			networkInterfaces = append(networkInterfaces, compute.NetworkInterfaceReference{
-				NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: to.BoolPtr(false)},
+				NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: pointer.Bool(false)},
 			})
 			expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces = &networkInterfaces
 		}
 		if test.isInvalidNICID {
 			networkInterfaces := *expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces
-			networkInterfaces[0].ID = to.StringPtr("invalid/id/")
+			networkInterfaces[0].ID = pointer.String("invalid/id/")
 			expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces = &networkInterfaces
 		}
 		mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
@@ -1387,27 +1387,27 @@ func TestListScaleSets(t *testing.T) {
 			description: "listScaleSets should return the correct scale sets",
 			existedScaleSets: []compute.VirtualMachineScaleSet{
 				{
-					Name: to.StringPtr("vmss-0"),
-					Sku:  &compute.Sku{Capacity: to.Int64Ptr(1)},
+					Name: pointer.String("vmss-0"),
+					Sku:  &compute.Sku{Capacity: pointer.Int64(1)},
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 						VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-1"),
+					Name: pointer.String("vmss-1"),
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 						VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-2"),
-					Sku:  &compute.Sku{Capacity: to.Int64Ptr(0)},
+					Name: pointer.String("vmss-2"),
+					Sku:  &compute.Sku{Capacity: pointer.Int64(0)},
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 						VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-3"),
+					Name: pointer.String("vmss-3"),
 				},
 			},
 			expectedVMSSNames: []string{"vmss-0", "vmss-1"},
@@ -1447,8 +1447,8 @@ func TestListScaleSetVMs(t *testing.T) {
 		{
 			description: "listScaleSetVMs should return the correct vmss vms",
 			existedVMSSVMs: []compute.VirtualMachineScaleSetVM{
-				{Name: to.StringPtr("vmss-vm-000000")},
-				{Name: to.StringPtr("vmss-vm-000001")},
+				{Name: pointer.String("vmss-vm-000000")},
+				{Name: pointer.String("vmss-vm-000001")},
 			},
 		},
 		{
@@ -1542,7 +1542,7 @@ func TestGetAgentPoolScaleSets(t *testing.T) {
 		expectedVMSSVMs := []compute.VirtualMachineScaleSetVM{
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000000")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000000")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1550,7 +1550,7 @@ func TestGetAgentPoolScaleSets(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000001")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000001")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1558,7 +1558,7 @@ func TestGetAgentPoolScaleSets(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000002")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000002")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1676,7 +1676,7 @@ func TestGetVMSetNames(t *testing.T) {
 		expectedVMSSVMs := []compute.VirtualMachineScaleSetVM{
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000000")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000000")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1684,7 +1684,7 @@ func TestGetVMSetNames(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000001")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000001")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1692,7 +1692,7 @@ func TestGetVMSetNames(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000002")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000002")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1700,7 +1700,7 @@ func TestGetVMSetNames(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000003")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000003")},
 				},
 			},
 		}
@@ -1723,7 +1723,7 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 	defer ctrl.Finish()
 
 	networkConfigs := []compute.VirtualMachineScaleSetNetworkConfiguration{
-		{Name: to.StringPtr("config-0")},
+		{Name: pointer.String("config-0")},
 	}
 	config, err := getPrimaryNetworkInterfaceConfigurationForScaleSet(networkConfigs, testVMSSName)
 	assert.Nil(t, err, "getPrimaryNetworkInterfaceConfigurationForScaleSet should return the correct network config")
@@ -1731,15 +1731,15 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 
 	networkConfigs = []compute.VirtualMachineScaleSetNetworkConfiguration{
 		{
-			Name: to.StringPtr("config-0"),
+			Name: pointer.String("config-0"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(false),
+				Primary: pointer.Bool(false),
 			},
 		},
 		{
-			Name: to.StringPtr("config-1"),
+			Name: pointer.String("config-1"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(true),
+				Primary: pointer.Bool(true),
 			},
 		},
 	}
@@ -1749,15 +1749,15 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 
 	networkConfigs = []compute.VirtualMachineScaleSetNetworkConfiguration{
 		{
-			Name: to.StringPtr("config-0"),
+			Name: pointer.String("config-0"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(false),
+				Primary: pointer.Bool(false),
 			},
 		},
 		{
-			Name: to.StringPtr("config-1"),
+			Name: pointer.String("config-1"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(false),
+				Primary: pointer.Bool(false),
 			},
 		},
 	}
@@ -1771,7 +1771,7 @@ func TestGetPrimaryIPConfigFromVMSSNetworkConfig(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 				},
 			},
 		},
@@ -1785,15 +1785,15 @@ func TestGetPrimaryIPConfigFromVMSSNetworkConfig(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 				{
-					Name: to.StringPtr("config-1"),
+					Name: pointer.String("config-1"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(true),
+						Primary: pointer.Bool(true),
 					},
 				},
 			},
@@ -1808,15 +1808,15 @@ func TestGetPrimaryIPConfigFromVMSSNetworkConfig(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 				{
-					Name: to.StringPtr("config-1"),
+					Name: pointer.String("config-1"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 			},
@@ -1836,13 +1836,13 @@ func TestGetConfigForScaleSetByIPFamily(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
 						PrivateIPAddressVersion: compute.IPv4,
 					},
 				},
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
 						PrivateIPAddressVersion: compute.IPv6,
 					},
@@ -1930,25 +1930,25 @@ func TestEnsureHostInPool(t *testing.T) {
 			expectedVMSSName:          testVMSSName,
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &compute.VirtualMachineScaleSetVM{
-				Location: to.StringPtr("westus"),
+				Location: pointer.String("westus"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 							{
-								Name: to.StringPtr("ipconfig1"),
-								ID:   to.StringPtr("fakeNetworkConfiguration"),
+								Name: pointer.String("ipconfig1"),
+								ID:   pointer.String("fakeNetworkConfiguration"),
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 										{
-											Name: to.StringPtr("ipconfig1"),
+											Name: pointer.String("ipconfig1"),
 											VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-												Primary: to.BoolPtr(true),
+												Primary: pointer.Bool(true),
 												LoadBalancerBackendAddressPools: &[]compute.SubResource{
 													{
-														ID: to.StringPtr(testLBBackendpoolID0),
+														ID: pointer.String(testLBBackendpoolID0),
 													},
 													{
-														ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb-internal/backendAddressPools/backendpool-1"),
+														ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb-internal/backendAddressPools/backendpool-1"),
 													},
 												},
 											},
@@ -2223,7 +2223,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 
 		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, test.setIPv6Config)
 		if test.isVMSSDeallocating {
-			expectedVMSS.ProvisioningState = to.StringPtr(consts.VirtualMachineScaleSetsDeallocating)
+			expectedVMSS.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
 		}
 		if test.isVMSSNilNICConfig {
 			expectedVMSS.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
@@ -2322,7 +2322,7 @@ func TestEnsureHostsInPool(t *testing.T) {
 		assert.NoError(t, err, test.description)
 
 		ss.LoadBalancerSku = consts.LoadBalancerSkuStandard
-		ss.ExcludeMasterFromStandardLB = to.BoolPtr(true)
+		ss.ExcludeMasterFromStandardLB = pointer.Bool(true)
 
 		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
 		mockVMSSClient := ss.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
@@ -2380,19 +2380,19 @@ func TestEnsureBackendPoolDeletedFromNode(t *testing.T) {
 			expectedVMSSName:          testVMSSName,
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &compute.VirtualMachineScaleSetVM{
-				Location: to.StringPtr("westus"),
+				Location: pointer.String("westus"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 							{
-								Name: to.StringPtr("ipconfig1"),
-								ID:   to.StringPtr("fakeNetworkConfiguration"),
+								Name: pointer.String("ipconfig1"),
+								ID:   pointer.String("fakeNetworkConfiguration"),
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 										{
-											Name: to.StringPtr("ipconfig1"),
+											Name: pointer.String("ipconfig1"),
 											VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-												Primary:                         to.BoolPtr(true),
+												Primary:                         pointer.Bool(true),
 												LoadBalancerBackendAddressPools: &[]compute.SubResource{},
 											},
 										},
@@ -2497,7 +2497,7 @@ func TestEnsureBackendPoolDeletedFromVMSS(t *testing.T) {
 
 		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
 		if test.isVMSSDeallocating {
-			expectedVMSS.ProvisioningState = to.StringPtr(consts.VirtualMachineScaleSetsDeallocating)
+			expectedVMSS.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
 		}
 		if test.isVMSSNilNICConfig {
 			expectedVMSS.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
@@ -2542,25 +2542,25 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 			backendpoolID: testLBBackendpoolID0,
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(testLBBackendpoolID0),
+					ID: pointer.String(testLBBackendpoolID0),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: to.StringPtr("ip-1"),
-								ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+								Name: pointer.String("ip-1"),
+								ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
 							},
 							{
-								Name: to.StringPtr("ip-2"),
+								Name: pointer.String("ip-2"),
 							},
 							{
-								Name: to.StringPtr("ip-3"),
-								ID:   to.StringPtr("/invalid/id"),
+								Name: pointer.String("ip-3"),
+								ID:   pointer.String("/invalid/id"),
 							},
 						},
 					},
 				},
 				{
-					ID: to.StringPtr(testLBBackendpoolID1),
+					ID: pointer.String(testLBBackendpoolID1),
 				},
 			},
 			expectedVMSSVMPutTimes: 1,
@@ -2570,18 +2570,18 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 			backendpoolID: testLBBackendpoolID0,
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(testLBBackendpoolID0),
+					ID: pointer.String(testLBBackendpoolID0),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: to.StringPtr("ip-1"),
-								ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+								Name: pointer.String("ip-1"),
+								ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
 							},
 						},
 					},
 				},
 				{
-					ID: to.StringPtr(testLBBackendpoolID1),
+					ID: pointer.String(testLBBackendpoolID1),
 				},
 			},
 			expectedVMSSVMPutTimes: 1,
@@ -2593,18 +2593,18 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 			backendpoolID: testLBBackendpoolID0,
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(testLBBackendpoolID0),
+					ID: pointer.String(testLBBackendpoolID0),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: to.StringPtr("ip-1"),
-								ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/6/networkInterfaces/nic"),
+								Name: pointer.String("ip-1"),
+								ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/6/networkInterfaces/nic"),
 							},
 						},
 					},
 				},
 				{
-					ID: to.StringPtr(testLBBackendpoolID1),
+					ID: pointer.String(testLBBackendpoolID1),
 				},
 			},
 		},
@@ -2652,34 +2652,34 @@ func TestEnsureBackendPoolDeletedConcurrently(t *testing.T) {
 
 	backendAddressPools := &[]network.BackendAddressPool{
 		{
-			ID: to.StringPtr(testLBBackendpoolID0),
+			ID: pointer.String(testLBBackendpoolID0),
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						Name: to.StringPtr("ip-1"),
-						ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
+						Name: pointer.String("ip-1"),
+						ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
 					},
 				},
 			},
 		},
 		{
-			ID: to.StringPtr(testLBBackendpoolID1),
+			ID: pointer.String(testLBBackendpoolID1),
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						Name: to.StringPtr("ip-1"),
-						ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-1/virtualMachines/0/networkInterfaces/nic"),
+						Name: pointer.String("ip-1"),
+						ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-1/virtualMachines/0/networkInterfaces/nic"),
 					},
 				},
 			},
 		},
 		{
-			ID: to.StringPtr(testLBBackendpoolID2),
+			ID: pointer.String(testLBBackendpoolID2),
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						Name: to.StringPtr("ip-1"),
-						ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
+						Name: pointer.String("ip-1"),
+						ID:   pointer.String("/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -2695,7 +2695,7 @@ func TestEnsureBackendPoolDeletedConcurrently(t *testing.T) {
 		vmssVMNetworkConfigs := expectedVMSSVMs[0].NetworkProfileConfiguration
 		vmssVMIPConfigs := (*vmssVMNetworkConfigs.NetworkInterfaceConfigurations)[0].VirtualMachineScaleSetNetworkConfigurationProperties.IPConfigurations
 		lbBackendpools := (*vmssVMIPConfigs)[0].LoadBalancerBackendAddressPools
-		*lbBackendpools = append(*lbBackendpools, compute.SubResource{ID: to.StringPtr(testLBBackendpoolID1)})
+		*lbBackendpools = append(*lbBackendpools, compute.SubResource{ID: pointer.String(testLBBackendpoolID1)})
 	}
 
 	mockVMClient := ss.cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -2749,8 +2749,8 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV4MaskSize: 24,
 			expectedIPV6MaskSize: 64,
@@ -2759,7 +2759,7 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes even if some of the tags are not specified",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
 			},
 			expectedIPV4MaskSize: 24,
 		},
@@ -2767,8 +2767,8 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should not fail even if some of the tag is invalid",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("abc"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("abc"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV6MaskSize: 64,
 		},
@@ -2778,7 +2778,7 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedVMSS := compute.VirtualMachineScaleSet{
-				Name: to.StringPtr("vmss"),
+				Name: pointer.String("vmss"),
 				Tags: tc.tags,
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 					OrchestrationMode: compute.Uniform,
@@ -2807,24 +2807,24 @@ func TestGetAgentPoolVMSetNamesMixedInstances(t *testing.T) {
 
 	existingVMs := []compute.VirtualMachine{
 		{
-			Name: to.StringPtr("vm-0"),
+			Name: pointer.String("vm-0"),
 			VirtualMachineProperties: &compute.VirtualMachineProperties{
 				OsProfile: &compute.OSProfile{
-					ComputerName: to.StringPtr("vm-0"),
+					ComputerName: pointer.String("vm-0"),
 				},
 				AvailabilitySet: &compute.SubResource{
-					ID: to.StringPtr("vmas-0"),
+					ID: pointer.String("vmas-0"),
 				},
 			},
 		},
 		{
-			Name: to.StringPtr("vm-1"),
+			Name: pointer.String("vm-1"),
 			VirtualMachineProperties: &compute.VirtualMachineProperties{
 				OsProfile: &compute.OSProfile{
-					ComputerName: to.StringPtr("vm-1"),
+					ComputerName: pointer.String("vm-1"),
 				},
 				AvailabilitySet: &compute.SubResource{
-					ID: to.StringPtr("vmas-1"),
+					ID: pointer.String("vmas-1"),
 				},
 			},
 		},
@@ -2923,9 +2923,9 @@ func TestScaleSet_VMSSBatchSize(t *testing.T) {
 		ss.Cloud.PutVMSSVMBatchSize = BatchSize
 
 		scaleSet := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr("foo"),
+			Name: pointer.String("foo"),
 			Tags: map[string]*string{
-				consts.VMSSTagForBatchOperation: to.StringPtr(""),
+				consts.VMSSTagForBatchOperation: pointer.String(""),
 			},
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				OrchestrationMode: compute.Uniform,
@@ -2935,7 +2935,7 @@ func TestScaleSet_VMSSBatchSize(t *testing.T) {
 		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).
 			Return([]compute.VirtualMachineScaleSet{scaleSet}, nil)
 
-		batchSize, err := ss.VMSSBatchSize(to.String(scaleSet.Name))
+		batchSize, err := ss.VMSSBatchSize(pointer.StringDeref(scaleSet.Name, ""))
 		assert.NoError(t, err)
 		assert.Equal(t, BatchSize, batchSize)
 	})
@@ -2948,7 +2948,7 @@ func TestScaleSet_VMSSBatchSize(t *testing.T) {
 		ss.Cloud.PutVMSSVMBatchSize = BatchSize
 
 		scaleSet := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr("bar"),
+			Name: pointer.String("bar"),
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				OrchestrationMode: compute.Uniform,
 			},
@@ -2957,7 +2957,7 @@ func TestScaleSet_VMSSBatchSize(t *testing.T) {
 		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).
 			Return([]compute.VirtualMachineScaleSet{scaleSet}, nil)
 
-		batchSize, err := ss.VMSSBatchSize(to.String(scaleSet.Name))
+		batchSize, err := ss.VMSSBatchSize(pointer.StringDeref(scaleSet.Name, ""))
 		assert.NoError(t, err)
 		assert.Equal(t, 0, batchSize)
 	})

--- a/pkg/provider/azure_vmssflex_cache.go
+++ b/pkg/provider/azure_vmssflex_cache.go
@@ -25,10 +25,10 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -186,11 +186,11 @@ func (fs *FlexScaleSet) getNodeVmssFlexID(nodeName string) (string, error) {
 		vmssFlexes.Range(func(key, value interface{}) bool {
 			vmssFlexID := key.(string)
 			vmssFlex := value.(*compute.VirtualMachineScaleSet)
-			vmssPrefix := to.String(vmssFlex.Name)
+			vmssPrefix := pointer.StringDeref(vmssFlex.Name, "")
 			if vmssFlex.VirtualMachineProfile != nil &&
 				vmssFlex.VirtualMachineProfile.OsProfile != nil &&
 				vmssFlex.VirtualMachineProfile.OsProfile.ComputerNamePrefix != nil {
-				vmssPrefix = to.String(vmssFlex.VirtualMachineProfile.OsProfile.ComputerNamePrefix)
+				vmssPrefix = pointer.StringDeref(vmssFlex.VirtualMachineProfile.OsProfile.ComputerNamePrefix, "")
 			}
 			if strings.EqualFold(vmssPrefix, nodeName[:len(nodeName)-6]) {
 				// we should check this vmss first since nodeName and vmssFlex.Name or

--- a/pkg/provider/azure_vmssflex_cache_test.go
+++ b/pkg/provider/azure_vmssflex_cache_test.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -43,13 +43,13 @@ var (
 		VMName:              "testvm1",
 		VMID:                "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/testvm1",
 		ComputerName:        "vmssflex1000001",
-		ProvisioningState:   to.StringPtr("Succeeded"),
+		ProvisioningState:   pointer.String("Succeeded"),
 		VmssFlexID:          testVmssFlex1ID,
 		Zones:               &[]string{"1", "2", "3"},
-		PlatformFaultDomain: to.Int32Ptr(1),
+		PlatformFaultDomain: pointer.Int32(1),
 		Status: &[]compute.InstanceViewStatus{
 			{
-				Code: to.StringPtr("PowerState/running"),
+				Code: pointer.String("PowerState/running"),
 			},
 		},
 		NicID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm1-nic",
@@ -61,13 +61,13 @@ var (
 		VMName:              "testvm2",
 		VMID:                "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/testvm2",
 		ComputerName:        "vmssflex1000002",
-		ProvisioningState:   to.StringPtr("Succeeded"),
+		ProvisioningState:   pointer.String("Succeeded"),
 		VmssFlexID:          testVmssFlex1ID,
 		Zones:               nil,
-		PlatformFaultDomain: to.Int32Ptr(1),
+		PlatformFaultDomain: pointer.Int32(1),
 		Status: &[]compute.InstanceViewStatus{
 			{
-				Code: to.StringPtr("PowerState/running"),
+				Code: pointer.String("PowerState/running"),
 			},
 		},
 		NicID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm2-nic",
@@ -110,12 +110,12 @@ func genreateTestVmssFlexList() []compute.VirtualMachineScaleSet {
 
 func genreteTestVmssFlex(vmssFlexName string, testVmssFlexID string) compute.VirtualMachineScaleSet {
 	return compute.VirtualMachineScaleSet{
-		ID:   to.StringPtr(testVmssFlexID),
-		Name: to.StringPtr(vmssFlexName),
+		ID:   pointer.String(testVmssFlexID),
+		Name: pointer.String(vmssFlexName),
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
 				OsProfile: &compute.VirtualMachineScaleSetOSProfile{
-					ComputerNamePrefix: to.StringPtr(vmssFlexName),
+					ComputerNamePrefix: pointer.String(vmssFlexName),
 				},
 				NetworkProfile: &compute.VirtualMachineScaleSetNetworkProfile{
 					NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
@@ -126,7 +126,7 @@ func genreteTestVmssFlex(vmssFlexName string, testVmssFlexID string) compute.Vir
 										VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
 											LoadBalancerBackendAddressPools: &[]compute.SubResource{
 												{
-													ID: to.StringPtr(testBackendPoolID0),
+													ID: pointer.String(testBackendPoolID0),
 												},
 											},
 										},
@@ -140,8 +140,8 @@ func genreteTestVmssFlex(vmssFlexName string, testVmssFlexID string) compute.Vir
 			OrchestrationMode: compute.Flexible,
 		},
 		Tags: map[string]*string{
-			consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
-			consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+			consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
+			consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 		},
 	}
 }
@@ -160,31 +160,31 @@ type VmssFlexTestVMSpec struct {
 
 func generateVmssFlexTestVMWithoutInstanceView(spec VmssFlexTestVMSpec) (testVMWithoutInstanceView compute.VirtualMachine) {
 	return compute.VirtualMachine{
-		Name: to.StringPtr(spec.VMName),
-		ID:   to.StringPtr(spec.VMID),
+		Name: pointer.String(spec.VMName),
+		ID:   pointer.String(spec.VMID),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			OsProfile: &compute.OSProfile{
-				ComputerName: to.StringPtr(spec.ComputerName),
+				ComputerName: pointer.String(spec.ComputerName),
 			},
 			ProvisioningState: spec.ProvisioningState,
 			VirtualMachineScaleSet: &compute.SubResource{
-				ID: to.StringPtr(spec.VmssFlexID),
+				ID: pointer.String(spec.VmssFlexID),
 			},
 			StorageProfile: &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk" + spec.VMName),
+					Name: pointer.String("osdisk" + spec.VMName),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID" + spec.VMName),
+						ID: pointer.String("ManagedID" + spec.VMName),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID" + spec.VMName),
+							ID: pointer.String("DiskEncryptionSetID" + spec.VMName),
 						},
 					},
 				},
 				DataDisks: &[]compute.DataDisk{
 					{
-						Lun:         to.Int32Ptr(1),
-						Name:        to.StringPtr("dataDisk" + spec.VMName),
-						ManagedDisk: &compute.ManagedDiskParameters{ID: to.StringPtr("uri")},
+						Lun:         pointer.Int32(1),
+						Name:        pointer.String("dataDisk" + spec.VMName),
+						ManagedDisk: &compute.ManagedDiskParameters{ID: pointer.String("uri")},
 					},
 				},
 			},
@@ -194,20 +194,20 @@ func generateVmssFlexTestVMWithoutInstanceView(spec VmssFlexTestVMSpec) (testVMW
 			NetworkProfile: &compute.NetworkProfile{
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
-						ID: to.StringPtr(spec.NicID),
+						ID: pointer.String(spec.NicID),
 					},
 				},
 			},
 		},
 		Zones:    spec.Zones,
-		Location: to.StringPtr("EastUS"),
+		Location: pointer.String("EastUS"),
 	}
 }
 
 func generateVmssFlexTestVMWithOnlyInstanceView(spec VmssFlexTestVMSpec) (testVMWithOnlyInstanceView compute.VirtualMachine) {
 	return compute.VirtualMachine{
-		Name: to.StringPtr(spec.VMName),
-		ID:   to.StringPtr(spec.VMID),
+		Name: pointer.String(spec.VMName),
+		ID:   pointer.String(spec.VMID),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			InstanceView: &compute.VirtualMachineInstanceView{
 				PlatformFaultDomain: spec.PlatformFaultDomain,

--- a/pkg/provider/azure_vmssflex_test.go
+++ b/pkg/provider/azure_vmssflex_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
@@ -62,11 +62,11 @@ var (
 
 	testBackendPools = &[]network.BackendAddressPool{
 		{
-			ID: to.StringPtr(testBackendPoolID0),
+			ID: pointer.String(testBackendPoolID0),
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						ID: to.StringPtr(testIPConfigurationID),
+						ID: pointer.String(testIPConfigurationID),
 					},
 				},
 			},
@@ -80,17 +80,17 @@ var (
 
 func generateTestNic(nicName string, isIPConfigurationsNil bool, provisioningState network.ProvisioningState, vmID string) network.Interface {
 	result := network.Interface{
-		ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/" + nicName),
-		Name: to.StringPtr(nicName),
+		ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/" + nicName),
+		Name: pointer.String(nicName),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						Primary:          to.BoolPtr(true),
-						PrivateIPAddress: to.StringPtr(nicName + "testPrivateIP"),
+						Primary:          pointer.Bool(true),
+						PrivateIPAddress: pointer.String(nicName + "testPrivateIP"),
 						LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
 							{
-								ID: to.StringPtr(testBackendPoolID0),
+								ID: pointer.String(testBackendPoolID0),
 							},
 						},
 					},
@@ -98,7 +98,7 @@ func generateTestNic(nicName string, isIPConfigurationsNil bool, provisioningSta
 			},
 			ProvisioningState: provisioningState,
 			VirtualMachine: &network.SubResource{
-				ID: to.StringPtr(vmID),
+				ID: pointer.String(vmID),
 			},
 		},
 	}
@@ -888,7 +888,7 @@ func TestGetNodeCIDRMasksByProviderIDVmssFlex(t *testing.T) {
 			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
 			vmListErr:                      nil,
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
 			},
 			expectedNodeMaskCIDRIPv4: 24,
 			expectedNodeMaskCIDRIPv6: 0,
@@ -901,8 +901,8 @@ func TestGetNodeCIDRMasksByProviderIDVmssFlex(t *testing.T) {
 			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
 			vmListErr:                      nil,
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("abc"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("abc"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedNodeMaskCIDRIPv4: 0,
 			expectedNodeMaskCIDRIPv6: 64,
@@ -1413,7 +1413,7 @@ func TestEnsureVMSSFlexInPool(t *testing.T) {
 		testVmssFlex := genreteTestVmssFlex("vmssflex1", testVmssFlex1ID)
 
 		if tc.isVMSSDeallocating {
-			testVmssFlex.ProvisioningState = to.StringPtr(consts.VirtualMachineScaleSetsDeallocating)
+			testVmssFlex.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
 		}
 		if !tc.hasDefaultVMProfile {
 			testVmssFlex.VirtualMachineProfile = nil
@@ -1670,7 +1670,7 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 		testVmssFlex := genreteTestVmssFlex("vmssflex1", testVmssFlex1ID)
 
 		if tc.isVMSSDeallocating {
-			testVmssFlex.ProvisioningState = to.StringPtr(consts.VirtualMachineScaleSetsDeallocating)
+			testVmssFlex.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
 		}
 		if !tc.hasDefaultVMProfile {
 			testVmssFlex.VirtualMachineProfile = nil

--- a/pkg/provider/azure_wrap.go
+++ b/pkg/provider/azure_wrap.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -212,7 +212,7 @@ func (az *Cloud) newVMCache() (*azcache.TimedCache, error) {
 		}
 
 		if vm.VirtualMachineProperties != nil &&
-			strings.EqualFold(to.String(vm.VirtualMachineProperties.ProvisioningState), string(compute.ProvisioningStateDeleting)) {
+			strings.EqualFold(pointer.StringDeref(vm.VirtualMachineProperties.ProvisioningState, ""), string(compute.ProvisioningStateDeleting)) {
 			klog.V(2).Infof("Virtual machine %q is under deleting", key)
 			return nil, nil
 		}

--- a/pkg/provider/azure_zones_test.go
+++ b/pkg/provider/azure_zones_test.go
@@ -27,12 +27,12 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/zoneclient/mockzoneclient"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -270,7 +270,7 @@ func TestGetZoneByProviderID(t *testing.T) {
 	mockVMClient := az.VirtualMachinesClient.(*mockvmclient.MockInterface)
 	mockVMClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "vm-0", gomock.Any()).Return(compute.VirtualMachine{
 		Zones:    &[]string{"1"},
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}, nil)
 	zone, err = az.GetZoneByProviderID(context.Background(), testAvailabilitySetNodeProviderID)
 	assert.NoError(t, err)

--- a/pkg/provider/virtualmachine/virtualmachine.go
+++ b/pkg/provider/virtualmachine/virtualmachine.go
@@ -18,7 +18,7 @@ package virtualmachine
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/utils/pointer"
 )
 
 type Variant string
@@ -79,12 +79,12 @@ func FromVirtualMachine(vm *compute.VirtualMachine, opt ...ManageOption) *Virtua
 		vm:      vm,
 		Variant: VariantVirtualMachine,
 
-		ID:        to.String(vm.ID),
-		Name:      to.String(vm.Name),
-		Type:      to.String(vm.Type),
-		Location:  to.String(vm.Location),
-		Tags:      to.StringMap(vm.Tags),
-		Zones:     to.StringSlice(vm.Zones),
+		ID:        pointer.StringDeref(vm.ID, ""),
+		Name:      pointer.StringDeref(vm.Name, ""),
+		Type:      pointer.StringDeref(vm.Type, ""),
+		Location:  pointer.StringDeref(vm.Location, ""),
+		Tags:      stringMap(vm.Tags),
+		Zones:     stringSlice(vm.Zones),
 		Plan:      vm.Plan,
 		Resources: vm.Resources,
 
@@ -104,17 +104,17 @@ func FromVirtualMachineScaleSetVM(vm *compute.VirtualMachineScaleSetVM, opt Mana
 		Variant: VariantVirtualMachineScaleSetVM,
 		vmssVM:  vm,
 
-		ID:        to.String(vm.ID),
-		Name:      to.String(vm.Name),
-		Type:      to.String(vm.Type),
-		Location:  to.String(vm.Location),
-		Tags:      to.StringMap(vm.Tags),
-		Zones:     to.StringSlice(vm.Zones),
+		ID:        pointer.StringDeref(vm.ID, ""),
+		Name:      pointer.StringDeref(vm.Name, ""),
+		Type:      pointer.StringDeref(vm.Type, ""),
+		Location:  pointer.StringDeref(vm.Location, ""),
+		Tags:      stringMap(vm.Tags),
+		Zones:     stringSlice(vm.Zones),
 		Plan:      vm.Plan,
 		Resources: vm.Resources,
 
 		SKU:                                vm.Sku,
-		InstanceID:                         to.String(vm.InstanceID),
+		InstanceID:                         pointer.StringDeref(vm.InstanceID, ""),
 		VirtualMachineScaleSetVMProperties: vm.VirtualMachineScaleSetVMProperties,
 	}
 
@@ -143,4 +143,27 @@ func (vm *VirtualMachine) AsVirtualMachine() *compute.VirtualMachine {
 
 func (vm *VirtualMachine) AsVirtualMachineScaleSetVM() *compute.VirtualMachineScaleSetVM {
 	return vm.vmssVM
+}
+
+// StringMap returns a map of strings built from the map of string pointers. The empty string is
+// used for nil pointers.
+func stringMap(msp map[string]*string) map[string]string {
+	ms := make(map[string]string, len(msp))
+	for k, sp := range msp {
+		if sp != nil {
+			ms[k] = *sp
+		} else {
+			ms[k] = ""
+		}
+	}
+	return ms
+}
+
+// stringSlice returns a string slice value for the passed string slice pointer. It returns a nil
+// slice if the pointer is nil.
+func stringSlice(s *[]string) []string {
+	if s != nil {
+		return *s
+	}
+	return nil
 }

--- a/pkg/util/deepcopy/deepcopy_test.go
+++ b/pkg/util/deepcopy/deepcopy_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 )
 
 type fakeStruct struct {
@@ -42,12 +42,12 @@ func TestCopyBasic(t *testing.T) {
 	zones := []string{"zone0", "zone1"}
 	var vmOriginal *compute.VirtualMachine = &compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			ProvisioningState: to.StringPtr("Failed"),
+			ProvisioningState: pointer.String("Failed"),
 		},
-		Name:  to.StringPtr("vmOriginal"),
+		Name:  pointer.String("vmOriginal"),
 		Zones: &zones,
 		Tags: map[string]*string{
-			"tag0": to.StringPtr("tagVal0"),
+			"tag0": pointer.String("tagVal0"),
 		},
 	}
 	vmCopied := Copy(vmOriginal).(*compute.VirtualMachine)
@@ -68,9 +68,9 @@ func TestCopyBasic(t *testing.T) {
 func TestCopyVMInSyncMap(t *testing.T) {
 	var vmOriginal *compute.VirtualMachine = &compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			ProvisioningState: to.StringPtr("Failed"),
+			ProvisioningState: pointer.String("Failed"),
 		},
-		Name: to.StringPtr("vmOriginal"),
+		Name: pointer.String("vmOriginal"),
 	}
 	vmCacheOriginal := &sync.Map{}
 	vmCacheOriginal.Store("vmOriginal", vmOriginal)
@@ -93,9 +93,9 @@ type vmssEntry struct {
 // TestCopyVMSSEntryInSyncMap tests object like vmssEntry in sync.Map.
 func TestCopyVMSSEntryInSyncMap(t *testing.T) {
 	vmssEntryOriginal := &vmssEntry{
-		Name: to.StringPtr("vmssEntryName"),
+		Name: pointer.String("vmssEntryName"),
 		VirtualMachineScaleSet: &compute.VirtualMachineScaleSet{
-			Name: to.StringPtr("vmssOriginal"),
+			Name: pointer.String("vmssOriginal"),
 		},
 	}
 	vmssCacheOriginal := &sync.Map{}

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -37,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
@@ -143,11 +143,11 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		for _, rule := range *lb.LoadBalancingRules {
 			switch {
 			case strings.EqualFold(string(rule.Protocol), string(v1.ProtocolTCP)):
-				if to.Int32(rule.FrontendPort) == serverPort {
+				if pointer.Int32Deref(rule.FrontendPort, 0) == serverPort {
 					foundTCP = true
 				}
 			case strings.EqualFold(string(rule.Protocol), string(v1.ProtocolUDP)):
-				if to.Int32(rule.FrontendPort) == testingPort {
+				if pointer.Int32Deref(rule.FrontendPort, 0) == testingPort {
 					foundUDP = true
 				}
 			}
@@ -161,13 +161,13 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		ipName := basename + "-public-IP" + string(uuid.NewUUID())[0:4]
 		pip := defaultPublicIPAddress(ipName, tc.IPFamily == utils.IPv6)
 		expectedTags := map[string]*string{
-			"foo": to.StringPtr("bar"),
+			"foo": pointer.String("bar"),
 		}
 		pip.Tags = expectedTags
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), pip)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pip.Tags).To(Equal(expectedTags))
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 		utils.Logf("created pip with address %s", targetIP)
 
 		By("creating a service referencing the public IP")
@@ -206,7 +206,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), defaultPublicIPAddress(ipName, tc.IPFamily == utils.IPv6))
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 		utils.Logf("PIP to %s", targetIP)
 
 		defer func() {
@@ -290,7 +290,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), defaultPublicIPAddress(ipName, tc.IPFamily == utils.IPv6))
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 
 		defer func() {
 			By("Cleaning up")
@@ -329,7 +329,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		ipName := basename + "-public-remain" + suffix
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), defaultPublicIPAddress(ipName, tc.IPFamily == utils.IPv6))
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 
 		service := utils.CreateLoadBalancerServiceManifest(testServiceName, serviceAnnotationLoadBalancerInternalFalse, labels, ns.Name, ports)
 		service = updateServiceLBIP(service, false, targetIP)
@@ -391,7 +391,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 
 		serviceNames := []string{}
 		for i := 0; i < 2; i++ {
@@ -623,7 +623,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		pip := defaultPublicIPAddress(ipName, tc.IPFamily == utils.IPv6)
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), pip)
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 		utils.Logf("created pip with address %s", targetIP)
 
 		By("creating a service referencing the public IP")
@@ -656,7 +656,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 			lbRuleSplit := strings.Split(*lbRule.Name, "-")
 			Expect(len(lbRuleSplit)).NotTo(Equal(0))
 			if pipFrontendConfigIDSplit[len(pipFrontendConfigIDSplit)-1] == lbRuleSplit[0] {
-				Expect(to.Bool(lbRule.EnableFloatingIP)).To(BeFalse())
+				Expect(pointer.BoolDeref(lbRule.EnableFloatingIP, false)).To(BeFalse())
 				found = true
 				break
 			}
@@ -751,7 +751,7 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 
 		customHealthProbeConfigPrefix := "service.beta.kubernetes.io/port_" + strconv.Itoa(int(ports[0].Port)) + "_health-probe_"
 		By("Creating a service and expose it")
@@ -799,7 +799,7 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 
 		By("Creating a service and expose it")
 		annotation := map[string]string{
-			consts.ServiceAnnotationPIPPrefixID:                   to.String(prefix.ID),
+			consts.ServiceAnnotationPIPPrefixID:                   pointer.StringDeref(prefix.ID, ""),
 			consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true",
 			consts.ServiceAnnotationSharedSecurityRule:            "true",
 		}
@@ -827,13 +827,13 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 		By("Creating a subnet for ilb frontend ip")
 		subnetName := "testSubnet"
 		subnet, isNew := createNewSubnet(tc, subnetName)
-		Expect(to.String(subnet.Name)).To(Equal(subnetName))
+		Expect(pointer.StringDeref(subnet.Name, "")).To(Equal(subnetName))
 		if isNew {
 			defer func() {
 				utils.Logf("cleaning up test subnet %s", subnetName)
 				vNet, err := tc.GetClusterVirtualNetwork()
 				Expect(err).NotTo(HaveOccurred())
-				err = tc.DeleteSubnet(to.String(vNet.Name), subnetName)
+				err = tc.DeleteSubnet(pointer.StringDeref(vNet.Name, ""), subnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}()
 		}
@@ -911,9 +911,9 @@ func createNewSubnet(tc *utils.AzureTestClient, subnetName string) (*network.Sub
 
 func getResourceEtags(tc *utils.AzureTestClient, ip, nsgRulePrefix string, internal bool) (lbEtag, nsgEtag, pipEtag string) {
 	if internal {
-		lbEtag = to.String(getAzureInternalLoadBalancerFromPrivateIP(tc, ip, "").Etag)
+		lbEtag = pointer.StringDeref(getAzureInternalLoadBalancerFromPrivateIP(tc, ip, "").Etag, "")
 	} else {
-		lbEtag = to.String(getAzureLoadBalancerFromPIP(tc, ip, tc.GetResourceGroup(), "").Etag)
+		lbEtag = pointer.StringDeref(getAzureLoadBalancerFromPIP(tc, ip, tc.GetResourceGroup(), "").Etag, "")
 	}
 
 	nsgs, err := tc.GetClusterSecurityGroups()
@@ -923,9 +923,9 @@ func getResourceEtags(tc *utils.AzureTestClient, ip, nsgRulePrefix string, inter
 			continue
 		}
 		for _, securityRule := range *nsg.SecurityRules {
-			utils.Logf("Checking security rule %q", to.String(securityRule.Name))
-			if strings.HasPrefix(to.String(securityRule.Name), nsgRulePrefix) {
-				nsgEtag = to.String(nsg.Etag)
+			utils.Logf("Checking security rule %q", pointer.StringDeref(securityRule.Name, ""))
+			if strings.HasPrefix(pointer.StringDeref(securityRule.Name, ""), nsgRulePrefix) {
+				nsgEtag = pointer.StringDeref(nsg.Etag, "")
 				break
 			}
 		}
@@ -934,7 +934,7 @@ func getResourceEtags(tc *utils.AzureTestClient, ip, nsgRulePrefix string, inter
 	if !internal {
 		pip, err := tc.GetPublicIPFromAddress(tc.GetResourceGroup(), ip)
 		Expect(err).NotTo(HaveOccurred())
-		pipEtag = to.String(pip.Etag)
+		pipEtag = pointer.StringDeref(pip.Etag, "")
 	}
 	utils.Logf("Got resource etags: lbEtag: %s; nsgEtag: %s, pipEtag: %s", lbEtag, nsgEtag, pipEtag)
 	return
@@ -1029,8 +1029,8 @@ func defaultPublicIPAddress(ipName string, isIPv6 bool) aznetwork.PublicIPAddres
 		}
 	}
 	pip := aznetwork.PublicIPAddress{
-		Name:     to.StringPtr(ipName),
-		Location: to.StringPtr(os.Getenv(utils.ClusterLocationEnv)),
+		Name:     pointer.String(ipName),
+		Location: pointer.String(os.Getenv(utils.ClusterLocationEnv)),
 		Sku: &aznetwork.PublicIPAddressSku{
 			Name: skuName,
 		},
@@ -1052,13 +1052,13 @@ func defaultPublicIPPrefix(name string, isIPv6 bool) aznetwork.PublicIPPrefix {
 		prefixLen = 124
 	}
 	return aznetwork.PublicIPPrefix{
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr(os.Getenv(utils.ClusterLocationEnv)),
+		Name:     pointer.String(name),
+		Location: pointer.String(os.Getenv(utils.ClusterLocationEnv)),
 		Sku: &aznetwork.PublicIPPrefixSku{
 			Name: aznetwork.PublicIPPrefixSkuNameStandard,
 		},
 		PublicIPPrefixPropertiesFormat: &aznetwork.PublicIPPrefixPropertiesFormat{
-			PrefixLength:           to.Int32Ptr(prefixLen),
+			PrefixLength:           pointer.Int32(prefixLen),
 			PublicIPAddressVersion: pipAddrVersion,
 		},
 	}

--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
@@ -142,13 +142,13 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 	It("should support service annotation 'service.beta.kubernetes.io/azure-pls-ip-configuration-subnet'", func() {
 		subnetName := "pls-subnet"
 		subnet, isNew := createNewSubnet(tc, subnetName)
-		Expect(to.String(subnet.Name)).To(Equal(subnetName))
+		Expect(pointer.StringDeref(subnet.Name, "")).To(Equal(subnetName))
 		if isNew {
 			defer func() {
 				utils.Logf("cleaning up test subnet %s", subnetName)
 				vNet, err := tc.GetClusterVirtualNetwork()
 				Expect(err).NotTo(HaveOccurred())
-				err = tc.DeleteSubnet(to.String(vNet.Name), subnetName)
+				err = tc.DeleteSubnet(pointer.StringDeref(vNet.Name, ""), subnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}()
 		}

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -39,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
@@ -184,8 +184,8 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
-		pipName := to.String(pip.Name)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
+		pipName := pointer.StringDeref(pip.Name, "")
 		utils.Logf("PIP %q to %q", pipName, targetIP)
 
 		By("Create a Service which will be deleted with the PIP")
@@ -386,7 +386,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 		By("creating a test resource group")
 		rg, cleanup := utils.CreateTestResourceGroup(tc)
-		defer cleanup(to.String(rg.Name))
+		defer cleanup(pointer.StringDeref(rg.Name, ""))
 
 		By("creating test PIP in the test resource group")
 		testPIPName := "testPIP-" + string(uuid.NewUUID())[0:4]
@@ -401,7 +401,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}()
 
 		annotation := map[string]string{
-			consts.ServiceAnnotationLoadBalancerResourceGroup: to.String(rg.Name),
+			consts.ServiceAnnotationLoadBalancerResourceGroup: pointer.StringDeref(rg.Name, ""),
 		}
 		By("Creating service " + serviceName + " in namespace " + ns.Name)
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
@@ -412,7 +412,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		//wait and get service's public IP Address
 		By("Waiting service to expose...")
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, to.String(pip.IPAddress))
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip.IPAddress, ""))
 		Expect(err).NotTo(HaveOccurred())
 
 		lb := getAzureLoadBalancerFromPIP(tc, *pip.IPAddress, *rg.Name, "")
@@ -425,7 +425,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		pip := defaultPublicIPAddress(ipName, tc.IPFamily == utils.IPv6)
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), pip)
 		Expect(err).NotTo(HaveOccurred())
-		additionalPIP := to.String(pip.IPAddress)
+		additionalPIP := pointer.StringDeref(pip.IPAddress, "")
 		utils.Logf("created pip with address %s", additionalPIP)
 
 		By("Exposing service with additional pip")
@@ -497,17 +497,17 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		By("Checking tags on the corresponding public IP")
 		expectedTags := map[string]*string{
-			"a": to.StringPtr("b"),
-			"c": to.StringPtr("d"),
-			"e": to.StringPtr(""),
+			"a": pointer.String("b"),
+			"c": pointer.String("d"),
+			"e": pointer.String(""),
 		}
 		pips, err := tc.ListPublicIPs(tc.GetResourceGroup())
 		Expect(err).NotTo(HaveOccurred())
 		var targetPIP network.PublicIPAddress
 		for _, pip := range pips {
-			if strings.EqualFold(to.String(pip.IPAddress), ip) {
+			if strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), ip) {
 				targetPIP = pip
-				err := waitComparePIPTags(tc, expectedTags, to.String(pip.Name))
+				err := waitComparePIPTags(tc, expectedTags, pointer.StringDeref(pip.Name, ""))
 				Expect(err).NotTo(HaveOccurred())
 				break
 			}
@@ -522,12 +522,12 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		expectedTags = map[string]*string{
-			"a": to.StringPtr("c"),
-			"c": to.StringPtr("d"),
-			"e": to.StringPtr(""),
-			"x": to.StringPtr("y"),
+			"a": pointer.String("c"),
+			"c": pointer.String("d"),
+			"e": pointer.String(""),
+			"x": pointer.String("y"),
 		}
-		err = waitComparePIPTags(tc, expectedTags, to.String(targetPIP.Name))
+		err = waitComparePIPTags(tc, expectedTags, pointer.StringDeref(targetPIP.Name, ""))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -566,7 +566,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		By("Waiting for the service to expose")
 		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ip).To(Equal(to.String(pip1.IPAddress)))
+		Expect(ip).To(Equal(pointer.StringDeref(pip1.IPAddress, "")))
 
 		By("Updating the service to refer to the second service")
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
@@ -576,7 +576,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for service IP to be updated")
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, to.String(pip2.IPAddress))
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip2.IPAddress, ""))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -607,7 +607,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		By("Creating a service referring to the prefix")
 		{
 			annotation := map[string]string{
-				consts.ServiceAnnotationPIPPrefixID: to.String(prefix1.ID),
+				consts.ServiceAnnotationPIPPrefixID: pointer.StringDeref(prefix1.ID, ""),
 			}
 			service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
 			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
@@ -629,14 +629,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 			Expect(pip.IPAddress).NotTo(BeNil())
 			Expect(pip.PublicIPPrefix.ID).To(Equal(prefix1.ID))
-			Expect(ip).To(Equal(to.String(pip.IPAddress)))
+			Expect(ip).To(Equal(pointer.StringDeref(pip.IPAddress, "")))
 		}
 
 		By("Updating the service to refer to the second prefix")
 		{
 			service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			service.Annotations[consts.ServiceAnnotationPIPPrefixID] = to.String(prefix2.ID)
+			service.Annotations[consts.ServiceAnnotationPIPPrefixID] = pointer.StringDeref(prefix2.ID, "")
 			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -652,7 +652,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			Expect(pip.IPAddress).NotTo(BeNil())
 			Expect(pip.PublicIPPrefix.ID).To(Equal(prefix2.ID))
 
-			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, to.String(pip.IPAddress))
+			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip.IPAddress, ""))
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -801,7 +801,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			err = utils.DeletePIPWithRetry(tc, pipName, rg)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		pipAddr := to.String(pip.IPAddress)
+		pipAddr := pointer.StringDeref(pip.IPAddress, "")
 		utils.Logf("Created pip with address %s", pipAddr)
 
 		annotation := map[string]string{}
@@ -925,7 +925,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 		"app": serviceName,
 	}
 	ports := []v1.ServicePort{{
-		AppProtocol: to.StringPtr("Tcp"),
+		AppProtocol: pointer.String("Tcp"),
 		Port:        serverPort,
 		Name:        "port1",
 		TargetPort:  intstr.FromInt(serverPort),
@@ -933,7 +933,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 		Port:        serverPort + 1,
 		Name:        "port2",
 		TargetPort:  intstr.FromInt(serverPort),
-		AppProtocol: to.StringPtr("Tcp"),
+		AppProtocol: pointer.String("Tcp"),
 	},
 	}
 

--- a/tests/e2e/utils/azure_auth.go
+++ b/tests/e2e/utils/azure_auth.go
@@ -24,10 +24,10 @@ import (
 	azauth "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 )
 
 // Environmental variables for validating Azure resource status.
@@ -116,8 +116,8 @@ func (tc *AzureTestClient) assignRoleByID(scope, roleDefinitionID string) (resul
 		string(uuid.NewUUID()),
 		azauth.RoleAssignmentCreateParameters{
 			Properties: &azauth.RoleAssignmentProperties{
-				PrincipalID:      to.StringPtr(authconfig.AADClientID),
-				RoleDefinitionID: to.StringPtr(roleDefinitionID),
+				PrincipalID:      pointer.String(authconfig.AADClientID),
+				RoleDefinitionID: pointer.String(roleDefinitionID),
 			},
 		})
 }

--- a/tests/e2e/utils/container_registry_utils.go
+++ b/tests/e2e/utils/container_registry_utils.go
@@ -22,9 +22,9 @@ import (
 	"os/exec"
 
 	acr "github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/pointer"
 )
 
 // CreateContainerRegistry creates a test acr
@@ -37,8 +37,8 @@ func (tc *AzureTestClient) CreateContainerRegistry() (registry acr.Registry, err
 			Name: "Basic",
 			Tier: "SkuTierBasic",
 		},
-		Name:     to.StringPtr(acrName),
-		Location: to.StringPtr(location),
+		Name:     pointer.String(acrName),
+		Location: pointer.String(location),
 	}
 
 	Logf("Creating acr %s in resource group %s.", acrName, rgName)

--- a/tests/e2e/utils/resource_group_utils.go
+++ b/tests/e2e/utils/resource_group_utils.go
@@ -21,17 +21,17 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/pointer"
 )
 
 // CreateTestResourceGroup create a test rg
 func CreateTestResourceGroup(tc *AzureTestClient) (*resources.Group, func(string)) {
 	gc := tc.createResourceGroupClient()
-	rgName := to.StringPtr("e2e-" + string(uuid.NewUUID())[0:4])
+	rgName := pointer.String("e2e-" + string(uuid.NewUUID())[0:4])
 	rg, err := gc.CreateOrUpdate(context.Background(), *rgName, createTestTemplate(tc, rgName))
 	Expect(err).NotTo(HaveOccurred())
 	By(fmt.Sprintf("resource group %s created", *rgName))
@@ -59,6 +59,6 @@ func WaitForDeleteResourceGroupCompletion(gc *resources.GroupsClient, future res
 func createTestTemplate(tc *AzureTestClient, name *string) resources.Group {
 	return resources.Group{
 		Name:     name,
-		Location: to.StringPtr(tc.location),
+		Location: pointer.String(tc.location),
 	}
 }

--- a/tests/e2e/utils/route_table_utils.go
+++ b/tests/e2e/utils/route_table_utils.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/utils/pointer"
 
 	providerazure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
@@ -47,7 +47,7 @@ func GetNodesInRouteTable(routeTable aznetwork.RouteTable) (map[string]interface
 
 	routeSet := make(map[string]interface{})
 	for _, route := range *routeTable.Routes {
-		routeSet[string(providerazure.MapRouteNameToNodeName(true, to.String(route.Name)))] = true
+		routeSet[string(providerazure.MapRouteNameToNodeName(true, pointer.StringDeref(route.Name, "")))] = true
 	}
 
 	return routeSet, nil

--- a/tests/e2e/utils/vmss_utils.go
+++ b/tests/e2e/utils/vmss_utils.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 
 	azcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
 )
 
 var (
@@ -76,7 +76,7 @@ func ScaleVMSS(tc *AzureTestClient, vmssName string, instanceCount int64) (err e
 		Location: vmss.Location,
 		Sku: &azcompute.Sku{
 			Name:     vmss.Sku.Name,
-			Capacity: to.Int64Ptr(instanceCount),
+			Capacity: pointer.Int64(instanceCount),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Use k8s utils pointer instead of Azure autorest/to

- to.FooPtr becomes pointer.Foo
- to.Foo becomes pointer.FooDeref with an appropriate default
- to.StringSlicePtr becomes &

to.StringMap and to.StringSlice has no functions in k8s utils so we add them as common function

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is related to https://github.com/kubernetes/kubernetes/issues/112431 (but doesn’t fix it).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
