### PR TITLE
fix: add more account search options

### DIFF
--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -54,7 +54,7 @@ type AccountOptions struct {
 	CreatePrivateEndpoint                   bool
 	StorageType                             StorageType
 	StorageEndpointSuffix                   string
-	DisableFileServiceDeleteRetentionPolicy bool
+	DisableFileServiceDeleteRetentionPolicy *bool
 	EnableLargeFileShare                    *bool
 	IsHnsEnabled                            *bool
 	EnableNfsV3                             *bool
@@ -104,6 +104,8 @@ func (az *Cloud) getStorageAccounts(ctx context.Context, accountOptions *Account
 				isRequireInfrastructureEncryptionEqual(acct, accountOptions) &&
 				isAllowSharedKeyAccessEqual(acct, accountOptions) &&
 				isAccessTierEqual(acct, accountOptions) &&
+				az.isMultichannelEnabledEqual(ctx, acct, accountOptions) &&
+				az.isDisableFileServiceDeleteRetentionPolicyEqual(ctx, acct, accountOptions) &&
 				isPrivateEndpointAsExpected(acct, accountOptions)) {
 				continue
 			}
@@ -353,7 +355,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 			return "", "", fmt.Errorf("failed to create storage account %s, error: %v", accountName, rerr)
 		}
 
-		if accountOptions.DisableFileServiceDeleteRetentionPolicy || pointer.BoolDeref(accountOptions.IsMultichannelEnabled, false) {
+		if accountOptions.DisableFileServiceDeleteRetentionPolicy != nil || accountOptions.IsMultichannelEnabled != nil {
 			prop, err := az.FileClient.WithSubscriptionID(subsID).GetServiceProperties(ctx, resourceGroup, accountName)
 			if err != nil {
 				return "", "", err
@@ -363,13 +365,16 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 			}
 			prop.FileServicePropertiesProperties.ProtocolSettings = nil
 			prop.FileServicePropertiesProperties.Cors = nil
-			if accountOptions.DisableFileServiceDeleteRetentionPolicy {
-				klog.V(2).Infof("disable FileServiceDeleteRetentionPolicy on account(%s), subscription(%s), resource group(%s)", accountName, subsID, resourceGroup)
-				prop.FileServicePropertiesProperties.ShareDeleteRetentionPolicy = &storage.DeleteRetentionPolicy{Enabled: pointer.Bool(false)}
+			if accountOptions.DisableFileServiceDeleteRetentionPolicy != nil {
+				enable := !*accountOptions.DisableFileServiceDeleteRetentionPolicy
+				klog.V(2).Infof("set ShareDeleteRetentionPolicy(%v) on account(%s), subscription(%s), resource group(%s)",
+					enable, accountName, subsID, resourceGroup)
+				prop.FileServicePropertiesProperties.ShareDeleteRetentionPolicy = &storage.DeleteRetentionPolicy{Enabled: &enable}
 			}
-			if pointer.BoolDeref(accountOptions.IsMultichannelEnabled, false) {
+			if accountOptions.IsMultichannelEnabled != nil {
 				klog.V(2).Infof("enable SMB Multichannel setting on account(%s), subscription(%s), resource group(%s)", accountName, subsID, resourceGroup)
-				prop.FileServicePropertiesProperties.ProtocolSettings = &storage.ProtocolSettings{Smb: &storage.SmbSetting{Multichannel: &storage.Multichannel{Enabled: pointer.Bool(true)}}}
+				enabled := *accountOptions.IsMultichannelEnabled
+				prop.FileServicePropertiesProperties.ProtocolSettings = &storage.ProtocolSettings{Smb: &storage.SmbSetting{Multichannel: &storage.Multichannel{Enabled: &enabled}}}
 			}
 			if _, err := az.FileClient.WithSubscriptionID(subsID).SetServiceProperties(ctx, resourceGroup, accountName, prop); err != nil {
 				return "", "", err
@@ -640,14 +645,14 @@ func isHnsPropertyEqual(account storage.Account, accountOptions *AccountOptions)
 	if accountOptions.IsHnsEnabled == nil {
 		return true
 	}
-	return pointer.BoolDeref(account.IsHnsEnabled, false) == pointer.BoolDeref(accountOptions.IsHnsEnabled, false)
+	return *accountOptions.IsHnsEnabled == pointer.BoolDeref(account.IsHnsEnabled, false)
 }
 
 func isEnableNfsV3PropertyEqual(account storage.Account, accountOptions *AccountOptions) bool {
 	if accountOptions.EnableNfsV3 == nil {
 		return true
 	}
-	return pointer.BoolDeref(account.EnableNfsV3, false) == pointer.BoolDeref(accountOptions.EnableNfsV3, false)
+	return *accountOptions.EnableNfsV3 == pointer.BoolDeref(account.EnableNfsV3, false)
 }
 
 func isPrivateEndpointAsExpected(account storage.Account, accountOptions *AccountOptions) bool {
@@ -664,24 +669,24 @@ func isAllowBlobPublicAccessEqual(account storage.Account, accountOptions *Accou
 	if accountOptions.AllowBlobPublicAccess == nil {
 		return true
 	}
-	return pointer.BoolDeref(account.AllowBlobPublicAccess, false) == pointer.BoolDeref(accountOptions.AllowBlobPublicAccess, false)
+	return *accountOptions.AllowBlobPublicAccess == pointer.BoolDeref(account.AllowBlobPublicAccess, false)
 }
 
 func isRequireInfrastructureEncryptionEqual(account storage.Account, accountOptions *AccountOptions) bool {
 	if accountOptions.RequireInfrastructureEncryption == nil {
 		return true
 	}
-	if *accountOptions.RequireInfrastructureEncryption {
-		return account.Encryption != nil && pointer.BoolDeref(account.Encryption.RequireInfrastructureEncryption, false)
+	if account.Encryption == nil {
+		return !*accountOptions.RequireInfrastructureEncryption
 	}
-	return account.Encryption == nil || !pointer.BoolDeref(account.Encryption.RequireInfrastructureEncryption, false)
+	return *accountOptions.RequireInfrastructureEncryption == pointer.BoolDeref(account.Encryption.RequireInfrastructureEncryption, false)
 }
 
 func isAllowSharedKeyAccessEqual(account storage.Account, accountOptions *AccountOptions) bool {
 	if accountOptions.AllowSharedKeyAccess == nil {
 		return true
 	}
-	return pointer.BoolDeref(account.AllowSharedKeyAccess, false) == pointer.BoolDeref(accountOptions.AllowSharedKeyAccess, false)
+	return *accountOptions.AllowSharedKeyAccess == pointer.BoolDeref(account.AllowSharedKeyAccess, false)
 }
 
 func isAccessTierEqual(account storage.Account, accountOptions *AccountOptions) bool {
@@ -689,4 +694,56 @@ func isAccessTierEqual(account storage.Account, accountOptions *AccountOptions) 
 		return true
 	}
 	return accountOptions.AccessTier == string(account.AccessTier)
+}
+
+func (az *Cloud) isMultichannelEnabledEqual(ctx context.Context, account storage.Account, accountOptions *AccountOptions) bool {
+	if accountOptions.IsMultichannelEnabled == nil {
+		return true
+	}
+
+	if account.Name == nil {
+		klog.Warningf("account.Name under resource group(%s) is nil", accountOptions.ResourceGroup)
+		return false
+	}
+
+	prop, err := az.FileClient.WithSubscriptionID(accountOptions.SubscriptionID).GetServiceProperties(ctx, accountOptions.ResourceGroup, *account.Name)
+	if err != nil {
+		klog.Warningf("GetServiceProperties(%s) under resource group(%s) failed with %v", *account.Name, accountOptions.ResourceGroup, err)
+		return false
+	}
+
+	if prop.FileServicePropertiesProperties == nil ||
+		prop.FileServicePropertiesProperties.ProtocolSettings == nil ||
+		prop.FileServicePropertiesProperties.ProtocolSettings.Smb == nil ||
+		prop.FileServicePropertiesProperties.ProtocolSettings.Smb.Multichannel == nil {
+		return !*accountOptions.IsMultichannelEnabled
+	}
+
+	return *accountOptions.IsMultichannelEnabled == pointer.BoolDeref(prop.FileServicePropertiesProperties.ProtocolSettings.Smb.Multichannel.Enabled, false)
+}
+
+func (az *Cloud) isDisableFileServiceDeleteRetentionPolicyEqual(ctx context.Context, account storage.Account, accountOptions *AccountOptions) bool {
+	if accountOptions.DisableFileServiceDeleteRetentionPolicy == nil {
+		return true
+	}
+
+	if account.Name == nil {
+		klog.Warningf("account.Name under resource group(%s) is nil", accountOptions.ResourceGroup)
+		return false
+	}
+
+	prop, err := az.FileClient.WithSubscriptionID(accountOptions.SubscriptionID).GetServiceProperties(ctx, accountOptions.ResourceGroup, *account.Name)
+	if err != nil {
+		klog.Warningf("GetServiceProperties(%s) under resource group(%s) failed with %v", *account.Name, accountOptions.ResourceGroup, err)
+		return false
+	}
+
+	if prop.FileServicePropertiesProperties == nil ||
+		prop.FileServicePropertiesProperties.ShareDeleteRetentionPolicy == nil ||
+		prop.FileServicePropertiesProperties.ShareDeleteRetentionPolicy.Enabled == nil {
+		// by default, ShareDeleteRetentionPolicy.Enabled is true if it's nil
+		return !*accountOptions.DisableFileServiceDeleteRetentionPolicy
+	}
+
+	return *accountOptions.DisableFileServiceDeleteRetentionPolicy != *prop.FileServicePropertiesProperties.ShareDeleteRetentionPolicy.Enabled
 }

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/pointer"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/fileclient/mockfileclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatednsclient/mockprivatednsclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatednszonegroupclient/mockprivatednszonegroupclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privateendpointclient/mockprivateendpointclient"
@@ -566,7 +567,7 @@ func TestIsPrivateEndpointAsExpected(t *testing.T) {
 
 	for _, test := range tests {
 		result := isPrivateEndpointAsExpected(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -659,7 +660,7 @@ func TestIsTagsEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isTagsEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -722,7 +723,7 @@ func TestIsHnsPropertyEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isHnsPropertyEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -785,7 +786,7 @@ func TestIsEnableNfsV3PropertyEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isEnableNfsV3PropertyEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -848,7 +849,7 @@ func TestIsAllowBlobPublicAccessEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isAllowBlobPublicAccessEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -911,7 +912,7 @@ func TestIsAllowSharedKeyAccessEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isAllowSharedKeyAccessEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -1006,7 +1007,7 @@ func TestIsRequireInfrastructureEncryptionEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isRequireInfrastructureEncryptionEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -1069,7 +1070,7 @@ func TestIsLargeFileSharesPropertyEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isLargeFileSharesPropertyEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
 	}
 }
 
@@ -1134,6 +1135,299 @@ func TestIsAccessTierEqual(t *testing.T) {
 
 	for _, test := range tests {
 		result := isAccessTierEqual(test.account, test.accountOptions)
-		assert.Equal(t, result, test.expectedResult)
+		assert.Equal(t, test.expectedResult, result)
+	}
+}
+
+func TestIsMultichannelEnabledEqual(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
+	accountName := "account2"
+
+	cloud := GetTestCloud(ctrl)
+
+	multichannelEnabled := storage.FileServiceProperties{
+		FileServicePropertiesProperties: &storage.FileServicePropertiesProperties{
+			ProtocolSettings: &storage.ProtocolSettings{
+				Smb: &storage.SmbSetting{Multichannel: &storage.Multichannel{Enabled: pointer.BoolPtr(true)}},
+			},
+		},
+	}
+
+	multichannelDisabled := storage.FileServiceProperties{
+		FileServicePropertiesProperties: &storage.FileServicePropertiesProperties{
+			ProtocolSettings: &storage.ProtocolSettings{
+				Smb: &storage.SmbSetting{Multichannel: &storage.Multichannel{Enabled: pointer.BoolPtr(false)}},
+			},
+		},
+	}
+
+	incompleteServiceProperties := storage.FileServiceProperties{
+		FileServicePropertiesProperties: &storage.FileServicePropertiesProperties{
+			ProtocolSettings: &storage.ProtocolSettings{},
+		},
+	}
+
+	mockFileClient := mockfileclient.NewMockInterface(ctrl)
+	cloud.FileClient = mockFileClient
+	mockFileClient.EXPECT().WithSubscriptionID(gomock.Any()).Return(mockFileClient).AnyTimes()
+
+	tests := []struct {
+		desc                      string
+		account                   storage.Account
+		accountOptions            *AccountOptions
+		serviceProperties         *storage.FileServiceProperties
+		servicePropertiesRetError error
+		expectedResult            bool
+	}{
+		{
+			desc: "IsMultichannelEnabled is nil",
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			desc: "account.Name is nil",
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsMultichannelEnabled: pointer.Bool(false),
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "IsMultichannelEnabled not equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsMultichannelEnabled: pointer.Bool(false),
+			},
+			serviceProperties: &multichannelEnabled,
+			expectedResult:    false,
+		},
+		{
+			desc: "GetServiceProperties return error",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsMultichannelEnabled: pointer.Bool(false),
+			},
+			serviceProperties:         &multichannelEnabled,
+			servicePropertiesRetError: fmt.Errorf("GetServiceProperties return error"),
+			expectedResult:            false,
+		},
+		{
+			desc: "IsMultichannelEnabled not equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsMultichannelEnabled: pointer.Bool(true),
+			},
+			serviceProperties: &multichannelDisabled,
+			expectedResult:    false,
+		},
+		{
+			desc: "IsMultichannelEnabled is equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsMultichannelEnabled: pointer.Bool(true),
+			},
+			serviceProperties: &multichannelEnabled,
+			expectedResult:    true,
+		},
+		{
+			desc: "IsMultichannelEnabled is equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsMultichannelEnabled: pointer.Bool(false),
+			},
+			serviceProperties: &multichannelDisabled,
+			expectedResult:    true,
+		},
+		{
+			desc: "incompleteServiceProperties should be regarded as IsMultichannelDisabled",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsMultichannelEnabled: pointer.Bool(false),
+			},
+			serviceProperties: &incompleteServiceProperties,
+			expectedResult:    true,
+		},
+	}
+
+	for _, test := range tests {
+		if test.serviceProperties != nil {
+			mockFileClient.EXPECT().GetServiceProperties(gomock.Any(), gomock.Any(), gomock.Any()).Return(*test.serviceProperties, test.servicePropertiesRetError).Times(1)
+		}
+
+		result := cloud.isMultichannelEnabledEqual(ctx, test.account, test.accountOptions)
+		assert.Equal(t, test.expectedResult, result, test.desc)
+	}
+}
+
+func TestIsDisableFileServiceDeleteRetentionPolicyEqual(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
+	accountName := "account"
+	cloud := GetTestCloud(ctrl)
+
+	deleteRetentionPolicyEnabled := storage.FileServiceProperties{
+		FileServicePropertiesProperties: &storage.FileServicePropertiesProperties{
+			ShareDeleteRetentionPolicy: &storage.DeleteRetentionPolicy{
+				Enabled: pointer.BoolPtr(true),
+			},
+		},
+	}
+
+	deleteRetentionPolicyDisabled := storage.FileServiceProperties{
+		FileServicePropertiesProperties: &storage.FileServicePropertiesProperties{
+			ShareDeleteRetentionPolicy: &storage.DeleteRetentionPolicy{
+				Enabled: pointer.BoolPtr(false),
+			},
+		},
+	}
+
+	incompleteServiceProperties := storage.FileServiceProperties{
+		FileServicePropertiesProperties: &storage.FileServicePropertiesProperties{},
+	}
+
+	mockFileClient := mockfileclient.NewMockInterface(ctrl)
+	cloud.FileClient = mockFileClient
+	mockFileClient.EXPECT().WithSubscriptionID(gomock.Any()).Return(mockFileClient).AnyTimes()
+
+	tests := []struct {
+		desc                      string
+		account                   storage.Account
+		accountOptions            *AccountOptions
+		serviceProperties         *storage.FileServiceProperties
+		servicePropertiesRetError error
+		expectedResult            bool
+	}{
+		{
+			desc: "DisableFileServiceDeleteRetentionPolicy is nil",
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			desc: "account.Name is nil",
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				DisableFileServiceDeleteRetentionPolicy: pointer.Bool(false),
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "DisableFileServiceDeleteRetentionPolicy not equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				DisableFileServiceDeleteRetentionPolicy: pointer.Bool(true),
+			},
+			serviceProperties: &deleteRetentionPolicyEnabled,
+			expectedResult:    false,
+		},
+		{
+			desc: "GetServiceProperties return error",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				DisableFileServiceDeleteRetentionPolicy: pointer.Bool(false),
+			},
+			serviceProperties:         &deleteRetentionPolicyEnabled,
+			servicePropertiesRetError: fmt.Errorf("GetServiceProperties return error"),
+			expectedResult:            false,
+		},
+		{
+			desc: "DisableFileServiceDeleteRetentionPolicy not equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				DisableFileServiceDeleteRetentionPolicy: pointer.Bool(false),
+			},
+			serviceProperties: &deleteRetentionPolicyDisabled,
+			expectedResult:    false,
+		},
+		{
+			desc: "DisableFileServiceDeleteRetentionPolicy is equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				DisableFileServiceDeleteRetentionPolicy: pointer.Bool(true),
+			},
+			serviceProperties: &deleteRetentionPolicyDisabled,
+			expectedResult:    true,
+		},
+		{
+			desc: "DisableFileServiceDeleteRetentionPolicy is equal",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				DisableFileServiceDeleteRetentionPolicy: pointer.Bool(false),
+			},
+			serviceProperties: &deleteRetentionPolicyEnabled,
+			expectedResult:    true,
+		},
+		{
+			desc: "incompleteServiceProperties should be regarded as not DisableFileServiceDeleteRetentionPolicy",
+			account: storage.Account{
+				Name:              &accountName,
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				DisableFileServiceDeleteRetentionPolicy: pointer.Bool(false),
+			},
+			serviceProperties: &incompleteServiceProperties,
+			expectedResult:    true,
+		},
+	}
+
+	for _, test := range tests {
+		if test.serviceProperties != nil {
+			mockFileClient.EXPECT().GetServiceProperties(gomock.Any(), gomock.Any(), gomock.Any()).Return(*test.serviceProperties, test.servicePropertiesRetError).Times(1)
+		}
+
+		result := cloud.isDisableFileServiceDeleteRetentionPolicyEqual(ctx, test.account, test.accountOptions)
+		assert.Equal(t, test.expectedResult, result, test.desc)
 	}
 }

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -1009,3 +1009,131 @@ func TestIsRequireInfrastructureEncryptionEqual(t *testing.T) {
 		assert.Equal(t, result, test.expectedResult)
 	}
 }
+
+func TestIsLargeFileSharesPropertyEqual(t *testing.T) {
+	tests := []struct {
+		account        storage.Account
+		accountOptions *AccountOptions
+		expectedResult bool
+	}{
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{
+					LargeFileSharesState: storage.LargeFileSharesStateEnabled,
+				},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				EnableLargeFileShare: pointer.Bool(false),
+			},
+			expectedResult: true,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{
+					LargeFileSharesState: storage.LargeFileSharesStateEnabled,
+				},
+			},
+			accountOptions: &AccountOptions{
+				EnableLargeFileShare: pointer.Bool(true),
+			},
+			expectedResult: true,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				EnableLargeFileShare: pointer.Bool(true),
+			},
+			expectedResult: false,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{
+					LargeFileSharesState: storage.LargeFileSharesStateEnabled,
+				},
+			},
+			accountOptions: &AccountOptions{
+				EnableLargeFileShare: pointer.Bool(false),
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := isLargeFileSharesPropertyEqual(test.account, test.accountOptions)
+		assert.Equal(t, result, test.expectedResult)
+	}
+}
+
+func TestIsAccessTierEqual(t *testing.T) {
+	tests := []struct {
+		account        storage.Account
+		accountOptions *AccountOptions
+		expectedResult bool
+	}{
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{
+					AccessTier: storage.AccessTierCool,
+				},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{
+					AccessTier: storage.AccessTierHot,
+				},
+			},
+			accountOptions: &AccountOptions{
+				AccessTier: "Hot",
+			},
+			expectedResult: true,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{
+					AccessTier: storage.AccessTierPremium,
+				},
+			},
+			accountOptions: &AccountOptions{
+				AccessTier: "Premium",
+			},
+			expectedResult: true,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				AccessTier: "Hot",
+			},
+			expectedResult: false,
+		},
+		{
+			account: storage.Account{
+				AccountProperties: &storage.AccountProperties{
+					AccessTier: storage.AccessTierPremium,
+				},
+			},
+			accountOptions: &AccountOptions{
+				AccessTier: "Hot",
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := isAccessTierEqual(test.account, test.accountOptions)
+		assert.Equal(t, result, test.expectedResult)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: add more account search options
a proceeding fix of https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3082

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: add more account search options
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: add more account search options
```
