### PR TITLE
Fix how getSecurityRuleName() handles IPv6 addr prefix

### DIFF
--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -292,11 +292,11 @@ func (az *Cloud) getloadbalancerHAmodeRuleName(service *v1.Service) string {
 }
 
 func (az *Cloud) getSecurityRuleName(service *v1.Service, port v1.ServicePort, sourceAddrPrefix string) string {
+	safePrefix := strings.Replace(sourceAddrPrefix, "/", "_", -1)
+	safePrefix = strings.Replace(safePrefix, ":", ".", -1) // Consider IPv6 address
 	if useSharedSecurityRule(service) {
-		safePrefix := strings.Replace(sourceAddrPrefix, "/", "_", -1)
 		return fmt.Sprintf("shared-%s-%d-%s", port.Protocol, port.Port, safePrefix)
 	}
-	safePrefix := strings.Replace(sourceAddrPrefix, "/", "_", -1)
 	rulePrefix := az.getRulePrefix(service)
 	return fmt.Sprintf("%s-%s-%d-%s", rulePrefix, port.Protocol, port.Port, safePrefix)
 }

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -2180,3 +2180,67 @@ func TestGetNodeVMSetName(t *testing.T) {
 		assert.Equal(t, tc.expectedVMSetName, vmSetName, tc.description)
 	}
 }
+
+func TestGetSecurityRuleName(t *testing.T) {
+	testcases := []struct {
+		desc             string
+		svc              *v1.Service
+		port             v1.ServicePort
+		sourceAddrPrefix string
+		expectedRuleName string
+	}{
+		{
+			"IPv4",
+			&v1.Service{
+				ObjectMeta: meta.ObjectMeta{
+					UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
+				},
+			},
+			v1.ServicePort{
+				Protocol: v1.ProtocolTCP,
+				Port:     80,
+			},
+			"10.0.0.1/24",
+			"a257b965551374ad2b091ef3f07043ad-TCP-80-10.0.0.1_24",
+		},
+		{
+			"IPv4-shared",
+			&v1.Service{
+				ObjectMeta: meta.ObjectMeta{
+					UID:         "257b9655-5137-4ad2-b091-ef3f07043ad3",
+					Annotations: map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"},
+				},
+			},
+			v1.ServicePort{
+				Protocol: v1.ProtocolTCP,
+				Port:     80,
+			},
+			"10.0.0.1/24",
+			"shared-TCP-80-10.0.0.1_24",
+		},
+		{
+			"IPv6",
+			&v1.Service{
+				ObjectMeta: meta.ObjectMeta{
+					UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
+				},
+			},
+			v1.ServicePort{
+				Protocol: v1.ProtocolTCP,
+				Port:     80,
+			},
+			"2001:0:0::1/64",
+			"a257b965551374ad2b091ef3f07043ad-TCP-80-2001.0.0..1_64",
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	az := GetTestCloud(ctrl)
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ruleName := az.getSecurityRuleName(tc.svc, tc.port, tc.sourceAddrPrefix)
+			assert.Equal(t, tc.expectedRuleName, ruleName)
+		})
+	}
+}

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -267,11 +267,13 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		allowCIDRs, ipRangesSuffixes := []string{}, []string{}
 		if v4Enabled {
 			allowCIDRs = append(allowCIDRs, fmt.Sprintf("%s/%d", hostExecPodIP, maskV4))
-			ipRangesSuffixes = append(ipRangesSuffixes, fmt.Sprintf("%s_%d", hostExecPodIP, maskV4))
+			ipRangesSuffix := strings.Replace(fmt.Sprintf("%s_%d", hostExecPodIP, maskV4), ":", ".", -1) // Handled in pkg/provider/getSecurityRuleName()
+			ipRangesSuffixes = append(ipRangesSuffixes, ipRangesSuffix)
 		}
 		if v6Enabled {
 			allowCIDRs = append(allowCIDRs, fmt.Sprintf("%s/%d", hostExecPodIP, maskV6))
-			ipRangesSuffixes = append(ipRangesSuffixes, fmt.Sprintf("%s_%d", hostExecPodIP, maskV6))
+			ipRangesSuffix := strings.Replace(fmt.Sprintf("%s_%d", hostExecPodIP, maskV6), ":", ".", -1) // Handled in pkg/provider/getSecurityRuleName()
+			ipRangesSuffixes = append(ipRangesSuffixes, ipRangesSuffix)
 		}
 		service.Spec.LoadBalancerSourceRanges = allowCIDRs
 		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
@@ -291,7 +293,7 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 
 		nsgs, err = tc.GetClusterSecurityGroups()
 		Expect(err).NotTo(HaveOccurred())
-		By("Checking if there is a LoadBalancerSourceRanges rule")
+		By("Checking if there are LoadBalancerSourceRanges rules")
 		found = validateLoadBalancerSourceRangesRuleExists(nsgs, internalIPs, allowCIDRs, ipRangesSuffixes)
 		Expect(found).To(BeTrue())
 


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix how getSecurityRuleName() handles IPv6 addr prefix
Error msg is like: `Resource name a29b3b265d9f84776b6c877408e7a519-TCP-80-2001:1234:5678:9abd::4_128 is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character or with '_'. The name may contain word characters or '.', '-', '_'."`
* Bug fix
* Add UT and adjust e2e
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix incorrect security rule name with IPv6 address prefix
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
