### PR TITLE
Fix go 1.17 mod selection issue in run-e2e.sh

### DIFF
--- a/.pipelines/scripts/run-e2e.sh
+++ b/.pipelines/scripts/run-e2e.sh
@@ -102,14 +102,19 @@ else
   sudo GOPATH="/home/vsts/go" make install
 fi
 popd
-if [[ -n "${RELEASE_PIPELINE:-}" ]]; then
-  rm -rf kubetest2-aks
-  go mod tidy
-  go mod vendor
-fi
 
 get_k8s_version
 echo "AKS Kubernetes version is: ${AKS_KUBERNETES_VERSION:-}"
+
+if [[ -n "${RELEASE_PIPELINE:-}" ]]; then
+  rm -rf kubetest2-aks
+  if [[ "${AKS_KUBERNETES_VERSION:-}" < "1.24" ]]; then
+    go mod tidy -compat=1.17
+  else
+    go mod tidy
+  fi
+  go mod vendor
+fi
 
 kubetest2 aks --up --rgName "${RESOURCE_GROUP:-}" \
 --location "${AZURE_LOCATION:-}" \


### PR DESCRIPTION
For release 1.23, go version is 1.17 but kubetest2-aks is 1.18. go mod tidy should use option -compa=1.17 to solve the mod selection problem.

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix go 1.17 mod selection issue in run-e2e.sh
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
