### PR TITLE
Set --skip-nodes-with-system-pods to false when running autoscaling tests

### DIFF
--- a/.pipelines/scripts/run-e2e.sh
+++ b/.pipelines/scripts/run-e2e.sh
@@ -80,7 +80,11 @@ if [[ -z "${CLUSTER_CONFIG_PATH:-}" ]]; then
   fi
 fi
 
-CUSTOM_CONFIG_PATH="${CUSTOM_CONFIG_PATH:-${REPO_ROOT}/.pipelines/templates/customconfiguration.json}"
+if [[ "${CLUSTER_TYPE:-}" =~ "autoscaling" ]]; then
+  CUSTOM_CONFIG_PATH="${CUSTOM_CONFIG_PATH:-${REPO_ROOT}/.pipelines/templates/customconfiguration-autoscaling.json}"
+else
+  CUSTOM_CONFIG_PATH="${CUSTOM_CONFIG_PATH:-${REPO_ROOT}/.pipelines/templates/customconfiguration.json}"
+fi
 
 rm -rf kubetest2-aks
 git clone https://github.com/kubernetes-sigs/cloud-provider-azure.git

--- a/.pipelines/templates/customconfiguration-autoscaling.json
+++ b/.pipelines/templates/customconfiguration-autoscaling.json
@@ -1,0 +1,25 @@
+{
+  "kubernetesConfigurations": {
+    "kube-cloud-controller-manager": {
+      "image": "{CUSTOM_CCM_IMAGE}",
+      "config": {
+          "--min-resync-period": "10h0m0s",
+          "--profiling": "false",
+          "--v": "6"
+      }
+    },
+    "kube-cloud-node-manager": {
+      "image": "{CUSTOM_CNM_IMAGE}",
+      "config": {
+          "--node-name": "$(NODE_NAME)",
+          "kube-api-burst": "50",
+          "kube-api-qps": "50"
+      }
+    },
+    "cluster-autoscaler": {
+      "config": {
+        "--skip-nodes-with-system-pods": "false"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Set --skip-nodes-with-system-pods to false when running autoscaling tests
Currently without this option (default: true), it is possible that some deployments like metrics-server will be allocated to the new Node. In this case, when scaling down, no Nodes can be deleted.
https://github.com/Azure/AKS/issues/875#issuecomment-475486313
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
