### PR TITLE
fix: skip removing nics from lb if there will be no nics in the backe…

### DIFF
--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -180,7 +180,7 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 				}
 			}
 
-			var backendIPConfigurationsToBeDeleted []network.InterfaceIPConfiguration
+			var backendIPConfigurationsToBeDeleted, bipConfigNotFound, bipConfigExclude []network.InterfaceIPConfiguration
 			if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
 				for _, ipConf := range *bp.BackendIPConfigurations {
 					ipConfID := pointer.StringDeref(ipConf.ID, "")
@@ -188,7 +188,7 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 					if err != nil {
 						if errors.Is(err, cloudprovider.InstanceNotFound) {
 							klog.V(2).Infof("bc.ReconcileBackendPools for service (%s): vm not found for ipConfID %s", serviceName, ipConfID)
-							backendIPConfigurationsToBeDeleted = append(backendIPConfigurationsToBeDeleted, ipConf)
+							bipConfigNotFound = append(bipConfigNotFound, ipConf)
 						} else {
 							return false, false, err
 						}
@@ -206,10 +206,11 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 					if shouldExcludeLoadBalancer {
 						klog.V(2).Infof("bc.ReconcileBackendPools for service (%s): lb backendpool - found unwanted node %s, decouple it from the LB %s", serviceName, nodeName, lbName)
 						// construct a backendPool that only contains the IP config of the node to be deleted
-						backendIPConfigurationsToBeDeleted = append(backendIPConfigurationsToBeDeleted, network.InterfaceIPConfiguration{ID: pointer.String(ipConfID)})
+						bipConfigExclude = append(bipConfigExclude, network.InterfaceIPConfiguration{ID: pointer.String(ipConfID)})
 					}
 				}
 			}
+			backendIPConfigurationsToBeDeleted = getBackendIPConfigurationsToBeDeleted(bp, bipConfigNotFound, bipConfigExclude)
 			if len(backendIPConfigurationsToBeDeleted) > 0 {
 				backendpoolToBeDeleted := &[]network.BackendAddressPool{
 					{
@@ -247,6 +248,47 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 	}
 
 	return isBackendPoolPreConfigured, changed, err
+}
+
+func getBackendIPConfigurationsToBeDeleted(
+	bp network.BackendAddressPool,
+	bipConfigNotFound, bipConfigExclude []network.InterfaceIPConfiguration,
+) []network.InterfaceIPConfiguration {
+	if bp.BackendAddressPoolPropertiesFormat == nil || bp.BackendIPConfigurations == nil {
+		return []network.InterfaceIPConfiguration{}
+	}
+
+	bipConfigNotFoundIDSet := sets.NewString()
+	bipConfigExcludeIDSet := sets.NewString()
+	for _, ipConfig := range bipConfigNotFound {
+		bipConfigNotFoundIDSet.Insert(pointer.StringDeref(ipConfig.ID, ""))
+	}
+	for _, ipConfig := range bipConfigExclude {
+		bipConfigExcludeIDSet.Insert(pointer.StringDeref(ipConfig.ID, ""))
+	}
+
+	var bipConfigToBeDeleted []network.InterfaceIPConfiguration
+	ipConfigs := *bp.BackendIPConfigurations
+	for i := len(ipConfigs) - 1; i >= 0; i-- {
+		ipConfigID := pointer.StringDeref(ipConfigs[i].ID, "")
+		if bipConfigNotFoundIDSet.Has(ipConfigID) {
+			bipConfigToBeDeleted = append(bipConfigToBeDeleted, ipConfigs[i])
+			ipConfigs = append(ipConfigs[:i], ipConfigs[i+1:]...)
+		}
+	}
+
+	var unwantedIPConfigs []network.InterfaceIPConfiguration
+	for _, ipConfig := range ipConfigs {
+		ipConfigID := pointer.StringDeref(ipConfig.ID, "")
+		if bipConfigExcludeIDSet.Has(ipConfigID) {
+			unwantedIPConfigs = append(unwantedIPConfigs, ipConfig)
+		}
+	}
+	if len(unwantedIPConfigs) == len(ipConfigs) {
+		klog.V(2).Info("getBackendIPConfigurationsToBeDeleted: the pool is empty or will be empty after removing the unwanted IP addresses, skipping the removal")
+		return bipConfigToBeDeleted
+	}
+	return append(bipConfigToBeDeleted, unwantedIPConfigs...)
 }
 
 func (bc *backendPoolTypeNodeIPConfig) GetBackendPrivateIPs(clusterName string, service *v1.Service, lb *network.LoadBalancer) ([]string, []string) {
@@ -574,22 +616,38 @@ func newBackendPool(lb *network.LoadBalancer, isBackendPoolPreConfigured bool, p
 func removeNodeIPAddressesFromBackendPool(backendPool network.BackendAddressPool, nodeIPAddresses []string, removeAll bool) bool {
 	changed := false
 	nodeIPsSet := sets.NewString(nodeIPAddresses...)
-	if backendPool.BackendAddressPoolPropertiesFormat != nil &&
-		backendPool.LoadBalancerBackendAddresses != nil {
-		for i := len(*backendPool.LoadBalancerBackendAddresses) - 1; i >= 0; i-- {
-			if (*backendPool.LoadBalancerBackendAddresses)[i].LoadBalancerBackendAddressPropertiesFormat != nil {
-				ipAddress := pointer.StringDeref((*backendPool.LoadBalancerBackendAddresses)[i].IPAddress, "")
-				if ipAddress == "" {
-					klog.V(4).Infof("removeNodeIPAddressFromBackendPool: LoadBalancerBackendAddress %s is not IP-based, skipping", pointer.StringDeref((*backendPool.LoadBalancerBackendAddresses)[i].Name, ""))
-					continue
-				}
-				if removeAll || nodeIPsSet.Has(ipAddress) {
-					klog.V(4).Infof("removeNodeIPAddressFromBackendPool: removing %s from the backend pool %s", ipAddress, pointer.StringDeref(backendPool.Name, ""))
-					*backendPool.LoadBalancerBackendAddresses = append((*backendPool.LoadBalancerBackendAddresses)[:i], (*backendPool.LoadBalancerBackendAddresses)[i+1:]...)
-					changed = true
-				}
+
+	if backendPool.BackendAddressPoolPropertiesFormat == nil ||
+		backendPool.LoadBalancerBackendAddresses == nil {
+		return false
+	}
+
+	addresses := *backendPool.LoadBalancerBackendAddresses
+	for i := len(addresses) - 1; i >= 0; i-- {
+		if addresses[i].LoadBalancerBackendAddressPropertiesFormat != nil {
+			ipAddress := pointer.StringDeref((*backendPool.LoadBalancerBackendAddresses)[i].IPAddress, "")
+			if ipAddress == "" {
+				klog.V(4).Infof("removeNodeIPAddressFromBackendPool: LoadBalancerBackendAddress %s is not IP-based, skipping", pointer.StringDeref(addresses[i].Name, ""))
+				continue
+			}
+			if removeAll || nodeIPsSet.Has(ipAddress) {
+				klog.V(4).Infof("removeNodeIPAddressFromBackendPool: removing %s from the backend pool %s", ipAddress, pointer.StringDeref(backendPool.Name, ""))
+				addresses = append(addresses[:i], addresses[i+1:]...)
+				changed = true
 			}
 		}
+	}
+
+	if removeAll {
+		backendPool.LoadBalancerBackendAddresses = &addresses
+		return changed
+	}
+
+	if len(addresses) == 0 {
+		klog.V(2).Info("removeNodeIPAddressFromBackendPool: the pool is empty or will be empty after removing the unwanted IP addresses, skipping the removal")
+		changed = false
+	} else if changed {
+		backendPool.LoadBalancerBackendAddresses = &addresses
 	}
 
 	return changed

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -605,7 +605,13 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		By("Labeling node")
 		node, err := utils.LabelNode(cs, &nodes[0], label, false)
 		Expect(err).NotTo(HaveOccurred())
-		err = waitForNodesInLBBackendPool(tc, publicIP, len(nodes)-1)
+		var expectedCount int
+		if len(nodes) == 1 {
+			expectedCount = 1
+		} else {
+			expectedCount = len(nodes) - 1
+		}
+		err = waitForNodesInLBBackendPool(tc, publicIP, expectedCount)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Unlabeling node")


### PR DESCRIPTION
…nd pool

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

We used to remove the nics from the lb backend pool if the corresponding VM is not ready. However, if all nodes in the pool go into not ready state at a time, the connection will be completely lost. This PR skips the removal if the backend pool will be empty after the operation. If the vms are not found, the nics will be removed, even if the pool will be empty, because in this case the nics are not supposed to exist any more.

> The manual removal by the node label `node.kubernetes.io/exclude-from-external-load-balancers=true` will also be ignored in this case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: skip removing nics from lb if there will be no nics in the backend pool
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
