### PR TITLE
[Helm] Update nodeSelector and tolerations

### DIFF
--- a/helm/cloud-provider-azure/templates/cloud-provider-azure.yaml
+++ b/helm/cloud-provider-azure/templates/cloud-provider-azure.yaml
@@ -164,18 +164,9 @@ spec:
     spec:
       priorityClassName: system-node-critical
       hostNetwork: true
-      nodeSelector:
-  {{- if ge .Capabilities.KubeVersion.Minor "24" }}
-        node-role.kubernetes.io/control-plane: ""
-  {{- else }}
-        node-role.kubernetes.io/master: ""
-  {{- end }}
+      nodeSelector: {{ toYaml .Values.cloudControllerManager.nodeSelector | nindent 8 }}
       serviceAccountName: cloud-controller-manager
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
+      tolerations: {{ toYaml .Values.cloudControllerManager.tolerations | nindent 8 }}
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/helm/cloud-provider-azure/values.yaml
+++ b/helm/cloud-provider-azure/values.yaml
@@ -41,6 +41,15 @@ cloudControllerManager:
     requestsMem: "128Mi"
     limitsCPU: "4"
     limitsMem: "2Gi"
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/etcd
+    effect: NoExecute
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
 cloudNodeManager:
   enabled: true
   imageRepository: "mcr.microsoft.com/oss/kubernetes"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This allows the `cloud-controller-manager` to start on nodes with `etcd` taints by default. Additionally, allows configuration for additional taints if the user chooses. Currently this customization is not available at all.

Additionally allows configuration for `nodeSelector`. This is similar to how the `cloud-provider-aws` configures their Helm chart. https://github.com/kubernetes/cloud-provider-aws/blob/5db84490841ebd1eede368d03eb03c27dc556233/charts/aws-cloud-controller-manager/values.yaml#L16

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Thank you!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Add tolerations in values for cloud-controller-manager in Helm chart
- Add nodeSelector in values for cloud-controller-manager in Helm chart
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
