### PR TITLE
fix: race condition in lockMap

### DIFF
--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -56,12 +56,13 @@ func newLockMap() *lockMap {
 func (lm *lockMap) LockEntry(entry string) {
 	lm.Lock()
 	// check if entry does not exists, then add entry
-	if _, exists := lm.mutexMap[entry]; !exists {
-		lm.addEntry(entry)
+	mutex, exists := lm.mutexMap[entry]
+	if !exists {
+		mutex = &sync.Mutex{}
+		lm.mutexMap[entry] = mutex
 	}
-
 	lm.Unlock()
-	lm.lockEntry(entry)
+	mutex.Lock()
 }
 
 // UnlockEntry release the lock associated with the specific entry
@@ -69,22 +70,11 @@ func (lm *lockMap) UnlockEntry(entry string) {
 	lm.Lock()
 	defer lm.Unlock()
 
-	if _, exists := lm.mutexMap[entry]; !exists {
+	mutex, exists := lm.mutexMap[entry]
+	if !exists {
 		return
 	}
-	lm.unlockEntry(entry)
-}
-
-func (lm *lockMap) addEntry(entry string) {
-	lm.mutexMap[entry] = &sync.Mutex{}
-}
-
-func (lm *lockMap) lockEntry(entry string) {
-	lm.mutexMap[entry].Lock()
-}
-
-func (lm *lockMap) unlockEntry(entry string) {
-	lm.mutexMap[entry].Unlock()
+	mutex.Unlock()
 }
 
 func getContextWithCancel() (context.Context, context.CancelFunc) {

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -2598,6 +2598,13 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 	}
 }
 
+func TestEnsureBackendPoolDeletedConcurrentlyLoop(t *testing.T) {
+	// run TestEnsureBackendPoolDeletedConcurrently 20 times to detect race conditions
+	for i := 0; i < 20; i++ {
+		TestEnsureBackendPoolDeletedConcurrently(t)
+	}
+}
+
 func TestEnsureBackendPoolDeletedConcurrently(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: race condition in lockMap

`lm.Lock()` is intended for locking `lm.mutexMap`, while original logic in `LockEntry` does not lock `lm.mutexMap` well, in `lm.lockEntry(entry)`, it's still accessing `lm.mutexMap` outside of `lm.Lock()`  ... ``lm.Unlock()``

This PR removes `addEntry` func invoke, make `lm.mutexMap` access inside of `lm.Lock()`  ... ``lm.Unlock()``, and then lock ougside.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
 - original race condition logs in unit test with `go test -race`:
```
=== RUN   TestEnsureBackendPoolDeletedConcurrently
W1221 07:57:03.975735   26563 azure_vmssflex_cache.go:59] failed to get the ID of VMSS Flex
W1221 07:57:03.975783   26563 azure_vmssflex_cache.go:59] failed to get the ID of VMSS Flex
==================
WARNING: DATA RACE
Write at 0x00c000596510 by goroutine 719:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*lockMap).addEntry()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_utils.go:79 +0xca
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*lockMap).LockEntry()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_utils.go:60 +0x7a
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*ScaleSet).DeleteCacheForNode()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss_cache.go:279 +0x412
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*ScaleSet).ensureBackendPoolDeleted.func2()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss.go:1926 +0x4c
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*ScaleSet).EnsureBackendPoolDeleted()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss.go:2034 +0x2e9
  sigs.k8s.io/cloud-provider-azure/pkg/provider.TestEnsureBackendPoolDeletedConcurrently.func1()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss_test.go:2717 +0x164
  k8s.io/apimachinery/pkg/util/errors.AggregateGoroutines.func1()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/errors/errors.go:237 +0x35
  k8s.io/apimachinery/pkg/util/errors.AggregateGoroutines.func2()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/errors/errors.go:237 +0x47

Previous read at 0x00c000596510 by goroutine 718:
  runtime.mapaccess1_faststr()
      /usr/local/go/src/runtime/map_faststr.go:13 +0x0
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*lockMap).lockEntry()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_utils.go:83 +0x138
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*lockMap).LockEntry()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_utils.go:64 +0x10f
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*ScaleSet).getVMManagementTypeByNodeName()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss_cache.go:390 +0x127
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*ScaleSet).DeleteCacheForNode()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss_cache.go:257 +0x78
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*ScaleSet).ensureBackendPoolDeleted.func2()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss.go:1926 +0x4c
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  sigs.k8s.io/cloud-provider-azure/pkg/provider.(*ScaleSet).EnsureBackendPoolDeleted()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss.go:2034 +0x2e9
  sigs.k8s.io/cloud-provider-azure/pkg/provider.TestEnsureBackendPoolDeletedConcurrently.func1()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss_test.go:2717 +0x164
  k8s.io/apimachinery/pkg/util/errors.AggregateGoroutines.func1()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/errors/errors.go:237 +0x35
  k8s.io/apimachinery/pkg/util/errors.AggregateGoroutines.func2()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/errors/errors.go:237 +0x47

Goroutine 719 (running) created at:
  k8s.io/apimachinery/pkg/util/errors.AggregateGoroutines()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/errors/errors.go:237 +0x69
  sigs.k8s.io/cloud-provider-azure/pkg/provider.TestEnsureBackendPoolDeletedConcurrently()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss_test.go:2721 +0x2bb9
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 718 (running) created at:
  k8s.io/apimachinery/pkg/util/errors.AggregateGoroutines()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/apimachinery/pkg/util/errors/errors.go:237 +0x69
  sigs.k8s.io/cloud-provider-azure/pkg/provider.TestEnsureBackendPoolDeletedConcurrently()
      /home/prow/go/src/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_vmss_test.go:2721 +0x2bb9
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
    testing.go:1319: race detected during execution of test
--- FAIL: TestEnsureBackendPoolDeletedConcurrently (0.01s)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: race condition in lockMap
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: race condition in lockMap
```
