### PR TITLE
Cleanup: cherry-pick #2983 Use k8s utils pointer instead of Azure autorest/to to release-1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/adal v0.9.22
 	github.com/Azure/go-autorest/autorest/mocks v0.4.2
-	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/go-autorest/tracing v0.6.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fsnotify/fsnotify v1.6.0
@@ -46,6 +45,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect

--- a/pkg/azureclients/armclient/azure_armclient_test.go
+++ b/pkg/azureclients/armclient/azure_armclient_test.go
@@ -27,13 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
-
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
@@ -86,19 +85,19 @@ func TestDoHackRegionalRetryForGET(t *testing.T) {
 			"RegionalRetry",
 			"{\"error\":{\"code\":\"ResourceGroupNotFound\"}}",
 			http.StatusInternalServerError,
-			to.StringPtr("100"),
+			pointer.String("100"),
 		},
 		{
 			"ReplicationLatency-Content-Length-0",
 			"{}",
 			http.StatusOK,
-			to.StringPtr("0"),
+			pointer.String("0"),
 		},
 		{
 			"ReplicationLatency-Content-Length-minus-1",
 			"{}",
 			http.StatusOK,
-			to.StringPtr("-1"),
+			pointer.String("-1"),
 		},
 	}
 

--- a/pkg/azureclients/containerserviceclient/azure_containerserviceclient.go
+++ b/pkg/azureclients/containerserviceclient/azure_containerserviceclient.go
@@ -24,10 +24,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-10-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -203,7 +203,7 @@ func (c *Client) listManagedCluster(ctx context.Context, resourceGroupName strin
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -229,12 +229,12 @@ func (c *Client) listResponder(resp *http.Response) (result containerservice.Man
 // managedClusterListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) managedClusterListResultPreparer(ctx context.Context, mclr containerservice.ManagedClusterListResult) (*http.Request, error) {
-	if mclr.NextLink == nil || len(to.String(mclr.NextLink)) < 1 {
+	if mclr.NextLink == nil || len(pointer.StringDeref(mclr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(mclr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(mclr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/deploymentclient/azure_deploymentclient.go
+++ b/pkg/azureclients/deploymentclient/azure_deploymentclient.go
@@ -24,10 +24,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -196,7 +196,7 @@ func (c *Client) listDeployment(ctx context.Context, resourceGroupName string) (
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -222,12 +222,12 @@ func (c *Client) listResponder(resp *http.Response) (result resources.Deployment
 // deploymentListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) deploymentListResultPreparer(ctx context.Context, dplr resources.DeploymentListResult) (*http.Request, error) {
-	if dplr.NextLink == nil || len(to.String(dplr.NextLink)) < 1 {
+	if dplr.NextLink == nil || len(pointer.StringDeref(dplr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(dplr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(dplr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/deploymentclient/azure_deploymentclient_test.go
+++ b/pkg/azureclients/deploymentclient/azure_deploymentclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -86,8 +86,8 @@ func getTestDeploymentClientWithRetryAfterReader(armClient armclient.Interface) 
 
 func getTestDeploymentExtended(name string) resources.DeploymentExtended {
 	return resources.DeploymentExtended{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Resources/deployments/%s", name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Resources/deployments/%s", name)),
+		Name: pointer.String(name),
 	}
 }
 
@@ -269,7 +269,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := resources.DeploymentListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -314,7 +314,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := resources.DeploymentListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -368,7 +368,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	dpList := []resources.DeploymentExtended{getTestDeploymentExtended("dep"), getTestDeploymentExtended("dep1"), getTestDeploymentExtended("dep2")}
-	partialResponse, err := json.Marshal(resources.DeploymentListResult{Value: &dpList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(resources.DeploymentListResult{Value: &dpList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	_, err = json.Marshal(resources.DeploymentListResult{Value: &dpList})
 	assert.NoError(t, err)
@@ -455,7 +455,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(dpExtended.ID), dp, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(dpExtended.ID, ""), dp, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
@@ -474,7 +474,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(dpExtended.ID), dp, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(dpExtended.ID, ""), dp, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
@@ -537,7 +537,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 	dp := resources.Deployment{}
 	dpExtended := getTestDeploymentExtended("dep")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(dpExtended.ID), dp, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(dpExtended.ID, ""), dp, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
@@ -552,7 +552,7 @@ func TestDelete(t *testing.T) {
 
 	dp := getTestDeploymentExtended("dep")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(dp.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(dp.ID, ""), "").Return(nil).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
 	rerr := dpClient.Delete(context.TODO(), "rg", "dep")
@@ -607,7 +607,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	dp := getTestDeploymentExtended("dep")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(dp.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(dp.ID, ""), "").Return(throttleErr).Times(1)
 
 	dpClient := getTestDeploymentClient(armClient)
 	rerr := dpClient.Delete(context.TODO(), "rg", "dep")

--- a/pkg/azureclients/diskclient/azure_diskclient.go
+++ b/pkg/azureclients/diskclient/azure_diskclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -355,7 +355,7 @@ func (c *Client) ListByResourceGroup(ctx context.Context, resourceGroupName stri
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -405,13 +405,13 @@ func (c *Client) listResponder(resp *http.Response) (result compute.DiskList, er
 }
 
 func (c *Client) diskListPreparer(ctx context.Context, lr compute.DiskList) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 	return autorest.Prepare((&http.Request{}).WithContext(ctx),
 		autorest.AsJSON(),
 		autorest.AsGet(),
-		autorest.WithBaseURL(to.String(lr.NextLink)))
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")))
 }
 
 // DiskListPage contains a page of Disk values.

--- a/pkg/azureclients/diskclient/azure_diskclient_test.go
+++ b/pkg/azureclients/diskclient/azure_diskclient_test.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -157,7 +157,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(disk.ID), disk).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(disk.ID, ""), disk).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	diskClient := getTestDiskClient(armClient)
@@ -175,7 +175,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		RetryAfter:     time.Unix(100, 0),
 	}
 
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(disk.ID), disk).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(disk.ID, ""), disk).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 	rerr = diskClient.CreateOrUpdate(context.TODO(), "rg", "disk1", disk)
 	assert.Equal(t, throttleErr, rerr)
@@ -218,7 +218,7 @@ func TestUpdate(t *testing.T) {
 func getTestDiskUpdate() compute.DiskUpdate {
 	return compute.DiskUpdate{
 		DiskUpdateProperties: &compute.DiskUpdateProperties{
-			DiskSizeGB: to.Int32Ptr(100),
+			DiskSizeGB: pointer.Int32(100),
 		},
 	}
 }
@@ -229,7 +229,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestDisk("disk1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(nil).Times(1)
 
 	diskClient := getTestDiskClient(armClient)
 	rerr := diskClient.Delete(context.TODO(), "rg", "disk1")
@@ -241,16 +241,16 @@ func TestDelete(t *testing.T) {
 		Retriable:      true,
 		RetryAfter:     time.Unix(100, 0),
 	}
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(throttleErr).Times(1)
 	rerr = diskClient.Delete(context.TODO(), "rg", "disk1")
 	assert.Equal(t, throttleErr, rerr)
 }
 
 func getTestDisk(name string) compute.Disk {
 	return compute.Disk{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/disks/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/disks/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/interfaceclient/azure_interfaceclient.go
+++ b/pkg/azureclients/interfaceclient/azure_interfaceclient.go
@@ -26,10 +26,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -264,8 +264,8 @@ func (c *Client) createOrUpdateInterface(ctx context.Context, resourceGroupName 
 		autorest.WithPathParameters("{resourceID}", map[string]interface{}{"resourceID": resourceID}),
 		autorest.WithJSON(parameters),
 	}
-	if to.String(parameters.Etag) != "" {
-		decorators = append(decorators, autorest.WithHeader("If-Match", autorest.String(to.String(parameters.Etag))))
+	if pointer.StringDeref(parameters.Etag, "") != "" {
+		decorators = append(decorators, autorest.WithHeader("If-Match", autorest.String(pointer.StringDeref(parameters.Etag, ""))))
 	}
 
 	response, rerr := c.armClient.PutResourceWithDecorators(ctx, resourceID, parameters, decorators)

--- a/pkg/azureclients/interfaceclient/azure_interfaceclient_test.go
+++ b/pkg/azureclients/interfaceclient/azure_interfaceclient_test.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -199,7 +199,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(testInterface.ID), testInterface, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(testInterface.ID, ""), testInterface, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nicClient := getTestInterfaceClient(armClient)
@@ -217,7 +217,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		RetryAfter:     time.Unix(100, 0),
 	}
 
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(testInterface.ID), testInterface, gomock.Any()).Return(response, noContentErr).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(testInterface.ID, ""), testInterface, gomock.Any()).Return(response, noContentErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 	rerr = nicClient.CreateOrUpdate(context.TODO(), "rg", "nic1", testInterface)
 	assert.Equal(t, noContentErr, rerr)
@@ -229,7 +229,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestInterface("interface1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(nil).Times(1)
 
 	nicClient := getTestInterfaceClient(armClient)
 	rerr := nicClient.Delete(context.TODO(), "rg", "interface1")
@@ -241,7 +241,7 @@ func TestDelete(t *testing.T) {
 		Retriable:      true,
 		RetryAfter:     time.Unix(100, 0),
 	}
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(noContentErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(noContentErr).Times(1)
 
 	rerr = nicClient.Delete(context.TODO(), "rg", "interface1")
 	assert.Equal(t, noContentErr, rerr)
@@ -250,19 +250,19 @@ func TestDelete(t *testing.T) {
 func getTestInterface(name string) network.Interface {
 	resourceID := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/%s", name)
 	return network.Interface{
-		ID:       to.StringPtr(resourceID),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(resourceID),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 
 func getTestVMSSInterface(name string) network.Interface {
 	resourceID := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/%s", name)
 	return network.Interface{
-		ID:       to.StringPtr(resourceID),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(resourceID),
+		Location: pointer.String("eastus"),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-			EnableAcceleratedNetworking: to.BoolPtr(true),
+			EnableAcceleratedNetworking: pointer.Bool(true),
 		},
 	}
 }

--- a/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient.go
+++ b/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -203,7 +203,7 @@ func (c *Client) listLB(ctx context.Context, resourceGroupName string) ([]networ
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -347,12 +347,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.LoadBalancer
 // loadBalancerListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) loadBalancerListResultPreparer(ctx context.Context, lblr network.LoadBalancerListResult) (*http.Request, error) {
-	if lblr.NextLink == nil || len(to.String(lblr.NextLink)) < 1 {
+	if lblr.NextLink == nil || len(pointer.StringDeref(lblr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lblr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lblr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient_test.go
+++ b/pkg/azureclients/loadbalancerclient/azure_loadbalancerclient_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -191,7 +191,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	lbList := []network.LoadBalancer{getTestLoadBalancer("lb1"), getTestLoadBalancer("lb2"), getTestLoadBalancer("lb3")}
-	partialResponse, err := json.Marshal(network.LoadBalancerListResult{Value: &lbList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.LoadBalancerListResult{Value: &lbList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	_, err = json.Marshal(network.LoadBalancerListResult{Value: &lbList})
 	assert.NoError(t, err)
@@ -229,7 +229,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.LoadBalancerListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -271,7 +271,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(lb.ID), lb, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(lb.ID, ""), lb, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	lbClient := getTestLoadBalancerClient(armClient)
@@ -289,7 +289,7 @@ func TestCreateOrUpdateBackendPools(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(backendAddressPool.ID), backendAddressPool, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(backendAddressPool.ID, ""), backendAddressPool, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	lbClient := getTestLoadBalancerClient(armClient)
@@ -320,7 +320,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range tests {
 		armClient := mockarmclient.NewMockInterface(ctrl)
-		armClient.EXPECT().DeleteResource(gomock.Any(), to.String(lb.ID), "").Return(test.armClientErr)
+		armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(lb.ID, ""), "").Return(test.armClientErr)
 
 		lbClient := getTestLoadBalancerClient(armClient)
 		rerr := lbClient.Delete(context.TODO(), "rg", "lb1")
@@ -330,18 +330,18 @@ func TestDelete(t *testing.T) {
 
 func getTestLoadBalancer(name string) network.LoadBalancer {
 	return network.LoadBalancer{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 
 func getTestBackendAddressPool(lbName, backendPoolName string) network.BackendAddressPool {
 	return network.BackendAddressPool{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s/backendAddressPools/%s", lbName, backendPoolName)),
-		Name: to.StringPtr(backendPoolName),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s/backendAddressPools/%s", lbName, backendPoolName)),
+		Name: pointer.String(backendPoolName),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
-			Location: to.StringPtr("eastus"),
+			Location: pointer.String("eastus"),
 		},
 	}
 }

--- a/pkg/azureclients/privatednsclient/azure_privatednsclient_test.go
+++ b/pkg/azureclients/privatednsclient/azure_privatednsclient_test.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -79,7 +79,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pz.ID), pz, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pz.ID, ""), pz, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzClient := getTestPrivateDNSZoneClient(armClient)
@@ -133,7 +133,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	pz := getTestPrivateDNSZone(pz0)
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pz.ID), pz, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pz.ID, ""), pz, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzClient := getTestPrivateDNSZoneClient(armClient)
@@ -152,7 +152,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pz.ID), pz, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pz.ID, ""), pz, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzClient := getTestPrivateDNSZoneClient(armClient)
@@ -162,9 +162,9 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 
 func getTestPrivateDNSZone(name string) privatedns.PrivateZone {
 	return privatedns.PrivateZone{
-		ID:       to.StringPtr(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/privatednszonegroupclient/azure_privatednszonegroupclient_test.go
+++ b/pkg/azureclients/privatednszonegroupclient/azure_privatednszonegroupclient_test.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -80,7 +80,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pzg.ID), pzg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pzg.ID, ""), pzg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzgClient := getTestPrivateDNSZoneGroupClient(armClient)
@@ -134,7 +134,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	pzg := getTestPrivateDNSZoneGroup(pzg0)
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pzg.ID), pzg, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pzg.ID, ""), pzg, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzgClient := getTestPrivateDNSZoneGroupClient(armClient)
@@ -153,7 +153,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pzg.ID), pzg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pzg.ID, ""), pzg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pzgClient := getTestPrivateDNSZoneGroupClient(armClient)
@@ -163,8 +163,8 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 
 func getTestPrivateDNSZoneGroup(name string) network.PrivateDNSZoneGroup {
 	return network.PrivateDNSZoneGroup{
-		ID:   to.StringPtr(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/privateendpointclient/azure_privateendpointclient_test.go
+++ b/pkg/azureclients/privateendpointclient/azure_privateendpointclient_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -138,7 +138,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pe.ID), pe, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pe.ID, ""), pe, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	peClient := getTestPrivateEndpointClient(armClient)
@@ -156,7 +156,7 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecoratorsAsync(gomock.Any(), to.String(pe.ID), pe, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecoratorsAsync(gomock.Any(), pointer.StringDeref(pe.ID, ""), pe, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	peClient := getTestPrivateEndpointClient(armClient)
@@ -166,9 +166,9 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 
 func getTestPrivateEndpoint(name string) network.PrivateEndpoint {
 	return network.PrivateEndpoint{
-		ID:       to.StringPtr(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("%s/%s", testResourcePrefix, name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient.go
+++ b/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient.go
@@ -26,10 +26,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -273,7 +273,7 @@ func (c *Client) listPLS(ctx context.Context, resourceGroupName string) ([]netwo
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -385,12 +385,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.PrivateLinkS
 // privateLinkServiceListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) privateLinkServiceListResultPreparer(ctx context.Context, plslr network.PrivateLinkServiceListResult) (*http.Request, error) {
-	if plslr.NextLink == nil || len(to.String(plslr.NextLink)) < 1 {
+	if plslr.NextLink == nil || len(pointer.StringDeref(plslr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(plslr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(plslr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient_test.go
+++ b/pkg/azureclients/privatelinkserviceclient/azure_privatelinkserviceclient_test.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -192,7 +192,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	plsList := []network.PrivateLinkService{getTestPrivateLinkService("pls1"), getTestPrivateLinkService("pls2"), getTestPrivateLinkService("pls3")}
-	partialResponse, err := json.Marshal(network.PrivateLinkServiceListResult{Value: &plsList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.PrivateLinkServiceListResult{Value: &plsList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	_, err = json.Marshal(network.PrivateLinkServiceListResult{Value: &plsList})
 	assert.NoError(t, err)
@@ -230,7 +230,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.PrivateLinkServiceListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -272,7 +272,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(pls.ID), pls, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(pls.ID, ""), pls, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	plsClient := getTestPrivateLinkServiceClient(armClient)
@@ -303,7 +303,7 @@ func TestDelete(t *testing.T) {
 
 	for _, test := range tests {
 		armClient := mockarmclient.NewMockInterface(ctrl)
-		armClient.EXPECT().DeleteResource(gomock.Any(), to.String(pls.ID), "").Return(test.armClientErr)
+		armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(pls.ID, ""), "").Return(test.armClientErr)
 
 		plsClient := getTestPrivateLinkServiceClient(armClient)
 		rerr := plsClient.Delete(context.TODO(), "rg", "pls1")
@@ -334,7 +334,7 @@ func TestDeletePEConnection(t *testing.T) {
 
 	for _, test := range tests {
 		armClient := mockarmclient.NewMockInterface(ctrl)
-		armClient.EXPECT().DeleteResource(gomock.Any(), to.String(peConn.ID), "").Return(test.armClientErr)
+		armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(peConn.ID, ""), "").Return(test.armClientErr)
 
 		plsClient := getTestPrivateLinkServiceClient(armClient)
 		rerr := plsClient.DeletePEConnection(context.TODO(), "rg", "pls1", "peconn")
@@ -344,16 +344,16 @@ func TestDeletePEConnection(t *testing.T) {
 
 func getTestPrivateLinkService(name string) network.PrivateLinkService {
 	return network.PrivateLinkService{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/%s/%s", PLSResourceType, name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/%s/%s", PLSResourceType, name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 
 func getTestPrivateEndpointConnection(PLSName string, PEConnName string) network.PrivateEndpointConnection {
 	return network.PrivateEndpointConnection{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/%s/%s/%s/%s", PLSResourceType, PLSName, PEConnResourceType, PEConnName)),
-		Name: to.StringPtr(PEConnName),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/%s/%s/%s/%s", PLSResourceType, PLSName, PEConnResourceType, PEConnName)),
+		Name: pointer.String(PEConnName),
 	}
 }
 

--- a/pkg/azureclients/publicipclient/azure_publicipclient.go
+++ b/pkg/azureclients/publicipclient/azure_publicipclient.go
@@ -26,10 +26,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -278,7 +278,7 @@ func (c *Client) listPublicIPAddress(ctx context.Context, resourceGroupName stri
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -415,12 +415,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.PublicIPAddr
 // publicIPAddressListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) publicIPAddressListResultPreparer(ctx context.Context, lr network.PublicIPAddressListResult) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }
@@ -543,7 +543,7 @@ func (c *Client) listAllPublicIPAddress(ctx context.Context) ([]network.PublicIP
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 

--- a/pkg/azureclients/publicipclient/azure_publicipclient_test.go
+++ b/pkg/azureclients/publicipclient/azure_publicipclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -214,7 +214,7 @@ func TestGetVMSSPublicIPAddress(t *testing.T) {
 
 	testPip := network.PublicIPAddress{
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("10.10.10.10"),
+			IPAddress: pointer.String("10.10.10.10"),
 		},
 	}
 	pip, err := testPip.MarshalJSON()
@@ -233,7 +233,7 @@ func TestGetVMSSPublicIPAddress(t *testing.T) {
 	expected := network.PublicIPAddress{
 		Response: autorest.Response{Response: response},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("10.10.10.10"),
+			IPAddress: pointer.String("10.10.10.10"),
 		},
 	}
 	result, rerr := pipClient.GetVirtualMachineScaleSetPublicIPAddress(context.TODO(), "rg", "vmss", "0", "nic", "ipConfig", "pip1", "")
@@ -455,7 +455,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	pipList := []network.PublicIPAddress{getTestPublicIPAddress("pip1"), getTestPublicIPAddress("pip2"), getTestPublicIPAddress("pip3")}
-	partialResponse, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(network.PublicIPAddressListResult{Value: &pipList})
 	assert.NoError(t, err)
@@ -533,7 +533,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.PublicIPAddressListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -578,7 +578,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := network.PublicIPAddressListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -616,7 +616,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pip.ID), pip).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), pip).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
@@ -633,7 +633,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pip.ID), pip).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), pip).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
@@ -686,7 +686,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	pip := getTestPublicIPAddress("pip1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(pip.ID), pip).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), pip).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
@@ -701,7 +701,7 @@ func TestDelete(t *testing.T) {
 
 	pip := getTestPublicIPAddress("pip1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(pip.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), "").Return(nil).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
 	rerr := pipClient.Delete(context.TODO(), "rg", "pip1")
@@ -754,7 +754,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	pip := getTestPublicIPAddress("pip1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(pip.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(pip.ID, ""), "").Return(throttleErr).Times(1)
 
 	pipClient := getTestPublicIPAddressClient(armClient)
 	rerr := pipClient.Delete(context.TODO(), "rg", "pip1")
@@ -769,9 +769,9 @@ func getFutureTime() time.Time {
 
 func getTestPublicIPAddress(name string) network.PublicIPAddress {
 	return network.PublicIPAddress{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/routeclient/azure_routeclient_test.go
+++ b/pkg/azureclients/routeclient/azure_routeclient_test.go
@@ -26,11 +26,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -95,7 +95,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(r.ID), r, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(r.ID, ""), r, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
@@ -149,7 +149,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	r := getTestRoute("r1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(r.ID), r, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(r.ID, ""), r, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
@@ -168,7 +168,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(r.ID), r, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(r.ID, ""), r, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
@@ -182,7 +182,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestRoute("r1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(nil).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
 	rerr := routeClient.Delete(context.TODO(), "rg", "rt", "r1")
@@ -235,7 +235,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	r := getTestRoute("r1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(throttleErr).Times(1)
 
 	routeClient := getTestRouteClient(armClient)
 	rerr := routeClient.Delete(context.TODO(), "rg", "rt", "r1")
@@ -244,8 +244,8 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestRoute(name string) network.Route {
 	return network.Route{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/rt/routes/%s", name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/rt/routes/%s", name)),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/routetableclient/azure_routetableclient_test.go
+++ b/pkg/azureclients/routetableclient/azure_routetableclient_test.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -222,7 +222,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(rt1.ID), rt1, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(rt1.ID, ""), rt1, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	rtClient := getTestRouteTableClient(armClient)
@@ -276,7 +276,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	rt1 := getTestRouteTable("rt1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(rt1.ID), rt1, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(rt1.ID, ""), rt1, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routetableClient := getTestRouteTableClient(armClient)
@@ -295,7 +295,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(rt1.ID), rt1, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(rt1.ID, ""), rt1, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	routetableClient := getTestRouteTableClient(armClient)
@@ -305,9 +305,9 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 
 func getTestRouteTable(name string) network.RouteTable {
 	return network.RouteTable{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/routeTables/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/securitygroupclient/azure_securitygroupclient.go
+++ b/pkg/azureclients/securitygroupclient/azure_securitygroupclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -203,7 +203,7 @@ func (c *Client) listSecurityGroup(ctx context.Context, resourceGroupName string
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -347,12 +347,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.SecurityGrou
 // securityGroupListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) securityGroupListResultPreparer(ctx context.Context, sglr network.SecurityGroupListResult) (*http.Request, error) {
-	if sglr.NextLink == nil || len(to.String(sglr.NextLink)) < 1 {
+	if sglr.NextLink == nil || len(pointer.StringDeref(sglr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(sglr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(sglr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/securitygroupclient/azure_securitygroupclient_test.go
+++ b/pkg/azureclients/securitygroupclient/azure_securitygroupclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -257,7 +257,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.SecurityGroupListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -302,7 +302,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := network.SecurityGroupListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -356,7 +356,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	nsgList := []network.SecurityGroup{getTestSecurityGroup("nsg1"), getTestSecurityGroup("nsg2"), getTestSecurityGroup("nsg3")}
-	partialResponse, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(network.SecurityGroupListResult{Value: &nsgList})
 	assert.NoError(t, err)
@@ -448,7 +448,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(nsg.ID), nsg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(nsg.ID, ""), nsg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
@@ -465,7 +465,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(nsg.ID), nsg, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(nsg.ID, ""), nsg, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
@@ -520,7 +520,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	nsg := getTestSecurityGroup("nsg1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(nsg.ID), nsg, gomock.Any()).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(nsg.ID, ""), nsg, gomock.Any()).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
@@ -535,7 +535,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestSecurityGroup("nsg1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(nil).Times(1)
 
 	rtClient := getTestSecurityGroupClient(armClient)
 	rerr := rtClient.Delete(context.TODO(), "rg", "nsg1")
@@ -590,7 +590,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	nsg := getTestSecurityGroup("nsg1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(nsg.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(nsg.ID, ""), "").Return(throttleErr).Times(1)
 
 	nsgClient := getTestSecurityGroupClient(armClient)
 	rerr := nsgClient.Delete(context.TODO(), "rg", "nsg1")
@@ -600,9 +600,9 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestSecurityGroup(name string) network.SecurityGroup {
 	return network.SecurityGroup{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/snapshotclient/azure_snapshotclient.go
+++ b/pkg/azureclients/snapshotclient/azure_snapshotclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -314,7 +314,7 @@ func (c *Client) listSnapshotsByResourceGroup(ctx context.Context, resourceGroup
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -340,12 +340,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.SnapshotList
 // SnapshotListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) SnapshotListResultPreparer(ctx context.Context, lr compute.SnapshotList) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/snapshotclient/azure_snapshotclient_test.go
+++ b/pkg/azureclients/snapshotclient/azure_snapshotclient_test.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -316,7 +316,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	snList := []compute.Snapshot{getTestSnapshot("sn1"), getTestSnapshot("sn2"), getTestSnapshot("sn3")}
-	partialResponse, err := json.Marshal(compute.SnapshotList{Value: &snList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.SnapshotList{Value: &snList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.SnapshotList{Value: &snList})
 	assert.NoError(t, err)
@@ -394,7 +394,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := compute.SnapshotList{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -439,7 +439,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := compute.SnapshotList{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -477,7 +477,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(sn.ID), sn).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(sn.ID, ""), sn).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
@@ -494,7 +494,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(sn.ID), sn).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(sn.ID, ""), sn).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
@@ -547,7 +547,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	sn := getTestSnapshot("sn1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(sn.ID), sn).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(sn.ID, ""), sn).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
@@ -562,7 +562,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestSnapshot("sn1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(nil).Times(1)
 
 	rtClient := getTestSnapshotClient(armClient)
 	rerr := rtClient.Delete(context.TODO(), "rg", "sn1")
@@ -615,7 +615,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	sn := getTestSnapshot("sn1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(sn.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(sn.ID, ""), "").Return(throttleErr).Times(1)
 
 	snClient := getTestSnapshotClient(armClient)
 	rerr := snClient.Delete(context.TODO(), "rg", "sn1")
@@ -625,9 +625,9 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestSnapshot(name string) compute.Snapshot {
 	return compute.Snapshot{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/snapshots/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/snapshots/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
+++ b/pkg/azureclients/storageaccountclient/azure_storageaccountclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-02-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -441,7 +441,7 @@ func (c *Client) ListStorageAccountByResourceGroup(ctx context.Context, resource
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -467,12 +467,12 @@ func (c *Client) listResponder(resp *http.Response) (result storage.AccountListR
 // StorageAccountResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) StorageAccountResultPreparer(ctx context.Context, lr storage.AccountListResult) (*http.Request, error) {
-	if lr.NextLink == nil || len(to.String(lr.NextLink)) < 1 {
+	if lr.NextLink == nil || len(pointer.StringDeref(lr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/storageaccountclient/azure_storageaccountclient_test.go
+++ b/pkg/azureclients/storageaccountclient/azure_storageaccountclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-02-01/storage"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -158,7 +158,7 @@ func TestAllNeverRateLimiter(t *testing.T) {
 	assert.Equal(t, saErr3, rerr3)
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 
 	rerr4 := saClient.Create(context.TODO(), "rg", "sa1", sa)
@@ -218,7 +218,7 @@ func TestAllRetryAfterReader(t *testing.T) {
 	assert.Equal(t, saErr3, rerr3)
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 
 	rerr4 := saClient.Create(context.TODO(), "rg", "sa1", sa)
@@ -244,7 +244,7 @@ func TestAllThrottle(t *testing.T) {
 	}
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 
 	r := getTestStorageAccount("sa1")
@@ -253,7 +253,7 @@ func TestAllThrottle(t *testing.T) {
 	armClient.EXPECT().PostResource(gomock.Any(), testResourceID, "listKeys", struct{}{}, map[string]interface{}{}).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().GetResource(gomock.Any(), testResourceID).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().PutResource(gomock.Any(), testResourceID, sa).Return(response, throttleErr).Times(1)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(3)
 
 	saClient := getTestStorageAccountClient(armClient)
@@ -379,7 +379,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := storage.AccountListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -424,7 +424,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := storage.AccountListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -498,7 +498,7 @@ func TestCreate(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -518,7 +518,7 @@ func TestCreateResponderError(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountCreateParameters{
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -538,7 +538,7 @@ func TestUpdate(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountUpdateParameters{
-		Tags: map[string]*string{"key": to.StringPtr("value")},
+		Tags: map[string]*string{"key": pointer.String("value")},
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -558,7 +558,7 @@ func TestUpdateResponderError(t *testing.T) {
 	defer ctrl.Finish()
 
 	sa := storage.AccountUpdateParameters{
-		Tags: map[string]*string{"key": to.StringPtr("value")},
+		Tags: map[string]*string{"key": pointer.String("value")},
 	}
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	response := &http.Response{
@@ -579,7 +579,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestStorageAccount("sa1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(nil).Times(1)
 
 	rtClient := getTestStorageAccountClient(armClient)
 	rerr := rtClient.Delete(context.TODO(), "rg", "sa1")
@@ -588,9 +588,9 @@ func TestDelete(t *testing.T) {
 
 func getTestStorageAccount(name string) storage.Account {
 	return storage.Account{
-		ID:       to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/%s", name)),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/%s", name)),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/subnetclient/azure_subnetclient.go
+++ b/pkg/azureclients/subnetclient/azure_subnetclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -211,7 +211,7 @@ func (c *Client) listSubnet(ctx context.Context, resourceGroupName string, virtu
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -350,12 +350,12 @@ func (c *Client) listResponder(resp *http.Response) (result network.SubnetListRe
 // subnetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) subnetListResultPreparer(ctx context.Context, lblr network.SubnetListResult) (*http.Request, error) {
-	if lblr.NextLink == nil || len(to.String(lblr.NextLink)) < 1 {
+	if lblr.NextLink == nil || len(pointer.StringDeref(lblr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(lblr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(lblr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/subnetclient/azure_subnetclient_test.go
+++ b/pkg/azureclients/subnetclient/azure_subnetclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -92,7 +92,7 @@ func TestGet(t *testing.T) {
 	defer ctrl.Finish()
 
 	testSubnet := network.Subnet{
-		Name: to.StringPtr("subnet1"),
+		Name: pointer.String("subnet1"),
 	}
 	subnet, err := testSubnet.MarshalJSON()
 	assert.NoError(t, err)
@@ -107,7 +107,7 @@ func TestGet(t *testing.T) {
 
 	expected := network.Subnet{
 		Response: autorest.Response{Response: response},
-		Name:     to.StringPtr("subnet1"),
+		Name:     pointer.String("subnet1"),
 	}
 	subnetClient := getTestSubnetClient(armClient)
 	result, rerr := subnetClient.Get(context.TODO(), "rg", "vnet", "subnet1", "")
@@ -327,7 +327,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	subnetList := []network.Subnet{getTestSubnet("subnet1"), getTestSubnet("subnet2"), getTestSubnet("subnet3")}
-	partialResponse, err := json.Marshal(network.SubnetListResult{Value: &subnetList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(network.SubnetListResult{Value: &subnetList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(network.SubnetListResult{Value: &subnetList})
 	assert.NoError(t, err)
@@ -405,7 +405,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := network.SubnetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -450,7 +450,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := network.SubnetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
@@ -488,7 +488,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(subnet.ID), subnet).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(subnet.ID, ""), subnet).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
@@ -505,7 +505,7 @@ func TestCreateOrUpdateWithCreateOrUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(subnet.ID), subnet).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(subnet.ID, ""), subnet).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
@@ -558,7 +558,7 @@ func TestCreateOrUpdateThrottle(t *testing.T) {
 
 	subnet := getTestSubnet("subnet1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(subnet.ID), subnet).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(subnet.ID, ""), subnet).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
@@ -573,7 +573,7 @@ func TestDelete(t *testing.T) {
 
 	r := getTestSubnet("subnet1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(r.ID), "").Return(nil).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(r.ID, ""), "").Return(nil).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
 	rerr := subnetClient.Delete(context.TODO(), "rg", "vnet", "subnet1")
@@ -626,7 +626,7 @@ func TestDeleteThrottle(t *testing.T) {
 
 	subnet := getTestSubnet("subnet1")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().DeleteResource(gomock.Any(), to.String(subnet.ID), "").Return(throttleErr).Times(1)
+	armClient.EXPECT().DeleteResource(gomock.Any(), pointer.StringDeref(subnet.ID, ""), "").Return(throttleErr).Times(1)
 
 	subnetClient := getTestSubnetClient(armClient)
 	rerr := subnetClient.Delete(context.TODO(), "rg", "vnet", "subnet1")
@@ -636,8 +636,8 @@ func TestDeleteThrottle(t *testing.T) {
 
 func getTestSubnet(name string) network.Subnet {
 	return network.Subnet{
-		ID:   to.StringPtr(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/%s", name)),
-		Name: to.StringPtr(name),
+		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/%s", name)),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/virtualnetworklinksclient/azure_virtualnetworklinksclient_test.go
+++ b/pkg/azureclients/virtualnetworklinksclient/azure_virtualnetworklinksclient_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -138,7 +138,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), to.String(vnl.ID), vnl, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecorators(gomock.Any(), pointer.StringDeref(vnl.ID, ""), vnl, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vnlClient := getTestVirtualNetworkLinkClient(armClient)
@@ -156,7 +156,7 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResourceWithDecoratorsAsync(gomock.Any(), to.String(vnl.ID), vnl, gomock.Any()).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResourceWithDecoratorsAsync(gomock.Any(), pointer.StringDeref(vnl.ID, ""), vnl, gomock.Any()).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vnlClient := getTestVirtualNetworkLinkClient(armClient)
@@ -166,9 +166,9 @@ func TestCreateOrUpdateAsync(t *testing.T) {
 
 func getTestVirtualNetworkLink(privateZoneName, virtualNetworkLinkName string) privatedns.VirtualNetworkLink {
 	return privatedns.VirtualNetworkLink{
-		ID:       to.StringPtr(fmt.Sprintf(testResourceIDFormat, privateZoneName, virtualNetworkLinkName)),
-		Name:     to.StringPtr(virtualNetworkLinkName),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String(fmt.Sprintf(testResourceIDFormat, privateZoneName, virtualNetworkLinkName)),
+		Name:     pointer.String(virtualNetworkLinkName),
+		Location: pointer.String("eastus"),
 	}
 }
 

--- a/pkg/azureclients/vmasclient/azure_vmasclient.go
+++ b/pkg/azureclients/vmasclient/azure_vmasclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -203,7 +203,7 @@ func (c *Client) listVMAS(ctx context.Context, resourceGroupName string) ([]comp
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -229,12 +229,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.Availability
 // availabilitySetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) availabilitySetListResultPreparer(ctx context.Context, vmaslr compute.AvailabilitySetListResult) (*http.Request, error) {
-	if vmaslr.NextLink == nil || len(to.String(vmaslr.NextLink)) < 1 {
+	if vmaslr.NextLink == nil || len(pointer.StringDeref(vmaslr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmaslr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmaslr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmasclient/azure_vmasclient_test.go
+++ b/pkg/azureclients/vmasclient/azure_vmasclient_test.go
@@ -29,11 +29,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -318,7 +318,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmasList := []compute.AvailabilitySet{getTestVMAS("vmas1"), getTestVMAS("vmas2"), getTestVMAS("vmas3")}
-	partialResponse, err := json.Marshal(compute.AvailabilitySetListResult{Value: &vmasList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.AvailabilitySetListResult{Value: &vmasList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.AvailabilitySetListResult{Value: &vmasList})
 	assert.NoError(t, err)
@@ -403,7 +403,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := compute.AvailabilitySetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -459,7 +459,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := compute.AvailabilitySetListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -495,12 +495,12 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 
 func getTestVMAS(name string) compute.AvailabilitySet {
 	return compute.AvailabilitySet{
-		ID:       to.StringPtr("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/vmas1"),
-		Name:     to.StringPtr(name),
-		Location: to.StringPtr("eastus"),
+		ID:       pointer.String("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/vmas1"),
+		Name:     pointer.String(name),
+		Location: pointer.String("eastus"),
 		Sku: &compute.Sku{
-			Name:     to.StringPtr("Standard"),
-			Capacity: to.Int64Ptr(3),
+			Name:     pointer.String("Standard"),
+			Capacity: pointer.Int64(3),
 		},
 	}
 }

--- a/pkg/azureclients/vmclient/azure_vmclient.go
+++ b/pkg/azureclients/vmclient/azure_vmclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -204,7 +204,7 @@ func (c *Client) listVM(ctx context.Context, resourceGroupName string) ([]comput
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -357,12 +357,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.VirtualMachi
 // vmListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) vmListResultPreparer(ctx context.Context, vmlr compute.VirtualMachineListResult) (*http.Request, error) {
-	if vmlr.NextLink == nil || len(to.String(vmlr.NextLink)) < 1 {
+	if vmlr.NextLink == nil || len(pointer.StringDeref(vmlr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmlr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmlr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmsizeclient/azure_vmsizeclient_test.go
+++ b/pkg/azureclients/vmsizeclient/azure_vmsizeclient_test.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -220,7 +220,7 @@ func getTestVMSizeClient(armClient armclient.Interface) *Client {
 
 func getTestVMSize(name string) compute.VirtualMachineSize {
 	return compute.VirtualMachineSize{
-		Name: to.StringPtr(name),
+		Name: pointer.String(name),
 	}
 }
 

--- a/pkg/azureclients/vmssclient/azure_vmssclient.go
+++ b/pkg/azureclients/vmssclient/azure_vmssclient.go
@@ -25,10 +25,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -207,7 +207,7 @@ func (c *Client) listVMSS(ctx context.Context, resourceGroupName string) ([]comp
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -366,12 +366,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.VirtualMachi
 // virtualMachineScaleSetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) virtualMachineScaleSetListResultPreparer(ctx context.Context, vmsslr compute.VirtualMachineScaleSetListResult) (*http.Request, error) {
-	if vmsslr.NextLink == nil || len(to.String(vmsslr.NextLink)) < 1 {
+	if vmsslr.NextLink == nil || len(pointer.StringDeref(vmsslr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmsslr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmsslr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmssvmclient/azure_vmssvmclient.go
+++ b/pkg/azureclients/vmssvmclient/azure_vmssvmclient.go
@@ -25,11 +25,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -217,7 +217,7 @@ func (c *Client) listVMSSVM(ctx context.Context, resourceGroupName string, virtu
 		result = append(result, page.Values()...)
 
 		// Abort the loop when there's no nextLink in the response.
-		if to.String(page.Response().NextLink) == "" {
+		if pointer.StringDeref(page.Response().NextLink, "") == "" {
 			break
 		}
 
@@ -371,12 +371,12 @@ func (c *Client) listResponder(resp *http.Response) (result compute.VirtualMachi
 // virtualMachineScaleSetListResultPreparer prepares a request to retrieve the next set of results.
 // It returns nil if no more results exist.
 func (c *Client) virtualMachineScaleSetVMListResultPreparer(ctx context.Context, vmssvmlr compute.VirtualMachineScaleSetVMListResult) (*http.Request, error) {
-	if vmssvmlr.NextLink == nil || len(to.String(vmssvmlr.NextLink)) < 1 {
+	if vmssvmlr.NextLink == nil || len(pointer.StringDeref(vmssvmlr.NextLink, "")) < 1 {
 		return nil, nil
 	}
 
 	decorators := []autorest.PrepareDecorator{
-		autorest.WithBaseURL(to.String(vmssvmlr.NextLink)),
+		autorest.WithBaseURL(pointer.StringDeref(vmssvmlr.NextLink, "")),
 	}
 	return c.armClient.PrepareGetRequest(ctx, decorators...)
 }

--- a/pkg/azureclients/vmssvmclient/azure_vmssvmclient_test.go
+++ b/pkg/azureclients/vmssvmclient/azure_vmssvmclient_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/pointer"
 
 	azclients "sigs.k8s.io/cloud-provider-azure/pkg/azureclients"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/armclient"
@@ -321,7 +321,7 @@ func TestListWithNextPage(t *testing.T) {
 
 	armClient := mockarmclient.NewMockInterface(ctrl)
 	vmssvmList := []compute.VirtualMachineScaleSetVM{getTestVMSSVM("vmss1", "1"), getTestVMSSVM("vmss1", "2"), getTestVMSSVM("vmss1", "3")}
-	partialResponse, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssvmList, NextLink: to.StringPtr("nextLink")})
+	partialResponse, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssvmList, NextLink: pointer.String("nextLink")})
 	assert.NoError(t, err)
 	pagedResponse, err := json.Marshal(compute.VirtualMachineScaleSetVMListResult{Value: &vmssvmList})
 	assert.NoError(t, err)
@@ -406,7 +406,7 @@ func TestListNextResultsMultiPages(t *testing.T) {
 	}
 
 	lastResult := compute.VirtualMachineScaleSetVMListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -462,7 +462,7 @@ func TestListNextResultsMultiPagesWithListResponderError(t *testing.T) {
 	}
 
 	lastResult := compute.VirtualMachineScaleSetVMListResult{
-		NextLink: to.StringPtr("next"),
+		NextLink: pointer.String("next"),
 	}
 
 	for _, test := range tests {
@@ -506,7 +506,7 @@ func TestUpdate(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vmssClient := getTestVMSSVMClient(armClient)
@@ -520,7 +520,7 @@ func TestUpdateAsync(t *testing.T) {
 
 	vmssVM := getTestVMSSVM("vmss1", "0")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResourceAsync(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(nil, nil).Times(1)
+	armClient.EXPECT().PutResourceAsync(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(nil, nil).Times(1)
 
 	vmssClient := getTestVMSSVMClient(armClient)
 	future, rerr := vmssClient.UpdateAsync(context.TODO(), "rg", "vmss1", "0", vmssVM, "test")
@@ -591,7 +591,7 @@ func TestUpdateWithUpdateResponderError(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(response, nil).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(response, nil).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vmssvmClient := getTestVMSSVMClient(armClient)
@@ -651,7 +651,7 @@ func TestUpdateThrottle(t *testing.T) {
 
 	vmssVM := getTestVMSSVM("vmss1", "0")
 	armClient := mockarmclient.NewMockInterface(ctrl)
-	armClient.EXPECT().PutResource(gomock.Any(), to.String(vmssVM.ID), vmssVM).Return(response, throttleErr).Times(1)
+	armClient.EXPECT().PutResource(gomock.Any(), pointer.StringDeref(vmssVM.ID, ""), vmssVM).Return(response, throttleErr).Times(1)
 	armClient.EXPECT().CloseResponse(gomock.Any(), gomock.Any()).Times(1)
 
 	vmssvmClient := getTestVMSSVMClient(armClient)
@@ -671,18 +671,18 @@ func TestUpdateVMs(t *testing.T) {
 		"2": vmssVM2,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM1.ID): vmssVM1,
-		to.String(vmssVM2.ID): vmssVM2,
+		pointer.StringDeref(vmssVM1.ID, ""): vmssVM1,
+		pointer.StringDeref(vmssVM2.ID, ""): vmssVM2,
 	}
 	response := &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM1.ID): {
+		pointer.StringDeref(vmssVM1.ID, ""): {
 			Response: response,
 		},
-		to.String(vmssVM2.ID): {
+		pointer.StringDeref(vmssVM2.ID, ""): {
 			Response: response,
 		},
 	}
@@ -705,14 +705,14 @@ func TestUpdateVMsWithUpdateVMsResponderError(t *testing.T) {
 		"1": vmssVM,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM.ID): vmssVM,
+		pointer.StringDeref(vmssVM.ID, ""): vmssVM,
 	}
 	response := &http.Response{
 		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM.ID): {
+		pointer.StringDeref(vmssVM.ID, ""): {
 			Response: response,
 		},
 	}
@@ -769,7 +769,7 @@ func TestUpdateVMsThrottle(t *testing.T) {
 		"1": vmssVM,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM.ID): vmssVM,
+		pointer.StringDeref(vmssVM.ID, ""): vmssVM,
 	}
 	throttleErr := retry.Error{
 		HTTPStatusCode: http.StatusTooManyRequests,
@@ -778,7 +778,7 @@ func TestUpdateVMsThrottle(t *testing.T) {
 		RetryAfter:     time.Unix(100, 0),
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM.ID): {
+		pointer.StringDeref(vmssVM.ID, ""): {
 			Response: &http.Response{
 				StatusCode: http.StatusTooManyRequests,
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
@@ -812,10 +812,10 @@ func TestUpdateVMsIgnoreError(t *testing.T) {
 		"4": vmssVM4,
 	}
 	testvmssVMs := map[string]interface{}{
-		to.String(vmssVM.ID):  vmssVM,
-		to.String(vmssVM2.ID): vmssVM2,
-		to.String(vmssVM3.ID): vmssVM3,
-		to.String(vmssVM4.ID): vmssVM4,
+		pointer.StringDeref(vmssVM.ID, ""):  vmssVM,
+		pointer.StringDeref(vmssVM2.ID, ""): vmssVM2,
+		pointer.StringDeref(vmssVM3.ID, ""): vmssVM3,
+		pointer.StringDeref(vmssVM4.ID, ""): vmssVM4,
 	}
 	notActiveError := retry.Error{
 		RawError:  fmt.Errorf(consts.VmssVMNotActiveErrorMessage),
@@ -834,16 +834,16 @@ func TestUpdateVMsIgnoreError(t *testing.T) {
 		Retriable: false,
 	}
 	responses := map[string]*armclient.PutResourcesResponse{
-		to.String(vmssVM.ID): {
+		pointer.StringDeref(vmssVM.ID, ""): {
 			Error: &notActiveError,
 		},
-		to.String(vmssVM2.ID): {
+		pointer.StringDeref(vmssVM2.ID, ""): {
 			Error: &parentResourceNotFoundError,
 		},
-		to.String(vmssVM3.ID): {
+		pointer.StringDeref(vmssVM3.ID, ""): {
 			Error: &concurrentRequestConflictError,
 		},
-		to.String(vmssVM4.ID): {
+		pointer.StringDeref(vmssVM4.ID, ""): {
 			Error: &beingDeletedError,
 		},
 	}
@@ -861,9 +861,9 @@ func TestUpdateVMsIgnoreError(t *testing.T) {
 func getTestVMSSVM(vmssName, instanceID string) compute.VirtualMachineScaleSetVM {
 	resourceID := fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s", vmssName, instanceID)
 	return compute.VirtualMachineScaleSetVM{
-		ID:         to.StringPtr(resourceID),
-		InstanceID: to.StringPtr(instanceID),
-		Location:   to.StringPtr("eastus"),
+		ID:         pointer.String(resourceID),
+		InstanceID: pointer.String(instanceID),
+		Location:   pointer.String("eastus"),
 	}
 }
 

--- a/pkg/consts/helpers_test.go
+++ b/pkg/consts/helpers_test.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestIsK8sServiceHasHAModeEnabled(t *testing.T) {
@@ -184,13 +184,13 @@ func Test_extractInt32FromString(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "value is not a number", args: args{val: "cookies"}, wantErr: true},
-		{name: "value is zero", args: args{val: "0"}, wantErr: false, want: to.Int32Ptr(0)},
+		{name: "value is zero", args: args{val: "0"}, wantErr: false, want: pointer.Int32(0)},
 		{name: "value is a float number", args: args{val: "0.1"}, wantErr: true},
-		{name: "value is a positive integer", args: args{val: "24"}, want: to.Int32Ptr(24), wantErr: false},
-		{name: "value negative integer", args: args{val: "-6"}, want: to.Int32Ptr(-6), wantErr: false},
+		{name: "value is a positive integer", args: args{val: "24"}, want: pointer.Int32(24), wantErr: false},
+		{name: "value negative integer", args: args{val: "-6"}, want: pointer.Int32(-6), wantErr: false},
 		{name: "validator is nil", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
 			nil,
-		}}, want: to.Int32Ptr(-6), wantErr: false},
+		}}, want: pointer.Int32(-6), wantErr: false},
 		{name: "validation failed", args: args{val: "-6", businessValidator: []Int32BusinessValidator{
 			func(i *int32) error {
 				return fmt.Errorf("validator failed")
@@ -349,7 +349,7 @@ func TestGetInt32HealthProbeConfigOfPortFromK8sSvcAnnotation(t *testing.T) {
 				port:        80,
 				key:         HealthProbeParamsNumOfProbe,
 			},
-			want:    to.Int32Ptr(2),
+			want:    pointer.Int32(2),
 			wantErr: false,
 		},
 		{

--- a/pkg/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -31,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -190,8 +190,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should put the correct mask sizes on the map",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("25"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("65"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("25"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("65"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{"vmss-0": {25, 65}},
 		},
@@ -199,8 +199,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should put the default mask sizes on the map if the providerID is invalid",
 			providerID:  "invalid",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{"vmss-0": {24, 64}},
 		},
@@ -208,8 +208,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should report an error if the ipv4 mask is smaller than the cluster mask",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("15"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("65"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("15"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("65"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{},
 			expectedErr:                        fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv4 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", 15, "vmss-0", 16),
@@ -218,8 +218,8 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			description: "updateNodeSubnetMaskSizes should report an error if the ipv6 mask is smaller than the cluster mask",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("25"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("45"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("25"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("45"),
 			},
 			expectedNodeNameSubnetMaskSizesMap: map[string][]int{},
 			expectedErr:                        fmt.Errorf("updateNodeSubnetMaskSizes: invalid ipv6 mask size %d of node %s because it is out of the range of the cluster CIDR with the mask size %d", 45, "vmss-0", 48),
@@ -231,7 +231,7 @@ func TestUpdateNodeSubnetMaskSizes(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedVMSS := compute.VirtualMachineScaleSet{
-				Name: to.StringPtr("vmss"),
+				Name: pointer.String("vmss"),
 				Tags: tc.tags,
 			}
 			mockVMSSClient := ss.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)

--- a/pkg/provider/azure_backoff.go
+++ b/pkg/provider/azure_backoff.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -153,7 +152,7 @@ func (az *Cloud) CreateOrUpdateSecurityGroup(sg network.SecurityGroup) error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	rerr := az.SecurityGroupsClient.CreateOrUpdate(ctx, az.SecurityGroupResourceGroup, *sg.Name, sg, to.String(sg.Etag))
+	rerr := az.SecurityGroupsClient.CreateOrUpdate(ctx, az.SecurityGroupResourceGroup, *sg.Name, sg, pointer.StringDeref(sg.Etag, ""))
 	klog.V(10).Infof("SecurityGroupsClient.CreateOrUpdate(%s): end", *sg.Name)
 	if rerr == nil {
 		// Invalidate the cache right after updating
@@ -162,7 +161,7 @@ func (az *Cloud) CreateOrUpdateSecurityGroup(sg network.SecurityGroup) error {
 	}
 
 	nsgJSON, _ := json.Marshal(sg)
-	klog.Warningf("CreateOrUpdateSecurityGroup(%s) failed: %v, NSG request: %s", to.String(sg.Name), rerr.Error(), string(nsgJSON))
+	klog.Warningf("CreateOrUpdateSecurityGroup(%s) failed: %v, NSG request: %s", pointer.StringDeref(sg.Name, ""), rerr.Error(), string(nsgJSON))
 
 	// Invalidate the cache because ETAG precondition mismatch.
 	if rerr.HTTPStatusCode == http.StatusPreconditionFailed {
@@ -214,7 +213,7 @@ func (az *Cloud) CreateOrUpdateLB(service *v1.Service, lb network.LoadBalancer) 
 	lb = cleanupSubnetInFrontendIPConfigurations(&lb)
 
 	rgName := az.getLoadBalancerResourceGroup()
-	rerr := az.LoadBalancerClient.CreateOrUpdate(ctx, rgName, to.String(lb.Name), lb, to.String(lb.Etag))
+	rerr := az.LoadBalancerClient.CreateOrUpdate(ctx, rgName, pointer.StringDeref(lb.Name, ""), lb, pointer.StringDeref(lb.Etag, ""))
 	klog.V(10).Infof("LoadBalancerClient.CreateOrUpdate(%s): end", *lb.Name)
 	if rerr == nil {
 		// Invalidate the cache right after updating
@@ -223,18 +222,18 @@ func (az *Cloud) CreateOrUpdateLB(service *v1.Service, lb network.LoadBalancer) 
 	}
 
 	lbJSON, _ := json.Marshal(lb)
-	klog.Warningf("LoadBalancerClient.CreateOrUpdate(%s) failed: %v, LoadBalancer request: %s", to.String(lb.Name), rerr.Error(), string(lbJSON))
+	klog.Warningf("LoadBalancerClient.CreateOrUpdate(%s) failed: %v, LoadBalancer request: %s", pointer.StringDeref(lb.Name, ""), rerr.Error(), string(lbJSON))
 
 	// Invalidate the cache because ETAG precondition mismatch.
 	if rerr.HTTPStatusCode == http.StatusPreconditionFailed {
-		klog.V(3).Infof("LoadBalancer cache for %s is cleanup because of http.StatusPreconditionFailed", to.String(lb.Name))
+		klog.V(3).Infof("LoadBalancer cache for %s is cleanup because of http.StatusPreconditionFailed", pointer.StringDeref(lb.Name, ""))
 		_ = az.lbCache.Delete(*lb.Name)
 	}
 
 	retryErrorMessage := rerr.Error().Error()
 	// Invalidate the cache because another new operation has canceled the current request.
 	if strings.Contains(strings.ToLower(retryErrorMessage), consts.OperationCanceledErrorMessage) {
-		klog.V(3).Infof("LoadBalancer cache for %s is cleanup because CreateOrUpdate is canceled by another operation", to.String(lb.Name))
+		klog.V(3).Infof("LoadBalancer cache for %s is cleanup because CreateOrUpdate is canceled by another operation", pointer.StringDeref(lb.Name, ""))
 		_ = az.lbCache.Delete(*lb.Name)
 	}
 
@@ -246,7 +245,7 @@ func (az *Cloud) CreateOrUpdateLB(service *v1.Service, lb network.LoadBalancer) 
 			return rerr.Error()
 		}
 		pipRG, pipName := matches[1], matches[2]
-		klog.V(3).Infof("The public IP %s referenced by load balancer %s is not in Succeeded provisioning state, will try to update it", pipName, to.String(lb.Name))
+		klog.V(3).Infof("The public IP %s referenced by load balancer %s is not in Succeeded provisioning state, will try to update it", pipName, pointer.StringDeref(lb.Name, ""))
 		pip, _, err := az.getPublicIPAddress(pipRG, pipName, azcache.CacheReadTypeDefault)
 		if err != nil {
 			klog.Errorf("Failed to get the public IP %s in resource group %s: %v", pipName, pipRG, err)
@@ -270,8 +269,8 @@ func (az *Cloud) CreateOrUpdateLBBackendPool(lbName string, backendPool network.
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	klog.V(4).Infof("CreateOrUpdateLBBackendPool: updating backend pool %s in LB %s", to.String(backendPool.Name), lbName)
-	rerr := az.LoadBalancerClient.CreateOrUpdateBackendPools(ctx, az.getLoadBalancerResourceGroup(), lbName, to.String(backendPool.Name), backendPool, to.String(backendPool.Etag))
+	klog.V(4).Infof("CreateOrUpdateLBBackendPool: updating backend pool %s in LB %s", pointer.StringDeref(backendPool.Name, ""), lbName)
+	rerr := az.LoadBalancerClient.CreateOrUpdateBackendPools(ctx, az.getLoadBalancerResourceGroup(), lbName, pointer.StringDeref(backendPool.Name, ""), backendPool, pointer.StringDeref(backendPool.Etag, ""))
 	if rerr == nil {
 		// Invalidate the cache right after updating
 		_ = az.lbCache.Delete(lbName)
@@ -356,11 +355,11 @@ func (az *Cloud) ListManagedLBs(service *v1.Service, nodes []*v1.Node, clusterNa
 	}
 
 	for _, lb := range allLBs {
-		vmSetNameFromLBName := az.mapLoadBalancerNameToVMSet(to.String(lb.Name), clusterName)
-		if strings.EqualFold(strings.TrimSuffix(to.String(lb.Name), consts.InternalLoadBalancerNameSuffix), clusterName) ||
+		vmSetNameFromLBName := az.mapLoadBalancerNameToVMSet(pointer.StringDeref(lb.Name, ""), clusterName)
+		if strings.EqualFold(strings.TrimSuffix(pointer.StringDeref(lb.Name, ""), consts.InternalLoadBalancerNameSuffix), clusterName) ||
 			agentPoolVMSetNamesSet.Has(strings.ToLower(vmSetNameFromLBName)) {
 			agentPoolLBs = append(agentPoolLBs, lb)
-			klog.V(4).Infof("ListManagedLBs: found agent pool LB %s", to.String(lb.Name))
+			klog.V(4).Infof("ListManagedLBs: found agent pool LB %s", pointer.StringDeref(lb.Name, ""))
 		}
 	}
 
@@ -391,8 +390,8 @@ func (az *Cloud) CreateOrUpdatePIP(service *v1.Service, pipResourceGroup string,
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	rerr := az.PublicIPAddressesClient.CreateOrUpdate(ctx, pipResourceGroup, to.String(pip.Name), pip)
-	klog.V(10).Infof("PublicIPAddressesClient.CreateOrUpdate(%s, %s): end", pipResourceGroup, to.String(pip.Name))
+	rerr := az.PublicIPAddressesClient.CreateOrUpdate(ctx, pipResourceGroup, pointer.StringDeref(pip.Name, ""), pip)
+	klog.V(10).Infof("PublicIPAddressesClient.CreateOrUpdate(%s, %s): end", pipResourceGroup, pointer.StringDeref(pip.Name, ""))
 	if rerr == nil {
 		// Invalidate the cache right after updating
 		_ = az.pipCache.Delete(pipResourceGroup)
@@ -400,7 +399,7 @@ func (az *Cloud) CreateOrUpdatePIP(service *v1.Service, pipResourceGroup string,
 	}
 
 	pipJSON, _ := json.Marshal(pip)
-	klog.Warningf("PublicIPAddressesClient.CreateOrUpdate(%s, %s) failed: %s, PublicIP request: %s", pipResourceGroup, to.String(pip.Name), rerr.Error().Error(), string(pipJSON))
+	klog.Warningf("PublicIPAddressesClient.CreateOrUpdate(%s, %s) failed: %s, PublicIP request: %s", pipResourceGroup, pointer.StringDeref(pip.Name, ""), rerr.Error().Error(), string(pipJSON))
 	az.Event(service, v1.EventTypeWarning, "CreateOrUpdatePublicIPAddress", rerr.Error().Error())
 
 	// Invalidate the cache because ETAG precondition mismatch.
@@ -480,7 +479,7 @@ func (az *Cloud) CreateOrUpdateRouteTable(routeTable network.RouteTable) error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	rerr := az.RouteTablesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, routeTable, to.String(routeTable.Etag))
+	rerr := az.RouteTablesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, routeTable, pointer.StringDeref(routeTable.Etag, ""))
 	if rerr == nil {
 		// Invalidate the cache right after updating
 		_ = az.rtCache.Delete(*routeTable.Name)
@@ -488,7 +487,7 @@ func (az *Cloud) CreateOrUpdateRouteTable(routeTable network.RouteTable) error {
 	}
 
 	rtJSON, _ := json.Marshal(routeTable)
-	klog.Warningf("RouteTablesClient.CreateOrUpdate(%s) failed: %v, RouteTable request: %s", to.String(routeTable.Name), rerr.Error(), string(rtJSON))
+	klog.Warningf("RouteTablesClient.CreateOrUpdate(%s) failed: %v, RouteTable request: %s", pointer.StringDeref(routeTable.Name, ""), rerr.Error(), string(rtJSON))
 
 	// Invalidate the cache because etag mismatch.
 	if rerr.HTTPStatusCode == http.StatusPreconditionFailed {
@@ -509,7 +508,7 @@ func (az *Cloud) CreateOrUpdateRoute(route network.Route) error {
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	rerr := az.RoutesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, *route.Name, route, to.String(route.Etag))
+	rerr := az.RoutesClient.CreateOrUpdate(ctx, az.RouteTableResourceGroup, az.RouteTableName, *route.Name, route, pointer.StringDeref(route.Etag, ""))
 	klog.V(10).Infof("RoutesClient.CreateOrUpdate(%s): end", *route.Name)
 	if rerr == nil {
 		_ = az.rtCache.Delete(az.RouteTableName)
@@ -575,27 +574,27 @@ func (az *Cloud) CreateOrUpdatePLS(service *v1.Service, pls network.PrivateLinkS
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	rerr := az.PrivateLinkServiceClient.CreateOrUpdate(ctx, az.PrivateLinkServiceResourceGroup, to.String(pls.Name), pls, to.String(pls.Etag))
+	rerr := az.PrivateLinkServiceClient.CreateOrUpdate(ctx, az.PrivateLinkServiceResourceGroup, pointer.StringDeref(pls.Name, ""), pls, pointer.StringDeref(pls.Etag, ""))
 	if rerr == nil {
 		// Invalidate the cache right after updating
-		_ = az.plsCache.Delete(to.String((*pls.LoadBalancerFrontendIPConfigurations)[0].ID))
+		_ = az.plsCache.Delete(pointer.StringDeref((*pls.LoadBalancerFrontendIPConfigurations)[0].ID, ""))
 		return nil
 	}
 
 	rtJSON, _ := json.Marshal(pls)
-	klog.Warningf("PrivateLinkServiceClient.CreateOrUpdate(%s) failed: %v, PrivateLinkService request: %s", to.String(pls.Name), rerr.Error(), string(rtJSON))
+	klog.Warningf("PrivateLinkServiceClient.CreateOrUpdate(%s) failed: %v, PrivateLinkService request: %s", pointer.StringDeref(pls.Name, ""), rerr.Error(), string(rtJSON))
 
 	// Invalidate the cache because etag mismatch.
 	if rerr.HTTPStatusCode == http.StatusPreconditionFailed {
-		klog.V(3).Infof("Private link service cache for %s is cleanup because of http.StatusPreconditionFailed", to.String(pls.Name))
-		_ = az.plsCache.Delete(to.String((*pls.LoadBalancerFrontendIPConfigurations)[0].ID))
+		klog.V(3).Infof("Private link service cache for %s is cleanup because of http.StatusPreconditionFailed", pointer.StringDeref(pls.Name, ""))
+		_ = az.plsCache.Delete(pointer.StringDeref((*pls.LoadBalancerFrontendIPConfigurations)[0].ID, ""))
 	}
 	// Invalidate the cache because another new operation has canceled the current request.
 	if strings.Contains(strings.ToLower(rerr.Error().Error()), consts.OperationCanceledErrorMessage) {
-		klog.V(3).Infof("Private link service for %s is cleanup because CreateOrUpdatePrivateLinkService is canceled by another operation", to.String(pls.Name))
-		_ = az.plsCache.Delete(to.String((*pls.LoadBalancerFrontendIPConfigurations)[0].ID))
+		klog.V(3).Infof("Private link service for %s is cleanup because CreateOrUpdatePrivateLinkService is canceled by another operation", pointer.StringDeref(pls.Name, ""))
+		_ = az.plsCache.Delete(pointer.StringDeref((*pls.LoadBalancerFrontendIPConfigurations)[0].ID, ""))
 	}
-	klog.Errorf("PrivateLinkServiceClient.CreateOrUpdate(%s) failed: %v", to.String(pls.Name), rerr.Error())
+	klog.Errorf("PrivateLinkServiceClient.CreateOrUpdate(%s) failed: %v", pointer.StringDeref(pls.Name, ""), rerr.Error())
 	return rerr.Error()
 }
 

--- a/pkg/provider/azure_backoff_test.go
+++ b/pkg/provider/azure_backoff_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -103,14 +102,14 @@ func TestGetPrivateIPsForMachine(t *testing.T) {
 
 	expectedVM := compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			AvailabilitySet: &compute.SubResource{ID: to.StringPtr("availability-set")},
+			AvailabilitySet: &compute.SubResource{ID: pointer.String("availability-set")},
 			NetworkProfile: &compute.NetworkProfile{
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
 						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-							Primary: to.BoolPtr(true),
+							Primary: pointer.Bool(true),
 						},
-						ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
+						ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -122,7 +121,7 @@ func TestGetPrivateIPsForMachine(t *testing.T) {
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("1.2.3.4"),
+						PrivateIPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -165,14 +164,14 @@ func TestGetIPForMachineWithRetry(t *testing.T) {
 
 	expectedVM := compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			AvailabilitySet: &compute.SubResource{ID: to.StringPtr("availability-set")},
+			AvailabilitySet: &compute.SubResource{ID: pointer.String("availability-set")},
 			NetworkProfile: &compute.NetworkProfile{
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
 						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-							Primary: to.BoolPtr(true),
+							Primary: pointer.Bool(true),
 						},
-						ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
+						ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -184,9 +183,9 @@ func TestGetIPForMachineWithRetry(t *testing.T) {
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("1.2.3.4"),
+						PrivateIPAddress: pointer.String("1.2.3.4"),
 						PublicIPAddress: &network.PublicIPAddress{
-							ID: to.StringPtr("test/pip"),
+							ID: pointer.String("test/pip"),
 						},
 					},
 				},
@@ -197,7 +196,7 @@ func TestGetIPForMachineWithRetry(t *testing.T) {
 	expectedPIP := network.PublicIPAddress{
 		Name: pointer.String("pip"),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("5.6.7.8"),
+			IPAddress: pointer.String("5.6.7.8"),
 		},
 	}
 
@@ -232,7 +231,7 @@ func TestCreateOrUpdateSecurityGroupCanceled(t *testing.T) {
 	})
 	mockSGClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "sg", gomock.Any()).Return(network.SecurityGroup{}, nil)
 
-	err := az.CreateOrUpdateSecurityGroup(network.SecurityGroup{Name: to.StringPtr("sg")})
+	err := az.CreateOrUpdateSecurityGroup(network.SecurityGroup{Name: pointer.String("sg")})
 	assert.EqualError(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: %w", fmt.Errorf("canceledandsupersededduetoanotheroperation")), err.Error())
 
 	// security group should be removed from cache if the operation is canceled
@@ -283,8 +282,8 @@ func TestCreateOrUpdateLB(t *testing.T) {
 		}}, nil).MaxTimes(2)
 
 		err := az.CreateOrUpdateLB(&v1.Service{}, network.LoadBalancer{
-			Name: to.StringPtr("lb"),
-			Etag: to.StringPtr("etag"),
+			Name: pointer.String("lb"),
+			Etag: pointer.String("etag"),
 		})
 		assert.EqualError(t, test.expectedErr, err.Error())
 
@@ -320,18 +319,18 @@ func TestListAgentPoolLBs(t *testing.T) {
 		},
 		{
 			existingLBs: []network.LoadBalancer{
-				{Name: to.StringPtr("kubernetes")},
-				{Name: to.StringPtr("kubernetes-internal")},
-				{Name: to.StringPtr("vmas-1")},
-				{Name: to.StringPtr("vmas-1-internal")},
-				{Name: to.StringPtr("unmanaged")},
-				{Name: to.StringPtr("unmanaged-internal")},
+				{Name: pointer.String("kubernetes")},
+				{Name: pointer.String("kubernetes-internal")},
+				{Name: pointer.String("vmas-1")},
+				{Name: pointer.String("vmas-1-internal")},
+				{Name: pointer.String("unmanaged")},
+				{Name: pointer.String("unmanaged-internal")},
 			},
 			expectedLBs: []network.LoadBalancer{
-				{Name: to.StringPtr("kubernetes")},
-				{Name: to.StringPtr("kubernetes-internal")},
-				{Name: to.StringPtr("vmas-1")},
-				{Name: to.StringPtr("vmas-1-internal")},
+				{Name: pointer.String("kubernetes")},
+				{Name: pointer.String("kubernetes-internal")},
+				{Name: pointer.String("vmas-1")},
+				{Name: pointer.String("vmas-1-internal")},
 			},
 			callTimes: 1,
 		},
@@ -387,7 +386,7 @@ func TestCreateOrUpdatePIP(t *testing.T) {
 			mockPIPClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return([]network.PublicIPAddress{}, nil)
 		}
 
-		err := az.CreateOrUpdatePIP(&v1.Service{}, az.ResourceGroup, network.PublicIPAddress{Name: to.StringPtr("nic")})
+		err := az.CreateOrUpdatePIP(&v1.Service{}, az.ResourceGroup, network.PublicIPAddress{Name: pointer.String("nic")})
 		assert.EqualError(t, test.expectedErr, err.Error())
 
 		cachedPIP, err := az.pipCache.GetWithDeepCopy(az.ResourceGroup, cache.CacheReadTypeDefault)
@@ -408,7 +407,7 @@ func TestCreateOrUpdateInterface(t *testing.T) {
 	mockInterfaceClient := az.InterfacesClient.(*mockinterfaceclient.MockInterface)
 	mockInterfaceClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, "nic", gomock.Any()).Return(&retry.Error{HTTPStatusCode: http.StatusInternalServerError})
 
-	err := az.CreateOrUpdateInterface(&v1.Service{}, network.Interface{Name: to.StringPtr("nic")})
+	err := az.CreateOrUpdateInterface(&v1.Service{}, network.Interface{Name: pointer.String("nic")})
 	assert.EqualError(t, fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: %w", error(nil)), err.Error())
 }
 
@@ -463,8 +462,8 @@ func TestCreateOrUpdateRouteTable(t *testing.T) {
 		mockRTClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "rt", gomock.Any()).Return(network.RouteTable{}, nil)
 
 		err := az.CreateOrUpdateRouteTable(network.RouteTable{
-			Name: to.StringPtr("rt"),
-			Etag: to.StringPtr("etag"),
+			Name: pointer.String("rt"),
+			Etag: pointer.String("etag"),
 		})
 		assert.EqualError(t, test.expectedErr, err.Error())
 
@@ -508,8 +507,8 @@ func TestCreateOrUpdateRoute(t *testing.T) {
 		mockRTableClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "rt", gomock.Any()).Return(network.RouteTable{}, nil)
 
 		err := az.CreateOrUpdateRoute(network.Route{
-			Name: to.StringPtr("rt"),
-			Etag: to.StringPtr("etag"),
+			Name: pointer.String("rt"),
+			Etag: pointer.String("etag"),
 		})
 		if test.expectedErr != nil {
 			assert.EqualError(t, test.expectedErr, err.Error())
@@ -576,7 +575,7 @@ func TestCreateOrUpdateVMSS(t *testing.T) {
 		{
 			vmss: compute.VirtualMachineScaleSet{
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-					ProvisioningState: to.StringPtr(consts.VirtualMachineScaleSetsDeallocating),
+					ProvisioningState: pointer.String(consts.VirtualMachineScaleSetsDeallocating),
 				},
 			},
 		},

--- a/pkg/provider/azure_config_test.go
+++ b/pkg/provider/azure_config_test.go
@@ -28,12 +28,12 @@ import (
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/zoneclient/mockzoneclient"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/yaml"
 )
@@ -55,7 +55,7 @@ func getTestConfig() *Config {
 		PrimaryAvailabilitySetName:  "PrimaryAvailabilitySetName",
 		PrimaryScaleSetName:         "PrimaryScaleSetName",
 		LoadBalancerSku:             "LoadBalancerSku",
-		ExcludeMasterFromStandardLB: to.BoolPtr(true),
+		ExcludeMasterFromStandardLB: pointer.Bool(true),
 	}
 }
 

--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -54,7 +53,7 @@ func TestCommonAttachDisk(t *testing.T) {
 	goodInstanceID := fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/%s", "vm1")
 	diskEncryptionSetID := fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/%s", "diskEncryptionSet-name")
 	testTags := make(map[string]*string)
-	testTags[WriteAcceleratorEnabled] = to.StringPtr("true")
+	testTags[WriteAcceleratorEnabled] = pointer.String("true")
 	testCases := []struct {
 		desc            string
 		diskName        string
@@ -80,7 +79,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			desc:        "LUN -1 and error shall be returned if there's no such instance corresponding to given nodeName",
 			nodeName:    "vm1",
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -90,7 +89,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			nodeName:        "vm1",
 			isDataDisksFull: true,
 			diskName:        "disk-name",
-			existedDisk:     &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk:     &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun:     -1,
 			expectedErr:     true,
 		},
@@ -99,10 +98,10 @@ func TestCommonAttachDisk(t *testing.T) {
 			vmList:   map[string]string{"vm1": "PowerState/Running"},
 			nodeName: "vm1",
 			diskName: "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name"),
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name"),
 				DiskProperties: &compute.DiskProperties{
 					Encryption: &compute.Encryption{DiskEncryptionSetID: &diskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey},
-					DiskSizeGB: to.Int32Ptr(4096),
+					DiskSizeGB: pointer.Int32(4096),
 					DiskState:  compute.Unattached,
 				},
 				Tags: testTags},
@@ -114,10 +113,10 @@ func TestCommonAttachDisk(t *testing.T) {
 			vmList:   map[string]string{"vm1": "PowerState/Running"},
 			nodeName: "vm1",
 			diskName: "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name"),
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name"),
 				DiskProperties: &compute.DiskProperties{
 					Encryption: &compute.Encryption{DiskEncryptionSetID: &diskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey},
-					DiskSizeGB: to.Int32Ptr(4096),
+					DiskSizeGB: pointer.Int32(4096),
 					DiskState:  compute.Attached,
 				},
 				Tags: testTags},
@@ -129,7 +128,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			vmList:      map[string]string{"vm1": "PowerState/Running"},
 			nodeName:    "vm1",
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name"), ManagedBy: to.StringPtr(goodInstanceID), DiskProperties: &compute.DiskProperties{MaxShares: &maxShare}},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name"), ManagedBy: pointer.String(goodInstanceID), DiskProperties: &compute.DiskProperties{MaxShares: &maxShare}},
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -138,7 +137,7 @@ func TestCommonAttachDisk(t *testing.T) {
 			vmList:      map[string]string{"vm1": "PowerState/Running"},
 			nodeName:    "vm1",
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name"), ManagedBy: to.StringPtr("test"), DiskProperties: &compute.DiskProperties{MaxShares: &maxShare}},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name"), ManagedBy: pointer.String("test"), DiskProperties: &compute.DiskProperties{MaxShares: &maxShare}},
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -210,7 +209,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 			isVMSS:      false,
 			isManagedBy: false,
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -221,7 +220,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 			isVMSS:      true,
 			isManagedBy: false,
 			diskName:    "disk-name",
-			existedDisk: &compute.Disk{Name: to.StringPtr("disk-name")},
+			existedDisk: &compute.Disk{Name: pointer.String("disk-name")},
 			expectedLun: -1,
 			expectedErr: true,
 		},
@@ -233,7 +232,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 		if test.isVMSS {
 			if test.isManagedBy {
 				testCloud.DisableAvailabilitySetNodes = false
-				expectedVMSS := compute.VirtualMachineScaleSet{Name: to.StringPtr(testVMSSName)}
+				expectedVMSS := compute.VirtualMachineScaleSet{Name: pointer.String(testVMSSName)}
 				mockVMSSClient := testCloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
 				mockVMSSClient.EXPECT().List(gomock.Any(), testCloud.ResourceGroup).Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 

--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -83,7 +83,7 @@ func (as *availabilitySet) AttachDisk(nodeName types.NodeName, diskMap map[strin
 				Caching:                 opt.cachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: to.BoolPtr(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
 			})
 	}
 
@@ -160,7 +160,7 @@ func (as *availabilitySet) DetachDisk(nodeName types.NodeName, diskMap map[strin
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-				disks[i].ToBeDetached = to.BoolPtr(true)
+				disks[i].ToBeDetached = pointer.Bool(true)
 				bFoundDisk = true
 			}
 		}
@@ -174,7 +174,7 @@ func (as *availabilitySet) DetachDisk(nodeName types.NodeName, diskMap map[strin
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			newDisks := []compute.DataDisk{}
 			for _, disk := range disks {
-				if !to.Bool(disk.ToBeDetached) {
+				if !pointer.BoolDeref(disk.ToBeDetached, false) {
 					newDisks = append(newDisks, disk)
 				}
 			}

--- a/pkg/provider/azure_controller_standard_test.go
+++ b/pkg/provider/azure_controller_standard_test.go
@@ -23,12 +23,12 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
@@ -80,11 +80,11 @@ func TestStandardAttachDisk(t *testing.T) {
 		for _, vm := range expectedVMs {
 			vm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
@@ -270,16 +270,16 @@ func TestGetDataDisks(t *testing.T) {
 			nodeName: "vm1",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 				{
-					Lun:  to.Int32Ptr(1),
-					Name: to.StringPtr("disk2"),
+					Lun:  pointer.Int32(1),
+					Name: pointer.String("disk2"),
 				},
 				{
-					Lun:  to.Int32Ptr(2),
-					Name: to.StringPtr("disk3"),
+					Lun:  pointer.Int32(2),
+					Name: pointer.String("disk3"),
 				},
 			},
 			expectedError: false,
@@ -290,16 +290,16 @@ func TestGetDataDisks(t *testing.T) {
 			nodeName: "vm1",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 				{
-					Lun:  to.Int32Ptr(1),
-					Name: to.StringPtr("disk2"),
+					Lun:  pointer.Int32(1),
+					Name: pointer.String("disk2"),
 				},
 				{
-					Lun:  to.Int32Ptr(2),
-					Name: to.StringPtr("disk3"),
+					Lun:  pointer.Int32(2),
+					Name: pointer.String("disk3"),
 				},
 			},
 			expectedError: false,

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -86,7 +86,7 @@ func (ss *ScaleSet) AttachDisk(nodeName types.NodeName, diskMap map[string]*Atta
 				Caching:                 opt.cachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: to.BoolPtr(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
 			})
 	}
 
@@ -159,7 +159,7 @@ func (ss *ScaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]strin
 				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
 				klog.V(2).Infof("azureDisk - detach disk: name %q uri %q", diskName, diskURI)
-				disks[i].ToBeDetached = to.BoolPtr(true)
+				disks[i].ToBeDetached = pointer.Bool(true)
 				bFoundDisk = true
 			}
 		}
@@ -173,7 +173,7 @@ func (ss *ScaleSet) DetachDisk(nodeName types.NodeName, diskMap map[string]strin
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			newDisks := []compute.DataDisk{}
 			for _, disk := range disks {
-				if !to.Bool(disk.ToBeDetached) {
+				if !pointer.BoolDeref(disk.ToBeDetached, false) {
 					newDisks = append(newDisks, disk)
 				}
 			}

--- a/pkg/provider/azure_controller_vmss_test.go
+++ b/pkg/provider/azure_controller_vmss_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
@@ -95,11 +95,11 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 		for _, vmssvm := range expectedVMSSVMs {
 			vmssvm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
@@ -212,26 +212,26 @@ func TestDetachDiskWithVMSS(t *testing.T) {
 		for _, vmssvm := range expectedVMSSVMs {
 			vmssvm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
 				DataDisks: &[]compute.DataDisk{
 					{
-						Lun:  to.Int32Ptr(0),
-						Name: to.StringPtr(diskName),
+						Lun:  pointer.Int32(0),
+						Name: pointer.String(diskName),
 					},
 					{
-						Lun:  to.Int32Ptr(1),
-						Name: to.StringPtr("disk2"),
+						Lun:  pointer.Int32(1),
+						Name: pointer.String("disk2"),
 					},
 					{
-						Lun:  to.Int32Ptr(2),
-						Name: to.StringPtr("disk3"),
+						Lun:  pointer.Int32(2),
+						Name: pointer.String("disk3"),
 					},
 				},
 			}
@@ -287,7 +287,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:     []string{"vmss-vm-000001"},
 			vmssName:       "vm1",
 			vmssvmName:     "vm1",
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("not a vmss instance"),
 		},
@@ -296,7 +296,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:  []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:    "vmss00",
 			vmssvmName:  "vmss00-vm-000000",
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName)},
+			existedDisk: compute.Disk{Name: pointer.String(diskName)},
 			expectedErr: false,
 		},
 		{
@@ -304,7 +304,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:     []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:       fakeStatusNotFoundVMSSName,
 			vmssvmName:     "vmss00-vm-000000",
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName)},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: %w", fmt.Errorf("instance not found")),
 		},
@@ -313,7 +313,7 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 			vmssVMList:  []string{"vmss00-vm-000000", "vmss00-vm-000001", "vmss00-vm-000002"},
 			vmssName:    "vmss00",
 			vmssvmName:  "vmss00-vm-000000",
-			existedDisk: compute.Disk{Name: to.StringPtr("disk-name-err")},
+			existedDisk: compute.Disk{Name: pointer.String("disk-name-err")},
 			expectedErr: false,
 		},
 	}
@@ -334,17 +334,17 @@ func TestUpdateVMWithVMSS(t *testing.T) {
 		for _, vmssvm := range expectedVMSSVMs {
 			vmssvm.StorageProfile = &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
-					Name: to.StringPtr("osdisk1"),
+					Name: pointer.String("osdisk1"),
 					ManagedDisk: &compute.ManagedDiskParameters{
-						ID: to.StringPtr("ManagedID"),
+						ID: pointer.String("ManagedID"),
 						DiskEncryptionSet: &compute.DiskEncryptionSetParameters{
-							ID: to.StringPtr("DiskEncryptionSetID"),
+							ID: pointer.String("DiskEncryptionSetID"),
 						},
 					},
 				},
 				DataDisks: &[]compute.DataDisk{{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr(diskName),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String(diskName),
 				}},
 			}
 		}
@@ -398,8 +398,8 @@ func TestGetDataDisksWithVMSS(t *testing.T) {
 			nodeName: "vmss00-vm-000000",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 			},
 			expectedErr: false,
@@ -410,8 +410,8 @@ func TestGetDataDisksWithVMSS(t *testing.T) {
 			nodeName: "vmss00-vm-000000",
 			expectedDataDisks: []compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 			},
 			expectedErr: false,
@@ -443,8 +443,8 @@ func TestGetDataDisksWithVMSS(t *testing.T) {
 			for _, vmssvm := range expectedVMSSVMs {
 				vmssvm.StorageProfile = &compute.StorageProfile{
 					DataDisks: &[]compute.DataDisk{{
-						Lun:  to.Int32Ptr(0),
-						Name: to.StringPtr("disk1"),
+						Lun:  pointer.Int32(0),
+						Name: pointer.String("disk1"),
 					}},
 				}
 			}

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -59,14 +58,14 @@ func setTestVirtualMachines(c *Cloud, vmList map[string]string, isDataDisksFull 
 		}
 		status := []compute.InstanceViewStatus{
 			{
-				Code: to.StringPtr(powerState),
+				Code: pointer.String(powerState),
 			},
 			{
-				Code: to.StringPtr("ProvisioningState/succeeded"),
+				Code: pointer.String("ProvisioningState/succeeded"),
 			},
 		}
 		vm.VirtualMachineProperties = &compute.VirtualMachineProperties{
-			ProvisioningState: to.StringPtr(string(compute.ProvisioningStateSucceeded)),
+			ProvisioningState: pointer.String(string(compute.ProvisioningStateSucceeded)),
 			HardwareProfile: &compute.HardwareProfile{
 				VMSize: compute.StandardA0,
 			},
@@ -80,22 +79,22 @@ func setTestVirtualMachines(c *Cloud, vmList map[string]string, isDataDisksFull 
 		if !isDataDisksFull {
 			vm.StorageProfile.DataDisks = &[]compute.DataDisk{
 				{
-					Lun:  to.Int32Ptr(0),
-					Name: to.StringPtr("disk1"),
+					Lun:  pointer.Int32(0),
+					Name: pointer.String("disk1"),
 				},
 				{
-					Lun:  to.Int32Ptr(1),
-					Name: to.StringPtr("disk2"),
+					Lun:  pointer.Int32(1),
+					Name: pointer.String("disk2"),
 				},
 				{
-					Lun:  to.Int32Ptr(2),
-					Name: to.StringPtr("disk3"),
+					Lun:  pointer.Int32(2),
+					Name: pointer.String("disk3"),
 				},
 			}
 		} else {
 			dataDisks := make([]compute.DataDisk, maxLUN)
 			for i := 0; i < maxLUN; i++ {
-				dataDisks[i] = compute.DataDisk{Lun: to.Int32Ptr(int32(i))}
+				dataDisks[i] = compute.DataDisk{Lun: pointer.Int32(int32(i))}
 			}
 			vm.StorageProfile.DataDisks = &dataDisks
 		}
@@ -358,7 +357,7 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 		cloud := GetTestCloud(ctrl)
 		expectedVMs := setTestVirtualMachines(cloud, test.vmList, false)
 		if test.provisioningState != "" {
-			expectedVMs[0].ProvisioningState = to.StringPtr(test.provisioningState)
+			expectedVMs[0].ProvisioningState = pointer.String(test.provisioningState)
 		}
 		mockVMsClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		for _, vm := range expectedVMs {
@@ -392,9 +391,9 @@ func TestNodeAddresses(t *testing.T) {
 				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 					{
 						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-							Primary: to.BoolPtr(true),
+							Primary: pointer.Bool(true),
 						},
-						ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
+						ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -405,7 +404,7 @@ func TestNodeAddresses(t *testing.T) {
 		Name: pointer.String("pip1"),
 		ID:   pointer.String("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("192.168.1.12"),
+			IPAddress: pointer.String("192.168.1.12"),
 		},
 	}
 
@@ -414,7 +413,7 @@ func TestNodeAddresses(t *testing.T) {
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("172.1.0.3"),
+						PrivateIPAddress: pointer.String("172.1.0.3"),
 						PublicIPAddress:  &expectedPIP,
 					},
 				},
@@ -880,17 +879,17 @@ func TestInstanceMetadata(t *testing.T) {
 		expectedVM.HardwareProfile = &compute.HardwareProfile{
 			VMSize: compute.BasicA0,
 		}
-		expectedVM.Location = to.StringPtr("westus2")
+		expectedVM.Location = pointer.String("westus2")
 		expectedVM.Zones = &[]string{"1"}
-		expectedVM.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/VirtualMachines/vm")
+		expectedVM.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/VirtualMachines/vm")
 		mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, "vm", gomock.Any()).Return(expectedVM, nil)
 		expectedNIC := buildDefaultTestInterface(true, []string{})
-		(*expectedNIC.IPConfigurations)[0].PrivateIPAddress = to.StringPtr("1.2.3.4")
+		(*expectedNIC.IPConfigurations)[0].PrivateIPAddress = pointer.String("1.2.3.4")
 		(*expectedNIC.IPConfigurations)[0].PublicIPAddress = &network.PublicIPAddress{
-			ID: to.StringPtr("pip"),
+			ID: pointer.String("pip"),
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-				IPAddress: to.StringPtr("5.6.7.8"),
+				IPAddress: pointer.String("5.6.7.8"),
 			},
 		}
 		mockNICClient := cloud.InterfacesClient.(*mockinterfaceclient.MockInterface)
@@ -898,7 +897,7 @@ func TestInstanceMetadata(t *testing.T) {
 		expectedPIP := network.PublicIPAddress{
 			Name: pointer.String("pip"),
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-				IPAddress: to.StringPtr("5.6.7.8"),
+				IPAddress: pointer.String("5.6.7.8"),
 			},
 		}
 		mockPIPClient := cloud.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,6 +38,7 @@ import (
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -166,7 +166,7 @@ func (az *Cloud) reconcileService(ctx context.Context, clusterName string, servi
 		}
 	}
 
-	updateService := updateServiceLoadBalancerIP(service, to.String(serviceIP))
+	updateService := updateServiceLoadBalancerIP(service, pointer.StringDeref(serviceIP, ""))
 	flippedService := flipServiceInternalAnnotation(updateService)
 	if _, err := az.reconcileLoadBalancer(clusterName, flippedService, nil, false /* wantLb */); err != nil {
 		klog.Errorf("reconcileLoadBalancer(%s) failed: %#v", serviceName, err)
@@ -175,7 +175,7 @@ func (az *Cloud) reconcileService(ctx context.Context, clusterName string, servi
 
 	// lb is not reused here because the ETAG may be changed in above operations, hence reconcilePublicIP() would get lb again from cache.
 	klog.V(2).Infof("reconcileService: reconciling pip")
-	if _, err := az.reconcilePublicIP(clusterName, updateService, to.String(lb.Name), true /* wantLb */); err != nil {
+	if _, err := az.reconcilePublicIP(clusterName, updateService, pointer.StringDeref(lb.Name, ""), true /* wantLb */); err != nil {
 		klog.Errorf("reconcilePublicIP(%s) failed: %#v", serviceName, err)
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadB
 	}
 	fipConfigs := *lb.FrontendIPConfigurations
 	for i, fipConfig := range fipConfigs {
-		if strings.EqualFold(to.String(fipConfig.Name), to.String(fip.Name)) {
+		if strings.EqualFold(pointer.StringDeref(fipConfig.Name, ""), pointer.StringDeref(fip.Name, "")) {
 			fipConfigs = append(fipConfigs[:i], fipConfigs[i+1:]...)
 			break
 		}
@@ -403,7 +403,7 @@ func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadB
 	if lb.LoadBalancingRules != nil {
 		lbRules := *lb.LoadBalancingRules
 		for i := len(lbRules) - 1; i >= 0; i-- {
-			if strings.Contains(to.String(lbRules[i].Name), to.String(fip.Name)) {
+			if strings.Contains(pointer.StringDeref(lbRules[i].Name, ""), pointer.StringDeref(fip.Name, "")) {
 				lbRules = append(lbRules[:i], lbRules[i+1:]...)
 			}
 		}
@@ -412,7 +412,7 @@ func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadB
 	if lb.Probes != nil {
 		lbProbes := *lb.Probes
 		for i := len(lbProbes) - 1; i >= 0; i-- {
-			if strings.Contains(to.String(lbProbes[i].Name), to.String(fip.Name)) {
+			if strings.Contains(pointer.StringDeref(lbProbes[i].Name, ""), pointer.StringDeref(fip.Name, "")) {
 				lbProbes = append(lbProbes[:i], lbProbes[i+1:]...)
 			}
 		}
@@ -422,31 +422,31 @@ func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadB
 	// clean up any private link service associated with the frontEndIPConfig
 	err := az.reconcilePrivateLinkService(clusterName, service, fip, false /* wantPLS */)
 	if err != nil {
-		klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to clean up PLS: %v", to.String(lb.Name), to.String(fip.Name), clusterName, service.Name, err)
+		klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to clean up PLS: %v", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name, err)
 		return err
 	}
 
 	if len(fipConfigs) == 0 {
-		klog.V(2).Infof("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): deleting load balancer because there is no remaining frontend IP configurations", to.String(lb.Name), to.String(fip.Name), clusterName, service.Name)
+		klog.V(2).Infof("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): deleting load balancer because there is no remaining frontend IP configurations", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name)
 		err := az.cleanOrphanedLoadBalancer(lb, existingLBs, service, clusterName)
 		if err != nil {
-			klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to cleanupOrphanedLoadBalancer: %v", to.String(lb.Name), to.String(fip.Name), clusterName, service.Name, err)
+			klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to cleanupOrphanedLoadBalancer: %v", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name, err)
 			return err
 		}
 	} else {
-		klog.V(2).Infof("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): updating the load balancer", to.String(lb.Name), to.String(fip.Name), clusterName, service.Name)
+		klog.V(2).Infof("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): updating the load balancer", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name)
 		err := az.CreateOrUpdateLB(service, *lb)
 		if err != nil {
-			klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to CreateOrUpdateLB: %v", to.String(lb.Name), to.String(fip.Name), clusterName, service.Name, err)
+			klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to CreateOrUpdateLB: %v", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name, err)
 			return err
 		}
-		_ = az.lbCache.Delete(to.String(lb.Name))
+		_ = az.lbCache.Delete(pointer.StringDeref(lb.Name, ""))
 	}
 	return nil
 }
 
 func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs []network.LoadBalancer, service *v1.Service, clusterName string) error {
-	lbName := to.String(lb.Name)
+	lbName := pointer.StringDeref(lb.Name, "")
 	serviceName := getServiceName(service)
 	isBackendPoolPreConfigured := az.isBackendPoolPreConfigured(service)
 	lbResourceGroup := az.getLoadBalancerResourceGroup()
@@ -457,13 +457,13 @@ func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs
 	} else {
 		foundLB := false
 		for _, existingLB := range existingLBs {
-			if strings.EqualFold(to.String(lb.Name), to.String(existingLB.Name)) {
+			if strings.EqualFold(pointer.StringDeref(lb.Name, ""), pointer.StringDeref(existingLB.Name, "")) {
 				foundLB = true
 				break
 			}
 		}
 		if !foundLB {
-			klog.V(2).Infof("cleanOrphanedLoadBalancer: the LB %s doesn't exist, will not delete it", to.String(lb.Name))
+			klog.V(2).Infof("cleanOrphanedLoadBalancer: the LB %s doesn't exist, will not delete it", pointer.StringDeref(lb.Name, ""))
 			return nil
 		}
 
@@ -522,18 +522,18 @@ func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs
 
 // safeDeleteLoadBalancer deletes the load balancer after decoupling it from the vmSet
 func (az *Cloud) safeDeleteLoadBalancer(lb network.LoadBalancer, clusterName, vmSetName string, service *v1.Service) *retry.Error {
-	lbBackendPoolID := az.getBackendPoolID(to.String(lb.Name), az.getLoadBalancerResourceGroup(), getBackendPoolName(clusterName, service))
+	lbBackendPoolID := az.getBackendPoolID(pointer.StringDeref(lb.Name, ""), az.getLoadBalancerResourceGroup(), getBackendPoolName(clusterName, service))
 	_, err := az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolID, vmSetName, lb.BackendAddressPools, true)
 	if err != nil {
 		return retry.NewError(false, fmt.Errorf("safeDeleteLoadBalancer: failed to EnsureBackendPoolDeleted: %w", err))
 	}
 
-	klog.V(2).Infof("safeDeleteLoadBalancer: deleting LB %s because the corresponding vmSet is supposed to be in the primary SLB", to.String(lb.Name))
-	rerr := az.DeleteLB(service, to.String(lb.Name))
+	klog.V(2).Infof("safeDeleteLoadBalancer: deleting LB %s because the corresponding vmSet is supposed to be in the primary SLB", pointer.StringDeref(lb.Name, ""))
+	rerr := az.DeleteLB(service, pointer.StringDeref(lb.Name, ""))
 	if rerr != nil {
 		return rerr
 	}
-	_ = az.lbCache.Delete(to.String(lb.Name))
+	_ = az.lbCache.Delete(pointer.StringDeref(lb.Name, ""))
 
 	return nil
 }
@@ -544,12 +544,12 @@ func extractBackendIPConfigurationIDsFromLB(lb network.LoadBalancer, lbBackendPo
 		lb.BackendAddressPools != nil {
 		for i := 0; i < len(*lb.BackendAddressPools); i++ {
 			backendPool := (*lb.BackendAddressPools)[i]
-			if strings.EqualFold(to.String(backendPool.Name), lbBackendPoolName) {
+			if strings.EqualFold(pointer.StringDeref(backendPool.Name, ""), lbBackendPoolName) {
 				if backendPool.BackendAddressPoolPropertiesFormat != nil &&
 					backendPool.BackendIPConfigurations != nil {
 					for _, ipConfiguration := range *backendPool.BackendIPConfigurations {
 						if ipConfiguration.ID != nil {
-							result = append(result, to.String(ipConfiguration.ID))
+							result = append(result, pointer.StringDeref(ipConfiguration.ID, ""))
 						}
 					}
 				}
@@ -605,8 +605,8 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 	lbNamesToBeDeleted := sets.NewString()
 	// 1: delete unwanted LBs
 	for _, lb := range existingLBs {
-		klog.V(4).Infof("reconcileSharedLoadBalancer: checking LB %s", to.String(lb.Name))
-		lbNamePrefix := strings.TrimSuffix(to.String(lb.Name), consts.InternalLoadBalancerNameSuffix)
+		klog.V(4).Infof("reconcileSharedLoadBalancer: checking LB %s", pointer.StringDeref(lb.Name, ""))
+		lbNamePrefix := strings.TrimSuffix(pointer.StringDeref(lb.Name, ""), consts.InternalLoadBalancerNameSuffix)
 
 		// skip the internal or external primary load balancer
 		if strings.EqualFold(lbNamePrefix, clusterName) {
@@ -616,7 +616,7 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 
 		// skip if the multiple slbs mode is enabled and
 		// the vmSet is supposed to have dedicated SLBs
-		vmSetName := strings.ToLower(az.mapLoadBalancerNameToVMSet(to.String(lb.Name), clusterName))
+		vmSetName := strings.ToLower(az.mapLoadBalancerNameToVMSet(pointer.StringDeref(lb.Name, ""), clusterName))
 		if az.EnableMultipleStandardLoadBalancers && !az.getVMSetNamesSharingPrimarySLB().Has(vmSetName) {
 			continue
 		}
@@ -632,7 +632,7 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 
 		// remove the deleted lb from the list and construct a new primary
 		// lb, so that getServiceLoadBalancer doesn't have to call list api again
-		lbNamesToBeDeleted.Insert(strings.ToLower(to.String(lb.Name)))
+		lbNamesToBeDeleted.Insert(strings.ToLower(pointer.StringDeref(lb.Name, "")))
 		changed = true
 	}
 
@@ -646,13 +646,13 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 	// 2: add nodes to the backend pool of the primary SLBs
 	for i := len(existingLBs) - 1; i >= 0; i-- {
 		lb := existingLBs[i]
-		if !lbNamesToBeDeleted.Has(strings.ToLower(to.String(lb.Name))) {
+		if !lbNamesToBeDeleted.Has(strings.ToLower(pointer.StringDeref(lb.Name, ""))) {
 			continue
 		}
 
-		vmSetName := strings.ToLower(az.mapLoadBalancerNameToVMSet(to.String(lb.Name), clusterName))
+		vmSetName := strings.ToLower(az.mapLoadBalancerNameToVMSet(pointer.StringDeref(lb.Name, ""), clusterName))
 		vmSetsToBeMovedToPrimarySLB.Insert(vmSetName)
-		isInternalLB := strings.HasSuffix(to.String(lb.Name), consts.InternalLoadBalancerNameSuffix)
+		isInternalLB := strings.HasSuffix(pointer.StringDeref(lb.Name, ""), consts.InternalLoadBalancerNameSuffix)
 		primarySLBName := clusterName
 		if isInternalLB {
 			primarySLBName = fmt.Sprintf("%s%s", clusterName, consts.InternalLoadBalancerNameSuffix)
@@ -679,12 +679,12 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 		if primarySLB.LoadBalancerPropertiesFormat != nil &&
 			primarySLB.BackendAddressPools != nil {
 			for i := 0; i < len(*primarySLB.BackendAddressPools); i++ {
-				if strings.EqualFold(to.String((*primarySLB.BackendAddressPools)[i].Name), lbBackendPoolName) {
+				if strings.EqualFold(pointer.StringDeref((*primarySLB.BackendAddressPools)[i].Name, ""), lbBackendPoolName) {
 					if az.isLBBackendPoolTypeNodeIPConfig() {
 						backendPoolIPConfigs := (*primarySLB.BackendAddressPools)[i].BackendIPConfigurations
 						for _, id := range ipConfigIDsToBeAddedToPrimarySLB.List() {
 							*backendPoolIPConfigs = append(*backendPoolIPConfigs, network.InterfaceIPConfiguration{
-								ID: to.StringPtr(id),
+								ID: pointer.String(id),
 							})
 						}
 					} else if az.isLBBackendPoolTypeNodeIP() {
@@ -694,7 +694,7 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 							backendPool.LoadBalancerBackendAddresses = &lbBackendPoolAddresses
 						}
 
-						if err := az.LoadBalancerBackendPool.EnsureHostsInPool(service, nodes, "", "", clusterName, to.String(primarySLB.Name), backendPool); err != nil {
+						if err := az.LoadBalancerBackendPool.EnsureHostsInPool(service, nodes, "", "", clusterName, pointer.StringDeref(primarySLB.Name, ""), backendPool); err != nil {
 							return nil, fmt.Errorf("reconcileSharedLoadBalancer: failed to EnsureHostsInPool: %w", err)
 						}
 
@@ -709,7 +709,7 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 
 	for i, existingLB := range existingLBs {
 		for _, primarySLB := range primarySLBs {
-			if strings.EqualFold(to.String(existingLB.Name), to.String(primarySLB.Name)) {
+			if strings.EqualFold(pointer.StringDeref(existingLB.Name, ""), pointer.StringDeref(primarySLB.Name, "")) {
 				// Proactively disable the etag to prevent etag mismatch error when putting lb later.
 				// This could happen because when we remove the hosts from the lb, the nrp
 				// would put the lb to remove the backend references as well.
@@ -749,7 +749,7 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 	// check if the service already has a load balancer
 	for i := range existingLBs {
 		existingLB := existingLBs[i]
-		existingLBNamePrefix := strings.TrimSuffix(to.String(existingLB.Name), consts.InternalLoadBalancerNameSuffix)
+		existingLBNamePrefix := strings.TrimSuffix(pointer.StringDeref(existingLB.Name, ""), consts.InternalLoadBalancerNameSuffix)
 
 		// for the primary standard load balancer (internal or external), when enabled multiple slbs
 		if strings.EqualFold(existingLBNamePrefix, clusterName) && useMultipleSLBs {
@@ -794,7 +794,7 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 
 		// select another load balancer instead of returning
 		// the current one if the change is needed
-		if wantLb && az.shouldChangeLoadBalancer(service, to.String(existingLB.Name), clusterName) {
+		if wantLb && az.shouldChangeLoadBalancer(service, pointer.StringDeref(existingLB.Name, ""), clusterName) {
 			if err := az.removeFrontendIPConfigurationFromLoadBalancer(&existingLB, existingLBs, fipConfig, clusterName, service); err != nil {
 				klog.Errorf("getServiceLoadBalancer(%s, %s, %v): failed to remove frontend IP configuration from load balancer: %v", service.Name, clusterName, wantLb, err)
 				return nil, nil, false, err
@@ -931,10 +931,10 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 	for _, ipConfiguration := range *lb.FrontendIPConfigurations {
 		owns, isPrimaryService, err := az.serviceOwnsFrontendIP(ipConfiguration, service, pips)
 		if err != nil {
-			return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to filter frontend IP configs with error: %w", serviceName, to.String(lb.Name), err)
+			return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to filter frontend IP configs with error: %w", serviceName, pointer.StringDeref(lb.Name, ""), err)
 		}
 		if owns {
-			klog.V(2).Infof("get(%s): lb(%s) - found frontend IP config, primary service: %v", serviceName, to.String(lb.Name), isPrimaryService)
+			klog.V(2).Infof("get(%s): lb(%s) - found frontend IP config, primary service: %v", serviceName, pointer.StringDeref(lb.Name, ""), isPrimaryService)
 
 			var lbIP *string
 			if isInternal {
@@ -960,10 +960,10 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 				}
 			}
 
-			klog.V(2).Infof("getServiceLoadBalancerStatus gets ingress IP %q from frontendIPConfiguration %q for service %q", to.String(lbIP), to.String(ipConfiguration.Name), serviceName)
+			klog.V(2).Infof("getServiceLoadBalancerStatus gets ingress IP %q from frontendIPConfiguration %q for service %q", pointer.StringDeref(lbIP, ""), pointer.StringDeref(ipConfiguration.Name, ""), serviceName)
 
 			// set additional public IPs to LoadBalancerStatus, so that kube-proxy would create their iptables rules.
-			lbIngress := []v1.LoadBalancerIngress{{IP: to.String(lbIP)}}
+			lbIngress := []v1.LoadBalancerIngress{{IP: pointer.StringDeref(lbIP, "")}}
 			additionalIPs, err := getServiceAdditionalPublicIPs(service)
 			if err != nil {
 				return &v1.LoadBalancerStatus{Ingress: lbIngress}, &ipConfiguration, err
@@ -1136,7 +1136,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 			}
 		}
 
-		klog.V(2).Infof("ensurePublicIPExists for service(%s): pip(%s) - updating", serviceName, to.String(pip.Name))
+		klog.V(2).Infof("ensurePublicIPExists for service(%s): pip(%s) - updating", serviceName, pointer.StringDeref(pip.Name, ""))
 		if pip.PublicIPAddressPropertiesFormat == nil {
 			pip.PublicIPAddressPropertiesFormat = &network.PublicIPAddressPropertiesFormat{
 				PublicIPAllocationMethod: network.Static,
@@ -1150,8 +1150,8 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 
 		changed = true
 
-		pip.Name = to.StringPtr(pipName)
-		pip.Location = to.StringPtr(az.Location)
+		pip.Name = pointer.String(pipName)
+		pip.Location = pointer.String(az.Location)
 		if az.HasExtendedLocation() {
 			klog.V(2).Infof("Using extended location with name %s, and type %s for PIP", az.ExtendedLocationName, az.ExtendedLocationType)
 			pip.ExtendedLocation = &network.ExtendedLocation{
@@ -1164,7 +1164,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 			IPTags:                   getServiceIPTagRequestForPublicIP(service).IPTags,
 		}
 		pip.Tags = map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr(""),
+			consts.ServiceTagKey:  pointer.String(""),
 			consts.ClusterNameKey: &clusterName,
 		}
 		if _, err = bindServicesToPIP(&pip, []string{serviceName}, false); err != nil {
@@ -1176,13 +1176,13 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 				Name: network.PublicIPAddressSkuNameStandard,
 			}
 			if pipPrefixName, ok := service.Annotations[consts.ServiceAnnotationPIPPrefixID]; ok && pipPrefixName != "" {
-				pip.PublicIPPrefix = &network.SubResource{ID: to.StringPtr(pipPrefixName)}
+				pip.PublicIPPrefix = &network.SubResource{ID: pointer.String(pipPrefixName)}
 			}
 
 			// skip adding zone info since edge zones doesn't support multiple availability zones.
 			if !az.HasExtendedLocation() {
 				// only add zone information for the new standard pips
-				zones, err := az.getRegionZonesBackoff(to.String(pip.Location))
+				zones, err := az.getRegionZonesBackoff(pointer.StringDeref(pip.Location, ""))
 				if err != nil {
 					return nil, err
 				}
@@ -1290,7 +1290,7 @@ func reconcileDNSSettings(pip *network.PublicIPAddress, domainNameLabel, service
 			changed = true
 		} else {
 			existingDNSLabel := pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel
-			if !strings.EqualFold(to.String(existingDNSLabel), domainNameLabel) {
+			if !strings.EqualFold(pointer.StringDeref(existingDNSLabel, ""), domainNameLabel) {
 				pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel = &domainNameLabel
 				changed = true
 			}
@@ -1397,8 +1397,8 @@ func sortIPTags(ipTags *[]network.IPTag) {
 	if ipTags != nil {
 		sort.Slice(*ipTags, func(i, j int) bool {
 			ipTag := *ipTags
-			return to.String(ipTag[i].IPTagType) < to.String(ipTag[j].IPTagType) ||
-				to.String(ipTag[i].Tag) < to.String(ipTag[j].Tag)
+			return pointer.StringDeref(ipTag[i].IPTagType, "") < pointer.StringDeref(ipTag[j].IPTagType, "") ||
+				pointer.StringDeref(ipTag[i].Tag, "") < pointer.StringDeref(ipTag[j].Tag, "")
 		})
 	}
 }
@@ -1430,8 +1430,8 @@ func convertIPTagMapToSlice(ipTagMap map[string]string) *[]network.IPTag {
 	outputTags := []network.IPTag{}
 	for k, v := range ipTagMap {
 		ipTag := network.IPTag{
-			IPTagType: to.StringPtr(k),
-			Tag:       to.StringPtr(v),
+			IPTagType: pointer.String(k),
+			Tag:       pointer.String(v),
 		}
 		outputTags = append(outputTags, ipTag)
 	}
@@ -1443,7 +1443,7 @@ func getDomainNameLabel(pip *network.PublicIPAddress) string {
 	if pip == nil || pip.PublicIPAddressPropertiesFormat == nil || pip.PublicIPAddressPropertiesFormat.DNSSettings == nil {
 		return ""
 	}
-	return to.String(pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel)
+	return pointer.StringDeref(pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel, "")
 }
 
 // pips: a non-nil pointer to a slice of existing PIPs, if the slice being pointed to is nil, listPIP would be called when needed and the slice would be filled
@@ -1452,10 +1452,10 @@ func (az *Cloud) isFrontendIPChanged(clusterName string, config network.Frontend
 	if err != nil {
 		return false, err
 	}
-	if isServiceOwnsFrontendIP && isPrimaryService && !strings.EqualFold(to.String(config.Name), lbFrontendIPConfigName) {
+	if isServiceOwnsFrontendIP && isPrimaryService && !strings.EqualFold(pointer.StringDeref(config.Name, ""), lbFrontendIPConfigName) {
 		return true, nil
 	}
-	if !strings.EqualFold(to.String(config.Name), lbFrontendIPConfigName) {
+	if !strings.EqualFold(pointer.StringDeref(config.Name, ""), lbFrontendIPConfigName) {
 		return false, nil
 	}
 	loadBalancerIP := getServiceLoadBalancerIP(service)
@@ -1471,11 +1471,11 @@ func (az *Cloud) isFrontendIPChanged(clusterName string, config network.Frontend
 			if !existsSubnet {
 				return false, fmt.Errorf("failed to get subnet")
 			}
-			if config.Subnet != nil && !strings.EqualFold(to.String(config.Subnet.ID), to.String(subnet.ID)) {
+			if config.Subnet != nil && !strings.EqualFold(pointer.StringDeref(config.Subnet.ID, ""), pointer.StringDeref(subnet.ID, "")) {
 				return true, nil
 			}
 		}
-		return loadBalancerIP != "" && !strings.EqualFold(loadBalancerIP, to.String(config.PrivateIPAddress)), nil
+		return loadBalancerIP != "" && !strings.EqualFold(loadBalancerIP, pointer.StringDeref(config.PrivateIPAddress, "")), nil
 	}
 	pipName, _, err := az.determinePublicIPName(clusterName, service, pips)
 	if err != nil {
@@ -1489,7 +1489,7 @@ func (az *Cloud) isFrontendIPChanged(clusterName string, config network.Frontend
 	if !existsPip {
 		return true, nil
 	}
-	return config.PublicIPAddress != nil && !strings.EqualFold(to.String(pip.ID), to.String(config.PublicIPAddress.ID)), nil
+	return config.PublicIPAddress != nil && !strings.EqualFold(pointer.StringDeref(pip.ID, ""), pointer.StringDeref(config.PublicIPAddress.ID, "")), nil
 }
 
 // isFrontendIPConfigUnsafeToDelete checks if a frontend IP config is safe to be deleted.
@@ -1721,7 +1721,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 						"reconcileLoadBalancer for service(%s): lb(%s) - failed to clean up PrivateLinkService for frontEnd(%s): %v",
 						serviceName,
 						lbName,
-						to.String(fipConfigToDel.Name),
+						pointer.StringDeref(fipConfigToDel.Name, ""),
 						err,
 					)
 				}
@@ -1766,7 +1766,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		if lb.LoadBalancerPropertiesFormat != nil && lb.BackendAddressPools != nil {
 			backendPools := *lb.BackendAddressPools
 			for _, backendPool := range backendPools {
-				if strings.EqualFold(to.String(backendPool.Name), getBackendPoolName(clusterName, service)) {
+				if strings.EqualFold(pointer.StringDeref(backendPool.Name, ""), getBackendPoolName(clusterName, service)) {
 					if err := az.LoadBalancerBackendPool.EnsureHostsInPool(service, nodes, lbBackendPoolID, vmSetName, clusterName, lbName, backendPool); err != nil {
 						return nil, err
 					}
@@ -1927,10 +1927,10 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			config := newConfigs[i]
 			isServiceOwnsFrontendIP, _, _ := az.serviceOwnsFrontendIP(config, service, &pips)
 			if !isServiceOwnsFrontendIP {
-				klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): the frontend IP configuration %s does not belong to the service", serviceName, to.String(config.Name))
+				klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): the frontend IP configuration %s does not belong to the service", serviceName, pointer.StringDeref(config.Name, ""))
 				continue
 			}
-			klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): checking owned frontend IP configuration %s", serviceName, to.String(config.Name))
+			klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): checking owned frontend IP configuration %s", serviceName, pointer.StringDeref(config.Name, ""))
 			isFipChanged, err = az.isFrontendIPChanged(clusterName, config, service, defaultLBFrontendIPConfigName, &pips)
 			if err != nil {
 				return nil, toDeleteConfigs, false, err
@@ -1984,7 +1984,7 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 				} else if status != nil && len(status.Ingress) > 0 && ipInSubnet(status.Ingress[0].IP, &subnet) {
 					klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): keep the original private IP %s", serviceName, status.Ingress[0].IP)
 					configProperties.PrivateIPAllocationMethod = network.Static
-					configProperties.PrivateIPAddress = to.StringPtr(status.Ingress[0].IP)
+					configProperties.PrivateIPAddress = pointer.String(status.Ingress[0].IP)
 				} else {
 					// We'll need to call GetLoadBalancer later to retrieve allocated IP.
 					klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): dynamically allocate the private IP", serviceName)
@@ -2008,8 +2008,8 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			}
 
 			newConfig := network.FrontendIPConfiguration{
-				Name:                                    to.StringPtr(defaultLBFrontendIPConfigName),
-				ID:                                      to.StringPtr(fmt.Sprintf(consts.FrontendIPConfigIDTemplate, az.getNetworkResourceSubscriptionID(), az.ResourceGroup, *lb.Name, defaultLBFrontendIPConfigName)),
+				Name:                                    pointer.String(defaultLBFrontendIPConfigName),
+				ID:                                      pointer.String(fmt.Sprintf(consts.FrontendIPConfigIDTemplate, az.getNetworkResourceSubscriptionID(), az.ResourceGroup, *lb.Name, defaultLBFrontendIPConfigName)),
 				FrontendIPConfigurationPropertiesFormat: fipConfigurationProperties,
 			}
 
@@ -2181,7 +2181,7 @@ func (az *Cloud) buildHealthProbeRulesForPort(annotations map[string]string, por
 	}
 	if requestPath == nil {
 		// TCP would be used as default probe protocol for backward compatibility when probe requestPath is not set.
-		port.AppProtocol = to.StringPtr(string(network.ProtocolTCP))
+		port.AppProtocol = pointer.String(string(network.ProtocolTCP))
 	}
 
 	properties := &network.ProbePropertiesFormat{}
@@ -2190,7 +2190,7 @@ func (az *Cloud) buildHealthProbeRulesForPort(annotations map[string]string, por
 			return nil, fmt.Errorf("failed to parse annotation %s: %w", consts.ServiceAnnotationLoadBalancerHealthProbeProtocol, err)
 		}
 		if port.AppProtocol == nil {
-			port.AppProtocol = to.StringPtr(string(network.ProtocolTCP))
+			port.AppProtocol = pointer.String(string(network.ProtocolTCP))
 		}
 	}
 	protocol := strings.TrimSpace(*port.AppProtocol)
@@ -2215,7 +2215,7 @@ func (az *Cloud) buildHealthProbeRulesForPort(annotations map[string]string, por
 	if strings.EqualFold(string(properties.Protocol), string(network.ProtocolHTTPS)) || strings.EqualFold(string(properties.Protocol), string(network.ProtocolHTTP)) {
 		if requestPath == nil {
 			// "/" is the default request path for HTTP/HTTPS probe
-			requestPath = to.StringPtr(consts.HealthProbeDefaultRequestPath)
+			requestPath = pointer.String(consts.HealthProbeDefaultRequestPath)
 		}
 		properties.RequestPath = requestPath
 	}
@@ -2242,7 +2242,7 @@ func (az *Cloud) buildHealthProbeRulesForPort(annotations map[string]string, por
 
 	// if numberOfProbes is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
 	if numberOfProbes == nil {
-		numberOfProbes = to.Int32Ptr(consts.HealthProbeDefaultNumOfProbe)
+		numberOfProbes = pointer.Int32(consts.HealthProbeDefaultNumOfProbe)
 	}
 
 	// get probe interval in seconds
@@ -2267,7 +2267,7 @@ func (az *Cloud) buildHealthProbeRulesForPort(annotations map[string]string, por
 	}
 	// if probeInterval is not set, set it to default instead ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
 	if probeInterval == nil {
-		probeInterval = to.Int32Ptr(consts.HealthProbeDefaultProbeInterval)
+		probeInterval = pointer.Int32(consts.HealthProbeDefaultProbeInterval)
 	}
 
 	// total probe should be less than 120 seconds ref: https://docs.microsoft.com/en-us/rest/api/load-balancer/load-balancers/create-or-update#probe
@@ -2308,11 +2308,11 @@ func (az *Cloud) getExpectedLBRules(
 		nodeEndpointHealthprobe = &network.Probe{
 			Name: &lbRuleName,
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				RequestPath:       to.StringPtr(podPresencePath),
+				RequestPath:       pointer.String(podPresencePath),
 				Protocol:          network.ProbeProtocolHTTP,
-				Port:              to.Int32Ptr(podPresencePort),
-				IntervalInSeconds: to.Int32Ptr(consts.HealthProbeDefaultProbeInterval),
-				NumberOfProbes:    to.Int32Ptr(consts.HealthProbeDefaultNumOfProbe),
+				Port:              pointer.Int32(podPresencePort),
+				IntervalInSeconds: pointer.Int32(consts.HealthProbeDefaultProbeInterval),
+				NumberOfProbes:    pointer.Int32(consts.HealthProbeDefaultNumOfProbe),
 			},
 		}
 		expectedProbes = append(expectedProbes, *nodeEndpointHealthprobe)
@@ -2344,14 +2344,14 @@ func (az *Cloud) getExpectedLBRules(
 				if portprobe != nil {
 					expectedProbes = append(expectedProbes, *portprobe)
 					props.Probe = &network.SubResource{
-						ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *portprobe.Name)),
+						ID: pointer.String(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *portprobe.Name)),
 					}
 					break
 				}
 			}
 		} else {
 			props.Probe = &network.SubResource{
-				ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *nodeEndpointHealthprobe.Name)),
+				ID: pointer.String(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *nodeEndpointHealthprobe.Name)),
 			}
 		}
 
@@ -2390,17 +2390,17 @@ func (az *Cloud) getExpectedLBRules(
 				if portprobe != nil {
 					expectedProbes = append(expectedProbes, *portprobe)
 					props.Probe = &network.SubResource{
-						ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *portprobe.Name)),
+						ID: pointer.String(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *portprobe.Name)),
 					}
 				}
 			} else {
 				props.Probe = &network.SubResource{
-					ID: to.StringPtr(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *nodeEndpointHealthprobe.Name)),
+					ID: pointer.String(az.getLoadBalancerProbeID(lbName, az.getLoadBalancerResourceGroup(), *nodeEndpointHealthprobe.Name)),
 				}
 			}
 			if consts.IsK8sServiceDisableLoadBalancerFloatingIP(service) {
-				props.BackendPort = to.Int32Ptr(port.NodePort)
-				props.EnableFloatingIP = to.BoolPtr(false)
+				props.BackendPort = pointer.Int32(port.NodePort)
+				props.EnableFloatingIP = pointer.Bool(false)
 			}
 			expectedRules = append(expectedRules, network.LoadBalancingRule{
 				Name:                              &lbRuleName,
@@ -2438,33 +2438,33 @@ func (az *Cloud) getExpectedLoadBalancingRulePropertiesForPort(
 	}); err != nil {
 		return nil, fmt.Errorf("error parsing idle timeout key: %s, err: %w", consts.ServiceAnnotationLoadBalancerIdleTimeout, err)
 	} else if lbIdleTimeout == nil {
-		lbIdleTimeout = to.Int32Ptr(4)
+		lbIdleTimeout = pointer.Int32(4)
 	}
 
 	props := &network.LoadBalancingRulePropertiesFormat{
 		Protocol:            transportProto,
-		FrontendPort:        to.Int32Ptr(servicePort.Port),
-		BackendPort:         to.Int32Ptr(servicePort.Port),
-		DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
-		EnableFloatingIP:    to.BoolPtr(true),
+		FrontendPort:        pointer.Int32(servicePort.Port),
+		BackendPort:         pointer.Int32(servicePort.Port),
+		DisableOutboundSnat: pointer.Bool(az.disableLoadBalancerOutboundSNAT()),
+		EnableFloatingIP:    pointer.Bool(true),
 		LoadDistribution:    loadDistribution,
 		FrontendIPConfiguration: &network.SubResource{
-			ID: to.StringPtr(lbFrontendIPConfigID),
+			ID: pointer.String(lbFrontendIPConfigID),
 		},
 		BackendAddressPool: &network.SubResource{
-			ID: to.StringPtr(lbBackendPoolID),
+			ID: pointer.String(lbBackendPoolID),
 		},
 		IdleTimeoutInMinutes: lbIdleTimeout,
 	}
 	if strings.EqualFold(string(transportProto), string(network.TransportProtocolTCP)) && az.useStandardLoadBalancer() {
-		props.EnableTCPReset = to.BoolPtr(true)
+		props.EnableTCPReset = pointer.Bool(true)
 	}
 
 	// Azure ILB does not support secondary IPs as floating IPs on the LB. Therefore, floating IP needs to be turned
 	// off and the rule should point to the nodeIP:nodePort.
 	if consts.IsK8sServiceInternalIPv6(service) {
-		props.BackendPort = to.Int32Ptr(servicePort.NodePort)
-		props.EnableFloatingIP = to.BoolPtr(false)
+		props.BackendPort = pointer.Int32(servicePort.NodePort)
+		props.EnableFloatingIP = pointer.Bool(false)
 	}
 	return props, nil
 }
@@ -2478,7 +2478,7 @@ func (az *Cloud) getExpectedHAModeLoadBalancingRuleProperties(
 	if err != nil {
 		return nil, fmt.Errorf("error generate lb rule for ha mod loadbalancer. err: %w", err)
 	}
-	props.EnableTCPReset = to.BoolPtr(true)
+	props.EnableTCPReset = pointer.Bool(true)
 	return props, nil
 }
 
@@ -2521,12 +2521,12 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 
 	backendIPAddresses := make([]string, 0)
 	if wantLb && disableFloatingIP {
-		lb, exist, err := az.getAzureLoadBalancer(to.String(lbName), azcache.CacheReadTypeDefault)
+		lb, exist, err := az.getAzureLoadBalancer(pointer.StringDeref(lbName, ""), azcache.CacheReadTypeDefault)
 		if err != nil {
 			return nil, err
 		}
 		if !exist {
-			return nil, fmt.Errorf("unable to get lb %s", to.String(lbName))
+			return nil, fmt.Errorf("unable to get lb %s", pointer.StringDeref(lbName, ""))
 		}
 		backendPrivateIPv4s, backendPrivateIPv6s := az.LoadBalancerBackendPool.GetBackendPrivateIPs(clusterName, service, lb)
 		backendIPAddresses = backendPrivateIPv4s
@@ -2592,7 +2592,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 			return nil, err
 		}
 		klog.V(10).Infof("CreateOrUpdateSecurityGroup(%q): end", *sg.Name)
-		_ = az.nsgCache.Delete(to.String(sg.Name))
+		_ = az.nsgCache.Delete(pointer.StringDeref(sg.Name, ""))
 	}
 	return &sg, nil
 }
@@ -2694,7 +2694,7 @@ func (az *Cloud) reconcileSecurityRules(sg network.SecurityGroup, service *v1.Se
 				return false, nil, err
 			}
 
-			expectedRule.Priority = to.Int32Ptr(nextAvailablePriority)
+			expectedRule.Priority = pointer.Int32(nextAvailablePriority)
 			updatedRules = append(updatedRules, expectedRule)
 			dirtySg = true
 		}
@@ -2727,24 +2727,24 @@ func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, s
 				ix := i*len(sourceAddressPrefixes) + j
 				securityRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefixes[j])
 				nsgRule := network.SecurityRule{
-					Name: to.StringPtr(securityRuleName),
+					Name: pointer.String(securityRuleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:             *securityProto,
-						SourcePortRange:      to.StringPtr("*"),
-						DestinationPortRange: to.StringPtr(strconv.Itoa(int(dstPort))),
-						SourceAddressPrefix:  to.StringPtr(sourceAddressPrefixes[j]),
+						SourcePortRange:      pointer.String("*"),
+						DestinationPortRange: pointer.String(strconv.Itoa(int(dstPort))),
+						SourceAddressPrefix:  pointer.String(sourceAddressPrefixes[j]),
 						Access:               network.SecurityRuleAccessAllow,
 						Direction:            network.SecurityRuleDirectionInbound,
 					},
 				}
 
 				if len(destinationIPAddresses) == 1 && disableFloatingIP {
-					nsgRule.DestinationAddressPrefixes = to.StringSlicePtr(backendIPAddresses)
+					nsgRule.DestinationAddressPrefixes = &(backendIPAddresses)
 				} else if len(destinationIPAddresses) == 1 && !disableFloatingIP {
 					// continue to use DestinationAddressPrefix to avoid NSG updates for existing rules.
-					nsgRule.DestinationAddressPrefix = to.StringPtr(destinationIPAddresses[0])
+					nsgRule.DestinationAddressPrefix = pointer.String(destinationIPAddresses[0])
 				} else {
-					nsgRule.DestinationAddressPrefixes = to.StringSlicePtr(destinationIPAddresses)
+					nsgRule.DestinationAddressPrefixes = &(destinationIPAddresses)
 				}
 				expectedSecurityRules[ix] = nsgRule
 			}
@@ -2764,21 +2764,21 @@ func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, s
 				}
 				securityRuleName := az.getSecurityRuleName(service, port, "deny_all")
 				nsgRule := network.SecurityRule{
-					Name: to.StringPtr(securityRuleName),
+					Name: pointer.String(securityRuleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:             *securityProto,
-						SourcePortRange:      to.StringPtr("*"),
-						DestinationPortRange: to.StringPtr(strconv.Itoa(int(port.Port))),
-						SourceAddressPrefix:  to.StringPtr("*"),
+						SourcePortRange:      pointer.String("*"),
+						DestinationPortRange: pointer.String(strconv.Itoa(int(port.Port))),
+						SourceAddressPrefix:  pointer.String("*"),
 						Access:               network.SecurityRuleAccessDeny,
 						Direction:            network.SecurityRuleDirectionInbound,
 					},
 				}
 				if len(destinationIPAddresses) == 1 {
 					// continue to use DestinationAddressPrefix to avoid NSG updates for existing rules.
-					nsgRule.DestinationAddressPrefix = to.StringPtr(destinationIPAddresses[0])
+					nsgRule.DestinationAddressPrefix = pointer.String(destinationIPAddresses[0])
 				} else {
-					nsgRule.DestinationAddressPrefixes = to.StringSlicePtr(destinationIPAddresses)
+					nsgRule.DestinationAddressPrefixes = &(destinationIPAddresses)
 				}
 				expectedSecurityRules = append(expectedSecurityRules, nsgRule)
 			}
@@ -2786,7 +2786,7 @@ func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, s
 	}
 
 	for _, r := range expectedSecurityRules {
-		klog.V(10).Infof("Expecting security rule for %s: %s:%s -> %v %v :%s", service.Name, to.String(r.SourceAddressPrefix), to.String(r.SourcePortRange), to.String(r.DestinationAddressPrefix), to.StringSlice(r.DestinationAddressPrefixes), to.String(r.DestinationPortRange))
+		klog.V(10).Infof("Expecting security rule for %s: %s:%s -> %v %v :%s", service.Name, pointer.StringDeref(r.SourceAddressPrefix, ""), pointer.StringDeref(r.SourcePortRange, ""), pointer.StringDeref(r.DestinationAddressPrefix, ""), stringSlice(r.DestinationAddressPrefixes), pointer.StringDeref(r.DestinationPortRange, ""))
 	}
 	return expectedSecurityRules, nil
 }
@@ -2837,13 +2837,13 @@ func findIndex(strs []string, s string) (int, bool) {
 }
 
 func allowsConsolidation(rule network.SecurityRule) bool {
-	return strings.HasPrefix(to.String(rule.Name), "shared")
+	return strings.HasPrefix(pointer.StringDeref(rule.Name, ""), "shared")
 }
 
 func findConsolidationCandidate(rules []network.SecurityRule, rule network.SecurityRule) (int, bool) {
 	for index, r := range rules {
 		if allowsConsolidation(r) {
-			if strings.EqualFold(to.String(r.Name), to.String(rule.Name)) {
+			if strings.EqualFold(pointer.StringDeref(r.Name, ""), pointer.StringDeref(rule.Name, "")) {
 				return index, true
 			}
 		}
@@ -2993,7 +2993,7 @@ func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *network.PublicIPAddre
 		found, key := findKeyInMapCaseInsensitive(configTags, k)
 		if !found {
 			configTags[k] = v
-		} else if !strings.EqualFold(to.String(v), to.String(configTags[key])) {
+		} else if !strings.EqualFold(pointer.StringDeref(v, ""), pointer.StringDeref(configTags[key], "")) {
 			configTags[key] = v
 		}
 	}
@@ -3181,12 +3181,12 @@ func (az *Cloud) safeDeletePublicIP(service *v1.Service, pipResourceGroup string
 		loadBalancerRuleUpdated := false
 
 		// Check whether there are still frontend IP configurations referring to it.
-		ipConfigurationID := to.String(pip.PublicIPAddressPropertiesFormat.IPConfiguration.ID)
+		ipConfigurationID := pointer.StringDeref(pip.PublicIPAddressPropertiesFormat.IPConfiguration.ID, "")
 		if ipConfigurationID != "" {
 			lbFrontendIPConfigs := *lb.LoadBalancerPropertiesFormat.FrontendIPConfigurations
 			for i := len(lbFrontendIPConfigs) - 1; i >= 0; i-- {
 				config := lbFrontendIPConfigs[i]
-				if strings.EqualFold(ipConfigurationID, to.String(config.ID)) {
+				if strings.EqualFold(ipConfigurationID, pointer.StringDeref(config.ID, "")) {
 					if config.FrontendIPConfigurationPropertiesFormat != nil &&
 						config.FrontendIPConfigurationPropertiesFormat.LoadBalancingRules != nil {
 						referencedLBRules = *config.FrontendIPConfigurationPropertiesFormat.LoadBalancingRules
@@ -3207,13 +3207,13 @@ func (az *Cloud) safeDeletePublicIP(service *v1.Service, pipResourceGroup string
 		if len(referencedLBRules) > 0 {
 			referencedLBRuleIDs := sets.NewString()
 			for _, refer := range referencedLBRules {
-				referencedLBRuleIDs.Insert(to.String(refer.ID))
+				referencedLBRuleIDs.Insert(pointer.StringDeref(refer.ID, ""))
 			}
 
 			if lb.LoadBalancerPropertiesFormat.LoadBalancingRules != nil {
 				lbRules := *lb.LoadBalancerPropertiesFormat.LoadBalancingRules
 				for i := len(lbRules) - 1; i >= 0; i-- {
-					ruleID := to.String(lbRules[i].ID)
+					ruleID := pointer.StringDeref(lbRules[i].ID, "")
 					if ruleID != "" && referencedLBRuleIDs.Has(ruleID) {
 						loadBalancerRuleUpdated = true
 						lbRules = append(lbRules[:i], lbRules[i+1:]...)
@@ -3236,7 +3236,7 @@ func (az *Cloud) safeDeletePublicIP(service *v1.Service, pipResourceGroup string
 		}
 	}
 
-	pipName := to.String(pip.Name)
+	pipName := pointer.StringDeref(pip.Name, "")
 	klog.V(10).Infof("DeletePublicIP(%s, %q): start", pipResourceGroup, pipName)
 	err := az.DeletePublicIP(service, pipResourceGroup, pipName)
 	if err != nil {
@@ -3249,12 +3249,12 @@ func (az *Cloud) safeDeletePublicIP(service *v1.Service, pipResourceGroup string
 
 func findProbe(probes []network.Probe, probe network.Probe) bool {
 	for _, existingProbe := range probes {
-		if strings.EqualFold(to.String(existingProbe.Name), to.String(probe.Name)) &&
-			to.Int32(existingProbe.Port) == to.Int32(probe.Port) &&
+		if strings.EqualFold(pointer.StringDeref(existingProbe.Name, ""), pointer.StringDeref(probe.Name, "")) &&
+			pointer.Int32Deref(existingProbe.Port, 0) == pointer.Int32Deref(probe.Port, 0) &&
 			strings.EqualFold(string(existingProbe.Protocol), string(probe.Protocol)) &&
-			strings.EqualFold(to.String(existingProbe.RequestPath), to.String(probe.RequestPath)) &&
-			to.Int32(existingProbe.IntervalInSeconds) == to.Int32(probe.IntervalInSeconds) &&
-			to.Int32(existingProbe.NumberOfProbes) == to.Int32(probe.NumberOfProbes) {
+			strings.EqualFold(pointer.StringDeref(existingProbe.RequestPath, ""), pointer.StringDeref(probe.RequestPath, "")) &&
+			pointer.Int32Deref(existingProbe.IntervalInSeconds, 0) == pointer.Int32Deref(probe.IntervalInSeconds, 0) &&
+			pointer.Int32Deref(existingProbe.NumberOfProbes, 0) == pointer.Int32Deref(probe.NumberOfProbes, 0) {
 			return true
 		}
 	}
@@ -3263,7 +3263,7 @@ func findProbe(probes []network.Probe, probe network.Probe) bool {
 
 func findRule(rules []network.LoadBalancingRule, rule network.LoadBalancingRule, wantLB bool) bool {
 	for _, existingRule := range rules {
-		if strings.EqualFold(to.String(existingRule.Name), to.String(rule.Name)) &&
+		if strings.EqualFold(pointer.StringDeref(existingRule.Name, ""), pointer.StringDeref(rule.Name, "")) &&
 			equalLoadBalancingRulePropertiesFormat(existingRule.LoadBalancingRulePropertiesFormat, rule.LoadBalancingRulePropertiesFormat, wantLB) {
 			return true
 		}
@@ -3284,7 +3284,7 @@ func equalLoadBalancingRulePropertiesFormat(s *network.LoadBalancingRuleProperti
 	}
 
 	if reflect.DeepEqual(s.Protocol, network.TransportProtocolTCP) {
-		properties = properties && reflect.DeepEqual(to.Bool(s.EnableTCPReset), to.Bool(t.EnableTCPReset))
+		properties = properties && reflect.DeepEqual(pointer.BoolDeref(s.EnableTCPReset, false), pointer.BoolDeref(t.EnableTCPReset, false))
 	}
 
 	properties = properties && equalSubResource(s.FrontendIPConfiguration, t.FrontendIPConfiguration) &&
@@ -3294,7 +3294,7 @@ func equalLoadBalancingRulePropertiesFormat(s *network.LoadBalancingRuleProperti
 		reflect.DeepEqual(s.BackendPort, t.BackendPort) &&
 		equalSubResource(s.Probe, t.Probe) &&
 		reflect.DeepEqual(s.EnableFloatingIP, t.EnableFloatingIP) &&
-		reflect.DeepEqual(to.Bool(s.DisableOutboundSnat), to.Bool(t.DisableOutboundSnat))
+		reflect.DeepEqual(pointer.BoolDeref(s.DisableOutboundSnat, false), pointer.BoolDeref(t.DisableOutboundSnat, false))
 
 	if wantLB && s.IdleTimeoutInMinutes != nil && t.IdleTimeoutInMinutes != nil {
 		return properties && reflect.DeepEqual(s.IdleTimeoutInMinutes, t.IdleTimeoutInMinutes)
@@ -3309,7 +3309,7 @@ func equalSubResource(s *network.SubResource, t *network.SubResource) bool {
 	if s == nil || t == nil {
 		return false
 	}
-	return strings.EqualFold(to.String(s.ID), to.String(t.ID))
+	return strings.EqualFold(pointer.StringDeref(s.ID, ""), pointer.StringDeref(t.ID, ""))
 }
 
 // This compares rule's Name, Protocol, SourcePortRange, DestinationPortRange, SourceAddressPrefix, Access, and Direction.
@@ -3318,26 +3318,26 @@ func equalSubResource(s *network.SubResource, t *network.SubResource) bool {
 // despite different DestinationAddressPrefixes, in order to give it a chance to consolidate the two rules.
 func findSecurityRule(rules []network.SecurityRule, rule network.SecurityRule) bool {
 	for _, existingRule := range rules {
-		if !strings.EqualFold(to.String(existingRule.Name), to.String(rule.Name)) {
+		if !strings.EqualFold(pointer.StringDeref(existingRule.Name, ""), pointer.StringDeref(rule.Name, "")) {
 			continue
 		}
 		if !strings.EqualFold(string(existingRule.Protocol), string(rule.Protocol)) {
 			continue
 		}
-		if !strings.EqualFold(to.String(existingRule.SourcePortRange), to.String(rule.SourcePortRange)) {
+		if !strings.EqualFold(pointer.StringDeref(existingRule.SourcePortRange, ""), pointer.StringDeref(rule.SourcePortRange, "")) {
 			continue
 		}
-		if !strings.EqualFold(to.String(existingRule.DestinationPortRange), to.String(rule.DestinationPortRange)) {
+		if !strings.EqualFold(pointer.StringDeref(existingRule.DestinationPortRange, ""), pointer.StringDeref(rule.DestinationPortRange, "")) {
 			continue
 		}
-		if !strings.EqualFold(to.String(existingRule.SourceAddressPrefix), to.String(rule.SourceAddressPrefix)) {
+		if !strings.EqualFold(pointer.StringDeref(existingRule.SourceAddressPrefix, ""), pointer.StringDeref(rule.SourceAddressPrefix, "")) {
 			continue
 		}
 		if !allowsConsolidation(existingRule) && !allowsConsolidation(rule) {
-			if !strings.EqualFold(to.String(existingRule.DestinationAddressPrefix), to.String(rule.DestinationAddressPrefix)) {
+			if !strings.EqualFold(pointer.StringDeref(existingRule.DestinationAddressPrefix, ""), pointer.StringDeref(rule.DestinationAddressPrefix, "")) {
 				continue
 			}
-			if !SliceEqual(to.StringSlice(existingRule.DestinationAddressPrefixes), to.StringSlice(rule.DestinationAddressPrefixes)) {
+			if !SliceEqual(stringSlice(existingRule.DestinationAddressPrefixes), stringSlice(rule.DestinationAddressPrefixes)) {
 				continue
 			}
 		}
@@ -3479,7 +3479,7 @@ func serviceOwnsPublicIP(service *v1.Service, pip *network.PublicIPAddress, clus
 		return false, false
 	}
 
-	if pip.PublicIPAddressPropertiesFormat == nil || to.String(pip.IPAddress) == "" {
+	if pip.PublicIPAddressPropertiesFormat == nil || pointer.StringDeref(pip.IPAddress, "") == "" {
 		klog.Warningf("serviceOwnsPublicIP: empty pip.IPAddress")
 		return false, false
 	}
@@ -3492,7 +3492,7 @@ func serviceOwnsPublicIP(service *v1.Service, pip *network.PublicIPAddress, clus
 
 		// if there is no service tag on the pip, it is user-created pip
 		if serviceTag == "" {
-			return strings.EqualFold(to.String(pip.IPAddress), getServiceLoadBalancerIP(service)), true
+			return strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), getServiceLoadBalancerIP(service)), true
 		}
 
 		// if there is service tag on the pip, it is system-created pip
@@ -3510,7 +3510,7 @@ func serviceOwnsPublicIP(service *v1.Service, pip *network.PublicIPAddress, clus
 		} else {
 			// if the service is not included in te tags of the system-created pip, check the ip address
 			// this could happen for secondary services
-			return strings.EqualFold(to.String(pip.IPAddress), getServiceLoadBalancerIP(service)), false
+			return strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), getServiceLoadBalancerIP(service)), false
 		}
 	}
 
@@ -3557,17 +3557,17 @@ func bindServicesToPIP(pip *network.PublicIPAddress, incomingServiceNames []stri
 	}
 
 	if pip.Tags == nil {
-		pip.Tags = map[string]*string{consts.ServiceTagKey: to.StringPtr("")}
+		pip.Tags = map[string]*string{consts.ServiceTagKey: pointer.String("")}
 	}
 
-	serviceTagValue := to.StringPtr(getServiceFromPIPServiceTags(pip.Tags))
+	serviceTagValue := pointer.String(getServiceFromPIPServiceTags(pip.Tags))
 	serviceTagValueSet := make(map[string]struct{})
 	existingServiceNames := parsePIPServiceTag(serviceTagValue)
 	addedNew := false
 
 	// replace is used when unbinding the service from PIP so addedNew remains false all the time
 	if replace {
-		serviceTagValue = to.StringPtr(strings.Join(incomingServiceNames, ","))
+		serviceTagValue = pointer.String(strings.Join(incomingServiceNames, ","))
 		pip.Tags[consts.ServiceTagKey] = serviceTagValue
 
 		return false, nil
@@ -3581,7 +3581,7 @@ func bindServicesToPIP(pip *network.PublicIPAddress, incomingServiceNames []stri
 
 	for _, serviceName := range incomingServiceNames {
 		if serviceTagValue == nil || *serviceTagValue == "" {
-			serviceTagValue = to.StringPtr(serviceName)
+			serviceTagValue = pointer.String(serviceName)
 			addedNew = true
 		} else {
 			// detect duplicates
@@ -3612,7 +3612,7 @@ func unbindServiceFromPIP(pip *network.PublicIPAddress, service *v1.Service,
 	}
 
 	// skip removing tags for user assigned pips
-	serviceTagValue := to.StringPtr(getServiceFromPIPServiceTags(pip.Tags))
+	serviceTagValue := pointer.String(getServiceFromPIPServiceTags(pip.Tags))
 	existingServiceNames := parsePIPServiceTag(serviceTagValue)
 	var found bool
 	for i := len(existingServiceNames) - 1; i >= 0; i-- {
@@ -3660,4 +3660,13 @@ func (az *Cloud) ensureSecurityGroupTagged(sg *network.SecurityGroup) bool {
 	sg.Tags = tags
 
 	return changed
+}
+
+// stringSlice returns a string slice value for the passed string slice pointer. It returns a nil
+// slice if the pointer is nil.
+func stringSlice(s *[]string) []string {
+	if s != nil {
+		return *s
+	}
+	return nil
 }

--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -24,13 +24,13 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -73,7 +73,7 @@ func (bc *backendPoolTypeNodeIPConfig) EnsureHostsInPool(service *v1.Service, no
 func (bc *backendPoolTypeNodeIPConfig) CleanupVMSetFromBackendPoolByCondition(slb *network.LoadBalancer, service *v1.Service, nodes []*v1.Node, clusterName string, shouldRemoveVMSetFromSLB func(string) bool) (*network.LoadBalancer, error) {
 	lbBackendPoolName := getBackendPoolName(clusterName, service)
 	lbResourceGroup := bc.getLoadBalancerResourceGroup()
-	lbBackendPoolID := bc.getBackendPoolID(to.String(slb.Name), lbResourceGroup, lbBackendPoolName)
+	lbBackendPoolID := bc.getBackendPoolID(pointer.StringDeref(slb.Name, ""), lbResourceGroup, lbBackendPoolName)
 	newBackendPools := make([]network.BackendAddressPool, 0)
 	if slb.LoadBalancerPropertiesFormat != nil && slb.BackendAddressPools != nil {
 		newBackendPools = *slb.BackendAddressPools
@@ -81,12 +81,12 @@ func (bc *backendPoolTypeNodeIPConfig) CleanupVMSetFromBackendPoolByCondition(sl
 	vmSetNameToBackendIPConfigurationsToBeDeleted := make(map[string][]network.InterfaceIPConfiguration)
 
 	for j, bp := range newBackendPools {
-		if strings.EqualFold(to.String(bp.Name), lbBackendPoolName) {
-			klog.V(2).Infof("bc.CleanupVMSetFromBackendPoolByCondition: checking the backend pool %s from standard load balancer %s", to.String(bp.Name), to.String(slb.Name))
+		if strings.EqualFold(pointer.StringDeref(bp.Name, ""), lbBackendPoolName) {
+			klog.V(2).Infof("bc.CleanupVMSetFromBackendPoolByCondition: checking the backend pool %s from standard load balancer %s", pointer.StringDeref(bp.Name, ""), pointer.StringDeref(slb.Name, ""))
 			if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
 				for i := len(*bp.BackendIPConfigurations) - 1; i >= 0; i-- {
 					ipConf := (*bp.BackendIPConfigurations)[i]
-					ipConfigID := to.String(ipConf.ID)
+					ipConfigID := pointer.StringDeref(ipConf.ID, "")
 					_, vmSetName, err := bc.VMSet.GetNodeNameByIPConfigurationID(ipConfigID)
 					if err != nil && !errors.Is(err, cloudprovider.InstanceNotFound) {
 						return nil, err
@@ -96,7 +96,7 @@ func (bc *backendPoolTypeNodeIPConfig) CleanupVMSetFromBackendPoolByCondition(sl
 						klog.V(2).Infof("bc.CleanupVMSetFromBackendPoolByCondition: found unwanted vmSet %s, decouple it from the LB", vmSetName)
 						// construct a backendPool that only contains the IP config of the node to be deleted
 						interfaceIPConfigToBeDeleted := network.InterfaceIPConfiguration{
-							ID: to.StringPtr(ipConfigID),
+							ID: pointer.String(ipConfigID),
 						}
 						vmSetNameToBackendIPConfigurationsToBeDeleted[vmSetName] = append(vmSetNameToBackendIPConfigurationsToBeDeleted[vmSetName], interfaceIPConfigToBeDeleted)
 						*bp.BackendIPConfigurations = append((*bp.BackendIPConfigurations)[:i], (*bp.BackendIPConfigurations)[i+1:]...)
@@ -113,7 +113,7 @@ func (bc *backendPoolTypeNodeIPConfig) CleanupVMSetFromBackendPoolByCondition(sl
 		backendIPConfigurationsToBeDeleted := vmSetNameToBackendIPConfigurationsToBeDeleted[vmSetName]
 		backendpoolToBeDeleted := &[]network.BackendAddressPool{
 			{
-				ID: to.StringPtr(lbBackendPoolID),
+				ID: pointer.String(lbBackendPoolID),
 				BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 					BackendIPConfigurations: &backendIPConfigurationsToBeDeleted,
 				},
@@ -125,9 +125,9 @@ func (bc *backendPoolTypeNodeIPConfig) CleanupVMSetFromBackendPoolByCondition(sl
 			return nil, err
 		}
 		if shouldRefreshLB {
-			slb, _, err = bc.getAzureLoadBalancer(to.String(slb.Name), cache.CacheReadTypeForceRefresh)
+			slb, _, err = bc.getAzureLoadBalancer(pointer.StringDeref(slb.Name, ""), cache.CacheReadTypeForceRefresh)
 			if err != nil {
-				return nil, fmt.Errorf("bc.CleanupVMSetFromBackendPoolByCondition: failed to get load balancer %s, err: %w", to.String(slb.Name), err)
+				return nil, fmt.Errorf("bc.CleanupVMSetFromBackendPoolByCondition: failed to get load balancer %s, err: %w", pointer.StringDeref(slb.Name, ""), err)
 			}
 		}
 	}
@@ -186,7 +186,7 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 			var backendIPConfigurationsToBeDeleted, bipConfigNotFound, bipConfigExclude []network.InterfaceIPConfiguration
 			if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
 				for _, ipConf := range *bp.BackendIPConfigurations {
-					ipConfID := to.String(ipConf.ID)
+					ipConfID := pointer.StringDeref(ipConf.ID, "")
 					nodeName, _, err := bc.VMSet.GetNodeNameByIPConfigurationID(ipConfID)
 					if err != nil {
 						if errors.Is(err, cloudprovider.InstanceNotFound) {
@@ -209,7 +209,7 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 					if shouldExcludeLoadBalancer {
 						klog.V(2).Infof("bc.ReconcileBackendPools for service (%s): lb backendpool - found unwanted node %s, decouple it from the LB %s", serviceName, nodeName, lbName)
 						// construct a backendPool that only contains the IP config of the node to be deleted
-						bipConfigExclude = append(bipConfigExclude, network.InterfaceIPConfiguration{ID: to.StringPtr(ipConfID)})
+						bipConfigExclude = append(bipConfigExclude, network.InterfaceIPConfiguration{ID: pointer.String(ipConfID)})
 					}
 				}
 			}
@@ -217,7 +217,7 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 			if len(backendIPConfigurationsToBeDeleted) > 0 {
 				backendpoolToBeDeleted := &[]network.BackendAddressPool{
 					{
-						ID: to.StringPtr(lbBackendPoolID),
+						ID: pointer.String(lbBackendPoolID),
 						BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 							BackendIPConfigurations: &backendIPConfigurationsToBeDeleted,
 						},
@@ -271,16 +271,16 @@ func getBackendIPConfigurationsToBeDeleted(
 	bipConfigNotFoundIDSet := sets.NewString()
 	bipConfigExcludeIDSet := sets.NewString()
 	for _, ipConfig := range bipConfigNotFound {
-		bipConfigNotFoundIDSet.Insert(to.String(ipConfig.ID))
+		bipConfigNotFoundIDSet.Insert(pointer.StringDeref(ipConfig.ID, ""))
 	}
 	for _, ipConfig := range bipConfigExclude {
-		bipConfigExcludeIDSet.Insert(to.String(ipConfig.ID))
+		bipConfigExcludeIDSet.Insert(pointer.StringDeref(ipConfig.ID, ""))
 	}
 
 	var bipConfigToBeDeleted []network.InterfaceIPConfiguration
 	ipConfigs := *bp.BackendIPConfigurations
 	for i := len(ipConfigs) - 1; i >= 0; i-- {
-		ipConfigID := to.String(ipConfigs[i].ID)
+		ipConfigID := pointer.StringDeref(ipConfigs[i].ID, "")
 		if bipConfigNotFoundIDSet.Has(ipConfigID) {
 			bipConfigToBeDeleted = append(bipConfigToBeDeleted, ipConfigs[i])
 			ipConfigs = append(ipConfigs[:i], ipConfigs[i+1:]...)
@@ -289,7 +289,7 @@ func getBackendIPConfigurationsToBeDeleted(
 
 	var unwantedIPConfigs []network.InterfaceIPConfiguration
 	for _, ipConfig := range ipConfigs {
-		ipConfigID := to.String(ipConfig.ID)
+		ipConfigID := pointer.StringDeref(ipConfig.ID, "")
 		if bipConfigExcludeIDSet.Has(ipConfigID) {
 			unwantedIPConfigs = append(unwantedIPConfigs, ipConfig)
 		}
@@ -310,11 +310,11 @@ func (bc *backendPoolTypeNodeIPConfig) GetBackendPrivateIPs(clusterName string, 
 
 	backendPrivateIPv4s, backendPrivateIPv6s := sets.NewString(), sets.NewString()
 	for _, bp := range *lb.BackendAddressPools {
-		if strings.EqualFold(to.String(bp.Name), lbBackendPoolName) {
-			klog.V(10).Infof("bc.GetBackendPrivateIPs for service (%s): found wanted backendpool %s", serviceName, to.String(bp.Name))
+		if strings.EqualFold(pointer.StringDeref(bp.Name, ""), lbBackendPoolName) {
+			klog.V(10).Infof("bc.GetBackendPrivateIPs for service (%s): found wanted backendpool %s", serviceName, pointer.StringDeref(bp.Name, ""))
 			if bp.BackendAddressPoolPropertiesFormat != nil && bp.BackendIPConfigurations != nil {
 				for _, backendIPConfig := range *bp.BackendIPConfigurations {
-					ipConfigID := to.String(backendIPConfig.ID)
+					ipConfigID := pointer.StringDeref(backendIPConfig.ID, "")
 					nodeName, _, err := bc.VMSet.GetNodeNameByIPConfigurationID(ipConfigID)
 					if err != nil {
 						klog.Errorf("bc.GetBackendPrivateIPs for service (%s): GetNodeNameByIPConfigurationID failed with error: %v", serviceName, err)
@@ -337,7 +337,7 @@ func (bc *backendPoolTypeNodeIPConfig) GetBackendPrivateIPs(clusterName string, 
 				}
 			}
 		} else {
-			klog.V(10).Infof("bc.GetBackendPrivateIPs for service (%s): found unmanaged backendpool %s", serviceName, to.String(bp.Name))
+			klog.V(10).Infof("bc.GetBackendPrivateIPs for service (%s): found unmanaged backendpool %s", serviceName, pointer.StringDeref(bp.Name, ""))
 		}
 	}
 	return backendPrivateIPv4s.List(), backendPrivateIPv6s.List()
@@ -361,7 +361,7 @@ func (bi *backendPoolTypeNodeIP) EnsureHostsInPool(service *v1.Service, nodes []
 	changed := false
 	numOfAdd := 0
 	lbBackendPoolName := getBackendPoolName(clusterName, service)
-	if strings.EqualFold(to.String(backendPool.Name), lbBackendPoolName) &&
+	if strings.EqualFold(pointer.StringDeref(backendPool.Name, ""), lbBackendPoolName) &&
 		backendPool.BackendAddressPoolPropertiesFormat != nil {
 		backendPool.VirtualNetwork = &network.SubResource{
 			ID: &vnetID,
@@ -376,8 +376,8 @@ func (bi *backendPoolTypeNodeIP) EnsureHostsInPool(service *v1.Service, nodes []
 		for _, loadBalancerBackendAddress := range *backendPool.LoadBalancerBackendAddresses {
 			if loadBalancerBackendAddress.LoadBalancerBackendAddressPropertiesFormat != nil &&
 				loadBalancerBackendAddress.IPAddress != nil {
-				klog.V(4).Infof("bi.EnsureHostsInPool: found existing IP %s in the backend pool %s", to.String(loadBalancerBackendAddress.IPAddress), lbBackendPoolName)
-				existingIPs.Insert(to.String(loadBalancerBackendAddress.IPAddress))
+				klog.V(4).Infof("bi.EnsureHostsInPool: found existing IP %s in the backend pool %s", pointer.StringDeref(loadBalancerBackendAddress.IPAddress, ""), lbBackendPoolName)
+				existingIPs.Insert(pointer.StringDeref(loadBalancerBackendAddress.IPAddress, ""))
 			}
 		}
 
@@ -422,9 +422,9 @@ func (bi *backendPoolTypeNodeIP) EnsureHostsInPool(service *v1.Service, nodes []
 
 				klog.V(6).Infof("bi.EnsureHostsInPool: adding %s with ip address %s", name, privateIP)
 				*backendPool.LoadBalancerBackendAddresses = append(*backendPool.LoadBalancerBackendAddresses, network.LoadBalancerBackendAddress{
-					Name: to.StringPtr(name),
+					Name: pointer.String(name),
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr(privateIP),
+						IPAddress: pointer.String(privateIP),
 					},
 				})
 				numOfAdd++
@@ -451,8 +451,8 @@ func (bi *backendPoolTypeNodeIP) CleanupVMSetFromBackendPoolByCondition(slb *net
 
 	var updatedPrivateIPs bool
 	for j, bp := range newBackendPools {
-		if strings.EqualFold(to.String(bp.Name), lbBackendPoolName) {
-			klog.V(2).Infof("bi.CleanupVMSetFromBackendPoolByCondition: checking the backend pool %s from standard load balancer %s", to.String(bp.Name), to.String(slb.Name))
+		if strings.EqualFold(pointer.StringDeref(bp.Name, ""), lbBackendPoolName) {
+			klog.V(2).Infof("bi.CleanupVMSetFromBackendPoolByCondition: checking the backend pool %s from standard load balancer %s", pointer.StringDeref(bp.Name, ""), pointer.StringDeref(slb.Name, ""))
 			vmIPsToBeDeleted := sets.NewString()
 			for _, node := range nodes {
 				vmSetName, err := bi.VMSet.GetNodeVMSetName(node)
@@ -470,7 +470,7 @@ func (bi *backendPoolTypeNodeIP) CleanupVMSetFromBackendPoolByCondition(slb *net
 			if bp.BackendAddressPoolPropertiesFormat != nil && bp.LoadBalancerBackendAddresses != nil {
 				for i := len(*bp.LoadBalancerBackendAddresses) - 1; i >= 0; i-- {
 					if (*bp.LoadBalancerBackendAddresses)[i].LoadBalancerBackendAddressPropertiesFormat != nil &&
-						vmIPsToBeDeleted.Has(to.String((*bp.LoadBalancerBackendAddresses)[i].IPAddress)) {
+						vmIPsToBeDeleted.Has(pointer.StringDeref((*bp.LoadBalancerBackendAddresses)[i].IPAddress, "")) {
 						*bp.LoadBalancerBackendAddresses = append((*bp.LoadBalancerBackendAddresses)[:i], (*bp.LoadBalancerBackendAddresses)[i+1:]...)
 						updatedPrivateIPs = true
 					}
@@ -482,12 +482,12 @@ func (bi *backendPoolTypeNodeIP) CleanupVMSetFromBackendPoolByCondition(slb *net
 		}
 	}
 	if updatedPrivateIPs {
-		klog.V(2).Infof("bi.CleanupVMSetFromBackendPoolByCondition: updating lb %s since there are private IP updates", to.String(slb.Name))
+		klog.V(2).Infof("bi.CleanupVMSetFromBackendPoolByCondition: updating lb %s since there are private IP updates", pointer.StringDeref(slb.Name, ""))
 		slb.BackendAddressPools = &newBackendPools
 
 		for _, backendAddressPool := range *slb.BackendAddressPools {
-			if strings.EqualFold(lbBackendPoolName, to.String(backendAddressPool.Name)) {
-				if err := bi.CreateOrUpdateLBBackendPool(to.String(slb.Name), backendAddressPool); err != nil {
+			if strings.EqualFold(lbBackendPoolName, pointer.StringDeref(backendAddressPool.Name, "")) {
+				if err := bi.CreateOrUpdateLBBackendPool(pointer.StringDeref(slb.Name, ""), backendAddressPool); err != nil {
 					return nil, fmt.Errorf("bi.CleanupVMSetFromBackendPoolByCondition: failed to create or update backend pool %s: %w", lbBackendPoolName, err)
 				}
 			}
@@ -508,7 +508,7 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 	serviceName := getServiceName(service)
 	lbBackendPoolName := getBackendPoolName(clusterName, service)
 	vmSetName := bi.mapLoadBalancerNameToVMSet(lbName, clusterName)
-	lbBackendPoolID := bi.getBackendPoolID(to.String(lb.Name), bi.getLoadBalancerResourceGroup(), getBackendPoolName(clusterName, service))
+	lbBackendPoolID := bi.getBackendPoolID(pointer.StringDeref(lb.Name, ""), bi.getLoadBalancerResourceGroup(), getBackendPoolName(clusterName, service))
 	isBackendPoolPreConfigured := bi.isBackendPoolPreConfigured(service)
 
 	mc := metrics.NewMetricContext("services", "migrate_to_ip_based_backend_pool", bi.ResourceGroup, bi.getNetworkResourceSubscriptionID(), serviceName)
@@ -555,13 +555,13 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 			var vnet string
 			if bp.BackendAddressPoolPropertiesFormat != nil {
 				if bp.VirtualNetwork == nil ||
-					to.String(bp.VirtualNetwork.ID) == "" {
+					pointer.StringDeref(bp.VirtualNetwork.ID, "") == "" {
 					if bp.LoadBalancerBackendAddresses != nil {
 						for _, a := range *bp.LoadBalancerBackendAddresses {
 							if a.LoadBalancerBackendAddressPropertiesFormat != nil &&
 								a.VirtualNetwork != nil {
 								if vnet == "" {
-									vnet = to.String(a.VirtualNetwork.ID)
+									vnet = pointer.StringDeref(a.VirtualNetwork.ID, "")
 								}
 								a.VirtualNetwork = nil
 							}
@@ -569,7 +569,7 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 					}
 					if vnet != "" {
 						bp.VirtualNetwork = &network.SubResource{
-							ID: to.StringPtr(vnet),
+							ID: pointer.String(vnet),
 						}
 						updated = true
 					}
@@ -620,8 +620,8 @@ func (bi *backendPoolTypeNodeIP) GetBackendPrivateIPs(clusterName string, servic
 
 	backendPrivateIPv4s, backendPrivateIPv6s := sets.NewString(), sets.NewString()
 	for _, bp := range *lb.BackendAddressPools {
-		if strings.EqualFold(to.String(bp.Name), lbBackendPoolName) {
-			klog.V(10).Infof("bi.GetBackendPrivateIPs for service (%s): found wanted backendpool %s", serviceName, to.String(bp.Name))
+		if strings.EqualFold(pointer.StringDeref(bp.Name, ""), lbBackendPoolName) {
+			klog.V(10).Infof("bi.GetBackendPrivateIPs for service (%s): found wanted backendpool %s", serviceName, pointer.StringDeref(bp.Name, ""))
 			if bp.BackendAddressPoolPropertiesFormat != nil && bp.LoadBalancerBackendAddresses != nil {
 				for _, backendAddress := range *bp.LoadBalancerBackendAddresses {
 					ipAddress := backendAddress.IPAddress
@@ -638,7 +638,7 @@ func (bi *backendPoolTypeNodeIP) GetBackendPrivateIPs(clusterName string, servic
 				}
 			}
 		} else {
-			klog.V(10).Infof("bi.GetBackendPrivateIPs for service (%s): found unmanaged backendpool %s", serviceName, to.String(bp.Name))
+			klog.V(10).Infof("bi.GetBackendPrivateIPs for service (%s): found unmanaged backendpool %s", serviceName, pointer.StringDeref(bp.Name, ""))
 		}
 	}
 	return backendPrivateIPv4s.List(), backendPrivateIPv6s.List()
@@ -656,7 +656,7 @@ func newBackendPool(lb *network.LoadBalancer, isBackendPoolPreConfigured bool, p
 		lb.BackendAddressPools = &[]network.BackendAddressPool{}
 	}
 	*lb.BackendAddressPools = append(*lb.BackendAddressPools, network.BackendAddressPool{
-		Name:                               to.StringPtr(lbBackendPoolName),
+		Name:                               pointer.String(lbBackendPoolName),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{},
 	})
 
@@ -675,13 +675,13 @@ func removeNodeIPAddressesFromBackendPool(backendPool network.BackendAddressPool
 	addresses := *backendPool.LoadBalancerBackendAddresses
 	for i := len(addresses) - 1; i >= 0; i-- {
 		if addresses[i].LoadBalancerBackendAddressPropertiesFormat != nil {
-			ipAddress := to.String((*backendPool.LoadBalancerBackendAddresses)[i].IPAddress)
+			ipAddress := pointer.StringDeref((*backendPool.LoadBalancerBackendAddresses)[i].IPAddress, "")
 			if ipAddress == "" {
-				klog.V(4).Infof("removeNodeIPAddressFromBackendPool: LoadBalancerBackendAddress %s is not IP-based, skipping", to.String(addresses[i].Name))
+				klog.V(4).Infof("removeNodeIPAddressFromBackendPool: LoadBalancerBackendAddress %s is not IP-based, skipping", pointer.StringDeref(addresses[i].Name, ""))
 				continue
 			}
 			if removeAll || nodeIPsSet.Has(ipAddress) {
-				klog.V(4).Infof("removeNodeIPAddressFromBackendPool: removing %s from the backend pool %s", ipAddress, to.String(backendPool.Name))
+				klog.V(4).Infof("removeNodeIPAddressFromBackendPool: removing %s from the backend pool %s", ipAddress, pointer.StringDeref(backendPool.Name, ""))
 				addresses = append(addresses[:i], addresses[i+1:]...)
 				changed = true
 			}

--- a/pkg/provider/azure_loadbalancer_backendpool_test.go
+++ b/pkg/provider/azure_loadbalancer_backendpool_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -48,31 +48,31 @@ func TestEnsureHostsInPoolNodeIP(t *testing.T) {
 	bi := newBackendPoolTypeNodeIP(az)
 
 	backendPool := network.BackendAddressPool{
-		Name: to.StringPtr("kubernetes"),
+		Name: pointer.String("kubernetes"),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("10.0.0.1"),
+						IPAddress: pointer.String("10.0.0.1"),
 					},
 				},
 			},
 		},
 	}
 	expectedBackendPool := network.BackendAddressPool{
-		Name: to.StringPtr("kubernetes"),
+		Name: pointer.String("kubernetes"),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
-			VirtualNetwork: &network.SubResource{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
+			VirtualNetwork: &network.SubResource{ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("10.0.0.1"),
+						IPAddress: pointer.String("10.0.0.1"),
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-0"),
+					Name: pointer.String("vmss-0"),
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("10.0.0.2"),
+						IPAddress: pointer.String("10.0.0.2"),
 					},
 				},
 			},
@@ -136,15 +136,15 @@ func TestCleanupVMSetFromBackendPoolByConditionNodeIPConfig(t *testing.T) {
 	cloud.VMSet = mockVMSet
 
 	expectedLB := network.LoadBalancer{
-		Name: to.StringPtr("testCluster"),
+		Name: pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
+								ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
 							},
 						},
 					},
@@ -229,15 +229,15 @@ func TestCleanupVMSetFromBackendPoolForInstanceNotFound(t *testing.T) {
 	cloud.VMSet = mockVMSet
 
 	expectedLB := network.LoadBalancer{
-		Name: to.StringPtr("testCluster"),
+		Name: pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
+								ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
 							},
 						},
 					},
@@ -286,7 +286,7 @@ func TestReconcileBackendPoolsNodeIPConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	lb = network.LoadBalancer{
-		Name:                         to.StringPtr(testClusterName),
+		Name:                         pointer.String(testClusterName),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 	}
 	az = GetTestCloud(ctrl)
@@ -415,15 +415,15 @@ func TestReconcileBackendPoolsNodeIP(t *testing.T) {
 	}
 
 	bp := network.BackendAddressPool{
-		Name: to.StringPtr("kubernetes"),
+		Name: pointer.String("kubernetes"),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 			VirtualNetwork: &network.SubResource{
-				ID: to.StringPtr("vnet"),
+				ID: pointer.String("vnet"),
 			},
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 				{
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						IPAddress: to.StringPtr("10.0.0.2"),
+						IPAddress: pointer.String("10.0.0.2"),
 					},
 				},
 			},
@@ -449,7 +449,7 @@ func TestReconcileBackendPoolsNodeIP(t *testing.T) {
 	assert.NoError(t, err)
 
 	lb = &network.LoadBalancer{
-		Name:                         to.StringPtr(testClusterName),
+		Name:                         pointer.String(testClusterName),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 	}
 	az = GetTestCloud(ctrl)
@@ -622,11 +622,11 @@ func TestGetBackendIPConfigurationsToBeDeleted(t *testing.T) {
 		{
 			description: "should ignore excluded IP configurations if the backend pool will be empty after removing IP configurations of not found vms",
 			bipConfigNotFound: []network.InterfaceIPConfiguration{
-				{ID: to.StringPtr("ipconfig1")},
-				{ID: to.StringPtr("ipconfig2")},
+				{ID: pointer.String("ipconfig1")},
+				{ID: pointer.String("ipconfig2")},
 			},
 			bipConfigExclude: []network.InterfaceIPConfiguration{
-				{ID: to.StringPtr("ipconfig3")},
+				{ID: pointer.String("ipconfig3")},
 			},
 			expected: map[string]bool{
 				"ipconfig1": true,
@@ -636,10 +636,10 @@ func TestGetBackendIPConfigurationsToBeDeleted(t *testing.T) {
 		{
 			description: "should remove both not found and excluded vms",
 			bipConfigNotFound: []network.InterfaceIPConfiguration{
-				{ID: to.StringPtr("ipconfig1")},
+				{ID: pointer.String("ipconfig1")},
 			},
 			bipConfigExclude: []network.InterfaceIPConfiguration{
-				{ID: to.StringPtr("ipconfig3")},
+				{ID: pointer.String("ipconfig3")},
 			},
 			expected: map[string]bool{
 				"ipconfig1": true,
@@ -649,12 +649,12 @@ func TestGetBackendIPConfigurationsToBeDeleted(t *testing.T) {
 		{
 			description: "should remove all not found vms even if the backend pool will be empty",
 			bipConfigNotFound: []network.InterfaceIPConfiguration{
-				{ID: to.StringPtr("ipconfig1")},
-				{ID: to.StringPtr("ipconfig2")},
-				{ID: to.StringPtr("ipconfig3")},
+				{ID: pointer.String("ipconfig1")},
+				{ID: pointer.String("ipconfig2")},
+				{ID: pointer.String("ipconfig3")},
 			},
 			bipConfigExclude: []network.InterfaceIPConfiguration{
-				{ID: to.StringPtr("ipconfig4")},
+				{ID: pointer.String("ipconfig4")},
 			},
 			expected: map[string]bool{
 				"ipconfig1": true,
@@ -666,9 +666,9 @@ func TestGetBackendIPConfigurationsToBeDeleted(t *testing.T) {
 		bp := network.BackendAddressPool{
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
-					{ID: to.StringPtr("ipconfig1")},
-					{ID: to.StringPtr("ipconfig2")},
-					{ID: to.StringPtr("ipconfig3")},
+					{ID: pointer.String("ipconfig1")},
+					{ID: pointer.String("ipconfig2")},
+					{ID: pointer.String("ipconfig3")},
 				},
 			},
 		}

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/cases"
@@ -62,30 +61,30 @@ const LBInUseRawError = `{
 
 func TestGetLoadBalancer(t *testing.T) {
 	lb1 := network.LoadBalancer{
-		Name:                         to.StringPtr("testCluster"),
+		Name:                         pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 	}
 	lb2 := network.LoadBalancer{
-		Name: to.StringPtr("testCluster"),
+		Name: pointer.String("testCluster"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("aservice"),
+					Name: pointer.String("aservice"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice")},
+						PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice")},
 					},
 				},
 			},
 		},
 	}
 	lb3 := network.LoadBalancer{
-		Name: to.StringPtr("testCluster-internal"),
+		Name: pointer.String("testCluster-internal"),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("aservice"),
+					Name: pointer.String("aservice"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PrivateIPAddress: to.StringPtr("10.0.0.6"),
+						PrivateIPAddress: pointer.String("10.0.0.6"),
 					},
 				},
 			},
@@ -205,16 +204,16 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe names match while ports don't should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("httpProbe"),
+					Name: pointer.String("httpProbe"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port: to.Int32Ptr(1),
+						Port: pointer.Int32(1),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("httpProbe"),
+				Name: pointer.String("httpProbe"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(2),
+					Port: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -223,16 +222,16 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe ports match while names don't should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port: to.Int32Ptr(1),
+						Port: pointer.Int32(1),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe2"),
+				Name: pointer.String("probe2"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(1),
+					Port: pointer.Int32(1),
 				},
 			},
 			expected: false,
@@ -241,17 +240,17 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe protocol don't match should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:     to.Int32Ptr(1),
+						Port:     pointer.Int32(1),
 						Protocol: network.ProbeProtocolHTTP,
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port:     to.Int32Ptr(1),
+					Port:     pointer.Int32(1),
 					Protocol: network.ProbeProtocolTCP,
 				},
 			},
@@ -261,18 +260,18 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe path don't match should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:        to.Int32Ptr(1),
-						RequestPath: to.StringPtr("/path1"),
+						Port:        pointer.Int32(1),
+						RequestPath: pointer.String("/path1"),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port:        to.Int32Ptr(1),
-					RequestPath: to.StringPtr("/path2"),
+					Port:        pointer.Int32(1),
+					RequestPath: pointer.String("/path2"),
 				},
 			},
 			expected: false,
@@ -281,20 +280,20 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe interval don't match should return false",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:              to.Int32Ptr(1),
-						RequestPath:       to.StringPtr("/path"),
-						IntervalInSeconds: to.Int32Ptr(5),
+						Port:              pointer.Int32(1),
+						RequestPath:       pointer.String("/path"),
+						IntervalInSeconds: pointer.Int32(5),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port:              to.Int32Ptr(1),
-					RequestPath:       to.StringPtr("/path"),
-					IntervalInSeconds: to.Int32Ptr(10),
+					Port:              pointer.Int32(1),
+					RequestPath:       pointer.String("/path"),
+					IntervalInSeconds: pointer.Int32(10),
 				},
 			},
 			expected: false,
@@ -303,16 +302,16 @@ func TestFindProbe(t *testing.T) {
 			msg: "probe match should return true",
 			existingProbe: []network.Probe{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port: to.Int32Ptr(1),
+						Port: pointer.Int32(1),
 					},
 				},
 			},
 			curProbe: network.Probe{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(1),
+					Port: pointer.Int32(1),
 				},
 			},
 			expected: true,
@@ -340,16 +339,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names don't match should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpProbe1"),
+					Name: pointer.String("httpProbe1"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendPort: to.Int32Ptr(1),
+						FrontendPort: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpProbe2"),
+				Name: pointer.String("httpProbe2"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendPort: to.Int32Ptr(1),
+					FrontendPort: pointer.Int32(1),
 				},
 			},
 			expected: false,
@@ -358,14 +357,14 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while protocols don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Protocol: network.TransportProtocolTCP,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					Protocol: network.TransportProtocolUDP,
 				},
@@ -376,18 +375,18 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while EnableTCPResets don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Protocol:       network.TransportProtocolTCP,
-						EnableTCPReset: to.BoolPtr(true),
+						EnableTCPReset: pointer.Bool(true),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					Protocol:       network.TransportProtocolTCP,
-					EnableTCPReset: to.BoolPtr(false),
+					EnableTCPReset: pointer.Bool(false),
 				},
 			},
 			expected: false,
@@ -396,16 +395,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while frontend ports don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpProbe"),
+					Name: pointer.String("httpProbe"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendPort: to.Int32Ptr(1),
+						FrontendPort: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpProbe"),
+				Name: pointer.String("httpProbe"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendPort: to.Int32Ptr(2),
+					FrontendPort: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -414,16 +413,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while backend ports don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpProbe"),
+					Name: pointer.String("httpProbe"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						BackendPort: to.Int32Ptr(1),
+						BackendPort: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpProbe"),
+				Name: pointer.String("httpProbe"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					BackendPort: to.Int32Ptr(2),
+					BackendPort: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -432,16 +431,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while idletimeout don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						IdleTimeoutInMinutes: to.Int32Ptr(1),
+						IdleTimeoutInMinutes: pointer.Int32(1),
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					IdleTimeoutInMinutes: to.Int32Ptr(2),
+					IdleTimeoutInMinutes: pointer.Int32(2),
 				},
 			},
 			expected: false,
@@ -450,14 +449,14 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while idletimeout nil should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name:                              to.StringPtr("httpRule"),
+					Name:                              pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					IdleTimeoutInMinutes: to.Int32Ptr(2),
+					IdleTimeoutInMinutes: pointer.Int32(2),
 				},
 			},
 			expected: true,
@@ -466,14 +465,14 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while LoadDistribution don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("httpRule"),
+					Name: pointer.String("httpRule"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						LoadDistribution: network.LoadDistributionSourceIP,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("httpRule"),
+				Name: pointer.String("httpRule"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					LoadDistribution: network.LoadDistributionDefault,
 				},
@@ -484,16 +483,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and probe names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						Probe: &network.SubResource{ID: to.StringPtr("probe")},
+						Probe: &network.SubResource{ID: pointer.String("probe")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					Probe: &network.SubResource{ID: to.StringPtr("probe")},
+					Probe: &network.SubResource{ID: pointer.String("probe")},
 				},
 			},
 			expected: true,
@@ -502,16 +501,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while probe don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("probe1"),
+					Name: pointer.String("probe1"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Probe: nil,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("probe1"),
+				Name: pointer.String("probe1"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					Probe: &network.SubResource{ID: to.StringPtr("probe")},
+					Probe: &network.SubResource{ID: pointer.String("probe")},
 				},
 			},
 			expected: false,
@@ -520,19 +519,19 @@ func TestFindRule(t *testing.T) {
 			msg: "both rule names and LoadBalancingRulePropertiesFormats match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						BackendPort:      to.Int32Ptr(2),
-						FrontendPort:     to.Int32Ptr(2),
+						BackendPort:      pointer.Int32(2),
+						FrontendPort:     pointer.Int32(2),
 						LoadDistribution: network.LoadDistributionSourceIP,
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					BackendPort:      to.Int32Ptr(2),
-					FrontendPort:     to.Int32Ptr(2),
+					BackendPort:      pointer.Int32(2),
+					FrontendPort:     pointer.Int32(2),
 					LoadDistribution: network.LoadDistributionSourceIP,
 				},
 			},
@@ -542,16 +541,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and FrontendIPConfiguration names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("FrontendIPConfiguration")},
+						FrontendIPConfiguration: &network.SubResource{ID: pointer.String("FrontendIPConfiguration")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("frontendipconfiguration")},
+					FrontendIPConfiguration: &network.SubResource{ID: pointer.String("frontendipconfiguration")},
 				},
 			},
 			expected: true,
@@ -560,16 +559,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule names match while FrontendIPConfiguration don't should return false",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("FrontendIPConfiguration")},
+						FrontendIPConfiguration: &network.SubResource{ID: pointer.String("FrontendIPConfiguration")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("frontendipconifguration")},
+					FrontendIPConfiguration: &network.SubResource{ID: pointer.String("frontendipconifguration")},
 				},
 			},
 			expected: false,
@@ -578,16 +577,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and BackendAddressPool names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						BackendAddressPool: &network.SubResource{ID: to.StringPtr("BackendAddressPool")},
+						BackendAddressPool: &network.SubResource{ID: pointer.String("BackendAddressPool")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					BackendAddressPool: &network.SubResource{ID: to.StringPtr("backendaddresspool")},
+					BackendAddressPool: &network.SubResource{ID: pointer.String("backendaddresspool")},
 				},
 			},
 			expected: true,
@@ -596,16 +595,16 @@ func TestFindRule(t *testing.T) {
 			msg: "rule and Probe names match should return true",
 			existingRule: []network.LoadBalancingRule{
 				{
-					Name: to.StringPtr("matchName"),
+					Name: pointer.String("matchName"),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-						Probe: &network.SubResource{ID: to.StringPtr("Probe")},
+						Probe: &network.SubResource{ID: pointer.String("Probe")},
 					},
 				},
 			},
 			curRule: network.LoadBalancingRule{
-				Name: to.StringPtr("matchName"),
+				Name: pointer.String("matchName"),
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-					Probe: &network.SubResource{ID: to.StringPtr("probe")},
+					Probe: &network.SubResource{ID: pointer.String("probe")},
 				},
 			},
 			expected: true,
@@ -674,7 +673,7 @@ func TestSubnet(t *testing.T) {
 					},
 				},
 			},
-			expected: to.StringPtr("subnet"),
+			expected: pointer.String("subnet"),
 		},
 	} {
 		real := subnet(c.service)
@@ -812,10 +811,10 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when service name tag doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey: to.StringPtr("default/nginx"),
+					consts.ServiceTagKey: pointer.String("default/nginx"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			serviceName:  "web",
@@ -825,10 +824,10 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned when service name tag matches and cluster name tag is not set",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey: to.StringPtr("default/nginx"),
+					consts.ServiceTagKey: pointer.String("default/nginx"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -839,11 +838,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when cluster name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "k8s",
@@ -854,11 +853,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when cluster name matches while service name doesn't match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/web"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/web"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -869,11 +868,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned when both service name tag and cluster name match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -884,11 +883,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned when the tag is empty and load balancer IP does not match",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr(""),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String(""),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:             "kubernetes",
@@ -900,11 +899,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned if there is a match among a multi-service tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx1,default/nginx2"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -915,11 +914,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "false should be returned if there is not a match among a multi-service tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx1,default/nginx2"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -930,11 +929,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned if the load balancer IP is matched even if the svc name is not included in the tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr(""),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String(""),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:             "kubernetes",
@@ -947,11 +946,11 @@ func TestServiceOwnsPublicIP(t *testing.T) {
 			desc: "true should be returned if the load balancer IP is not matched but the svc name is included in the tag",
 			pip: &network.PublicIPAddress{
 				Tags: map[string]*string{
-					consts.ServiceTagKey:  to.StringPtr("default/nginx1,default/nginx2"),
-					consts.ClusterNameKey: to.StringPtr("kubernetes"),
+					consts.ServiceTagKey:  pointer.String("default/nginx1,default/nginx2"),
+					consts.ClusterNameKey: pointer.String("kubernetes"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			clusterName:  "kubernetes",
@@ -1010,24 +1009,24 @@ func TestGetPublicIPAddressResourceGroup(t *testing.T) {
 
 func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 	existingPipWithTag := network.PublicIPAddress{
-		ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-		Name: to.StringPtr("testPIP"),
+		ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+		Name: pointer.String("testPIP"),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   network.IPv4,
 			PublicIPAllocationMethod: network.Static,
 			IPTags: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 			},
 		},
 	}
 
 	existingPipWithNoPublicIPAddressFormatProperties := network.PublicIPAddress{
-		ID:                              to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-		Name:                            to.StringPtr("testPIP"),
-		Tags:                            map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test2")},
+		ID:                              pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+		Name:                            pointer.String("testPIP"),
+		Tags:                            map[string]*string{consts.ServiceTagKey: pointer.String("default/test2")},
 		PublicIPAddressPropertiesFormat: nil,
 	}
 
@@ -1124,8 +1123,8 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 				IPTagsRequestedByAnnotation: true,
 				IPTags: &[]network.IPTag{
 					{
-						IPTagType: to.StringPtr("tag2"),
-						Tag:       to.StringPtr("tag2value"),
+						IPTagType: pointer.String("tag2"),
+						Tag:       pointer.String("tag2value"),
 					},
 				},
 			},
@@ -1137,7 +1136,7 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbShouldExist:  false,
 			lbIsInternal:   false,
 			desiredPipName: *existingPipWithTag.Name,
-			tags:           map[string]*string{consts.ServiceTagKey: to.StringPtr("")},
+			tags:           map[string]*string{consts.ServiceTagKey: pointer.String("")},
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
@@ -1150,7 +1149,7 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbShouldExist:  false,
 			lbIsInternal:   false,
 			desiredPipName: *existingPipWithTag.Name,
-			tags:           map[string]*string{consts.ServiceTagKey: to.StringPtr("svc1")},
+			tags:           map[string]*string{consts.ServiceTagKey: pointer.String("svc1")},
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
@@ -1162,7 +1161,7 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbShouldExist:  false,
 			lbIsInternal:   false,
 			desiredPipName: *existingPipWithTag.Name,
-			tags:           map[string]*string{consts.ServiceTagKey: to.StringPtr("")},
+			tags:           map[string]*string{consts.ServiceTagKey: pointer.String("")},
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags:                      existingPipWithTag.PublicIPAddressPropertiesFormat.IPTags,
@@ -1277,8 +1276,8 @@ func TestConvertIPTagMapToSlice(t *testing.T) {
 			},
 			expected: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 			},
 		},
@@ -1290,12 +1289,12 @@ func TestConvertIPTagMapToSlice(t *testing.T) {
 			},
 			expected: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 		},
@@ -1309,13 +1308,13 @@ func TestConvertIPTagMapToSlice(t *testing.T) {
 		if actual != nil {
 			sort.Slice(*actual, func(i, j int) bool {
 				ipTagSlice := *actual
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 		}
 		if c.expected != nil {
 			sort.Slice(*c.expected, func(i, j int) bool {
 				ipTagSlice := *c.expected
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 
 		}
@@ -1377,12 +1376,12 @@ func TestGetserviceIPTagRequestForPublicIP(t *testing.T) {
 				IPTagsRequestedByAnnotation: true,
 				IPTags: &[]network.IPTag{
 					{
-						IPTagType: to.StringPtr("tag1"),
-						Tag:       to.StringPtr("tag1value"),
+						IPTagType: pointer.String("tag1"),
+						Tag:       pointer.String("tag1value"),
 					},
 					{
-						IPTagType: to.StringPtr("tag2"),
-						Tag:       to.StringPtr("tag2value"),
+						IPTagType: pointer.String("tag2"),
+						Tag:       pointer.String("tag2value"),
 					},
 				},
 			},
@@ -1396,13 +1395,13 @@ func TestGetserviceIPTagRequestForPublicIP(t *testing.T) {
 		if actual.IPTags != nil {
 			sort.Slice(*actual.IPTags, func(i, j int) bool {
 				ipTagSlice := *actual.IPTags
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 		}
 		if c.expected.IPTags != nil {
 			sort.Slice(*c.expected.IPTags, func(i, j int) bool {
 				ipTagSlice := *c.expected.IPTags
-				return to.String(ipTagSlice[i].IPTagType) < to.String(ipTagSlice[j].IPTagType)
+				return pointer.StringDeref(ipTagSlice[i].IPTagType, "") < pointer.StringDeref(ipTagSlice[j].IPTagType, "")
 			})
 
 		}
@@ -1440,12 +1439,12 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "nil should not be considered equal to anything (case 1)",
 			input1: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input2:   nil,
@@ -1455,12 +1454,12 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "nil should not be considered equal to anything (case 2)",
 			input2: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input1:   nil,
@@ -1470,22 +1469,22 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "exactly equal should be treated as equal",
 			input1: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input2: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			expected: true,
@@ -1494,22 +1493,22 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 			desc: "equal but out of order should be treated as equal",
 			input1: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 			},
 			input2: &[]network.IPTag{
 				{
-					IPTagType: to.StringPtr("tag2"),
-					Tag:       to.StringPtr("tag2value"),
+					IPTagType: pointer.String("tag2"),
+					Tag:       pointer.String("tag2value"),
 				},
 				{
-					IPTagType: to.StringPtr("tag1"),
-					Tag:       to.StringPtr("tag1value"),
+					IPTagType: pointer.String("tag1"),
+					Tag:       pointer.String("tag1value"),
 				},
 			},
 			expected: true,
@@ -1595,13 +1594,13 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			desc: "getServiceLoadBalancer shall return corresponding lb, status, exists if there are existed lbs",
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 							{
-								Name: to.StringPtr("aservice1"),
+								Name: pointer.String("aservice1"),
 								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-									PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+									PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 								},
 							},
 						},
@@ -1611,13 +1610,13 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			service: getTestService("service1", v1.ProtocolTCP, nil, false, 80),
 			wantLB:  false,
 			expectedLB: &network.LoadBalancer{
-				Name: to.StringPtr("testCluster"),
+				Name: pointer.String("testCluster"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 						{
-							Name: to.StringPtr("aservice1"),
+							Name: pointer.String("aservice1"),
 							FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-								PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+								PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 							},
 						},
 					},
@@ -1632,29 +1631,29 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 				"not standard and there are existing lbs already",
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("testCluster"),
+					Name: pointer.String("testCluster"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						LoadBalancingRules: &[]network.LoadBalancingRule{
-							{Name: to.StringPtr("rule1")},
+							{Name: pointer.String("rule1")},
 						},
 					},
 				},
 				{
-					Name: to.StringPtr("as-1"),
+					Name: pointer.String("as-1"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						LoadBalancingRules: &[]network.LoadBalancingRule{
-							{Name: to.StringPtr("rule1")},
-							{Name: to.StringPtr("rule2")},
+							{Name: pointer.String("rule1")},
+							{Name: pointer.String("rule2")},
 						},
 					},
 				},
 				{
-					Name: to.StringPtr("as-2"),
+					Name: pointer.String("as-2"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						LoadBalancingRules: &[]network.LoadBalancingRule{
-							{Name: to.StringPtr("rule1")},
-							{Name: to.StringPtr("rule2")},
-							{Name: to.StringPtr("rule3")},
+							{Name: pointer.String("rule1")},
+							{Name: pointer.String("rule2")},
+							{Name: pointer.String("rule3")},
 						},
 					},
 				},
@@ -1663,10 +1662,10 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "__auto__"},
 			wantLB:      true,
 			expectedLB: &network.LoadBalancer{
-				Name: to.StringPtr("testCluster"),
+				Name: pointer.String("testCluster"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
-						{Name: to.StringPtr("rule1")},
+						{Name: pointer.String("rule1")},
 					},
 				},
 			},
@@ -1677,8 +1676,8 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			desc:    "getServiceLoadBalancer shall create a new lb otherwise",
 			service: getTestService("service1", v1.ProtocolTCP, nil, false, 80),
 			expectedLB: &network.LoadBalancer{
-				Name:                         to.StringPtr("testCluster"),
-				Location:                     to.StringPtr("westus"),
+				Name:                         pointer.String("testCluster"),
+				Location:                     pointer.String("westus"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
 			},
 			expectedExists: false,
@@ -1691,15 +1690,15 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			service: getTestService("service1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationLoadBalancerMode: "as", consts.ServiceAnnotationLoadBalancerInternal: consts.TrueAnnotationValue}, false, 80),
 			existingLBs: []network.LoadBalancer{
 				{
-					Name:     to.StringPtr("as-internal"),
-					Location: to.StringPtr("westus"),
+					Name:     pointer.String("as-internal"),
+					Location: pointer.String("westus"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 							{
-								Name: to.StringPtr("aservice1"),
-								ID:   to.StringPtr("as-internal-aservice1"),
+								Name: pointer.String("aservice1"),
+								ID:   pointer.String("as-internal-aservice1"),
 								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-									PrivateIPAddress: to.StringPtr("1.2.3.4"),
+									PrivateIPAddress: pointer.String("1.2.3.4"),
 								},
 							},
 						},
@@ -1707,8 +1706,8 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 				},
 			},
 			expectedLB: &network.LoadBalancer{
-				Name:     to.StringPtr("testCluster-internal"),
-				Location: to.StringPtr("westus"),
+				Name:     pointer.String("testCluster-internal"),
+				Location: pointer.String("westus"),
 				Sku: &network.LoadBalancerSku{
 					Name: network.LoadBalancerSkuNameBasic,
 				},
@@ -1766,10 +1765,10 @@ func TestGetServiceLoadBalancerWithExtendedLocation(t *testing.T) {
 
 	// Test with wantLB=false
 	expectedLB := &network.LoadBalancer{
-		Name:     to.StringPtr("testCluster"),
-		Location: to.StringPtr("westus"),
+		Name:     pointer.String("testCluster"),
+		Location: pointer.String("westus"),
 		ExtendedLocation: &network.ExtendedLocation{
-			Name: to.StringPtr("microsoftlosangeles1"),
+			Name: pointer.String("microsoftlosangeles1"),
 			Type: network.EdgeZone,
 		},
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
@@ -1787,10 +1786,10 @@ func TestGetServiceLoadBalancerWithExtendedLocation(t *testing.T) {
 
 	// Test with wantLB=true
 	expectedLB = &network.LoadBalancer{
-		Name:     to.StringPtr("testCluster"),
-		Location: to.StringPtr("westus"),
+		Name:     pointer.String("testCluster"),
+		Location: pointer.String("westus"),
 		ExtendedLocation: &network.ExtendedLocation{
-			Name: to.StringPtr("microsoftlosangeles1"),
+			Name: pointer.String("microsoftlosangeles1"),
 			Type: network.EdgeZone,
 		},
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
@@ -1830,7 +1829,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return true if config.Name has a prefix of lb's name and " +
 				"config.Name != lbFrontendIPConfigName",
-			config:                 network.FrontendIPConfiguration{Name: to.StringPtr("atest1-name")},
+			config:                 network.FrontendIPConfiguration{Name: pointer.String("atest1-name")},
 			service:                getInternalTestService("test1", 80),
 			lbFrontendIPConfigName: "configName",
 			expectedFlag:           true,
@@ -1839,7 +1838,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return false if config.Name doesn't have a prefix of lb's name " +
 				"and config.Name != lbFrontendIPConfigName",
-			config:                 network.FrontendIPConfiguration{Name: to.StringPtr("btest1-name")},
+			config:                 network.FrontendIPConfiguration{Name: pointer.String("btest1-name")},
 			service:                getInternalTestService("test1", 80),
 			lbFrontendIPConfigName: "configName",
 			expectedFlag:           false,
@@ -1849,7 +1848,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, no loadBalancerIP is given, " +
 				"subnetName == nil and config.PrivateIPAllocationMethod == network.Static",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.Static,
 				},
@@ -1863,7 +1862,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, no loadBalancerIP is given, " +
 				"subnetName == nil and config.PrivateIPAllocationMethod != network.Static",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.Dynamic,
 				},
@@ -1877,15 +1876,15 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return true if the service is internal and " +
 				"config.Subnet.ID != subnet.ID",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					Subnet: &network.Subnet{ID: to.StringPtr("testSubnet")},
+					Subnet: &network.Subnet{ID: pointer.String("testSubnet")},
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
 			service:                getInternalTestService("test1", 80),
 			annotations:            "testSubnet",
-			existingSubnet:         network.Subnet{ID: to.StringPtr("testSubnet1")},
+			existingSubnet:         network.Subnet{ID: pointer.String("testSubnet1")},
 			expectedFlag:           true,
 			expectedError:          false,
 		},
@@ -1893,10 +1892,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, subnet == nil, " +
 				"loadBalancerIP == config.PrivateIPAddress and config.PrivateIPAllocationMethod != 'static'",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.Dynamic,
-					PrivateIPAddress:          to.StringPtr("1.1.1.1"),
+					PrivateIPAddress:          pointer.String("1.1.1.1"),
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1909,10 +1908,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return false if the service is internal, subnet == nil, " +
 				"loadBalancerIP == config.PrivateIPAddress and config.PrivateIPAllocationMethod == 'static'",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.Static,
-					PrivateIPAddress:          to.StringPtr("1.1.1.1"),
+					PrivateIPAddress:          pointer.String("1.1.1.1"),
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1925,10 +1924,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			desc: "isFrontendIPChanged shall return true if the service is internal, subnet == nil and " +
 				"loadBalancerIP != config.PrivateIPAddress",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: network.Static,
-					PrivateIPAddress:          to.StringPtr("1.1.1.2"),
+					PrivateIPAddress:          pointer.String("1.1.1.2"),
 				},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1940,7 +1939,7 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return false if config.PublicIPAddress == nil",
 			config: network.FrontendIPConfiguration{
-				Name:                                    to.StringPtr("btest1-name"),
+				Name:                                    pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{},
 			},
 			lbFrontendIPConfigName: "btest1-name",
@@ -1948,10 +1947,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			loadBalancerIP:         "1.1.1.1",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
-					ID:   to.StringPtr("pip"),
+					Name: pointer.String("pipName"),
+					ID:   pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.1.1.1"),
+						IPAddress: pointer.String("1.1.1.1"),
 					},
 				},
 			},
@@ -1961,9 +1960,9 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return false if pip.ID == config.PublicIPAddress.ID",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription" +
+					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("/subscriptions/subscription" +
 						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName")},
 				},
 			},
@@ -1972,11 +1971,11 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			loadBalancerIP:         "1.1.1.1",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
+					Name: pointer.String("pipName"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.1.1.1"),
+						IPAddress: pointer.String("1.1.1.1"),
 					},
-					ID: to.StringPtr("/subscriptions/subscription" +
+					ID: pointer.String("/subscriptions/subscription" +
 						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName"),
 				},
 			},
@@ -1986,10 +1985,10 @@ func TestIsFrontendIPChanged(t *testing.T) {
 		{
 			desc: "isFrontendIPChanged shall return true if pip.ID != config.PublicIPAddress.ID",
 			config: network.FrontendIPConfiguration{
-				Name: to.StringPtr("btest1-name"),
+				Name: pointer.String("btest1-name"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("/subscriptions/subscription" +
+						ID: pointer.String("/subscriptions/subscription" +
 							"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName1"),
 					},
 				},
@@ -1999,11 +1998,11 @@ func TestIsFrontendIPChanged(t *testing.T) {
 			loadBalancerIP:         "1.1.1.1",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
-					ID: to.StringPtr("/subscriptions/subscription" +
+					Name: pointer.String("pipName"),
+					ID: pointer.String("/subscriptions/subscription" +
 						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName2"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.1.1.1"),
+						IPAddress: pointer.String("1.1.1.1"),
 					},
 				},
 			},
@@ -2050,9 +2049,9 @@ func TestFindMatchedPIPByLoadBalancerIP(t *testing.T) {
 	defer ctrl.Finish()
 
 	testPIP := network.PublicIPAddress{
-		Name: to.StringPtr("pipName"),
+		Name: pointer.String("pipName"),
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-			IPAddress: to.StringPtr("1.2.3.4"),
+			IPAddress: pointer.String("1.2.3.4"),
 		},
 	}
 	var nilPIPs []network.PublicIPAddress
@@ -2131,9 +2130,9 @@ func TestDeterminePublicIPName(t *testing.T) {
 			loadBalancerIP: "1.2.3.4",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pipName"),
+					Name: pointer.String("pipName"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -2380,7 +2379,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			loadBalancerSku: "standard",
 			probeProtocol:   "Https",
 			probePath:       "/healthy1",
-			expectedProbes:  getTestProbes("Https", "/healthy1", to.Int32Ptr(20), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedProbes:  getTestProbes("Https", "/healthy1", pointer.Int32(20), pointer.Int32(10080), pointer.Int32(5)),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -2391,7 +2390,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			}, false, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Http",
-			expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(20), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedProbes:  getTestProbes("Tcp", "", pointer.Int32(20), pointer.Int32(10080), pointer.Int32(5)),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -2402,7 +2401,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			}, false, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
-			expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(20), to.Int32Ptr(10080), to.Int32Ptr(5)),
+			expectedProbes:  getTestProbes("Tcp", "", pointer.Int32(20), pointer.Int32(10080), pointer.Int32(5)),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
@@ -2456,7 +2455,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 	}
 	rules := getDefaultTestRules(true)
-	rules[0].IdleTimeoutInMinutes = to.Int32Ptr(5)
+	rules[0].IdleTimeoutInMinutes = pointer.Int32(5)
 	testCases = append(testCases, struct {
 		desc            string
 		service         v1.Service
@@ -2475,7 +2474,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		}, false, 80),
 		loadBalancerSku: "standard",
 		probeProtocol:   "Tcp",
-		expectedProbes:  getTestProbes("Tcp", "", to.Int32Ptr(10), to.Int32Ptr(10080), to.Int32Ptr(10)),
+		expectedProbes:  getTestProbes("Tcp", "", pointer.Int32(10), pointer.Int32(10080), pointer.Int32(10)),
 		expectedRules:   rules,
 	})
 	rules1 := []network.LoadBalancingRule{
@@ -2483,17 +2482,17 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		getTestRule(true, 443),
 		getTestRule(true, 421),
 	}
-	rules1[0].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
-	rules1[1].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
-	rules1[2].Probe.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[0].Probe.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[1].Probe.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
+	rules1[2].Probe.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-34567")
 	svc := getTestService("test1", v1.ProtocolTCP, map[string]string{
 		"service.beta.kubernetes.io/port_80_health-probe_interval":     "10",
 		"service.beta.kubernetes.io/port_80_health-probe_num-of-probe": "10",
 	}, false, 80, 443, 421)
 	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 	svc.Spec.HealthCheckNodePort = 34567
-	probes := getTestProbes("Http", "/healthz", to.Int32Ptr(5), to.Int32Ptr(34567), to.Int32Ptr(2))
-	probes[0].Name = to.StringPtr("atest1-TCP-34567")
+	probes := getTestProbes("Http", "/healthz", pointer.Int32(5), pointer.Int32(34567), pointer.Int32(2))
+	probes[0].Name = pointer.String("atest1-TCP-34567")
 	testCases = append(testCases, struct {
 		desc            string
 		service         v1.Service
@@ -2544,7 +2543,7 @@ func getTestProbes(protocol, path string, interval, port, numOfProbe *int32) []n
 
 func getTestProbe(protocol, path string, interval, port, numOfProbe *int32) network.Probe {
 	expectedProbes := network.Probe{
-		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", *port-10000)),
+		Name: pointer.String(fmt.Sprintf("atest1-TCP-%d", *port-10000)),
 		ProbePropertiesFormat: &network.ProbePropertiesFormat{
 			Protocol:          network.ProbeProtocol(protocol),
 			Port:              port,
@@ -2553,12 +2552,12 @@ func getTestProbe(protocol, path string, interval, port, numOfProbe *int32) netw
 		},
 	}
 	if (strings.EqualFold(protocol, "Http") || strings.EqualFold(protocol, "Https")) && len(strings.TrimSpace(path)) > 0 {
-		expectedProbes.RequestPath = to.StringPtr(path)
+		expectedProbes.RequestPath = pointer.String(path)
 	}
 	return expectedProbes
 }
 func getDefaultTestProbes(protocol, path string) []network.Probe {
-	return getTestProbes(protocol, path, to.Int32Ptr(5), to.Int32Ptr(10080), to.Int32Ptr(2))
+	return getTestProbes(protocol, path, pointer.Int32(5), pointer.Int32(10080), pointer.Int32(2))
 }
 
 func getDefaultTestRules(enableTCPReset bool) []network.LoadBalancingRule {
@@ -2570,37 +2569,37 @@ func getDefaultTestRules(enableTCPReset bool) []network.LoadBalancingRule {
 func getDefaultInternalIPv6Rules(enableTCPReset bool) []network.LoadBalancingRule {
 	rules := getDefaultTestRules(true)
 	for _, rule := range rules {
-		rule.EnableFloatingIP = to.BoolPtr(false)
-		rule.BackendPort = to.Int32Ptr(getBackendPort(*rule.FrontendPort))
+		rule.EnableFloatingIP = pointer.Bool(false)
+		rule.BackendPort = pointer.Int32(getBackendPort(*rule.FrontendPort))
 	}
 	return rules
 }
 
 func getTestRule(enableTCPReset bool, port int32) network.LoadBalancingRule {
 	expectedRules := network.LoadBalancingRule{
-		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", port)),
+		Name: pointer.String(fmt.Sprintf("atest1-TCP-%d", port)),
 		LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 			Protocol: network.TransportProtocol("Tcp"),
 			FrontendIPConfiguration: &network.SubResource{
-				ID: to.StringPtr("frontendIPConfigID"),
+				ID: pointer.String("frontendIPConfigID"),
 			},
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("backendPoolID"),
+				ID: pointer.String("backendPoolID"),
 			},
 			LoadDistribution:     "Default",
-			FrontendPort:         to.Int32Ptr(port),
-			BackendPort:          to.Int32Ptr(port),
-			EnableFloatingIP:     to.BoolPtr(true),
-			DisableOutboundSnat:  to.BoolPtr(false),
-			IdleTimeoutInMinutes: to.Int32Ptr(4),
+			FrontendPort:         pointer.Int32(port),
+			BackendPort:          pointer.Int32(port),
+			EnableFloatingIP:     pointer.Bool(true),
+			DisableOutboundSnat:  pointer.Bool(false),
+			IdleTimeoutInMinutes: pointer.Int32(4),
 			Probe: &network.SubResource{
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/" +
 					fmt.Sprintf("Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-%d", port)),
 			},
 		},
 	}
 	if enableTCPReset {
-		expectedRules.EnableTCPReset = to.BoolPtr(true)
+		expectedRules.EnableTCPReset = pointer.Bool(true)
 	}
 	return expectedRules
 }
@@ -2608,28 +2607,28 @@ func getTestRule(enableTCPReset bool, port int32) network.LoadBalancingRule {
 func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol) []network.LoadBalancingRule {
 	expectedRules := []network.LoadBalancingRule{
 		{
-			Name: to.StringPtr(fmt.Sprintf("atest1-%s-80", string(protocol))),
+			Name: pointer.String(fmt.Sprintf("atest1-%s-80", string(protocol))),
 			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 				Protocol: network.TransportProtocol("All"),
 				FrontendIPConfiguration: &network.SubResource{
-					ID: to.StringPtr("frontendIPConfigID"),
+					ID: pointer.String("frontendIPConfigID"),
 				},
 				BackendAddressPool: &network.SubResource{
-					ID: to.StringPtr("backendPoolID"),
+					ID: pointer.String("backendPoolID"),
 				},
 				LoadDistribution:     "Default",
-				FrontendPort:         to.Int32Ptr(0),
-				BackendPort:          to.Int32Ptr(0),
-				EnableFloatingIP:     to.BoolPtr(true),
-				DisableOutboundSnat:  to.BoolPtr(false),
-				IdleTimeoutInMinutes: to.Int32Ptr(4),
-				EnableTCPReset:       to.BoolPtr(true),
+				FrontendPort:         pointer.Int32(0),
+				BackendPort:          pointer.Int32(0),
+				EnableFloatingIP:     pointer.Bool(true),
+				DisableOutboundSnat:  pointer.Bool(false),
+				IdleTimeoutInMinutes: pointer.Int32(4),
+				EnableTCPReset:       pointer.Bool(true),
 			},
 		},
 	}
 	if hasProbe {
 		expectedRules[0].Probe = &network.SubResource{
-			ID: to.StringPtr(fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/"+
+			ID: pointer.String(fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/"+
 				"Microsoft.Network/loadBalancers/lbname/probes/atest1-%s-80", string(protocol))),
 		}
 	}
@@ -2638,29 +2637,29 @@ func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol) []netwo
 
 func getFloatingIPTestRule(enableTCPReset, enableFloatingIP bool, port int32) network.LoadBalancingRule {
 	expectedRules := network.LoadBalancingRule{
-		Name: to.StringPtr(fmt.Sprintf("atest1-TCP-%d", port)),
+		Name: pointer.String(fmt.Sprintf("atest1-TCP-%d", port)),
 		LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 			Protocol: network.TransportProtocol("Tcp"),
 			FrontendIPConfiguration: &network.SubResource{
-				ID: to.StringPtr("frontendIPConfigID"),
+				ID: pointer.String("frontendIPConfigID"),
 			},
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("backendPoolID"),
+				ID: pointer.String("backendPoolID"),
 			},
 			LoadDistribution:     "Default",
-			FrontendPort:         to.Int32Ptr(port),
-			BackendPort:          to.Int32Ptr(getBackendPort(port)),
-			EnableFloatingIP:     to.BoolPtr(enableFloatingIP),
-			DisableOutboundSnat:  to.BoolPtr(false),
-			IdleTimeoutInMinutes: to.Int32Ptr(4),
+			FrontendPort:         pointer.Int32(port),
+			BackendPort:          pointer.Int32(getBackendPort(port)),
+			EnableFloatingIP:     pointer.Bool(enableFloatingIP),
+			DisableOutboundSnat:  pointer.Bool(false),
+			IdleTimeoutInMinutes: pointer.Int32(4),
 			Probe: &network.SubResource{
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/" +
 					fmt.Sprintf("Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-%d", port)),
 			},
 		},
 	}
 	if enableTCPReset {
-		expectedRules.EnableTCPReset = to.BoolPtr(true)
+		expectedRules.EnableTCPReset = pointer.Bool(true)
 	}
 	return expectedRules
 }
@@ -2676,10 +2675,10 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 				{
 					Name: identifier,
-					ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
+					ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 						"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/" + *identifier),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+						PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 					},
 				},
 			},
@@ -2688,39 +2687,39 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 			},
 			Probes: &[]network.Probe{
 				{
-					Name: to.StringPtr(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
+					Name: pointer.String(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
 						"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Port:              to.Int32Ptr(10080),
+						Port:              pointer.Int32(10080),
 						Protocol:          network.ProbeProtocolTCP,
-						IntervalInSeconds: to.Int32Ptr(5),
-						NumberOfProbes:    to.Int32Ptr(2),
+						IntervalInSeconds: pointer.Int32(5),
+						NumberOfProbes:    pointer.Int32(2),
 					},
 				},
 			},
 			LoadBalancingRules: &[]network.LoadBalancingRule{
 				{
-					Name: to.StringPtr(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
+					Name: pointer.String(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
 						"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						Protocol: network.TransportProtocol(caser.String((strings.ToLower(string(service.Spec.Ports[0].Protocol))))),
 						FrontendIPConfiguration: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
+							ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 								"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/aservice1"),
 						},
 						BackendAddressPool: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
+							ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 								"Microsoft.Network/loadBalancers/" + *name + "/backendAddressPools/" + *clusterName),
 						},
 						LoadDistribution:     network.LoadDistribution("Default"),
-						FrontendPort:         to.Int32Ptr(service.Spec.Ports[0].Port),
-						BackendPort:          to.Int32Ptr(service.Spec.Ports[0].Port),
-						EnableFloatingIP:     to.BoolPtr(true),
-						EnableTCPReset:       to.BoolPtr(strings.EqualFold(lbSku, "standard")),
-						DisableOutboundSnat:  to.BoolPtr(false),
-						IdleTimeoutInMinutes: to.Int32Ptr(4),
+						FrontendPort:         pointer.Int32(service.Spec.Ports[0].Port),
+						BackendPort:          pointer.Int32(service.Spec.Ports[0].Port),
+						EnableFloatingIP:     pointer.Bool(true),
+						EnableTCPReset:       pointer.Bool(strings.EqualFold(lbSku, "standard")),
+						DisableOutboundSnat:  pointer.Bool(false),
+						IdleTimeoutInMinutes: pointer.Int32(4),
 						Probe: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-80"),
+							ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-80"),
 						},
 					},
 				},
@@ -2735,17 +2734,17 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	defer ctrl.Finish()
 
 	service1 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
-	basicLb1 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service1, "Basic")
+	basicLb1 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service1, "Basic")
 
 	service2 := getTestService("test1", v1.ProtocolTCP, nil, false, 80)
-	basicLb2 := getTestLoadBalancer(to.StringPtr("lb1"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("bservice1"), service2, "Basic")
-	basicLb2.Name = to.StringPtr("testCluster")
+	basicLb2 := getTestLoadBalancer(pointer.String("lb1"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("bservice1"), service2, "Basic")
+	basicLb2.Name = pointer.String("testCluster")
 	basicLb2.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
@@ -2753,186 +2752,186 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	service3 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
 	modifiedLbs := make([]network.LoadBalancer, 2)
 	for i := range modifiedLbs {
-		modifiedLbs[i] = getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service3, "Basic")
+		modifiedLbs[i] = getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service3, "Basic")
 		modifiedLbs[i].FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 			{
-				Name: to.StringPtr("aservice1"),
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+				Name: pointer.String("aservice1"),
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 				},
 			},
 			{
-				Name: to.StringPtr("bservice1"),
-				ID:   to.StringPtr("bservice1"),
+				Name: pointer.String("bservice1"),
+				ID:   pointer.String("bservice1"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 				},
 			},
 		}
 		modifiedLbs[i].Probes = &[]network.Probe{
 			{
-				Name: to.StringPtr("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
+				Name: pointer.String("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
 					"-" + strconv.Itoa(int(service3.Spec.Ports[0].Port))),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(10080),
+					Port: pointer.Int32(10080),
 				},
 			},
 			{
-				Name: to.StringPtr("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
+				Name: pointer.String("aservice1-" + string(service3.Spec.Ports[0].Protocol) +
 					"-" + strconv.Itoa(int(service3.Spec.Ports[0].Port))),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Port: to.Int32Ptr(10081),
+					Port: pointer.Int32(10081),
 				},
 			},
 		}
 	}
-	expectedLb1 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service3, "Basic")
+	expectedLb1 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service3, "Basic")
 	expectedLb1.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 
 	service4 := getTestService("service1", v1.ProtocolTCP, map[string]string{}, false, 80)
-	existingSLB := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service4, "Standard")
+	existingSLB := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service4, "Standard")
 	existingSLB.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 	existingSLB.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10080),
+				Port: pointer.Int32(10080),
 			},
 		},
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10081),
+				Port: pointer.Int32(10081),
 			},
 		},
 	}
 
-	expectedSLb := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service4, "Standard")
-	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
-	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = to.BoolPtr(true)
-	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = to.Int32Ptr(4)
+	expectedSLb := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service4, "Standard")
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(true)
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = pointer.Bool(true)
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = pointer.Int32(4)
 	expectedSLb.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 
 	service5 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
-	slb5 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service5, "Standard")
+	slb5 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service5, "Standard")
 	slb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 	slb5.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10080),
+				Port: pointer.Int32(10080),
 			},
 		},
 		{
-			Name: to.StringPtr("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service4.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service4.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port: to.Int32Ptr(10081),
+				Port: pointer.Int32(10081),
 			},
 		},
 	}
 
 	//change to false to test that reconciliation will fix it (despite the fact that disable-tcp-reset was removed in 1.20)
-	(*slb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = to.BoolPtr(false)
+	(*slb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = pointer.Bool(false)
 
-	expectedSLb5 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service5, "Standard")
-	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
-	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = to.Int32Ptr(4)
+	expectedSLb5 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service5, "Standard")
+	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(true)
+	(*expectedSLb5.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].IdleTimeoutInMinutes = pointer.Int32(4)
 	expectedSLb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 		{
-			Name: to.StringPtr("bservice1"),
-			ID:   to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
+			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
 			},
 		},
 	}
 
 	service6 := getTestService("service1", v1.ProtocolUDP, nil, false, 80)
-	lb6 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service6, "basic")
+	lb6 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service6, "basic")
 	lb6.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	lb6.Probes = &[]network.Probe{}
-	expectedLB6 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service6, "basic")
+	expectedLB6 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service6, "basic")
 	expectedLB6.Probes = &[]network.Probe{}
 	(*expectedLB6.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].Probe = nil
 	(*expectedLB6.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = nil
 	expectedLB6.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 	}
@@ -2940,62 +2939,62 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	service7 := getTestService("service1", v1.ProtocolUDP, nil, false, 80)
 	service7.Spec.HealthCheckNodePort = 10081
 	service7.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
-	lb7 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service7, "basic")
+	lb7 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service7, "basic")
 	lb7.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	lb7.Probes = &[]network.Probe{}
-	expectedLB7 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service7, "basic")
+	expectedLB7 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("aservice1"), service7, "basic")
 	(*expectedLB7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].Probe = &network.SubResource{
-		ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-10081"),
+		ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-10081"),
 	}
 	(*expectedLB7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = nil
-	(*lb7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
+	(*lb7.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(true)
 	expectedLB7.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 	}
 	expectedLB7.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(v1.ProtocolTCP) +
+			Name: pointer.String("aservice1-" + string(v1.ProtocolTCP) +
 				"-" + strconv.Itoa(int(service7.Spec.HealthCheckNodePort))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port:              to.Int32Ptr(10081),
-				RequestPath:       to.StringPtr("/healthz"),
+				Port:              pointer.Int32(10081),
+				RequestPath:       pointer.String("/healthz"),
 				Protocol:          network.ProbeProtocolHTTP,
-				IntervalInSeconds: to.Int32Ptr(5),
-				NumberOfProbes:    to.Int32Ptr(2),
+				IntervalInSeconds: pointer.Int32(5),
+				NumberOfProbes:    pointer.Int32(2),
 			},
 		},
 	}
 
 	service8 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
-	lb8 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("anotherRG"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service8, "Standard")
+	lb8 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("anotherRG"), pointer.String("testCluster"), pointer.String("aservice1"), service8, "Standard")
 	lb8.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	lb8.Probes = &[]network.Probe{}
-	expectedLB8 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("anotherRG"), to.StringPtr("testCluster"), to.StringPtr("aservice1"), service8, "Standard")
-	(*expectedLB8.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(false)
+	expectedLB8 := getTestLoadBalancer(pointer.String("testCluster"), pointer.String("anotherRG"), pointer.String("testCluster"), pointer.String("aservice1"), service8, "Standard")
+	(*expectedLB8.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = pointer.Bool(false)
 	expectedLB8.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
-			ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: pointer.String("aservice1"),
+			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 			},
 		},
 	}
 	expectedLB8.Probes = &[]network.Probe{
 		{
-			Name: to.StringPtr("aservice1-" + string(service8.Spec.Ports[0].Protocol) +
+			Name: pointer.String("aservice1-" + string(service8.Spec.Ports[0].Protocol) +
 				"-" + strconv.Itoa(int(service7.Spec.Ports[0].Port))),
 			ProbePropertiesFormat: &network.ProbePropertiesFormat{
-				Port:              to.Int32Ptr(10080),
+				Port:              pointer.Int32(10080),
 				Protocol:          network.ProbeProtocolTCP,
-				IntervalInSeconds: to.Int32Ptr(5),
-				NumberOfProbes:    to.Int32Ptr(2),
+				IntervalInSeconds: pointer.Int32(5),
+				NumberOfProbes:    pointer.Int32(2),
 			},
 		},
 	}
@@ -3058,7 +3057,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			desc:                "reconcileLoadBalancer shall remove and reconstruct the corresponding field of lb and set enableTcpReset to true in lbRule",
 			loadBalancerSku:     "standard",
 			service:             service4,
-			disableOutboundSnat: to.BoolPtr(true),
+			disableOutboundSnat: pointer.Bool(true),
 			existingLB:          existingSLB,
 			wantLb:              true,
 			expectedLB:          expectedSLb,
@@ -3069,7 +3068,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			desc:                "reconcileLoadBalancer shall remove and reconstruct the corresponding field of lb and set enableTcpReset (false => true) in lbRule",
 			loadBalancerSku:     "standard",
 			service:             service5,
-			disableOutboundSnat: to.BoolPtr(true),
+			disableOutboundSnat: pointer.Bool(true),
 			existingLB:          slb5,
 			wantLb:              true,
 			expectedLB:          expectedSLb5,
@@ -3125,9 +3124,9 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			setServiceLoadBalancerIP(&test.service, "1.2.3.4")
 
 			err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "pipName", network.PublicIPAddress{
-				Name: to.StringPtr("pipName"),
+				Name: pointer.String("pipName"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			})
 			assert.NoError(t, err.Error())
@@ -3169,61 +3168,61 @@ func TestGetServiceLoadBalancerStatus(t *testing.T) {
 
 	setMockPublicIPs(az, ctrl, 1)
 
-	lb1 := getTestLoadBalancer(to.StringPtr("lb1"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), internalService, "Basic")
+	lb1 := getTestLoadBalancer(pointer.String("lb1"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), internalService, "Basic")
 	lb1.FrontendIPConfigurations = nil
-	lb2 := getTestLoadBalancer(to.StringPtr("lb2"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), internalService, "Basic")
+	lb2 := getTestLoadBalancer(pointer.String("lb2"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), internalService, "Basic")
 	lb2.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
-				PrivateIPAddress: to.StringPtr("private"),
+				PublicIPAddress:  &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb3 := getTestLoadBalancer(to.StringPtr("lb3"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("test1"), internalService, "Basic")
+	lb3 := getTestLoadBalancer(pointer.String("lb3"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("test1"), internalService, "Basic")
 	lb3.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("bservice1"),
+			Name: pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("testCluster-bservice1")},
-				PrivateIPAddress: to.StringPtr("private"),
+				PublicIPAddress:  &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb4 := getTestLoadBalancer(to.StringPtr("lb4"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), service, "Basic")
+	lb4 := getTestLoadBalancer(pointer.String("lb4"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), service, "Basic")
 	lb4.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PublicIPAddress:  &network.PublicIPAddress{ID: nil},
-				PrivateIPAddress: to.StringPtr("private"),
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb5 := getTestLoadBalancer(to.StringPtr("lb5"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), service, "Basic")
+	lb5 := getTestLoadBalancer(pointer.String("lb5"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), service, "Basic")
 	lb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PublicIPAddress:  nil,
-				PrivateIPAddress: to.StringPtr("private"),
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
-	lb6 := getTestLoadBalancer(to.StringPtr("lb6"), to.StringPtr("rg"), to.StringPtr("testCluster"),
-		to.StringPtr("aservice1"), service, "Basic")
+	lb6 := getTestLoadBalancer(pointer.String("lb6"), pointer.String("rg"), pointer.String("testCluster"),
+		pointer.String("aservice1"), service, "Basic")
 	lb6.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: to.StringPtr("aservice1"),
+			Name: pointer.String("aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("illegal/id/")},
-				PrivateIPAddress: to.StringPtr("private"),
+				PublicIPAddress:  &network.PublicIPAddress{ID: pointer.String("illegal/id/")},
+				PrivateIPAddress: pointer.String("private"),
 			},
 		},
 	}
@@ -3341,16 +3340,16 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall delete unwanted sg if wantLb is false and lbIP is nil",
 			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-toBeDeleted"),
+							Name: pointer.String("atest1-toBeDeleted"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-								SourceAddressPrefix:      to.StringPtr("prefix"),
-								SourcePortRange:          to.StringPtr("range"),
-								DestinationAddressPrefix: to.StringPtr("desPrefix"),
-								DestinationPortRange:     to.StringPtr("desRange"),
+								SourceAddressPrefix:      pointer.String("prefix"),
+								SourcePortRange:          pointer.String("range"),
+								DestinationAddressPrefix: pointer.String("desPrefix"),
+								DestinationPortRange:     pointer.String("desRange"),
 							},
 						},
 					},
@@ -3358,7 +3357,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			}},
 			wantLb: false,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{},
 				},
@@ -3368,37 +3367,37 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall delete unwanted sgs and create needed ones",
 			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-toBeDeleted"),
+							Name: pointer.String("atest1-toBeDeleted"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-								SourceAddressPrefix:      to.StringPtr("prefix"),
-								SourcePortRange:          to.StringPtr("range"),
-								DestinationAddressPrefix: to.StringPtr("desPrefix"),
-								DestinationPortRange:     to.StringPtr("desRange"),
+								SourceAddressPrefix:      pointer.String("prefix"),
+								SourcePortRange:          pointer.String("range"),
+								DestinationAddressPrefix: pointer.String("desPrefix"),
+								DestinationPortRange:     pointer.String("desRange"),
 							},
 						},
 					},
 				},
 			}},
-			lbIP:   to.StringPtr("1.1.1.1"),
+			lbIP:   pointer.String("1.1.1.1"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("80"),
-								SourceAddressPrefix:      to.StringPtr("Internet"),
-								DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("Internet"),
+								DestinationAddressPrefix: pointer.String("1.1.1.1"),
 								Access:                   network.SecurityRuleAccess("Allow"),
-								Priority:                 to.Int32Ptr(500),
+								Priority:                 pointer.Int32(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3410,25 +3409,25 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix for IPv6",
 			service: getTestService("test1", v1.ProtocolTCP, nil, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("fd00::eef0"),
+			lbIP:   pointer.String("fd00::eef0"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("80"),
-								SourceAddressPrefix:      to.StringPtr("Internet"),
-								DestinationAddressPrefix: to.StringPtr("fd00::eef0"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("Internet"),
+								DestinationAddressPrefix: pointer.String("fd00::eef0"),
 								Access:                   network.SecurityRuleAccess("Allow"),
-								Priority:                 to.Int32Ptr(500),
+								Priority:                 pointer.Int32(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3440,25 +3439,25 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix with additional public IPs",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAdditionalPublicIPs: "2.3.4.5"}, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1.2.3.4"),
+			lbIP:   pointer.String("1.2.3.4"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr("80"),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"1.2.3.4", "2.3.4.5"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String("80"),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"1.2.3.4", "2.3.4.5"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3470,37 +3469,37 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall not create unwanted security rules if there is service tags",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAllowedServiceTag: "tag"}, true, 80),
 			wantLb:  true,
-			lbIP:    to.StringPtr("1.1.1.1"),
+			lbIP:    pointer.String("1.1.1.1"),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-toBeDeleted"),
+							Name: pointer.String("atest1-toBeDeleted"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-								SourceAddressPrefix:      to.StringPtr("prefix"),
-								SourcePortRange:          to.StringPtr("range"),
-								DestinationAddressPrefix: to.StringPtr("destPrefix"),
-								DestinationPortRange:     to.StringPtr("desRange"),
+								SourceAddressPrefix:      pointer.String("prefix"),
+								SourcePortRange:          pointer.String("range"),
+								DestinationAddressPrefix: pointer.String("destPrefix"),
+								DestinationPortRange:     pointer.String("desRange"),
 							},
 						},
 					},
 				},
 			}},
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-tag"),
+							Name: pointer.String("atest1-TCP-80-tag"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                 network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:          to.StringPtr("*"),
-								DestinationPortRange:     to.StringPtr("80"),
-								SourceAddressPrefix:      to.StringPtr("tag"),
-								DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("tag"),
+								DestinationAddressPrefix: pointer.String("1.1.1.1"),
 								Access:                   network.SecurityRuleAccess("Allow"),
-								Priority:                 to.Int32Ptr(500),
+								Priority:                 pointer.Int32(500),
 								Direction:                network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3512,25 +3511,25 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create shared sgs for service with azure-shared-securityrule annotations",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1.2.3.4"),
+			lbIP:   pointer.String("1.2.3.4"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("shared-TCP-80-Internet"),
+							Name: pointer.String("shared-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr("80"),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"1.2.3.4"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String("80"),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"1.2.3.4"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3542,26 +3541,26 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with floating IP disabled",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1.2.3.4"),
-			lbName: to.StringPtr("lb"),
+			lbIP:   pointer.String("1.2.3.4"),
+			lbName: pointer.String("lb"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr(strconv.Itoa(int(getBackendPort(80)))),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"1.2.3.4", "5.6.7.8"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String(strconv.Itoa(int(getBackendPort(80)))),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"1.2.3.4", "5.6.7.8"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3573,26 +3572,26 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			desc:    "reconcileSecurityGroup shall create sgs with only IPv6 destination addresses for IPv6 services with floating IP disabled",
 			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
-				Name:                          to.StringPtr("nsg"),
+				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   to.StringPtr("1234::5"),
-			lbName: to.StringPtr("lb"),
+			lbIP:   pointer.String("1234::5"),
+			lbName: pointer.String("lb"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
-				Name: to.StringPtr("nsg"),
+				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							Name: pointer.String("atest1-TCP-80-Internet"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            to.StringPtr("*"),
-								DestinationPortRange:       to.StringPtr(strconv.Itoa(int(getBackendPort(80)))),
-								SourceAddressPrefix:        to.StringPtr("Internet"),
-								DestinationAddressPrefixes: to.StringSlicePtr([]string{"fc00::1", "fc00::2"}),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String(strconv.Itoa(int(getBackendPort(80)))),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"fc00::1", "fc00::2"}),
 								Access:                     network.SecurityRuleAccess("Allow"),
-								Priority:                   to.Int32Ptr(500),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -3636,39 +3635,39 @@ func TestReconcileSecurityGroupLoadBalancerSourceRanges(t *testing.T) {
 	service := getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true"}, false, 80)
 	service.Spec.LoadBalancerSourceRanges = []string{"1.2.3.4/32"}
 	existingSg := network.SecurityGroup{
-		Name: to.StringPtr("nsg"),
+		Name: pointer.String("nsg"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &[]network.SecurityRule{},
 		},
 	}
-	lbIP := to.StringPtr("1.1.1.1")
+	lbIP := pointer.String("1.1.1.1")
 	expectedSg := network.SecurityGroup{
-		Name: to.StringPtr("nsg"),
+		Name: pointer.String("nsg"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &[]network.SecurityRule{
 				{
-					Name: to.StringPtr("atest1-TCP-80-1.2.3.4_32"),
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:                 network.SecurityRuleProtocol("Tcp"),
-						SourcePortRange:          to.StringPtr("*"),
-						SourceAddressPrefix:      to.StringPtr("1.2.3.4/32"),
-						DestinationPortRange:     to.StringPtr("80"),
-						DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
 						Access:                   network.SecurityRuleAccess("Allow"),
-						Priority:                 to.Int32Ptr(500),
+						Priority:                 pointer.Int32(500),
 						Direction:                network.SecurityRuleDirection("Inbound"),
 					},
 				},
 				{
-					Name: to.StringPtr("atest1-TCP-80-deny_all"),
+					Name: pointer.String("atest1-TCP-80-deny_all"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Protocol:                 network.SecurityRuleProtocol("Tcp"),
-						SourcePortRange:          to.StringPtr("*"),
-						SourceAddressPrefix:      to.StringPtr("*"),
-						DestinationPortRange:     to.StringPtr("80"),
-						DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
 						Access:                   network.SecurityRuleAccess("Deny"),
-						Priority:                 to.Int32Ptr(501),
+						Priority:                 pointer.Int32(501),
 						Direction:                network.SecurityRuleDirection("Inbound"),
 					},
 				},
@@ -3696,25 +3695,25 @@ func TestSafeDeletePublicIP(t *testing.T) {
 		{
 			desc: "safeDeletePublicIP shall delete corresponding ip configurations and lb rules",
 			pip: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					IPConfiguration: &network.IPConfiguration{
-						ID: to.StringPtr("id1"),
+						ID: pointer.String("id1"),
 					},
 				},
 			},
 			lb: &network.LoadBalancer{
-				Name: to.StringPtr("lb1"),
+				Name: pointer.String("lb1"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 						{
-							ID: to.StringPtr("id1"),
+							ID: pointer.String("id1"),
 							FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-								LoadBalancingRules: &[]network.SubResource{{ID: to.StringPtr("rules1")}},
+								LoadBalancingRules: &[]network.SubResource{{ID: pointer.String("rules1")}},
 							},
 						},
 					},
-					LoadBalancingRules: &[]network.LoadBalancingRule{{ID: to.StringPtr("rules1")}},
+					LoadBalancingRules: &[]network.LoadBalancingRule{{ID: pointer.String("rules1")}},
 				},
 			},
 		},
@@ -3727,10 +3726,10 @@ func TestSafeDeletePublicIP(t *testing.T) {
 			mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "pip1", gomock.Any()).Return(nil).AnyTimes()
 			mockPIPsClient.EXPECT().Delete(gomock.Any(), "rg", "pip1").Return(nil).AnyTimes()
 			err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "pip1", network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					IPConfiguration: &network.IPConfiguration{
-						ID: to.StringPtr("id1"),
+						ID: pointer.String("id1"),
 					},
 				},
 			})
@@ -3778,7 +3777,7 @@ func TestReconcilePublicIP(t *testing.T) {
 			wantLb: false,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
+					Name: pointer.String("pip1"),
 				},
 			},
 			expectedCreateOrUpdateCount: 0,
@@ -3789,10 +3788,10 @@ func TestReconcilePublicIP(t *testing.T) {
 			wantLb: true,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -3808,12 +3807,12 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				},
 			},
 			expectedError:               true,
@@ -3826,34 +3825,34 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion: network.IPv4,
-					IPAddress:              to.StringPtr("1.2.3.4"),
+					IPAddress:              pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -3865,34 +3864,34 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1,default/test2")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion: network.IPv4,
-					IPAddress:              to.StringPtr("1.2.3.4"),
+					IPAddress:              pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -3907,38 +3906,38 @@ func TestReconcilePublicIP(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv4,
 					PublicIPAllocationMethod: network.Static,
 					IPTags: &[]network.IPTag{
 						{
-							IPTagType: to.StringPtr("tag1"),
-							Tag:       to.StringPtr("tag1value"),
+							IPTagType: pointer.String("tag1"),
+							Tag:       pointer.String("tag1value"),
 						},
 					},
 				},
@@ -3955,35 +3954,35 @@ func TestReconcilePublicIP(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv4,
 						PublicIPAllocationMethod: network.Static,
 						IPTags: &[]network.IPTag{
 							{
-								IPTagType: to.StringPtr("tag1"),
-								Tag:       to.StringPtr("tag1value"),
+								IPTagType: pointer.String("tag1"),
+								Tag:       pointer.String("tag1value"),
 							},
 						},
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
-				Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv4,
 					PublicIPAllocationMethod: network.Static,
 					IPTags: &[]network.IPTag{
 						{
-							IPTagType: to.StringPtr("tag1"),
-							Tag:       to.StringPtr("tag1value"),
+							IPTagType: pointer.String("tag1"),
+							Tag:       pointer.String("tag1value"),
 						},
 					},
-					IPAddress: to.StringPtr("1.2.3.4"),
+					IPAddress: pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 0,
@@ -3995,31 +3994,31 @@ func TestReconcilePublicIP(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPName: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
+					Name: pointer.String("pip1"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1")},
+					Name: pointer.String("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: to.StringPtr("testPIP"),
+					Name: pointer.String("testPIP"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
-				Name: to.StringPtr("testPIP"),
+				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+				Name: pointer.String("testPIP"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion: network.IPv4,
-					IPAddress:              to.StringPtr("1.2.3.4"),
+					IPAddress:              pointer.String("1.2.3.4"),
 				},
 			},
 			expectedCreateOrUpdateCount: 1,
@@ -4030,10 +4029,10 @@ func TestReconcilePublicIP(t *testing.T) {
 			wantLb: false,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("default/test1,default/test2")},
+					Name: pointer.String("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("1.2.3.4"),
+						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 			},
@@ -4088,7 +4087,7 @@ func TestReconcilePublicIP(t *testing.T) {
 					return nil
 				})
 
-				err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", to.String(pip.Name), pip)
+				err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", pointer.StringDeref(pip.Name, ""), pip)
 				assert.NoError(t, err.Error())
 
 				// Clear create or update count to prepare for main execution
@@ -4111,7 +4110,7 @@ func TestReconcilePublicIP(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			if test.expectedID != "" {
-				assert.Equal(t, test.expectedID, to.String(pip.ID))
+				assert.Equal(t, test.expectedID, pointer.StringDeref(pip.ID, ""))
 			} else if test.expectedPIP != nil && test.expectedPIP.Name != nil {
 				assert.Equal(t, *test.expectedPIP.Name, *pip.Name)
 
@@ -4159,10 +4158,10 @@ func TestEnsurePublicIPExists(t *testing.T) {
 	}{
 		{
 			desc:         "shall return existed PIP if there is any",
-			existingPIPs: []network.PublicIPAddress{{Name: to.StringPtr("pip1")}},
+			existingPIPs: []network.PublicIPAddress{{Name: pointer.String("pip1")}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv4,
@@ -4183,20 +4182,20 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			inputDNSLabel:           "newdns",
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name:                            to.StringPtr("pip1"),
+				Name:                            pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("newdns"),
+						DomainNameLabel: pointer.String("newdns"),
 					},
 					PublicIPAddressVersion: network.IPv4,
 				},
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("default/test1")},
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("default/test1")},
 			},
 			shouldPutPIP: true,
 		},
@@ -4204,16 +4203,16 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			desc:                    "shall delete DNS from PIP if DNS label is set empty",
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings:            nil,
@@ -4227,20 +4226,20 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			desc:                    "shall not delete DNS from PIP if DNS label annotation is not set",
 			foundDNSLabelAnnotation: false,
 			existingPIPs: []network.PublicIPAddress{{
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 					PublicIPAddressVersion: network.IPv4,
 				},
@@ -4252,21 +4251,21 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			foundDNSLabelAnnotation: true,
 			isIPv6:                  true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name:                            to.StringPtr("pip1"),
+				Name:                            pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("newdns"),
+						DomainNameLabel: pointer.String("newdns"),
 					},
 					PublicIPAllocationMethod: network.Dynamic,
 					PublicIPAddressVersion:   network.IPv6,
 				},
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("default/test1")},
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("default/test1")},
 			},
 			shouldPutPIP: true,
 		},
@@ -4277,27 +4276,27 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			isIPv6:                  false,
 			existingPIPs: []network.PublicIPAddress{{
 
-				Name: to.StringPtr("pip1"),
+				Name: pointer.String("pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 					PublicIPAllocationMethod: network.Dynamic,
 					PublicIPAddressVersion:   network.IPv4,
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("newdns"),
+						DomainNameLabel: pointer.String("newdns"),
 					},
 					PublicIPAllocationMethod: network.Dynamic,
 					PublicIPAddressVersion:   network.IPv4,
 				},
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("default/test1")},
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("default/test1")},
 			},
 			shouldPutPIP: true,
 		},
@@ -4306,11 +4305,11 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			inputDNSLabel:           "test",
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
-				Name: to.StringPtr("pip1"),
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("test1")},
+				Name: pointer.String("pip1"),
+				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("previousdns"),
+						DomainNameLabel: pointer.String("previousdns"),
 					},
 				},
 			}},
@@ -4321,16 +4320,16 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			inputDNSLabel: "test",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
-					ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+					Name: pointer.String("pip1"),
+					ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 						"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{
-						consts.ServiceUsingDNSKey: to.StringPtr("default/test1"),
-						consts.ServiceTagKey:      to.StringPtr("default/test1"),
+						consts.ServiceUsingDNSKey: pointer.String("default/test1"),
+						consts.ServiceTagKey:      pointer.String("default/test1"),
 					},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						DNSSettings: &network.PublicIPAddressDNSSettings{
-							DomainNameLabel: to.StringPtr("test"),
+							DomainNameLabel: pointer.String("test"),
 						},
 						PublicIPAllocationMethod: network.Static,
 						PublicIPAddressVersion:   network.IPv4,
@@ -4338,16 +4337,16 @@ func TestEnsurePublicIPExists(t *testing.T) {
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				Tags: map[string]*string{
-					consts.ServiceUsingDNSKey: to.StringPtr("default/test1"),
-					consts.ServiceTagKey:      to.StringPtr("default/test1"),
+					consts.ServiceUsingDNSKey: pointer.String("default/test1"),
+					consts.ServiceTagKey:      pointer.String("default/test1"),
 				},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
-						DomainNameLabel: to.StringPtr("test"),
+						DomainNameLabel: pointer.String("test"),
 					},
 					PublicIPAllocationMethod: network.Static,
 					PublicIPAddressVersion:   network.IPv4,
@@ -4357,11 +4356,11 @@ func TestEnsurePublicIPExists(t *testing.T) {
 		{
 			desc: "shall tag the service name to the pip correctly",
 			existingPIPs: []network.PublicIPAddress{
-				{Name: to.StringPtr("pip1")},
+				{Name: pointer.String("pip1")},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv4,
@@ -4377,7 +4376,7 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			useSLB: true,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: to.StringPtr("pip1"),
+					Name: pointer.String("pip1"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv6,
 						PublicIPAllocationMethod: network.Static,
@@ -4385,8 +4384,8 @@ func TestEnsurePublicIPExists(t *testing.T) {
 				},
 			},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv6,
@@ -4398,11 +4397,11 @@ func TestEnsurePublicIPExists(t *testing.T) {
 		},
 		{
 			desc:         "shall update pip tags if there is any change",
-			existingPIPs: []network.PublicIPAddress{{Name: to.StringPtr("pip1"), Tags: map[string]*string{"a": to.StringPtr("b")}}},
+			existingPIPs: []network.PublicIPAddress{{Name: pointer.String("pip1"), Tags: map[string]*string{"a": pointer.String("b")}}},
 			expectedPIP: &network.PublicIPAddress{
-				Name: to.StringPtr("pip1"),
-				Tags: map[string]*string{"a": to.StringPtr("c")},
-				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				Name: pointer.String("pip1"),
+				Tags: map[string]*string{"a": pointer.String("c")},
+				ID: pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv4,
@@ -4449,7 +4448,7 @@ func TestEnsurePublicIPExists(t *testing.T) {
 					basicPIP = &test.existingPIPs[0]
 				}
 
-				basicPIP.ID = to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+				basicPIP.ID = pointer.String("/subscriptions/subscription/resourceGroups/rg" +
 					"/providers/Microsoft.Network/publicIPAddresses/pip1")
 
 				if basicPIP.PublicIPAddressPropertiesFormat == nil {
@@ -4469,7 +4468,7 @@ func TestEnsurePublicIPExists(t *testing.T) {
 			pip, err := az.ensurePublicIPExists(&service, "pip1", test.inputDNSLabel, "", false, test.foundDNSLabelAnnotation)
 			assert.Equal(t, test.expectedError, err != nil, "unexpectedly encountered (or not) error: %v", err)
 			if test.expectedID != "" {
-				assert.Equal(t, test.expectedID, to.String(pip.ID))
+				assert.Equal(t, test.expectedID, pointer.StringDeref(pip.ID, ""))
 			} else {
 				assert.Equal(t, test.expectedPIP, pip)
 			}
@@ -4486,10 +4485,10 @@ func TestEnsurePublicIPExistsWithExtendedLocation(t *testing.T) {
 
 	exLocName := "microsoftlosangeles1"
 	expectedPIP := &network.PublicIPAddress{
-		Name:     to.StringPtr("pip1"),
+		Name:     pointer.String("pip1"),
 		Location: &az.location,
 		ExtendedLocation: &network.ExtendedLocation{
-			Name: to.StringPtr("microsoftlosangeles1"),
+			Name: pointer.String("microsoftlosangeles1"),
 			Type: network.EdgeZone,
 		},
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
@@ -4498,8 +4497,8 @@ func TestEnsurePublicIPExistsWithExtendedLocation(t *testing.T) {
 			ProvisioningState:        "",
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("default/test1"),
-			consts.ClusterNameKey: to.StringPtr(""),
+			consts.ServiceTagKey:  pointer.String("default/test1"),
+			consts.ClusterNameKey: pointer.String(""),
 		},
 	}
 	mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
@@ -4586,13 +4585,13 @@ func TestShouldUpdateLoadBalancer(t *testing.T) {
 			}
 			if test.existsLb {
 				lb := network.LoadBalancer{
-					Name: to.StringPtr("vmas"),
+					Name: pointer.String("vmas"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
 							{
-								Name: to.StringPtr("atest1"),
+								Name: pointer.String("atest1"),
 								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-									PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("testCluster-aservice1")},
+									PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
 								},
 							},
 						},
@@ -4708,10 +4707,10 @@ func TestIsBackendPoolPreConfigured(t *testing.T) {
 
 func TestParsePIPServiceTag(t *testing.T) {
 	tags := []*string{
-		to.StringPtr("ns1/svc1,ns2/svc2"),
-		to.StringPtr(" ns1/svc1, ns2/svc2 "),
-		to.StringPtr("ns1/svc1,"),
-		to.StringPtr(""),
+		pointer.String("ns1/svc1,ns2/svc2"),
+		pointer.String(" ns1/svc1, ns2/svc2 "),
+		pointer.String("ns1/svc1,"),
+		pointer.String(""),
 		nil,
 	}
 	expectedNames := [][]string{
@@ -4732,17 +4731,17 @@ func TestBindServicesToPIP(t *testing.T) {
 	pips := []*network.PublicIPAddress{
 		{Tags: nil},
 		{Tags: map[string]*string{}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")}},
 	}
 	serviceNames := []string{"ns2/svc2", "ns3/svc3"}
 	expectedTags := []map[string]*string{
-		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2,ns3/svc3")},
-		{consts.ServiceTagKey: to.StringPtr("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2,ns3/svc3")},
+		{consts.ServiceTagKey: pointer.String("ns2/svc2,ns3/svc3")},
 	}
 
 	flags := []bool{true, true, true, true, false}
@@ -4757,18 +4756,18 @@ func TestBindServicesToPIP(t *testing.T) {
 func TestUnbindServiceFromPIP(t *testing.T) {
 	pips := []*network.PublicIPAddress{
 		{Tags: nil},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1")}},
-		{Tags: map[string]*string{consts.ServiceTagKey: to.StringPtr("ns1/svc1,ns2/svc2")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1")}},
+		{Tags: map[string]*string{consts.ServiceTagKey: pointer.String("ns1/svc1,ns2/svc2")}},
 	}
 	serviceName := "ns2/svc2"
 	service := getTestService(serviceName, v1.ProtocolTCP, nil, false, 80)
 	setServiceLoadBalancerIP(&service, "1.2.3.4")
 	expectedTags := []map[string]*string{
 		nil,
-		{consts.ServiceTagKey: to.StringPtr("")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1")},
-		{consts.ServiceTagKey: to.StringPtr("ns1/svc1")},
+		{consts.ServiceTagKey: pointer.String("")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1")},
+		{consts.ServiceTagKey: pointer.String("ns1/svc1")},
 	}
 
 	for i, pip := range pips {
@@ -4783,7 +4782,7 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 
 	service := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
 	az := GetTestCloud(ctrl)
-	fipID := to.StringPtr("fip")
+	fipID := pointer.String("fip")
 
 	testCases := []struct {
 		desc       string
@@ -4794,13 +4793,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return true if there is a " +
 				"loadBalancing rule from other service referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -4812,14 +4811,14 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return false if there is a " +
 				"loadBalancing rule from this service referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					OutboundRules: &[]network.OutboundRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							OutboundRulePropertiesFormat: &network.OutboundRulePropertiesFormat{
 								FrontendIPConfigurations: &[]network.SubResource{
-									{ID: to.StringPtr("fip")},
+									{ID: pointer.String("fip")},
 								},
 							},
 						},
@@ -4832,13 +4831,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return false if there is a " +
 				"outbound rule referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -4849,13 +4848,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return true if there is a " +
 				"inbound NAT rule referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatRules: &[]network.InboundNatRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -4867,13 +4866,13 @@ func TestIsFrontendIPConfigIsUnsafeToDelete(t *testing.T) {
 			desc: "isFrontendIPConfigUnsafeToDelete should return true if there is a " +
 				"inbound NAT pool referencing the frontend IP config",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatPools: &[]network.InboundNatPool{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							InboundNatPoolPropertiesFormat: &network.InboundNatPoolPropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
 							},
 						},
 					},
@@ -4906,14 +4905,14 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted loadBalancing rule",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(80),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(80),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -4926,14 +4925,14 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted inbound NAT rule",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatRules: &[]network.InboundNatRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(80),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(80),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -4946,15 +4945,15 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should report the conflict error if " +
 				"there is a conflicted inbound NAT pool",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					InboundNatPools: &[]network.InboundNatPool{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatPoolPropertiesFormat: &network.InboundNatPoolPropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPortRangeStart:  to.Int32Ptr(80),
-								FrontendPortRangeEnd:    to.Int32Ptr(90),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPortRangeStart:  pointer.Int32(80),
+								FrontendPortRangeEnd:    pointer.Int32(90),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -4967,35 +4966,35 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 			desc: "checkLoadBalancerResourcesConflicts should not report the conflict error if there " +
 				"is no conflicted loadBalancer resources",
 			existingLB: &network.LoadBalancer{
-				Name: to.StringPtr("lb"),
+				Name: pointer.String("lb"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: &[]network.LoadBalancingRule{
 						{
-							Name: to.StringPtr("aservice2-rule"),
+							Name: pointer.String("aservice2-rule"),
 							LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(90),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(90),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
 					},
 					InboundNatRules: &[]network.InboundNatRule{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPort:            to.Int32Ptr(90),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPort:            pointer.Int32(90),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
 					},
 					InboundNatPools: &[]network.InboundNatPool{
 						{
-							Name: to.StringPtr("aservice1-rule"),
+							Name: pointer.String("aservice1-rule"),
 							InboundNatPoolPropertiesFormat: &network.InboundNatPoolPropertiesFormat{
-								FrontendIPConfiguration: &network.SubResource{ID: to.StringPtr("fip")},
-								FrontendPortRangeStart:  to.Int32Ptr(800),
-								FrontendPortRangeEnd:    to.Int32Ptr(900),
+								FrontendIPConfiguration: &network.SubResource{ID: pointer.String("fip")},
+								FrontendPortRangeStart:  pointer.Int32(800),
+								FrontendPortRangeEnd:    pointer.Int32(900),
 								Protocol:                network.TransportProtocol(v1.ProtocolTCP),
 							},
 						},
@@ -5013,11 +5012,11 @@ func TestCheckLoadBalancerResourcesConflicted(t *testing.T) {
 
 func buildLBWithVMIPs(clusterName string, vmIPs []string) *network.LoadBalancer {
 	lb := network.LoadBalancer{
-		Name: to.StringPtr(clusterName),
+		Name: pointer.String(clusterName),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr(clusterName),
+					Name: pointer.String(clusterName),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{},
 					},
@@ -5043,11 +5042,11 @@ func buildLBWithVMIPs(clusterName string, vmIPs []string) *network.LoadBalancer 
 
 func buildDefaultTestLB(name string, backendIPConfigs []string) network.LoadBalancer {
 	expectedLB := network.LoadBalancer{
-		Name: to.StringPtr(name),
+		Name: pointer.String(name),
 		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 			BackendAddressPools: &[]network.BackendAddressPool{
 				{
-					Name: to.StringPtr(name),
+					Name: pointer.String(name),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{},
 					},
@@ -5057,7 +5056,7 @@ func buildDefaultTestLB(name string, backendIPConfigs []string) network.LoadBala
 	}
 	backendIPConfigurations := make([]network.InterfaceIPConfiguration, 0)
 	for _, ipConfig := range backendIPConfigs {
-		backendIPConfigurations = append(backendIPConfigurations, network.InterfaceIPConfiguration{ID: to.StringPtr(ipConfig)})
+		backendIPConfigurations = append(backendIPConfigurations, network.InterfaceIPConfiguration{ID: pointer.String(ipConfig)})
 	}
 	(*expectedLB.BackendAddressPools)[0].BackendIPConfigurations = &backendIPConfigurations
 	return expectedLB
@@ -5079,25 +5078,25 @@ func TestEnsurePIPTagged(t *testing.T) {
 	}
 	pip := network.PublicIPAddress{
 		Tags: map[string]*string{
-			consts.ClusterNameKey: to.StringPtr("testCluster"),
-			consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-			"foo":                 to.StringPtr("bar"),
-			"a":                   to.StringPtr("j"),
-			"m":                   to.StringPtr("n"),
+			consts.ClusterNameKey: pointer.String("testCluster"),
+			consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+			"foo":                 pointer.String("bar"),
+			"a":                   pointer.String("j"),
+			"m":                   pointer.String("n"),
 		},
 	}
 
 	t.Run("ensurePIPTagged should ensure the pip is tagged as configured", func(t *testing.T) {
 		expectedPIP := network.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey: to.StringPtr("testCluster"),
-				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":                 to.StringPtr("bar"),
-				"a":                   to.StringPtr("b"),
-				"c":                   to.StringPtr("d"),
-				"y":                   to.StringPtr("z"),
-				"m":                   to.StringPtr("n"),
-				"e":                   to.StringPtr(""),
+				consts.ClusterNameKey: pointer.String("testCluster"),
+				consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+				"foo":                 pointer.String("bar"),
+				"a":                   pointer.String("b"),
+				"c":                   pointer.String("d"),
+				"y":                   pointer.String("z"),
+				"m":                   pointer.String("n"),
+				"e":                   pointer.String(""),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -5109,13 +5108,13 @@ func TestEnsurePIPTagged(t *testing.T) {
 		cloud.SystemTags = "a,foo"
 		expectedPIP := network.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey: to.StringPtr("testCluster"),
-				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":                 to.StringPtr("bar"),
-				"a":                   to.StringPtr("b"),
-				"c":                   to.StringPtr("d"),
-				"y":                   to.StringPtr("z"),
-				"e":                   to.StringPtr(""),
+				consts.ClusterNameKey: pointer.String("testCluster"),
+				consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+				"foo":                 pointer.String("bar"),
+				"a":                   pointer.String("b"),
+				"c":                   pointer.String("d"),
+				"y":                   pointer.String("z"),
+				"e":                   pointer.String(""),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -5128,13 +5127,13 @@ func TestEnsurePIPTagged(t *testing.T) {
 		cloud.TagsMap = map[string]string{"a": "c", "a=b": "c=d", "Y": "zz"}
 		expectedPIP := network.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey: to.StringPtr("testCluster"),
-				consts.ServiceTagKey:  to.StringPtr("default/svc1,default/svc2"),
-				"foo":                 to.StringPtr("bar"),
-				"a":                   to.StringPtr("b"),
-				"c":                   to.StringPtr("d"),
-				"a=b":                 to.StringPtr("c=d"),
-				"e":                   to.StringPtr(""),
+				consts.ClusterNameKey: pointer.String("testCluster"),
+				consts.ServiceTagKey:  pointer.String("default/svc1,default/svc2"),
+				"foo":                 pointer.String("bar"),
+				"a":                   pointer.String("b"),
+				"c":                   pointer.String("d"),
+				"a=b":                 pointer.String("c=d"),
+				"e":                   pointer.String(""),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -5155,17 +5154,17 @@ func TestEnsureLoadBalancerTagged(t *testing.T) {
 	}{
 		{
 			description:     "ensureLoadBalancerTagged should not delete the old tags if SystemTags is not specified",
-			existedTags:     map[string]*string{"a": to.StringPtr("b")},
+			existedTags:     map[string]*string{"a": pointer.String("b")},
 			newTags:         "c=d",
-			expectedTags:    map[string]*string{"a": to.StringPtr("b"), "c": to.StringPtr("d")},
+			expectedTags:    map[string]*string{"a": pointer.String("b"), "c": pointer.String("d")},
 			expectedChanged: true,
 		},
 		{
 			description:     "ensureLoadBalancerTagged should delete the old tags if SystemTags is specified",
-			existedTags:     map[string]*string{"a": to.StringPtr("b"), "c": to.StringPtr("d"), "h": to.StringPtr("i")},
+			existedTags:     map[string]*string{"a": pointer.String("b"), "c": pointer.String("d"), "h": pointer.String("i")},
 			newTags:         "c=e,f=g",
 			systemTags:      "a,x,y,z",
-			expectedTags:    map[string]*string{"a": to.StringPtr("b"), "c": to.StringPtr("e"), "f": to.StringPtr("g")},
+			expectedTags:    map[string]*string{"a": pointer.String("b"), "c": pointer.String("e"), "f": pointer.String("g")},
 			expectedChanged: true,
 		},
 	} {
@@ -5228,18 +5227,18 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerDelete(t *testing.T) {
 	defer ctrl.Finish()
 	t.Run("removeFrontendIPConfigurationFromLoadBalancer should remove the unwanted frontend IP configuration and delete the orphaned LB", func(t *testing.T) {
 		fip := &network.FrontendIPConfiguration{
-			Name: to.StringPtr("testCluster"),
-			ID:   to.StringPtr("testCluster-fip"),
+			Name: pointer.String("testCluster"),
+			ID:   pointer.String("testCluster-fip"),
 		}
 		service := getTestService("svc1", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("lb"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("testCluster"), service, "standard")
+		lb := getTestLoadBalancer(pointer.String("lb"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("testCluster"), service, "standard")
 		bid := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-0/ipConfigurations/ipconfig1"
 		lb.BackendAddressPools = &[]network.BackendAddressPool{
 			{
-				Name: to.StringPtr("testCluster"),
+				Name: pointer.String("testCluster"),
 				BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 					BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
-						{ID: to.StringPtr(bid)},
+						{ID: pointer.String(bid)},
 					},
 				},
 			},
@@ -5250,7 +5249,7 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerDelete(t *testing.T) {
 		expectedPLS := make([]network.PrivateLinkService, 0)
 		mockPLSClient := cloud.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
 		mockPLSClient.EXPECT().List(gomock.Any(), "rg").Return(expectedPLS, nil).MaxTimes(1)
-		existingLBs := []network.LoadBalancer{{Name: to.StringPtr("lb")}}
+		existingLBs := []network.LoadBalancer{{Name: pointer.String("lb")}}
 		err := cloud.removeFrontendIPConfigurationFromLoadBalancer(&lb, existingLBs, fip, "testCluster", &service)
 		assert.NoError(t, err)
 	})
@@ -5261,12 +5260,12 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerUpdate(t *testing.T) {
 	defer ctrl.Finish()
 	t.Run("removeFrontendIPConfigurationFromLoadBalancer should remove the unwanted frontend IP configuration and update the LB if there are remaining frontend IP configurations", func(t *testing.T) {
 		fip := &network.FrontendIPConfiguration{
-			Name: to.StringPtr("testCluster"),
-			ID:   to.StringPtr("testCluster-fip"),
+			Name: pointer.String("testCluster"),
+			ID:   pointer.String("testCluster-fip"),
 		}
 		service := getTestService("svc1", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("lb"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("testCluster"), service, "standard")
-		*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, network.FrontendIPConfiguration{Name: to.StringPtr("fip1")})
+		lb := getTestLoadBalancer(pointer.String("lb"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("testCluster"), service, "standard")
+		*lb.FrontendIPConfigurations = append(*lb.FrontendIPConfigurations, network.FrontendIPConfiguration{Name: pointer.String("fip1")})
 		cloud := GetTestCloud(ctrl)
 		mockLBClient := cloud.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 		mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "lb", gomock.Any(), gomock.Any()).Return(nil)
@@ -5298,10 +5297,10 @@ func TestCleanOrphanedLoadBalancerLBInUseByVMSS(t *testing.T) {
 		mockVMSSClient.EXPECT().List(gomock.Any(), "rg").Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil)
 
 		service := getTestService("test", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("test"), to.StringPtr("rg"), to.StringPtr("test"), to.StringPtr("test"), service, consts.LoadBalancerSkuStandard)
-		(*lb.BackendAddressPools)[0].ID = to.StringPtr(testLBBackendpoolID0)
+		lb := getTestLoadBalancer(pointer.String("test"), pointer.String("rg"), pointer.String("test"), pointer.String("test"), service, consts.LoadBalancerSkuStandard)
+		(*lb.BackendAddressPools)[0].ID = pointer.String(testLBBackendpoolID0)
 
-		existingLBs := []network.LoadBalancer{{Name: to.StringPtr("test")}}
+		existingLBs := []network.LoadBalancer{{Name: pointer.String("test")}}
 
 		err = cloud.cleanOrphanedLoadBalancer(&lb, existingLBs, &service, "test")
 		assert.NoError(t, err)
@@ -5315,8 +5314,8 @@ func TestCleanOrphanedLoadBalancerLBInUseByVMSS(t *testing.T) {
 		cloud.LoadBalancerSku = consts.LoadBalancerSkuStandard
 
 		service := getTestService("test", v1.ProtocolTCP, nil, false, 80)
-		lb := getTestLoadBalancer(to.StringPtr("test"), to.StringPtr("rg"), to.StringPtr("test"), to.StringPtr("test"), service, consts.LoadBalancerSkuStandard)
-		(*lb.BackendAddressPools)[0].ID = to.StringPtr(testLBBackendpoolID0)
+		lb := getTestLoadBalancer(pointer.String("test"), pointer.String("rg"), pointer.String("test"), pointer.String("test"), service, consts.LoadBalancerSkuStandard)
+		(*lb.BackendAddressPools)[0].ID = pointer.String(testLBBackendpoolID0)
 
 		existingLBs := []network.LoadBalancer{}
 
@@ -5372,10 +5371,10 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 				consts.ServiceAnnotationLoadBalancerInternal:       consts.TrueAnnotationValue}, 80),
 			existingFrontendIPConfigs: []network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("atest1"),
+					Name: pointer.String("atest1"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 						Subnet: &network.Subnet{
-							Name: to.StringPtr("subnet-1"),
+							Name: pointer.String("subnet-1"),
 						},
 					},
 				},
@@ -5389,19 +5388,19 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 				consts.ServiceAnnotationLoadBalancerInternal:       consts.TrueAnnotationValue}, 80),
 			existingFrontendIPConfigs: []network.FrontendIPConfiguration{
 				{
-					Name: to.StringPtr("not-this-one"),
+					Name: pointer.String("not-this-one"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 						Subnet: &network.Subnet{
-							Name: to.StringPtr("subnet-1"),
+							Name: pointer.String("subnet-1"),
 						},
 					},
 					Zones: &[]string{"2"},
 				},
 				{
-					Name: to.StringPtr("atest1"),
+					Name: pointer.String("atest1"),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 						Subnet: &network.Subnet{
-							Name: to.StringPtr("subnet-1"),
+							Name: pointer.String("subnet-1"),
 						},
 					},
 					Zones: &[]string{"1"},
@@ -5418,7 +5417,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 					{IP: "1.2.3.4"},
 				},
 			},
-			expectedIP:    to.StringPtr("1.2.3.4"),
+			expectedIP:    pointer.String("1.2.3.4"),
 			expectedDirty: true,
 		},
 		{
@@ -5429,7 +5428,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 					{IP: "1.2.3.6"},
 				},
 			},
-			expectedIP:    to.StringPtr(""),
+			expectedIP:    pointer.String(""),
 			expectedDirty: true,
 		},
 	} {
@@ -5438,7 +5437,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 			cloud.regionZonesMap = tc.regionZonesMap
 			cloud.LoadBalancerSku = string(network.LoadBalancerSkuNameStandard)
 
-			lb := getTestLoadBalancer(to.StringPtr("lb"), to.StringPtr("rg"), to.StringPtr("testCluster"), to.StringPtr("testCluster"), tc.service, "standard")
+			lb := getTestLoadBalancer(pointer.String("lb"), pointer.String("rg"), pointer.String("testCluster"), pointer.String("testCluster"), tc.service, "standard")
 			lb.FrontendIPConfigurations = &tc.existingFrontendIPConfigs
 
 			mockPIPClient := cloud.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
@@ -5448,7 +5447,7 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 
 			subnetClient := cloud.SubnetsClient.(*mocksubnetclient.MockInterface)
 			subnetClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", gomock.Any()).Return(
-				network.Subnet{SubnetPropertiesFormat: &network.SubnetPropertiesFormat{AddressPrefix: to.StringPtr("1.2.3.4/31")}}, nil).MaxTimes(1)
+				network.Subnet{SubnetPropertiesFormat: &network.SubnetPropertiesFormat{AddressPrefix: pointer.String("1.2.3.4/31")}}, nil).MaxTimes(1)
 
 			zoneClient := mockzoneclient.NewMockInterface(ctrl)
 			zoneClient.EXPECT().GetZones(gomock.Any(), gomock.Any()).Return(map[string][]string{}, tc.getZoneError).MaxTimes(1)
@@ -5464,13 +5463,13 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 			assert.Equal(t, tc.expectedDirty, dirty)
 
 			for _, fip := range *lb.FrontendIPConfigurations {
-				if strings.EqualFold(to.String(fip.Name), defaultLBFrontendIPConfigName) {
+				if strings.EqualFold(pointer.StringDeref(fip.Name, ""), defaultLBFrontendIPConfigName) {
 					assert.Equal(t, tc.expectedZones, fip.Zones)
 				}
 			}
 
 			if tc.expectedIP != nil {
-				assert.Equal(t, *tc.expectedIP, to.String((*lb.FrontendIPConfigurations)[0].PrivateIPAddress))
+				assert.Equal(t, *tc.expectedIP, pointer.StringDeref((*lb.FrontendIPConfigurations)[0].PrivateIPAddress, ""))
 				if *tc.expectedIP != "" {
 					assert.Equal(t, network.Static, (*lb.FrontendIPConfigurations)[0].PrivateIPAllocationMethod)
 				} else {
@@ -5506,15 +5505,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 									},
 								},
@@ -5523,15 +5522,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("kubernetes-internal"),
+					Name: pointer.String("kubernetes-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 									},
 								},
@@ -5540,15 +5539,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss1-nic-1"),
+											ID: pointer.String("vmss1-nic-1"),
 										},
 									},
 								},
@@ -5557,15 +5556,15 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("vmss1-internal"),
+					Name: pointer.String("vmss1-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss1-nic-1"),
+											ID: pointer.String("vmss1-nic-1"),
 										},
 									},
 								},
@@ -5576,18 +5575,18 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			expectedLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 										{
-											ID: to.StringPtr("vmss1-nic-1"),
+											ID: pointer.String("vmss1-nic-1"),
 										},
 									},
 								},
@@ -5596,18 +5595,18 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("kubernetes-internal"),
+					Name: pointer.String("kubernetes-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 										{
-											ID: to.StringPtr("vmss2-nic-1"),
+											ID: pointer.String("vmss2-nic-1"),
 										},
 										{
-											ID: to.StringPtr("vmss1-nic-1"),
+											ID: pointer.String("vmss1-nic-1"),
 										},
 									},
 								},
@@ -5652,44 +5651,44 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name:                               to.StringPtr("kubernetes"),
+								Name:                               pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{},
 							},
 						},
 					},
 				},
 				{
-					Name: to.StringPtr("kubernetes-internal"),
+					Name: pointer.String("kubernetes-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name:                               to.StringPtr("kubernetes"),
+								Name:                               pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{},
 							},
 						},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name:                               to.StringPtr("kubernetes"),
+								Name:                               pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{},
 							},
 						},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss1-internal"),
+					Name: pointer.String("vmss1-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name:                               to.StringPtr("kubernetes"),
+								Name:                               pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{},
 							},
 						},
@@ -5698,18 +5697,18 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			expectedLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 										{
-											Name: to.StringPtr("vmss1"),
+											Name: pointer.String("vmss1"),
 											LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-												VirtualNetwork: &network.SubResource{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
-												IPAddress:      to.StringPtr("10.0.0.1"),
+												VirtualNetwork: &network.SubResource{ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
+												IPAddress:      pointer.String("10.0.0.1"),
 											},
 										},
 									},
@@ -5719,18 +5718,18 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("kubernetes-internal"),
+					Name: pointer.String("kubernetes-internal"),
 					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 						BackendAddressPools: &[]network.BackendAddressPool{
 							{
-								Name: to.StringPtr("kubernetes"),
+								Name: pointer.String("kubernetes"),
 								BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 									LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{
 										{
-											Name: to.StringPtr("vmss1"),
+											Name: pointer.String("vmss1"),
 											LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-												VirtualNetwork: &network.SubResource{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
-												IPAddress:      to.StringPtr("10.0.0.1"),
+												VirtualNetwork: &network.SubResource{ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
+												IPAddress:      pointer.String("10.0.0.1"),
 											},
 										},
 									},
@@ -5763,18 +5762,18 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			},
 			existingLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 				},
 				{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 				},
 			},
 			expectedLBs: []network.LoadBalancer{
 				{
-					Name: to.StringPtr("kubernetes"),
+					Name: pointer.String("kubernetes"),
 				},
 				{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 				},
 			},
 			expectedListCount:     1,
@@ -5827,10 +5826,10 @@ func TestReconcileSharedLoadBalancer(t *testing.T) {
 			mockLBBackendPool := cloud.LoadBalancerBackendPool.(*MockBackendPool)
 			mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(service *v1.Service, nodes []*v1.Node, backendPoolID, vmSetName, clusterName, lbName string, backendPool network.BackendAddressPool) error {
 				*backendPool.LoadBalancerBackendAddresses = append(*backendPool.LoadBalancerBackendAddresses, network.LoadBalancerBackendAddress{
-					Name: to.StringPtr("vmss1"),
+					Name: pointer.String("vmss1"),
 					LoadBalancerBackendAddressPropertiesFormat: &network.LoadBalancerBackendAddressPropertiesFormat{
-						VirtualNetwork: &network.SubResource{ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
-						IPAddress:      to.StringPtr("10.0.0.1"),
+						VirtualNetwork: &network.SubResource{ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet")},
+						IPAddress:      pointer.String("10.0.0.1"),
 					},
 				})
 
@@ -5861,12 +5860,12 @@ func TestGetServiceFromPIPDNSTags(t *testing.T) {
 		},
 		{
 			desc:     "Expected service should be returned when tags contain dns label tag",
-			tags:     map[string]*string{consts.ServiceUsingDNSKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.ServiceUsingDNSKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 		{
 			desc:     "Expected service should be returned when tags contain legacy dns label tag",
-			tags:     map[string]*string{consts.LegacyServiceUsingDNSKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.LegacyServiceUsingDNSKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 	}
@@ -5890,12 +5889,12 @@ func TestGetServiceFromPIPServiceTags(t *testing.T) {
 		},
 		{
 			desc:     "Expected service should be returned when tags contain service tag",
-			tags:     map[string]*string{consts.ServiceTagKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.ServiceTagKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 		{
 			desc:     "Expected service should be returned when tags contain legacy service tag",
-			tags:     map[string]*string{consts.LegacyServiceTagKey: to.StringPtr("test-service")},
+			tags:     map[string]*string{consts.LegacyServiceTagKey: pointer.String("test-service")},
 			expected: "test-service",
 		},
 	}
@@ -5919,12 +5918,12 @@ func TestGetClusterFromPIPClusterTags(t *testing.T) {
 		},
 		{
 			desc:     "Expected service should be returned when tags contain cluster name tag",
-			tags:     map[string]*string{consts.ClusterNameKey: to.StringPtr("test-cluster")},
+			tags:     map[string]*string{consts.ClusterNameKey: pointer.String("test-cluster")},
 			expected: "test-cluster",
 		},
 		{
 			desc:     "Expected service should be returned when tags contain legacy cluster name tag",
-			tags:     map[string]*string{consts.LegacyClusterNameKey: to.StringPtr("test-cluster")},
+			tags:     map[string]*string{consts.LegacyClusterNameKey: pointer.String("test-cluster")},
 			expected: "test-cluster",
 		},
 	}
@@ -5935,8 +5934,8 @@ func TestGetClusterFromPIPClusterTags(t *testing.T) {
 }
 
 func TestEqualLoadBalancingRulePropertiesFormat(t *testing.T) {
-	var enableTCPReset, disableTCPReset *bool = to.BoolPtr(true), to.BoolPtr(false)
-	var frontPort *int32 = to.Int32Ptr(80)
+	var enableTCPReset, disableTCPReset *bool = pointer.Bool(true), pointer.Bool(false)
+	var frontPort *int32 = pointer.Int32(80)
 
 	testcases := []struct {
 		s        *network.LoadBalancingRulePropertiesFormat
@@ -6025,7 +6024,7 @@ func TestSafeDeleteLoadBalancer(t *testing.T) {
 			cloud.LoadBalancerClient = mockLBClient
 			svc := getTestService("svc", v1.ProtocolTCP, nil, false, 80)
 			lb := network.LoadBalancer{
-				Name: to.StringPtr("test"),
+				Name: pointer.String("test"),
 				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 					BackendAddressPools: &[]network.BackendAddressPool{},
 				},

--- a/pkg/provider/azure_managedDiskController.go
+++ b/pkg/provider/azure_managedDiskController.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -33,6 +32,7 @@ import (
 	cloudvolume "k8s.io/cloud-provider/volume"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
@@ -144,7 +144,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 			}
 			diskIOPSReadWrite = int64(v)
 		}
-		diskProperties.DiskIOPSReadWrite = to.Int64Ptr(diskIOPSReadWrite)
+		diskProperties.DiskIOPSReadWrite = pointer.Int64(diskIOPSReadWrite)
 
 		diskMBpsReadWrite := int64(consts.DefaultDiskMBpsReadWrite)
 		if options.DiskMBpsReadWrite != "" {
@@ -154,11 +154,11 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 			}
 			diskMBpsReadWrite = int64(v)
 		}
-		diskProperties.DiskMBpsReadWrite = to.Int64Ptr(diskMBpsReadWrite)
+		diskProperties.DiskMBpsReadWrite = pointer.Int64(diskMBpsReadWrite)
 
 		if options.LogicalSectorSize != 0 {
 			klog.V(2).Infof("AzureDisk - requested LogicalSectorSize: %v", options.LogicalSectorSize)
-			diskProperties.CreationData.LogicalSectorSize = to.Int32Ptr(options.LogicalSectorSize)
+			diskProperties.CreationData.LogicalSectorSize = pointer.Int32(options.LogicalSectorSize)
 		}
 	} else {
 		if options.DiskIOPSReadWrite != "" {
@@ -197,7 +197,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 
 	if el := c.common.extendedLocation; el != nil {
 		model.ExtendedLocation = &compute.ExtendedLocation{
-			Name: to.StringPtr(el.Name),
+			Name: pointer.String(el.Name),
 			Type: compute.ExtendedLocationTypes(el.Type),
 		}
 	}
@@ -340,7 +340,7 @@ func (c *ManagedDiskController) ResizeDisk(diskURI string, oldSize resource.Quan
 	}
 
 	if !supportOnlineResize && result.DiskProperties.DiskState != compute.Unattached {
-		return oldSize, fmt.Errorf("azureDisk - disk resize is only supported on Unattached disk, current disk state: %s, already attached to %s", result.DiskProperties.DiskState, to.String(result.ManagedBy))
+		return oldSize, fmt.Errorf("azureDisk - disk resize is only supported on Unattached disk, current disk state: %s, already attached to %s", result.DiskProperties.DiskState, pointer.StringDeref(result.ManagedBy, ""))
 	}
 
 	diskParameter := compute.DiskUpdate{

--- a/pkg/provider/azure_managedDiskController_test.go
+++ b/pkg/provider/azure_managedDiskController_test.go
@@ -23,13 +23,13 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	cloudvolume "k8s.io/cloud-provider/volume"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/diskclient/mockdiskclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -50,7 +50,7 @@ func TestCreateManagedDisk(t *testing.T) {
 	goodDiskEncryptionSetID := fmt.Sprintf("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/%s", "diskEncryptionSet-name")
 	badDiskEncryptionSetID := "badDiskEncryptionSetID"
 	testTags := make(map[string]*string)
-	testTags[WriteAcceleratorEnabled] = to.StringPtr("true")
+	testTags[WriteAcceleratorEnabled] = pointer.String("true")
 	testCases := []struct {
 		desc                string
 		diskID              string
@@ -75,7 +75,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -87,7 +87,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -99,7 +99,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - failed to parse DiskIOPSReadWrite: strconv.Atoi: parsing \"invalid\": invalid syntax"),
 		},
@@ -112,7 +112,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "invalid",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - failed to parse DiskMBpsReadWrite: strconv.Atoi: parsing \"invalid\": invalid syntax"),
 		},
@@ -125,7 +125,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: badDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - format of DiskEncryptionSetID(%s) is incorrect, correct format: %s", badDiskEncryptionSetID, consts.DiskEncryptionSetIDFormat),
 		},
@@ -138,7 +138,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - DiskIOPSReadWrite parameter is only applicable in UltraSSD_LRS disk type"),
 		},
@@ -151,7 +151,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskMBPSReadWrite:   "100",
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("AzureDisk - DiskMBpsReadWrite parameter is only applicable in UltraSSD_LRS disk type"),
 		},
@@ -163,7 +163,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			networkAccessPolicy: compute.DenyAll,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -174,7 +174,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			networkAccessPolicy: compute.AllowAll,
 			expectedDiskID:      disk1ID,
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         false,
 		},
 		{
@@ -185,7 +185,7 @@ func TestCreateManagedDisk(t *testing.T) {
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			networkAccessPolicy: compute.AllowPrivate,
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("DiskAccessID should not be empty when NetworkAccessPolicy is AllowPrivate"),
 		},
@@ -196,9 +196,9 @@ func TestCreateManagedDisk(t *testing.T) {
 			storageAccountType:  compute.StandardLRS,
 			diskEncryptionSetID: goodDiskEncryptionSetID,
 			networkAccessPolicy: compute.AllowAll,
-			diskAccessID:        to.StringPtr("diskAccessID"),
+			diskAccessID:        pointer.String("diskAccessID"),
 			expectedDiskID:      "",
-			existedDisk:         compute.Disk{ID: to.StringPtr(disk1ID), Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: to.StringPtr("Succeeded")}, Tags: testTags},
+			existedDisk:         compute.Disk{ID: pointer.String(disk1ID), Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{Encryption: &compute.Encryption{DiskEncryptionSetID: &goodDiskEncryptionSetID, Type: compute.EncryptionTypeEncryptionAtRestWithCustomerKey}, ProvisioningState: pointer.String("Succeeded")}, Tags: testTags},
 			expectedErr:         true,
 			expectedErrMsg:      fmt.Errorf("DiskAccessID(diskAccessID) must be empty when NetworkAccessPolicy(AllowAll) is not AllowPrivate"),
 		},
@@ -244,16 +244,16 @@ func TestCreateManagedDiskWithExtendedLocation(t *testing.T) {
 	diskName := disk1Name
 	expectedDiskID := disk1ID
 	el := &compute.ExtendedLocation{
-		Name: to.StringPtr("microsoftlosangeles1"),
+		Name: pointer.String("microsoftlosangeles1"),
 		Type: compute.ExtendedLocationTypesEdgeZone,
 	}
 
 	diskreturned := compute.Disk{
-		ID:               to.StringPtr(expectedDiskID),
-		Name:             to.StringPtr(diskName),
+		ID:               pointer.String(expectedDiskID),
+		Name:             pointer.String(diskName),
 		ExtendedLocation: el,
 		DiskProperties: &compute.DiskProperties{
-			ProvisioningState: to.StringPtr("Succeeded"),
+			ProvisioningState: pointer.String("Succeeded"),
 		},
 	}
 
@@ -296,20 +296,20 @@ func TestDeleteManagedDisk(t *testing.T) {
 			desc:           "an error shall be returned if delete an attaching disk",
 			diskName:       disk1Name,
 			diskState:      "attaching",
-			existedDisk:    compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk:    compute.Disk{Name: pointer.String(disk1Name)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("failed to delete disk(/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/disks/disk1) since it's in attaching or detaching state"),
 		},
 		{
 			desc:        "no error shall be returned if everything is good",
 			diskName:    disk1Name,
-			existedDisk: compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk: compute.Disk{Name: pointer.String(disk1Name)},
 			expectedErr: false,
 		},
 		{
 			desc:           "an error shall be returned if get disk failed",
 			diskName:       fakeGetDiskFailed,
-			existedDisk:    compute.Disk{Name: to.StringPtr(fakeGetDiskFailed)},
+			existedDisk:    compute.Disk{Name: pointer.String(fakeGetDiskFailed)},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
 		},
@@ -358,7 +358,7 @@ func TestGetDisk(t *testing.T) {
 		{
 			desc:                      "no error shall be returned if get a normal disk without DiskProperties",
 			diskName:                  disk1Name,
-			existedDisk:               compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk:               compute.Disk{Name: pointer.String(disk1Name)},
 			expectedErr:               false,
 			expectedProvisioningState: "",
 			expectedDiskID:            "",
@@ -366,7 +366,7 @@ func TestGetDisk(t *testing.T) {
 		{
 			desc:                      "an error shall be returned if get disk failed",
 			diskName:                  fakeGetDiskFailed,
-			existedDisk:               compute.Disk{Name: to.StringPtr(fakeGetDiskFailed)},
+			existedDisk:               compute.Disk{Name: pointer.String(fakeGetDiskFailed)},
 			expectedErr:               true,
 			expectedErrMsg:            fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
 			expectedProvisioningState: "",
@@ -417,7 +417,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         diskName,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      false,
 		},
@@ -426,7 +426,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         diskName,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(disk1Name)},
+			existedDisk:      compute.Disk{Name: pointer.String(disk1Name)},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("DiskProperties of disk(%s) is nil", diskName),
@@ -436,7 +436,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         diskName,
 			oldSize:          *resource.NewQuantity(1*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(disk1Name), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      false,
 		},
@@ -445,7 +445,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         fakeGetDiskFailed,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
@@ -455,7 +455,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         fakeCreateDiskFailed,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
+			existedDisk:      compute.Disk{Name: pointer.String(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Unattached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Create Disk failed"),
@@ -465,7 +465,7 @@ func TestResizeDisk(t *testing.T) {
 			diskName:         fakeCreateDiskFailed,
 			oldSize:          *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			newSize:          *resource.NewQuantity(3*(1024*1024*1024), resource.BinarySI),
-			existedDisk:      compute.Disk{Name: to.StringPtr(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Attached}},
+			existedDisk:      compute.Disk{Name: pointer.String(fakeCreateDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB, DiskState: compute.Attached}},
 			expectedQuantity: *resource.NewQuantity(2*(1024*1024*1024), resource.BinarySI),
 			expectedErr:      true,
 			expectedErrMsg:   fmt.Errorf("azureDisk - disk resize is only supported on Unattached disk, current disk state: Attached, already attached to "),
@@ -532,7 +532,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expected: map[string]string{
 				consts.LabelFailureDomainBetaRegion: testCloud0.Location,
 				consts.LabelFailureDomainBetaZone:   testCloud0.makeZone(testCloud0.Location, 1),
@@ -552,7 +552,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"invalid"}},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"invalid"}},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("failed to parse zone [invalid] for AzureDisk %v: %v", diskName, "strconv.Atoi: parsing \"invalid\": invalid syntax"),
 		},
@@ -569,7 +569,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected: map[string]string{
 				consts.LabelFailureDomainBetaRegion: testCloud0.Location,
 			},
@@ -589,7 +589,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk:    compute.Disk{Name: to.StringPtr(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
+			existedDisk:    compute.Disk{Name: pointer.String(fakeGetDiskFailed), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: Get Disk failed"),
 		},
@@ -606,7 +606,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk:    compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
+			existedDisk:    compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}, Zones: &[]string{"1"}},
 			expectedErr:    true,
 			expectedErrMsg: fmt.Errorf("invalid disk URI: invalidDiskURI"),
 		},
@@ -623,7 +623,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected:    nil,
 			expectedErr: false,
 		},
@@ -635,7 +635,7 @@ func TestGetLabelsForVolume(t *testing.T) {
 					PersistentVolumeSource: v1.PersistentVolumeSource{},
 				},
 			},
-			existedDisk: compute.Disk{Name: to.StringPtr(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
+			existedDisk: compute.Disk{Name: pointer.String(diskName), DiskProperties: &compute.DiskProperties{DiskSizeGB: &diskSizeGB}},
 			expected:    nil,
 			expectedErr: false,
 		},

--- a/pkg/provider/azure_privatelinkservice_test.go
+++ b/pkg/provider/azure_privatelinkservice_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
@@ -72,8 +72,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -81,7 +81,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList:   true,
 			existingPLSList:   []network.PrivateLinkService{},
 			expectedPLSCreate: true,
-			expectedPLS:       &network.PrivateLinkService{Name: to.StringPtr("pls-fipConfig")},
+			expectedPLS:       &network.PrivateLinkService{Name: pointer.String("pls-fipConfig")},
 		},
 		{
 			desc: "reconcilePrivateLinkService should create a new PLS if no existing PLS attached to the LB frontend",
@@ -93,8 +93,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -102,7 +102,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList:   true,
 			existingPLSList:   []network.PrivateLinkService{},
 			expectedPLSCreate: true,
-			expectedPLS:       &network.PrivateLinkService{Name: to.StringPtr("testpls")},
+			expectedPLS:       &network.PrivateLinkService{Name: pointer.String("testpls")},
 		},
 		{
 			desc: "reconcilePrivateLinkService should report error if existing PLS attached to LB frontEnd is unmanaged",
@@ -115,15 +115,15 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.Dynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPv4,
 								},
 							},
@@ -144,23 +144,23 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.Dynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test1"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test1"),
 					},
 				},
 			},
@@ -176,24 +176,24 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.Static,
-									PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									PrivateIPAddress:          pointer.String("10.2.0.4"),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test1"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test1"),
 					},
 				},
 			},
@@ -208,8 +208,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -217,23 +217,23 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.Dynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test"),
 					},
 				},
 			},
@@ -249,8 +249,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			wantPLS:           true,
 			expectedSubnetGet: true,
 			existingSubnet: &network.Subnet{
-				Name: to.StringPtr("subnet"),
-				ID:   to.StringPtr("subnetID"),
+				Name: pointer.String("subnet"),
+				ID:   pointer.String("subnetID"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -258,28 +258,28 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 						IPConfigurations: &[]network.PrivateLinkServiceIPConfiguration{
 							{
 								PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 									PrivateIPAllocationMethod: network.Dynamic,
-									Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-									Primary:                   to.BoolPtr(true),
+									Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+									Primary:                   pointer.Bool(true),
 									PrivateIPAddressVersion:   network.IPv4,
 								},
 							},
 						},
 					},
 					Tags: map[string]*string{
-						consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-						consts.OwnerServiceTagKey: to.StringPtr("default/test"),
+						consts.ClusterNameTagKey:  pointer.String(testClusterName),
+						consts.OwnerServiceTagKey: pointer.String("default/test"),
 					},
 				},
 			},
 			expectedPLSCreate: true,
-			expectedPLS:       &network.PrivateLinkService{Name: to.StringPtr("testpls")},
+			expectedPLS:       &network.PrivateLinkService{Name: pointer.String("testpls")},
 		},
 		{
 			desc: "reconcilePrivateLinkService should not do anything if no existing PLS attached to the LB frontend when deleting",
@@ -291,9 +291,9 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID2")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID2")}},
 					},
 				},
 			},
@@ -308,9 +308,9 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSList: true,
 			existingPLSList: []network.PrivateLinkService{
 				{
-					Name: to.StringPtr("testpls"),
+					Name: pointer.String("testpls"),
 					PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("fipConfigID")}},
+						LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("fipConfigID")}},
 					},
 				},
 			},
@@ -321,8 +321,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 		az := GetTestCloud(ctrl)
 		service := getTestServiceWithAnnotation("test", test.annotations, 80)
 		fipConfig := &network.FrontendIPConfiguration{
-			Name: to.StringPtr("fipConfig"),
-			ID:   to.StringPtr("fipConfigID"),
+			Name: pointer.String("fipConfig"),
+			ID:   pointer.String("fipConfigID"),
 		}
 		clusterName := testClusterName
 
@@ -335,7 +335,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			mockPLSsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPLSList, nil).MaxTimes(1)
 		}
 		if test.expectedPLSCreate {
-			mockPLSsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", to.String(test.expectedPLS.Name), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockPLSsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", pointer.StringDeref(test.expectedPLS.Name, ""), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		}
 		if test.expectedPLSDelete {
 			mockPLSsClient.EXPECT().Delete(gomock.Any(), "rg", "testpls").Return(nil).Times(1)
@@ -358,7 +358,7 @@ func TestDisablePLSNetworkPolicy(t *testing.T) {
 		{
 			desc: "disablePLSNetworkPolicy shall not update subnet if pls-network-policy is disabled",
 			subnet: network.Subnet{
-				Name: to.StringPtr("plsSubnet"),
+				Name: pointer.String("plsSubnet"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -368,7 +368,7 @@ func TestDisablePLSNetworkPolicy(t *testing.T) {
 		{
 			desc: "disablePLSNetworkPolicy shall update subnet if pls-network-policy is enabled",
 			subnet: network.Subnet{
-				Name: to.StringPtr("plsSubnet"),
+				Name: pointer.String("plsSubnet"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
 				},
@@ -387,7 +387,7 @@ func TestDisablePLSNetworkPolicy(t *testing.T) {
 		mockSubnetsClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "plsSubnet", "").Return(test.subnet, nil).Times(1)
 		if test.expectedSubnetUpdate {
 			mockSubnetsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", "vnet", "plsSubnet", network.Subnet{
-				Name: to.StringPtr("plsSubnet"),
+				Name: pointer.String("plsSubnet"),
 				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
 					PrivateLinkServiceNetworkPolicies: network.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
 				},
@@ -410,12 +410,12 @@ func TestSafeDeletePLS(t *testing.T) {
 		{
 			desc: "safeDeletePLS shall delete all PE connections and pls itself",
 			pls: &network.PrivateLinkService{
-				Name: to.StringPtr("testpls"),
+				Name: pointer.String("testpls"),
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: to.StringPtr("FipConfigID")}},
+					LoadBalancerFrontendIPConfigurations: &[]network.FrontendIPConfiguration{{ID: pointer.String("FipConfigID")}},
 					PrivateEndpointConnections: &[]network.PrivateEndpointConnection{
-						{Name: to.StringPtr("pe1")},
-						{Name: to.StringPtr("pe2")},
+						{Name: pointer.String("pe1")},
+						{Name: pointer.String("pe2")},
 					},
 				},
 			},
@@ -459,14 +459,14 @@ func TestGetPrivateLinkServiceName(t *testing.T) {
 			desc: "If pls name does not set, and service does not configure, sets it as default(pls-fipConfigName)",
 			pls:  &network.PrivateLinkService{},
 			fipConfig: &network.FrontendIPConfiguration{
-				Name: to.StringPtr("fipname"),
+				Name: pointer.String("fipname"),
 			},
 			expectedName: "pls-fipname",
 		},
 		{
 			desc: "If pls name is not equal to service configuration, error should be reported",
 			pls: &network.PrivateLinkService{
-				Name: to.StringPtr("testpls"),
+				Name: pointer.String("testpls"),
 			},
 			annotations: map[string]string{
 				consts.ServiceAnnotationPLSName: "testpls1",
@@ -476,7 +476,7 @@ func TestGetPrivateLinkServiceName(t *testing.T) {
 		{
 			desc: "If pls name is same as service configuration, simply return it",
 			pls: &network.PrivateLinkService{
-				Name: to.StringPtr("testpls"),
+				Name: pointer.String("testpls"),
 			},
 			annotations: map[string]string{
 				consts.ServiceAnnotationPLSName: "testpls",
@@ -520,13 +520,13 @@ func TestGetExpectedPrivateLinkService(t *testing.T) {
 		}
 		plsName := "testPLS"
 		clusterName := testClusterName
-		fipConfig := &network.FrontendIPConfiguration{ID: to.StringPtr("fipConfigID")}
+		fipConfig := &network.FrontendIPConfiguration{ID: pointer.String("fipConfigID")}
 		pls := &network.PrivateLinkService{PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{}}
 		subnetClient := cloud.SubnetsClient.(*mocksubnetclient.MockInterface)
 		subnetClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", gomock.Any()).Return(
 			network.Subnet{
-				ID:   to.StringPtr("subnetID"),
-				Name: to.StringPtr("subnet"),
+				ID:   pointer.String("subnetID"),
+				Name: pointer.String("subnet"),
 			}, nil).MaxTimes(1)
 
 		dirtyPLS, err := cloud.getExpectedPrivateLinkService(pls, &plsName, &clusterName, service, fipConfig)
@@ -540,31 +540,31 @@ func TestGetExpectedPrivateLinkService(t *testing.T) {
 
 		expectedConfigs := []network.PrivateLinkServiceIPConfiguration{
 			{
-				Name: to.StringPtr("subnet-testPLS-static-10.2.0.4"),
+				Name: pointer.String("subnet-testPLS-static-10.2.0.4"),
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 					PrivateIPAllocationMethod: network.Static,
-					PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-					Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-					Primary:                   to.BoolPtr(true),
+					PrivateIPAddress:          pointer.String("10.2.0.4"),
+					Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+					Primary:                   pointer.Bool(true),
 					PrivateIPAddressVersion:   network.IPv4,
 				},
 			},
 			{
-				Name: to.StringPtr("subnet-testPLS-static-10.2.0.5"),
+				Name: pointer.String("subnet-testPLS-static-10.2.0.5"),
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 					PrivateIPAllocationMethod: network.Static,
-					PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-					Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-					Primary:                   to.BoolPtr(false),
+					PrivateIPAddress:          pointer.String("10.2.0.5"),
+					Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+					Primary:                   pointer.Bool(false),
 					PrivateIPAddressVersion:   network.IPv4,
 				},
 			},
 			{
-				Name: to.StringPtr("subnet-testPLS-dynamic-0"),
+				Name: pointer.String("subnet-testPLS-dynamic-0"),
 				PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 					PrivateIPAllocationMethod: network.Dynamic,
-					Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-					Primary:                   to.BoolPtr(false),
+					Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+					Primary:                   pointer.Bool(false),
 					PrivateIPAddressVersion:   network.IPv4,
 				},
 			},
@@ -619,11 +619,11 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should change existingPLS if its ipConfig is nil",
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -637,31 +637,31 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-1"),
+					Name: pointer.String("subnet-testpls-dynamic-1"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(false),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(false),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -672,22 +672,22 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should change existingPLS if its subnetID is different",
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID1")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID1")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -702,32 +702,32 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.4"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.4"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Static,
-						PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.4"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(false),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(false),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -738,23 +738,23 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should change existingPLS if ip allocation type is changed from static to dynamic",
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.4"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.4"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Static,
-						PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.4"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -768,24 +768,24 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.4"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.4"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Static,
-						PrivateIPAddress:          to.StringPtr("10.2.0.4"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.4"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.5"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.5"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Static,
-						PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.5"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -796,22 +796,22 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			desc: "reconcilePLSIpConfigs should not change existingPLS if ip allocation type is dynamic only",
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-dynamic-0"),
+					Name: pointer.String("subnet-testpls-dynamic-0"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -824,24 +824,24 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 			existingIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.5"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.5"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Static,
-						PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.5"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
 			},
 			expectedIPConfigs: &[]network.PrivateLinkServiceIPConfiguration{
 				{
-					Name: to.StringPtr("subnet-testpls-static-10.2.0.5"),
+					Name: pointer.String("subnet-testpls-static-10.2.0.5"),
 					PrivateLinkServiceIPConfigurationProperties: &network.PrivateLinkServiceIPConfigurationProperties{
 						PrivateIPAllocationMethod: network.Static,
-						PrivateIPAddress:          to.StringPtr("10.2.0.5"),
-						Subnet:                    &network.Subnet{ID: to.StringPtr("subnetID")},
-						Primary:                   to.BoolPtr(true),
+						PrivateIPAddress:          pointer.String("10.2.0.5"),
+						Subnet:                    &network.Subnet{ID: pointer.String("subnetID")},
+						Primary:                   pointer.Bool(true),
 						PrivateIPAddressVersion:   network.IPv4,
 					},
 				},
@@ -857,7 +857,7 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 			},
 		}
 		pls := &network.PrivateLinkService{
-			Name: to.StringPtr("testpls"),
+			Name: pointer.String("testpls"),
 			PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
 				IPConfigurations: test.existingIPConfigs,
 			},
@@ -865,8 +865,8 @@ func TestReconcilePLSIpConfigs(t *testing.T) {
 		subnetClient := cloud.SubnetsClient.(*mocksubnetclient.MockInterface)
 		subnetClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", gomock.Any()).Return(
 			network.Subnet{
-				ID:   to.StringPtr("subnetID"),
-				Name: to.StringPtr("subnet"),
+				ID:   pointer.String("subnetID"),
+				Name: pointer.String("subnet"),
 			}, test.getSubnetError).MaxTimes(1)
 
 		changed, err := cloud.reconcilePLSIpConfigs(pls, service)
@@ -883,10 +883,10 @@ func testSamePLSIpConfigs(t *testing.T, actual []network.PrivateLinkServiceIPCon
 	actualIPConfigs := make(map[string]network.PrivateLinkServiceIPConfiguration)
 	expectedIPConfigs := make(map[string]network.PrivateLinkServiceIPConfiguration)
 	for _, ipConfig := range actual {
-		actualIPConfigs[to.String(ipConfig.Name)] = ipConfig
+		actualIPConfigs[pointer.StringDeref(ipConfig.Name, "")] = ipConfig
 	}
 	for _, ipConfig := range expected {
-		expectedIPConfigs[to.String(ipConfig.Name)] = ipConfig
+		expectedIPConfigs[pointer.StringDeref(ipConfig.Name, "")] = ipConfig
 	}
 	assert.Equal(t, actualIPConfigs, expectedIPConfigs)
 }
@@ -957,10 +957,10 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			},
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					EnableProxyProtocol: to.BoolPtr(false),
+					EnableProxyProtocol: pointer.Bool(false),
 				},
 			},
-			expectedEnabled: to.BoolPtr(false),
+			expectedEnabled: pointer.Bool(false),
 		},
 		{
 			desc: "true service enableProxyProto and true pls enableProxyProto should not trigger any change",
@@ -969,10 +969,10 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			},
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					EnableProxyProtocol: to.BoolPtr(true),
+					EnableProxyProtocol: pointer.Bool(true),
 				},
 			},
-			expectedEnabled: to.BoolPtr(true),
+			expectedEnabled: pointer.Bool(true),
 		},
 		{
 			desc: "true service enableProxyProto and empty pls enableProxyProto should trigger update",
@@ -982,7 +982,7 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{},
 			},
-			expectedEnabled: to.BoolPtr(true),
+			expectedEnabled: pointer.Bool(true),
 			expectedChanged: true,
 		},
 		{
@@ -992,10 +992,10 @@ func TestReconcilePLSEnableProxyProtocol(t *testing.T) {
 			},
 			pls: &network.PrivateLinkService{
 				PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
-					EnableProxyProtocol: to.BoolPtr(true),
+					EnableProxyProtocol: pointer.Bool(true),
 				},
 			},
-			expectedEnabled: to.BoolPtr(false),
+			expectedEnabled: pointer.Bool(false),
 			expectedChanged: true,
 		},
 	}
@@ -1254,9 +1254,9 @@ func TestReconcilePLSTags(t *testing.T) {
 	}
 	pls := network.PrivateLinkService{
 		Tags: map[string]*string{
-			"foo": to.StringPtr("bar"),
-			"a":   to.StringPtr("j"),
-			"m":   to.StringPtr("n"),
+			"foo": pointer.String("bar"),
+			"a":   pointer.String("j"),
+			"m":   pointer.String("n"),
 		},
 	}
 	clusterName := testClusterName
@@ -1264,12 +1264,12 @@ func TestReconcilePLSTags(t *testing.T) {
 	t.Run("reconcilePLSTags should ensure the pls is tagged as configured", func(t *testing.T) {
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-				consts.OwnerServiceTagKey: to.StringPtr("test-ns/test-svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("x"),
-				"y":                       to.StringPtr("z"),
-				"m":                       to.StringPtr("n"),
+				consts.ClusterNameTagKey:  pointer.String(testClusterName),
+				consts.OwnerServiceTagKey: pointer.String("test-ns/test-svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("x"),
+				"y":                       pointer.String("z"),
+				"m":                       pointer.String("n"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1281,11 +1281,11 @@ func TestReconcilePLSTags(t *testing.T) {
 		cloud.SystemTags = "a,foo,b"
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-				consts.OwnerServiceTagKey: to.StringPtr("test-ns/test-svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("x"),
-				"y":                       to.StringPtr("z"),
+				consts.ClusterNameTagKey:  pointer.String(testClusterName),
+				consts.OwnerServiceTagKey: pointer.String("test-ns/test-svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("x"),
+				"y":                       pointer.String("z"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1298,11 +1298,11 @@ func TestReconcilePLSTags(t *testing.T) {
 		cloud.TagsMap = map[string]string{"a": "c", "a=b": "c=d", "Y": "zz"}
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr(testClusterName),
-				consts.OwnerServiceTagKey: to.StringPtr("test-ns/test-svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("c"),
-				"a=b":                     to.StringPtr("c=d"),
+				consts.ClusterNameTagKey:  pointer.String(testClusterName),
+				consts.OwnerServiceTagKey: pointer.String("test-ns/test-svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("c"),
+				"a=b":                     pointer.String("c=d"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1310,18 +1310,18 @@ func TestReconcilePLSTags(t *testing.T) {
 		assert.Equal(t, expectedPLS, pls)
 	})
 
-	pls.Tags[consts.ClusterNameTagKey] = to.StringPtr("testCluster1")
-	pls.Tags[consts.OwnerServiceTagKey] = to.StringPtr("default/svc")
+	pls.Tags[consts.ClusterNameTagKey] = pointer.String("testCluster1")
+	pls.Tags[consts.OwnerServiceTagKey] = pointer.String("default/svc")
 
 	t.Run("reconcilePLSTags should respect cluster and owner service tag keys", func(t *testing.T) {
 		expectedPLS := network.PrivateLinkService{
 			Tags: map[string]*string{
-				consts.ClusterNameTagKey:  to.StringPtr("testCluster1"),
-				consts.OwnerServiceTagKey: to.StringPtr("default/svc"),
-				"foo":                     to.StringPtr("bar"),
-				"a":                       to.StringPtr("c"),
-				"a=b":                     to.StringPtr("c=d"),
-				"Y":                       to.StringPtr("zz"),
+				consts.ClusterNameTagKey:  pointer.String("testCluster1"),
+				consts.OwnerServiceTagKey: pointer.String("default/svc"),
+				"foo":                     pointer.String("bar"),
+				"a":                       pointer.String("c"),
+				"a=b":                     pointer.String("c=d"),
+				"Y":                       pointer.String("zz"),
 			},
 		}
 		changed := cloud.reconcilePLSTags(&pls, &clusterName, &service)
@@ -1347,7 +1347,7 @@ func TestGetPLSSubnetName(t *testing.T) {
 			annotations: map[string]string{
 				consts.ServiceAnnotationPLSIpConfigurationSubnet: "pls-subnet",
 			},
-			expectedSubnet: to.StringPtr("pls-subnet"),
+			expectedSubnet: pointer.String("pls-subnet"),
 		},
 		{
 			desc: "Service with empty private link subnet specified but LB subnet specified should return LB subnet",
@@ -1356,7 +1356,7 @@ func TestGetPLSSubnetName(t *testing.T) {
 				consts.ServiceAnnotationPLSIpConfigurationSubnet:   "",
 				consts.ServiceAnnotationLoadBalancerInternalSubnet: "lb-subnet",
 			},
-			expectedSubnet: to.StringPtr("lb-subnet"),
+			expectedSubnet: pointer.String("lb-subnet"),
 		},
 		{
 			desc: "Service with LB subnet specified should return it",
@@ -1364,7 +1364,7 @@ func TestGetPLSSubnetName(t *testing.T) {
 				consts.ServiceAnnotationLoadBalancerInternal:       "true",
 				consts.ServiceAnnotationLoadBalancerInternalSubnet: "lb-subnet",
 			},
-			expectedSubnet: to.StringPtr("lb-subnet"),
+			expectedSubnet: pointer.String("lb-subnet"),
 		},
 		{
 			desc: "Service with both empty subnets specified should return nil",
@@ -1702,7 +1702,7 @@ func TestIsManagedPrivateLinkSerivce(t *testing.T) {
 			desc: "Private link service with different cluster name should return false",
 			pls: &network.PrivateLinkService{
 				Tags: map[string]*string{
-					"k8s-azure-cluster-name": to.StringPtr("test-cluster1"),
+					"k8s-azure-cluster-name": pointer.String("test-cluster1"),
 				},
 			},
 			clusterName: "test-cluster",
@@ -1711,7 +1711,7 @@ func TestIsManagedPrivateLinkSerivce(t *testing.T) {
 			desc: "Private link service with same cluster name should return true",
 			pls: &network.PrivateLinkService{
 				Tags: map[string]*string{
-					"k8s-azure-cluster-name": to.StringPtr("test-cluster"),
+					"k8s-azure-cluster-name": pointer.String("test-cluster"),
 				},
 			},
 			clusterName: "test-cluster",
@@ -1743,7 +1743,7 @@ func TestGetPrivateLinkServiceOwner(t *testing.T) {
 		{
 			desc: "Private link service with service owner tag should return service owner",
 			pls: &network.PrivateLinkService{
-				Tags: map[string]*string{"k8s-azure-owner-service": to.StringPtr("test-service")},
+				Tags: map[string]*string{"k8s-azure-owner-service": pointer.String("test-service")},
 			},
 			expected: "test-service",
 		},

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -24,13 +24,13 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -168,13 +168,13 @@ func (d *delayedRouteUpdater) updateRoutes() {
 		routeMatch := false
 		onlyUpdateTags = false
 		for i, existingRoute := range routes {
-			if strings.EqualFold(to.String(existingRoute.Name), to.String(rt.route.Name)) {
+			if strings.EqualFold(pointer.StringDeref(existingRoute.Name, ""), pointer.StringDeref(rt.route.Name, "")) {
 				// delete the name-matched routes here (missing routes would be added later if the operation is add).
 				routes = append(routes[:i], routes[i+1:]...)
 				if existingRoute.RoutePropertiesFormat != nil &&
 					rt.route.RoutePropertiesFormat != nil &&
-					strings.EqualFold(to.String(existingRoute.AddressPrefix), to.String(rt.route.AddressPrefix)) &&
-					strings.EqualFold(to.String(existingRoute.NextHopIPAddress), to.String(rt.route.NextHopIPAddress)) {
+					strings.EqualFold(pointer.StringDeref(existingRoute.AddressPrefix, ""), pointer.StringDeref(rt.route.AddressPrefix, "")) &&
+					strings.EqualFold(pointer.StringDeref(existingRoute.NextHopIPAddress, ""), pointer.StringDeref(rt.route.NextHopIPAddress, "")) {
 					routeMatch = true
 				}
 				if rt.operation == routeOperationDelete {
@@ -184,7 +184,7 @@ func (d *delayedRouteUpdater) updateRoutes() {
 			}
 		}
 		if rt.operation == routeOperationDelete && !dirty {
-			klog.Warningf("updateRoutes: route to be deleted %s does not match any of the existing route", to.String(rt.route.Name))
+			klog.Warningf("updateRoutes: route to be deleted %s does not match any of the existing route", pointer.StringDeref(rt.route.Name, ""))
 		}
 
 		// Add missing routes if the operation is add.
@@ -217,7 +217,7 @@ func (d *delayedRouteUpdater) updateRoutes() {
 // and deletes all dualstack routes when dualstack is not enabled.
 func (d *delayedRouteUpdater) cleanupOutdatedRoutes(existingRoutes []network.Route) (routes []network.Route, changed bool) {
 	for i := len(existingRoutes) - 1; i >= 0; i-- {
-		existingRouteName := to.String(existingRoutes[i].Name)
+		existingRouteName := pointer.StringDeref(existingRoutes[i].Name, "")
 		split := strings.Split(existingRouteName, consts.RouteNameSeparator)
 
 		klog.V(4).Infof("cleanupOutdatedRoutes: checking route %s", existingRouteName)
@@ -300,7 +300,7 @@ func (az *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpr
 	// ensure the route table is tagged as configured
 	tags, changed := az.ensureRouteTableTagged(&routeTable)
 	if changed {
-		klog.V(2).Infof("ListRoutes: updating tags on route table %s", to.String(routeTable.Name))
+		klog.V(2).Infof("ListRoutes: updating tags on route table %s", pointer.StringDeref(routeTable.Name, ""))
 		op, err := az.routeUpdater.addUpdateRouteTableTagsOperation(routeTableOperationUpdateTags, tags)
 		if err != nil {
 			klog.Errorf("ListRoutes: failed to add route table operation with error: %v", err)
@@ -349,8 +349,8 @@ func processRoutes(ipv6DualStackEnabled bool, routeTable network.RouteTable, exi
 
 func (az *Cloud) createRouteTable() error {
 	routeTable := network.RouteTable{
-		Name:                       to.StringPtr(az.RouteTableName),
-		Location:                   to.StringPtr(az.Location),
+		Name:                       pointer.String(az.RouteTableName),
+		Location:                   pointer.String(az.Location),
 		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{},
 	}
 
@@ -417,11 +417,11 @@ func (az *Cloud) CreateRoute(ctx context.Context, clusterName string, nameHint s
 	}
 	routeName := mapNodeNameToRouteName(az.ipv6DualStackEnabled, kubeRoute.TargetNode, kubeRoute.DestinationCIDR)
 	route := network.Route{
-		Name: to.StringPtr(routeName),
+		Name: pointer.String(routeName),
 		RoutePropertiesFormat: &network.RoutePropertiesFormat{
-			AddressPrefix:    to.StringPtr(kubeRoute.DestinationCIDR),
+			AddressPrefix:    pointer.String(kubeRoute.DestinationCIDR),
 			NextHopType:      network.RouteNextHopTypeVirtualAppliance,
-			NextHopIPAddress: to.StringPtr(targetIP),
+			NextHopIPAddress: pointer.String(targetIP),
 		},
 	}
 
@@ -471,7 +471,7 @@ func (az *Cloud) DeleteRoute(ctx context.Context, clusterName string, kubeRoute 
 	routeName := mapNodeNameToRouteName(az.ipv6DualStackEnabled, kubeRoute.TargetNode, kubeRoute.DestinationCIDR)
 	klog.V(2).Infof("DeleteRoute: deleting route. clusterName=%q instance=%q cidr=%q routeName=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR, routeName)
 	route := network.Route{
-		Name:                  to.StringPtr(routeName),
+		Name:                  pointer.String(routeName),
 		RoutePropertiesFormat: &network.RoutePropertiesFormat{},
 	}
 	op, err := az.routeUpdater.addRouteOperation(routeOperationDelete, route)
@@ -492,7 +492,7 @@ func (az *Cloud) DeleteRoute(ctx context.Context, clusterName string, kubeRoute 
 		routeNameWithoutIPV6Suffix := strings.Split(routeName, consts.RouteNameSeparator)[0]
 		klog.V(2).Infof("DeleteRoute: deleting route. clusterName=%q instance=%q cidr=%q routeName=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR, routeNameWithoutIPV6Suffix)
 		route := network.Route{
-			Name:                  to.StringPtr(routeNameWithoutIPV6Suffix),
+			Name:                  pointer.String(routeNameWithoutIPV6Suffix),
 			RoutePropertiesFormat: &network.RoutePropertiesFormat{},
 		}
 		op, err := az.routeUpdater.addRouteOperation(routeOperationDelete, route)

--- a/pkg/provider/azure_routes_test.go
+++ b/pkg/provider/azure_routes_test.go
@@ -25,13 +25,13 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/routetableclient/mockroutetableclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -206,9 +206,9 @@ func TestCreateRoute(t *testing.T) {
 	nodePrivateIP := "2.4.6.8"
 	networkRoute := &[]network.Route{
 		{
-			Name: to.StringPtr("node"),
+			Name: pointer.String("node"),
 			RoutePropertiesFormat: &network.RoutePropertiesFormat{
-				AddressPrefix:    to.StringPtr("1.2.3.4/24"),
+				AddressPrefix:    pointer.String("1.2.3.4/24"),
 				NextHopIPAddress: &nodePrivateIP,
 				NextHopType:      network.RouteNextHopTypeVirtualAppliance,
 			},
@@ -314,9 +314,9 @@ func TestCreateRoute(t *testing.T) {
 			routeTableName: "rt9",
 			updatedRoute: &[]network.Route{
 				{
-					Name: to.StringPtr("node____123424"),
+					Name: pointer.String("node____123424"),
 					RoutePropertiesFormat: &network.RoutePropertiesFormat{
-						AddressPrefix:    to.StringPtr("1.2.3.4/24"),
+						AddressPrefix:    pointer.String("1.2.3.4/24"),
 						NextHopIPAddress: &nodePrivateIP,
 						NextHopType:      network.RouteNextHopTypeVirtualAppliance,
 					},
@@ -333,14 +333,14 @@ func TestCreateRoute(t *testing.T) {
 
 	for _, test := range testCases {
 		initialTable := network.RouteTable{
-			Name:     to.StringPtr(test.routeTableName),
+			Name:     pointer.String(test.routeTableName),
 			Location: &cloud.Location,
 			RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 				Routes: test.initialRoute,
 			},
 		}
 		updatedTable := network.RouteTable{
-			Name:     to.StringPtr(test.routeTableName),
+			Name:     pointer.String(test.routeTableName),
 			Location: &cloud.Location,
 			RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 				Routes: test.updatedRoute,
@@ -443,9 +443,9 @@ func TestProcessRoutes(t *testing.T) {
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("name"),
+							Name: pointer.String("name"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/16"),
+								AddressPrefix: pointer.String("1.2.3.4/16"),
 							},
 						},
 					},
@@ -466,15 +466,15 @@ func TestProcessRoutes(t *testing.T) {
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("name"),
+							Name: pointer.String("name"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/16"),
+								AddressPrefix: pointer.String("1.2.3.4/16"),
 							},
 						},
 						{
-							Name: to.StringPtr("name2"),
+							Name: pointer.String("name2"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("5.6.7.8/16"),
+								AddressPrefix: pointer.String("5.6.7.8/16"),
 							},
 						},
 					},
@@ -625,14 +625,14 @@ func TestListRoutes(t *testing.T) {
 			name:           "ListRoutes should return correct routes",
 			routeTableName: "rt1",
 			routeTable: network.RouteTable{
-				Name:     to.StringPtr("rt1"),
+				Name:     pointer.String("rt1"),
 				Location: &cloud.Location,
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("node"),
+							Name: pointer.String("node"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/24"),
+								AddressPrefix: pointer.String("1.2.3.4/24"),
 							},
 						},
 					},
@@ -653,14 +653,14 @@ func TestListRoutes(t *testing.T) {
 			unmanagedNodeName: "unmanaged-node",
 			routeCIDRs:        map[string]string{"unmanaged-node": "2.2.3.4/24"},
 			routeTable: network.RouteTable{
-				Name:     to.StringPtr("rt2"),
+				Name:     pointer.String("rt2"),
 				Location: &cloud.Location,
 				RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
 					Routes: &[]network.Route{
 						{
-							Name: to.StringPtr("node"),
+							Name: pointer.String("node"),
 							RoutePropertiesFormat: &network.RoutePropertiesFormat{
-								AddressPrefix: to.StringPtr("1.2.3.4/24"),
+								AddressPrefix: pointer.String("1.2.3.4/24"),
 							},
 						},
 					},
@@ -747,11 +747,11 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should delete outdated non-dualstack routes when dualstack is enabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
 			},
 			existingNodeNames:   sets.NewString("aks-node1-vmss000000"),
 			enableIPV6DualStack: true,
@@ -760,11 +760,11 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should delete outdated dualstack routes when dualstack is disabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			existingNodeNames: sets.NewString("aks-node1-vmss000000"),
 			expectedChanged:   true,
@@ -772,12 +772,12 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should not delete unmanaged routes when dualstack is enabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			existingNodeNames:   sets.NewString("aks-node1-vmss000001"),
 			enableIPV6DualStack: true,
@@ -785,12 +785,12 @@ func TestCleanupOutdatedRoutes(t *testing.T) {
 		{
 			description: "cleanupOutdatedRoutes should not delete unmanaged routes when dualstack is disabled",
 			existingRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			expectedRoutes: []network.Route{
-				{Name: to.StringPtr("aks-node1-vmss000000____xxx")},
-				{Name: to.StringPtr("aks-node1-vmss000000")},
+				{Name: pointer.String("aks-node1-vmss000000____xxx")},
+				{Name: pointer.String("aks-node1-vmss000000")},
 			},
 			existingNodeNames: sets.NewString("aks-node1-vmss000001"),
 		},

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,6 +40,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -210,7 +210,7 @@ func getPrimaryInterfaceID(machine compute.VirtualMachine) (string, error) {
 	}
 
 	for _, ref := range *machine.NetworkProfile.NetworkInterfaces {
-		if to.Bool(ref.Primary) {
+		if pointer.BoolDeref(ref.Primary, false) {
 			return *ref.ID, nil
 		}
 	}
@@ -253,7 +253,7 @@ func getIPConfigByIPFamily(nic network.Interface, IPv6 bool) (*network.Interface
 			return &ref, nil
 		}
 	}
-	return nil, fmt.Errorf("failed to determine the ipconfig(IPv6=%v). nicname=%q", IPv6, to.String(nic.Name))
+	return nil, fmt.Errorf("failed to determine the ipconfig(IPv6=%v). nicname=%q", IPv6, pointer.StringDeref(nic.Name, ""))
 }
 
 func isInternalLoadBalancer(lb *network.LoadBalancer) bool {
@@ -346,7 +346,7 @@ func (az *Cloud) serviceOwnsRule(service *v1.Service, rule string) bool {
 func (az *Cloud) serviceOwnsFrontendIP(fip network.FrontendIPConfiguration, service *v1.Service, pips *[]network.PublicIPAddress) (bool, bool, error) {
 	var isPrimaryService bool
 	baseName := az.GetLoadBalancerName(context.TODO(), "", service)
-	if strings.HasPrefix(to.String(fip.Name), baseName) {
+	if strings.HasPrefix(pointer.StringDeref(fip.Name, ""), baseName) {
 		klog.V(6).Infof("serviceOwnsFrontendIP: found primary service %s of the frontend IP config %s", service.Name, *fip.Name)
 		isPrimaryService = true
 		return true, isPrimaryService, nil
@@ -373,7 +373,7 @@ func (az *Cloud) serviceOwnsFrontendIP(fip network.FrontendIPConfiguration, serv
 			pip.IPAddress != nil &&
 			fip.FrontendIPConfigurationPropertiesFormat != nil &&
 			fip.FrontendIPConfigurationPropertiesFormat.PublicIPAddress != nil {
-			if strings.EqualFold(to.String(pip.ID), to.String(fip.PublicIPAddress.ID)) {
+			if strings.EqualFold(pointer.StringDeref(pip.ID, ""), pointer.StringDeref(fip.PublicIPAddress.ID, "")) {
 				klog.V(4).Infof("serviceOwnsFrontendIP: found secondary service %s of the frontend IP config %s", service.Name, *fip.Name)
 
 				return true, isPrimaryService, nil
@@ -472,11 +472,11 @@ func (as *availabilitySet) newVMASCache() (*azcache.TimedCache, error) {
 
 			for i := range allAvailabilitySets {
 				vmas := allAvailabilitySets[i]
-				if strings.EqualFold(to.String(vmas.Name), "") {
+				if strings.EqualFold(pointer.StringDeref(vmas.Name, ""), "") {
 					klog.Warning("failed to get the name of the VMAS")
 					continue
 				}
-				localCache.Store(to.String(vmas.Name), &AvailabilitySetEntry{
+				localCache.Store(pointer.StringDeref(vmas.Name, ""), &AvailabilitySetEntry{
 					VMAS:          &vmas,
 					ResourceGroup: resourceGroup,
 				})
@@ -552,7 +552,7 @@ func (as *availabilitySet) GetPowerStatusByNodeName(name string) (powerState str
 	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
 		statuses := *vm.InstanceView.Statuses
 		for _, status := range statuses {
-			state := to.String(status.Code)
+			state := pointer.StringDeref(status.Code, "")
 			if strings.HasPrefix(state, vmPowerStatePrefix) {
 				return strings.TrimPrefix(state, vmPowerStatePrefix), nil
 			}
@@ -575,7 +575,7 @@ func (as *availabilitySet) GetProvisioningStateByNodeName(name string) (provisio
 		return provisioningState, nil
 	}
 
-	return to.String(vm.VirtualMachineProperties.ProvisioningState), nil
+	return pointer.StringDeref(vm.VirtualMachineProperties.ProvisioningState, ""), nil
 }
 
 // GetNodeNameByProviderID gets the node name by provider ID.
@@ -621,15 +621,15 @@ func (as *availabilitySet) GetZoneByNodeName(name string) (cloudprovider.Zone, e
 			return cloudprovider.Zone{}, fmt.Errorf("failed to parse zone %q: %w", zones, err)
 		}
 
-		failureDomain = as.makeZone(to.String(vm.Location), zoneID)
+		failureDomain = as.makeZone(pointer.StringDeref(vm.Location, ""), zoneID)
 	} else {
 		// Availability zone is not used for the node, falling back to fault domain.
-		failureDomain = strconv.Itoa(int(to.Int32(vm.VirtualMachineProperties.InstanceView.PlatformFaultDomain)))
+		failureDomain = strconv.Itoa(int(pointer.Int32Deref(vm.VirtualMachineProperties.InstanceView.PlatformFaultDomain, 0)))
 	}
 
 	zone := cloudprovider.Zone{
 		FailureDomain: strings.ToLower(failureDomain),
-		Region:        strings.ToLower(to.String(vm.Location)),
+		Region:        strings.ToLower(pointer.StringDeref(vm.Location, "")),
 	}
 	return zone, nil
 }
@@ -804,13 +804,13 @@ func (as *availabilitySet) GetNodeVMSetName(node *v1.Node) (string, error) {
 
 	var asName string
 	for _, vm := range vms {
-		if strings.EqualFold(to.String(vm.Name), hostName) {
-			if vm.AvailabilitySet != nil && to.String(vm.AvailabilitySet.ID) != "" {
+		if strings.EqualFold(pointer.StringDeref(vm.Name, ""), hostName) {
+			if vm.AvailabilitySet != nil && pointer.StringDeref(vm.AvailabilitySet.ID, "") != "" {
 				klog.V(4).Infof("as.GetNodeVMSetName: found vm %s", hostName)
 
-				asName, err = getLastSegment(to.String(vm.AvailabilitySet.ID), "/")
+				asName, err = getLastSegment(pointer.StringDeref(vm.AvailabilitySet.ID, ""), "/")
 				if err != nil {
-					klog.Errorf("as.GetNodeVMSetName: failed to get last segment of ID %s: %s", to.String(vm.AvailabilitySet.ID), err)
+					klog.Errorf("as.GetNodeVMSetName: failed to get last segment of ID %s: %s", pointer.StringDeref(vm.AvailabilitySet.ID, ""), err)
 					return "", err
 				}
 			}
@@ -901,7 +901,7 @@ func (as *availabilitySet) getPrimaryInterfaceWithVMSet(nodeName, vmSetName stri
 
 	var availabilitySetID string
 	if machine.VirtualMachineProperties != nil && machine.AvailabilitySet != nil {
-		availabilitySetID = to.String(machine.AvailabilitySet.ID)
+		availabilitySetID = pointer.StringDeref(machine.AvailabilitySet.ID, "")
 	}
 	return nic, availabilitySetID, nil
 }
@@ -976,7 +976,7 @@ func (as *availabilitySet) EnsureHostInPool(service *v1.Service, nodeName types.
 
 		newBackendPools = append(newBackendPools,
 			network.BackendAddressPool{
-				ID: to.StringPtr(backendPoolID),
+				ID: pointer.String(backendPoolID),
 			})
 
 		primaryIPConfig.LoadBalancerBackendAddressPools = &newBackendPools
@@ -1052,7 +1052,7 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 
 	ipConfigurationIDs := []string{}
 	for _, backendPool := range *backendAddressPools {
-		if strings.EqualFold(to.String(backendPool.ID), backendPoolID) &&
+		if strings.EqualFold(pointer.StringDeref(backendPool.ID, ""), backendPoolID) &&
 			backendPool.BackendAddressPoolPropertiesFormat != nil &&
 			backendPool.BackendIPConfigurations != nil {
 			for _, ipConf := range *backendPool.BackendIPConfigurations {
@@ -1108,7 +1108,7 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 		if nic.InterfacePropertiesFormat != nil && nic.InterfacePropertiesFormat.IPConfigurations != nil {
 			newIPConfigs := *nic.IPConfigurations
 			for j, ipConf := range newIPConfigs {
-				if !to.Bool(ipConf.Primary) {
+				if !pointer.BoolDeref(ipConf.Primary, false) {
 					continue
 				}
 				// found primary ip configuration
@@ -1116,7 +1116,7 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 					newLBAddressPools := *ipConf.LoadBalancerBackendAddressPools
 					for k := len(newLBAddressPools) - 1; k >= 0; k-- {
 						pool := newLBAddressPools[k]
-						if strings.EqualFold(to.String(pool.ID), backendPoolID) {
+						if strings.EqualFold(pointer.StringDeref(pool.ID, ""), backendPoolID) {
 							newLBAddressPools = append(newLBAddressPools[:k], newLBAddressPools[k+1:]...)
 							break
 						}
@@ -1128,10 +1128,10 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 			nicUpdaters = append(nicUpdaters, func() error {
 				ctx, cancel := getContextWithCancel()
 				defer cancel()
-				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", as.resourceGroup, to.String(nic.Name), backendPoolID)
-				rerr := as.InterfacesClient.CreateOrUpdate(ctx, as.ResourceGroup, to.String(nic.Name), nic)
+				klog.V(2).Infof("EnsureBackendPoolDeleted begins to CreateOrUpdate for NIC(%s, %s) with backendPoolID %s", as.resourceGroup, pointer.StringDeref(nic.Name, ""), backendPoolID)
+				rerr := as.InterfacesClient.CreateOrUpdate(ctx, as.ResourceGroup, pointer.StringDeref(nic.Name, ""), nic)
 				if rerr != nil {
-					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", as.resourceGroup, to.String(nic.Name), rerr.Error())
+					klog.Errorf("EnsureBackendPoolDeleted CreateOrUpdate for NIC(%s, %s) failed with error %v", as.resourceGroup, pointer.StringDeref(nic.Name, ""), rerr.Error())
 					return rerr.Error()
 				}
 				nicUpdated = true
@@ -1194,7 +1194,7 @@ func (as *availabilitySet) GetNodeNameByIPConfigurationID(ipConfigurationID stri
 	}
 	vmID := ""
 	if nic.InterfacePropertiesFormat != nil && nic.VirtualMachine != nil {
-		vmID = to.String(nic.VirtualMachine.ID)
+		vmID = pointer.StringDeref(nic.VirtualMachine.ID, "")
 	}
 	if vmID == "" {
 		klog.V(2).Infof("GetNodeNameByIPConfigurationID(%s): empty vmID", ipConfigurationID)
@@ -1214,7 +1214,7 @@ func (as *availabilitySet) GetNodeNameByIPConfigurationID(ipConfigurationID stri
 	}
 	asID := ""
 	if vm.VirtualMachineProperties != nil && vm.AvailabilitySet != nil {
-		asID = to.String(vm.AvailabilitySet.ID)
+		asID = pointer.StringDeref(vm.AvailabilitySet.ID, "")
 	}
 	if asID == "" {
 		return vmName, "", nil
@@ -1246,9 +1246,9 @@ func (as *availabilitySet) getAvailabilitySetByNodeName(nodeName string, crt azc
 		if vmas != nil && vmas.AvailabilitySetProperties != nil && vmas.VirtualMachines != nil {
 			for _, vmIDRef := range *vmas.VirtualMachines {
 				if vmIDRef.ID != nil {
-					matches := vmIDRE.FindStringSubmatch(to.String(vmIDRef.ID))
+					matches := vmIDRE.FindStringSubmatch(pointer.StringDeref(vmIDRef.ID, ""))
 					if len(matches) != 2 {
-						err = fmt.Errorf("invalid vm ID %s", to.String(vmIDRef.ID))
+						err = fmt.Errorf("invalid vm ID %s", pointer.StringDeref(vmIDRef.ID, ""))
 						return false
 					}
 
@@ -1293,15 +1293,15 @@ func (as *availabilitySet) GetNodeCIDRMasksByProviderID(providerID string) (int,
 
 	var ipv4Mask, ipv6Mask int
 	if v4, ok := vmas.Tags[consts.VMSetCIDRIPV4TagKey]; ok && v4 != nil {
-		ipv4Mask, err = strconv.Atoi(to.String(v4))
+		ipv4Mask, err = strconv.Atoi(pointer.StringDeref(v4, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", to.String(v4), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", pointer.StringDeref(v4, ""), err)
 		}
 	}
 	if v6, ok := vmas.Tags[consts.VMSetCIDRIPV6TagKey]; ok && v6 != nil {
-		ipv6Mask, err = strconv.Atoi(to.String(v6))
+		ipv6Mask, err = strconv.Atoi(pointer.StringDeref(v6, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", to.String(v6), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", pointer.StringDeref(v6, ""), err)
 		}
 	}
 

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmasclient/mockvmasclient"
@@ -664,21 +664,21 @@ func TestGetStandardVMPrimaryInterfaceID(t *testing.T) {
 		{
 			name: "GetPrimaryInterfaceID should get primary NIC ID",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm2"),
+				Name: pointer.String("vm2"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(true),
+									Primary: pointer.Bool(true),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
 							},
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(false),
+									Primary: pointer.Bool(false),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
 							},
 						},
 					},
@@ -689,21 +689,21 @@ func TestGetStandardVMPrimaryInterfaceID(t *testing.T) {
 		{
 			name: "GetPrimaryInterfaceID should report error if node don't have primary NIC",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm3"),
+				Name: pointer.String("vm3"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(false),
+									Primary: pointer.Bool(false),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"),
 							},
 							{
 								NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-									Primary: to.BoolPtr(false),
+									Primary: pointer.Bool(false),
 								},
-								ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
+								ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic2"),
 							},
 						},
 					},
@@ -731,51 +731,51 @@ func TestGetPrimaryIPConfig(t *testing.T) {
 		{
 			name: "GetPrimaryIPConfig should get the only IP configuration",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 						},
 					},
 				},
 			},
 			expectedIPConfig: &network.InterfaceIPConfiguration{
-				Name: to.StringPtr("ipconfig1"),
+				Name: pointer.String("ipconfig1"),
 			},
 		},
 		{
 			name: "GetPrimaryIPConfig should get the primary IP configuration",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(true),
+								Primary: pointer.Bool(true),
 							},
 						},
 						{
-							Name: to.StringPtr("ipconfig2"),
+							Name: pointer.String("ipconfig2"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(false),
+								Primary: pointer.Bool(false),
 							},
 						},
 					},
 				},
 			},
 			expectedIPConfig: &network.InterfaceIPConfiguration{
-				Name: to.StringPtr("ipconfig1"),
+				Name: pointer.String("ipconfig1"),
 				InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-					Primary: to.BoolPtr(true),
+					Primary: pointer.Bool(true),
 				},
 			},
 		},
 		{
 			name: "GetPrimaryIPConfig should report error if nic don't have IP configuration",
 			nic: network.Interface{
-				Name:                      to.StringPtr("nic"),
+				Name:                      pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{},
 			},
 			expectedErrMsg: fmt.Errorf("nic.IPConfigurations for nic (nicname=%q) is nil", "nic"),
@@ -783,19 +783,19 @@ func TestGetPrimaryIPConfig(t *testing.T) {
 		{
 			name: "GetPrimaryIPConfig should report error if node has more than one IP configuration and don't have primary IP configuration",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(false),
+								Primary: pointer.Bool(false),
 							},
 						},
 						{
-							Name: to.StringPtr("ipconfig2"),
+							Name: pointer.String("ipconfig2"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-								Primary: to.BoolPtr(false),
+								Primary: pointer.Bool(false),
 							},
 						},
 					},
@@ -814,21 +814,21 @@ func TestGetPrimaryIPConfig(t *testing.T) {
 
 func TestGetIPConfigByIPFamily(t *testing.T) {
 	ipv4IPconfig := network.InterfaceIPConfiguration{
-		Name: to.StringPtr("ipconfig1"),
+		Name: pointer.String("ipconfig1"),
 		InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 			PrivateIPAddressVersion: network.IPv4,
-			PrivateIPAddress:        to.StringPtr("10.10.0.12"),
+			PrivateIPAddress:        pointer.String("10.10.0.12"),
 		},
 	}
 	ipv6IPconfig := network.InterfaceIPConfiguration{
-		Name: to.StringPtr("ipconfig2"),
+		Name: pointer.String("ipconfig2"),
 		InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 			PrivateIPAddressVersion: network.IPv6,
-			PrivateIPAddress:        to.StringPtr("1111:11111:00:00:1111:1111:000:111"),
+			PrivateIPAddress:        pointer.String("1111:11111:00:00:1111:1111:000:111"),
 		},
 	}
 	testNic := network.Interface{
-		Name: to.StringPtr("nic"),
+		Name: pointer.String("nic"),
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 			IPConfigurations: &[]network.InterfaceIPConfiguration{ipv4IPconfig, ipv6IPconfig},
 		},
@@ -854,7 +854,7 @@ func TestGetIPConfigByIPFamily(t *testing.T) {
 		{
 			name: "GetIPConfigByIPFamily should report error if nic don't have IP configuration",
 			nic: network.Interface{
-				Name:                      to.StringPtr("nic"),
+				Name:                      pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{},
 			},
 			expectedErrMsg: fmt.Errorf("nic.IPConfigurations for nic (nicname=%q) is nil", "nic"),
@@ -862,7 +862,7 @@ func TestGetIPConfigByIPFamily(t *testing.T) {
 		{
 			name: "GetIPConfigByIPFamily should report error if nic don't have IPv6 configuration when IPv6 is true",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{ipv4IPconfig},
 				},
@@ -873,11 +873,11 @@ func TestGetIPConfigByIPFamily(t *testing.T) {
 		{
 			name: "GetIPConfigByIPFamily should report error if nic don't have PrivateIPAddress",
 			nic: network.Interface{
-				Name: to.StringPtr("nic"),
+				Name: pointer.String("nic"),
 				InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 					IPConfigurations: &[]network.InterfaceIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 								PrivateIPAddressVersion: network.IPv4,
 							},
@@ -928,8 +928,8 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 	cloud := GetTestCloud(ctrl)
 
 	expectedVM := compute.VirtualMachine{
-		Name: to.StringPtr("vm1"),
-		ID:   to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"),
+		Name: pointer.String("vm1"),
+		ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"),
 	}
 	invalidResouceID := "/subscriptions/subscription/resourceGroups/rg/Microsoft.Compute/virtualMachines/vm4"
 	testcases := []struct {
@@ -968,8 +968,8 @@ func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 			RawError:       fmt.Errorf("VMGet error"),
 		}).AnyTimes()
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, "vm4", gomock.Any()).Return(compute.VirtualMachine{
-			Name: to.StringPtr("vm4"),
-			ID:   to.StringPtr(invalidResouceID),
+			Name: pointer.String("vm4"),
+			ID:   pointer.String(invalidResouceID),
 		}, nil).AnyTimes()
 
 		instanceID, err := cloud.VMSet.GetInstanceIDByNodeName(test.nodeName)
@@ -1007,13 +1007,13 @@ func TestGetStandardVMPowerStatusByNodeName(t *testing.T) {
 			name:     "GetPowerStatusByNodeName should get power status as expected",
 			nodeName: "vm2",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm2"),
+				Name: pointer.String("vm2"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 					InstanceView: &compute.VirtualMachineInstanceView{
 						Statuses: &[]compute.InstanceViewStatus{
 							{
-								Code: to.StringPtr("PowerState/Running"),
+								Code: pointer.String("PowerState/Running"),
 							},
 						},
 					},
@@ -1025,9 +1025,9 @@ func TestGetStandardVMPowerStatusByNodeName(t *testing.T) {
 			name:     "GetPowerStatusByNodeName should get vmPowerStateStopped if vm.InstanceView is nil",
 			nodeName: "vm3",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm3"),
+				Name: pointer.String("vm3"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 				},
 			},
 			expectedStatus: vmPowerStateStopped,
@@ -1036,9 +1036,9 @@ func TestGetStandardVMPowerStatusByNodeName(t *testing.T) {
 			name:     "GetPowerStatusByNodeName should get vmPowerStateStopped if vm.InstanceView.statuses is nil",
 			nodeName: "vm4",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm4"),
+				Name: pointer.String("vm4"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 					InstanceView:      &compute.VirtualMachineInstanceView{},
 				},
 			},
@@ -1082,13 +1082,13 @@ func TestGetStandardVMProvisioningStateByNodeName(t *testing.T) {
 			name:     "GetProvisioningStateByNodeName should return Succeeded for running VM",
 			nodeName: "vm2",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm2"),
+				Name: pointer.String("vm2"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
-					ProvisioningState: to.StringPtr("Succeeded"),
+					ProvisioningState: pointer.String("Succeeded"),
 					InstanceView: &compute.VirtualMachineInstanceView{
 						Statuses: &[]compute.InstanceViewStatus{
 							{
-								Code: to.StringPtr("PowerState/Running"),
+								Code: pointer.String("PowerState/Running"),
 							},
 						},
 					},
@@ -1100,7 +1100,7 @@ func TestGetStandardVMProvisioningStateByNodeName(t *testing.T) {
 			name:     "GetProvisioningStateByNodeName should return empty string when vm.ProvisioningState is nil",
 			nodeName: "vm3",
 			vm: compute.VirtualMachine{
-				Name: to.StringPtr("vm3"),
+				Name: pointer.String("vm3"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					ProvisioningState: nil,
 				},
@@ -1146,8 +1146,8 @@ func TestGetStandardVMZoneByNodeName(t *testing.T) {
 			name:     "GetZoneByNodeName should get zone as expected",
 			nodeName: "vm2",
 			vm: compute.VirtualMachine{
-				Name:     to.StringPtr("vm2"),
-				Location: to.StringPtr("EASTUS"),
+				Name:     pointer.String("vm2"),
+				Location: pointer.String("EASTUS"),
 				Zones:    &[]string{"2"},
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
@@ -1164,8 +1164,8 @@ func TestGetStandardVMZoneByNodeName(t *testing.T) {
 			name:     "GetZoneByNodeName should get FailureDomain as zone if zone is not used for node",
 			nodeName: "vm3",
 			vm: compute.VirtualMachine{
-				Name:     to.StringPtr("vm3"),
-				Location: to.StringPtr("EASTUS"),
+				Name:     pointer.String("vm3"),
+				Location: pointer.String("EASTUS"),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
 						PlatformFaultDomain: &faultDomain,
@@ -1181,8 +1181,8 @@ func TestGetStandardVMZoneByNodeName(t *testing.T) {
 			name:     "GetZoneByNodeName should report error if zones is invalid",
 			nodeName: "vm4",
 			vm: compute.VirtualMachine{
-				Name:     to.StringPtr("vm4"),
-				Location: to.StringPtr("EASTUS"),
+				Name:     pointer.String("vm4"),
+				Location: pointer.String("EASTUS"),
 				Zones:    &[]string{"a"},
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
@@ -1210,13 +1210,13 @@ func TestGetStandardVMSetNames(t *testing.T) {
 	defer ctrl.Finish()
 
 	testVM := compute.VirtualMachine{
-		Name: to.StringPtr("vm1"),
+		Name: pointer.String("vm1"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			AvailabilitySet: &compute.SubResource{ID: to.StringPtr(asID)},
+			AvailabilitySet: &compute.SubResource{ID: pointer.String(asID)},
 		},
 	}
 	testVMWithoutAS := compute.VirtualMachine{
-		Name:                     to.StringPtr("vm2"),
+		Name:                     pointer.String("vm2"),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{},
 	}
 	testCases := []struct {
@@ -1463,10 +1463,10 @@ func TestStandardEnsureHostInPool(t *testing.T) {
 		}
 
 		testVM := buildDefaultTestVirtualMachine(availabilitySetID, []string{test.nicID})
-		testVM.Name = to.StringPtr(string(test.nodeName))
+		testVM.Name = pointer.String(string(test.nodeName))
 		testNIC := buildDefaultTestInterface(false, []string{backendAddressPoolID})
-		testNIC.Name = to.StringPtr(test.nicName)
-		testNIC.ID = to.StringPtr(test.nicID)
+		testNIC.Name = pointer.String(test.nicName)
+		testNIC.ID = pointer.String(test.nicID)
 		testNIC.ProvisioningState = test.nicProvisionState
 
 		mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -1601,13 +1601,13 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 
 	for _, test := range testCases {
 		cloud.Config.LoadBalancerSku = consts.LoadBalancerSkuStandard
-		cloud.Config.ExcludeMasterFromStandardLB = to.BoolPtr(true)
+		cloud.Config.ExcludeMasterFromStandardLB = pointer.Bool(true)
 		cloud.excludeLoadBalancerNodes = sets.NewString(test.excludeLBNodes...)
 
 		testVM := buildDefaultTestVirtualMachine(availabilitySetID, []string{test.nicID})
 		testNIC := buildDefaultTestInterface(false, []string{backendAddressPoolID})
-		testNIC.Name = to.StringPtr(test.nicName)
-		testNIC.ID = to.StringPtr(test.nicID)
+		testNIC.Name = pointer.String(test.nicName)
+		testNIC.ID = pointer.String(test.nicID)
 
 		mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 		mockVMClient.EXPECT().Get(gomock.Any(), cloud.ResourceGroup, test.nodeName, gomock.Any()).Return(testVM, nil).AnyTimes()
@@ -1642,7 +1642,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 		{
 			desc: "serviceOwnsFrontendIP should detect the primary service",
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 			},
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
@@ -1655,7 +1655,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 		{
 			desc: "serviceOwnsFrontendIP should return false if the secondary external service doesn't set it's loadBalancer IP",
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 			},
 			service: &v1.Service{
 				ObjectMeta: meta.ObjectMeta{
@@ -1668,17 +1668,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 				"found according to the external service's loadBalancer IP but do not return the error",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("pip"),
+						ID: pointer.String("pip"),
 					},
 				},
 			},
@@ -1694,17 +1694,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 				"the counterpart on the frontend IP config",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("pip1"),
+						ID: pointer.String("pip1"),
 					},
 				},
 			},
@@ -1719,17 +1719,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			desc: "serviceOwnsFrontendIP should return false if there is no public IP address in the frontend IP config",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPPrefix: &network.SubResource{
-						ID: to.StringPtr("pip1"),
+						ID: pointer.String("pip1"),
 					},
 				},
 			},
@@ -1744,17 +1744,17 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			desc: "serviceOwnsFrontendIP should detect the secondary external service",
 			existingPIPs: []network.PublicIPAddress{
 				{
-					ID: to.StringPtr("pip"),
+					ID: pointer.String("pip"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: to.StringPtr("4.3.2.1"),
+						IPAddress: pointer.String("4.3.2.1"),
 					},
 				},
 			},
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{
-						ID: to.StringPtr("pip"),
+						ID: pointer.String("pip"),
 					},
 				},
 			},
@@ -1769,9 +1769,9 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 		{
 			desc: "serviceOwnsFrontendIP should detect the secondary internal service",
 			fip: network.FrontendIPConfiguration{
-				Name: to.StringPtr("auid"),
+				Name: pointer.String("auid"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PrivateIPAddress: to.StringPtr("4.3.2.1"),
+					PrivateIPAddress: pointer.String("4.3.2.1"),
 				},
 			},
 			service: &v1.Service{
@@ -1814,11 +1814,11 @@ func TestStandardEnsureBackendPoolDeleted(t *testing.T) {
 			desc: "EnsureBackendPoolDeleted should decouple the nic and the load balancer properly",
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(backendPoolID),
+					ID: pointer.String(backendPoolID),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
+								ID: pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1/ipConfigurations/ipconfig1"),
 							},
 						},
 					},
@@ -1838,7 +1838,7 @@ func TestStandardEnsureBackendPoolDeleted(t *testing.T) {
 		cloud.VirtualMachinesClient = mockVMClient
 		mockNICClient := mockinterfaceclient.NewMockInterface(ctrl)
 		test.existingNIC.VirtualMachine = &network.SubResource{
-			ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-1"),
+			ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-1"),
 		}
 		mockNICClient.EXPECT().Get(gomock.Any(), "rg", "k8s-agentpool1-00000000-nic-1", gomock.Any()).Return(test.existingNIC, nil).Times(2)
 		mockNICClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -1857,7 +1857,7 @@ func buildDefaultTestInterface(isPrimary bool, lbBackendpoolIDs []string) networ
 			IPConfigurations: &[]network.InterfaceIPConfiguration{
 				{
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-						Primary: to.BoolPtr(isPrimary),
+						Primary: pointer.Bool(isPrimary),
 					},
 				},
 			},
@@ -1866,7 +1866,7 @@ func buildDefaultTestInterface(isPrimary bool, lbBackendpoolIDs []string) networ
 	backendAddressPool := make([]network.BackendAddressPool, 0)
 	for _, id := range lbBackendpoolIDs {
 		backendAddressPool = append(backendAddressPool, network.BackendAddressPool{
-			ID: to.StringPtr(id),
+			ID: pointer.String(id),
 		})
 	}
 	(*expectedNIC.IPConfigurations)[0].LoadBalancerBackendAddressPools = &backendAddressPool
@@ -1877,7 +1877,7 @@ func buildDefaultTestVirtualMachine(asID string, nicIDs []string) compute.Virtua
 	expectedVM := compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			AvailabilitySet: &compute.SubResource{
-				ID: to.StringPtr(asID),
+				ID: pointer.String(asID),
 			},
 			NetworkProfile: &compute.NetworkProfile{},
 		},
@@ -1885,7 +1885,7 @@ func buildDefaultTestVirtualMachine(asID string, nicIDs []string) compute.Virtua
 	networkInterfaces := make([]compute.NetworkInterfaceReference, 0)
 	for _, nicID := range nicIDs {
 		networkInterfaces = append(networkInterfaces, compute.NetworkInterfaceReference{
-			ID: to.StringPtr(nicID),
+			ID: pointer.String(nicID),
 		})
 	}
 	expectedVM.VirtualMachineProperties.NetworkProfile.NetworkInterfaces = &networkInterfaces
@@ -1897,12 +1897,12 @@ func TestStandardGetNodeNameByIPConfigurationID(t *testing.T) {
 	defer ctrl.Finish()
 	cloud := GetTestCloud(ctrl)
 	expectedVM := buildDefaultTestVirtualMachine("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL1-AVAILABILITYSET-00000000", []string{})
-	expectedVM.Name = to.StringPtr("name")
+	expectedVM.Name = pointer.String("name")
 	mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 	mockVMClient.EXPECT().Get(gomock.Any(), "rg", "k8s-agentpool1-00000000-0", gomock.Any()).Return(expectedVM, nil)
 	expectedNIC := buildDefaultTestInterface(true, []string{})
 	expectedNIC.VirtualMachine = &network.SubResource{
-		ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-0"),
+		ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1-00000000-0"),
 	}
 	mockNICClient := cloud.InterfacesClient.(*mockinterfaceclient.MockInterface)
 	mockNICClient.EXPECT().Get(gomock.Any(), "rg", "k8s-agentpool1-00000000-nic-0", gomock.Any()).Return(expectedNIC, nil)
@@ -1962,11 +1962,11 @@ func TestGetAvailabilitySetByNodeName(t *testing.T) {
 		subResources := make([]compute.SubResource, 0)
 		for _, vmID := range test.vmasVMIDs {
 			subResources = append(subResources, compute.SubResource{
-				ID: to.StringPtr(vmID),
+				ID: pointer.String(vmID),
 			})
 		}
 		expected := compute.AvailabilitySet{
-			Name: to.StringPtr("vmas-1"),
+			Name: pointer.String("vmas-1"),
 			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 				VirtualMachines: &subResources,
 			},
@@ -2002,8 +2002,8 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV4MaskSize: 24,
 			expectedIPV6MaskSize: 64,
@@ -2018,7 +2018,7 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes even if some of the tags are not specified",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
 			},
 			expectedIPV4MaskSize: 24,
 		},
@@ -2026,8 +2026,8 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should not fail even if some of the tag is invalid",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("abc"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("abc"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV6MaskSize: 64,
 		},
@@ -2042,10 +2042,10 @@ func TestGetNodeCIDRMasksByProviderIDAvailabilitySet(t *testing.T) {
 			cloud.AvailabilitySetsClient = mockVMASClient
 
 			expected := compute.AvailabilitySet{
-				Name: to.StringPtr("vmas-1"),
+				Name: pointer.String("vmas-1"),
 				AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 					VirtualMachines: &[]compute.SubResource{
-						{ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0")},
+						{ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-0")},
 					},
 				},
 				Tags: tc.tags,
@@ -2129,10 +2129,10 @@ func TestGetNodeVMSetName(t *testing.T) {
 			},
 			expectedVMs: []compute.VirtualMachine{
 				{
-					Name: to.StringPtr("vm"),
+					Name: pointer.String("vm"),
 					VirtualMachineProperties: &compute.VirtualMachineProperties{
 						AvailabilitySet: &compute.SubResource{
-							ID: to.StringPtr("/"),
+							ID: pointer.String("/"),
 						},
 					},
 				},
@@ -2154,10 +2154,10 @@ func TestGetNodeVMSetName(t *testing.T) {
 			},
 			expectedVMs: []compute.VirtualMachine{
 				{
-					Name: to.StringPtr("vm"),
+					Name: pointer.String("vm"),
 					VirtualMachineProperties: &compute.VirtualMachineProperties{
 						AvailabilitySet: &compute.SubResource{
-							ID: to.StringPtr("as"),
+							ID: pointer.String("as"),
 						},
 					},
 				},

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -236,7 +235,7 @@ func setMockLBs(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadB
 			LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
 				BackendAddressPools: &[]network.BackendAddressPool{
 					{
-						Name: to.StringPtr("testCluster"),
+						Name: pointer.String("testCluster"),
 					},
 				},
 			},
@@ -244,39 +243,39 @@ func setMockLBs(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadB
 		lb.Name = &expectedLBName
 		lb.LoadBalancingRules = &[]network.LoadBalancingRule{
 			{
-				Name: to.StringPtr(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
+				Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
 			},
 		}
 		fips := []network.FrontendIPConfiguration{
 			{
-				Name: to.StringPtr(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
-				ID:   to.StringPtr("fip"),
+				Name: pointer.String(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
+				ID:   pointer.String("fip"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: "Dynamic",
-					PublicIPAddress:           &network.PublicIPAddress{ID: to.StringPtr(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+					PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
 				},
 			},
 		}
 		if isInternal {
-			fips[0].Subnet = &network.Subnet{Name: to.StringPtr("subnet")}
+			fips[0].Subnet = &network.Subnet{Name: pointer.String("subnet")}
 		}
 		lb.FrontendIPConfigurations = &fips
 
 		*expectedLBs = append(*expectedLBs, lb)
 	} else {
 		*(*expectedLBs)[lbIndex].LoadBalancingRules = append(*(*expectedLBs)[lbIndex].LoadBalancingRules, network.LoadBalancingRule{
-			Name: to.StringPtr(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
+			Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
 		})
 		fip := network.FrontendIPConfiguration{
-			Name: to.StringPtr(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
-			ID:   to.StringPtr("fip"),
+			Name: pointer.String(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
+			ID:   pointer.String("fip"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PrivateIPAllocationMethod: "Dynamic",
-				PublicIPAddress:           &network.PublicIPAddress{ID: to.StringPtr(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+				PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
 			},
 		}
 		if isInternal {
-			fip.Subnet = &network.Subnet{Name: to.StringPtr("subnet")}
+			fip.Subnet = &network.Subnet{Name: pointer.String("subnet")}
 		}
 		*(*expectedLBs)[lbIndex].FrontendIPConfigurations = append(*(*expectedLBs)[lbIndex].FrontendIPConfigurations, fip)
 	}
@@ -724,11 +723,11 @@ func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t
 	setMockSecurityGroup(az, ctrl, sg)
 
 	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(""), nil, true)
+	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(""), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -747,7 +746,7 @@ func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 	setMockSecurityGroup(az, ctrl, sg)
 
 	dynamicallyAssignedIP := "192.168.0.0"
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(dynamicallyAssignedIP), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(dynamicallyAssignedIP), nil, true)
 	if err != nil {
 		t.Errorf("unexpected error: %q", err)
 	}
@@ -1070,20 +1069,20 @@ func TestServiceDefaultsToNoSessionPersistence(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service-sa-omitted", 1, 1, false)
 
 	expectedPIP := network.PublicIPAddress{
-		Name:     to.StringPtr("testCluster-aservicesaomitted1"),
+		Name:     pointer.String("testCluster-aservicesaomitted1"),
 		Location: &az.Location,
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.Static,
 			PublicIPAddressVersion:   network.IPv4,
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("aservicesaomitted1"),
-			consts.ClusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  pointer.String("aservicesaomitted1"),
+			consts.ClusterNameKey: pointer.String(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
 		},
-		ID: to.StringPtr("testCluster-aservicesaomitted1"),
+		ID: pointer.String("testCluster-aservicesaomitted1"),
 	}
 
 	mockPIPsClient := mockpublicipclient.NewMockInterface(ctrl)
@@ -1124,20 +1123,20 @@ func TestServiceRespectsNoSessionAffinity(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service-sa-none", 1, 1, false)
 
 	expectedPIP := network.PublicIPAddress{
-		Name:     to.StringPtr("testCluster-aservicesanone"),
+		Name:     pointer.String("testCluster-aservicesanone"),
 		Location: &az.Location,
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.Static,
 			PublicIPAddressVersion:   network.IPv4,
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("aservicesanone"),
-			consts.ClusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  pointer.String("aservicesanone"),
+			consts.ClusterNameKey: pointer.String(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
 		},
-		ID: to.StringPtr("testCluster-aservicesanone"),
+		ID: pointer.String("testCluster-aservicesanone"),
 	}
 
 	mockPIPsClient := mockpublicipclient.NewMockInterface(ctrl)
@@ -1185,20 +1184,20 @@ func TestServiceRespectsClientIPSessionAffinity(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service-sa-clientip", 1, 1, false)
 
 	expectedPIP := network.PublicIPAddress{
-		Name:     to.StringPtr("testCluster-aservicesaclientip"),
+		Name:     pointer.String("testCluster-aservicesaclientip"),
 		Location: &az.Location,
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.Static,
 			PublicIPAddressVersion:   network.IPv4,
 		},
 		Tags: map[string]*string{
-			consts.ServiceTagKey:  to.StringPtr("aservicesaclientip"),
-			consts.ClusterNameKey: to.StringPtr(testClusterName),
+			consts.ServiceTagKey:  pointer.String("aservicesaclientip"),
+			consts.ClusterNameKey: pointer.String(testClusterName),
 		},
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
 		},
-		ID: to.StringPtr("testCluster-aservicesaclientip"),
+		ID: pointer.String("testCluster-aservicesaclientip"),
 	}
 
 	mockPIPsClient := mockpublicipclient.NewMockInterface(ctrl)
@@ -1299,10 +1298,10 @@ func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(to.StringPtr(testClusterName),
-			to.StringPtr(az.ResourceGroup),
-			to.StringPtr(testClusterName),
-			to.StringPtr("aservice1"),
+		getTestLoadBalancer(pointer.String(testClusterName),
+			pointer.String(az.ResourceGroup),
+			pointer.String(testClusterName),
+			pointer.String("aservice1"),
 			service1,
 			"Standard"), nil).AnyTimes()
 
@@ -1345,10 +1344,10 @@ func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(to.StringPtr(testClusterName),
-			to.StringPtr(az.ResourceGroup),
-			to.StringPtr(testClusterName),
-			to.StringPtr("aservice1"),
+		getTestLoadBalancer(pointer.String(testClusterName),
+			pointer.String(az.ResourceGroup),
+			pointer.String(testClusterName),
+			pointer.String("aservice1"),
 			svc,
 			"Standard"), nil).AnyTimes()
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true)
@@ -1400,8 +1399,8 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 
 	sg := getTestSecurityGroup(az)
 	cachedSG := *sg
-	cachedSG.Etag = to.StringPtr("1111111-0000-0000-0000-000000000000")
-	az.nsgCache.Set(to.String(sg.Name), &cachedSG)
+	cachedSG.Etag = pointer.String("1111111-0000-0000-0000-000000000000")
+	az.nsgCache.Set(pointer.StringDeref(sg.Name, ""), &cachedSG)
 
 	svc1 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
@@ -1419,10 +1418,10 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(to.StringPtr(testClusterName),
-			to.StringPtr(az.ResourceGroup),
-			to.StringPtr(testClusterName),
-			to.StringPtr("aservice1"),
+		getTestLoadBalancer(pointer.String(testClusterName),
+			pointer.String(az.ResourceGroup),
+			pointer.String(testClusterName),
+			pointer.String("aservice1"),
 			svc1,
 			"Standard"), nil).AnyTimes()
 
@@ -1743,10 +1742,10 @@ func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGr
 			for _, src := range sources {
 				ruleName := az.getSecurityRuleName(&services[i], port, src)
 				rules = append(rules, network.SecurityRule{
-					Name: to.StringPtr(ruleName),
+					Name: pointer.String(ruleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						SourceAddressPrefix:  to.StringPtr(src),
-						DestinationPortRange: to.StringPtr(fmt.Sprintf("%d", port.Port)),
+						SourceAddressPrefix:  pointer.String(src),
+						DestinationPortRange: pointer.String(fmt.Sprintf("%d", port.Port)),
 					},
 				})
 			}
@@ -1755,7 +1754,7 @@ func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGr
 
 	sg := network.SecurityGroup{
 		Name: &az.SecurityGroupName,
-		Etag: to.StringPtr("0000000-0000-0000-0000-000000000000"),
+		Etag: pointer.String("0000000-0000-0000-0000-000000000000"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 			SecurityRules: &rules,
 		},
@@ -1785,7 +1784,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 			}
 			expectedFrontendIP := ExpectedFrontendIPInfo{
 				Name:   az.getDefaultFrontendIPConfigName(&services[i]),
-				Subnet: to.StringPtr(expectedSubnetName),
+				Subnet: pointer.String(expectedSubnetName),
 			}
 			expectedFrontendIPs = append(expectedFrontendIPs, expectedFrontendIP)
 		}
@@ -1850,7 +1849,7 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 	frontendIPs := *loadBalancer.FrontendIPConfigurations
 	for _, expectedFrontendIP := range expectedFrontendIPs {
 		if !expectedFrontendIP.existsIn(frontendIPs) {
-			t.Errorf("Expected the loadbalancer to have frontend IP %s/%s. Found %s", expectedFrontendIP.Name, to.String(expectedFrontendIP.Subnet), describeFIPs(frontendIPs))
+			t.Errorf("Expected the loadbalancer to have frontend IP %s/%s. Found %s", expectedFrontendIP.Name, pointer.StringDeref(expectedFrontendIP.Subnet, ""), describeFIPs(frontendIPs))
 		}
 	}
 
@@ -1871,7 +1870,7 @@ type ExpectedFrontendIPInfo struct {
 }
 
 func (expected ExpectedFrontendIPInfo) matches(frontendIP network.FrontendIPConfiguration) bool {
-	return strings.EqualFold(expected.Name, to.String(frontendIP.Name)) && strings.EqualFold(to.String(expected.Subnet), to.String(subnetName(frontendIP)))
+	return strings.EqualFold(expected.Name, pointer.StringDeref(frontendIP.Name, "")) && strings.EqualFold(pointer.StringDeref(expected.Subnet, ""), pointer.StringDeref(subnetName(frontendIP), ""))
 }
 
 func (expected ExpectedFrontendIPInfo) existsIn(frontendIPs []network.FrontendIPConfiguration) bool {
@@ -1895,9 +1894,9 @@ func describeFIPs(frontendIPs []network.FrontendIPConfiguration) string {
 	for _, actualFIP := range frontendIPs {
 		actualSubnetName := ""
 		if actualFIP.Subnet != nil {
-			actualSubnetName = to.String(actualFIP.Subnet.Name)
+			actualSubnetName = pointer.StringDeref(actualFIP.Subnet.Name, "")
 		}
-		actualFIPText := fmt.Sprintf("%s/%s ", to.String(actualFIP.Name), actualSubnetName)
+		actualFIPText := fmt.Sprintf("%s/%s ", pointer.StringDeref(actualFIP.Name, ""), actualSubnetName)
 		description = description + actualFIPText
 	}
 	return description
@@ -2038,7 +2037,7 @@ func TestSecurityRulePriorityPicksNextAvailablePriority(t *testing.T) {
 	for i = consts.LoadBalancerMinimumPriority; i < expectedPriority; i++ {
 		rules = append(rules, network.SecurityRule{
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-				Priority: to.Int32Ptr(i),
+				Priority: pointer.Int32(i),
 			},
 		})
 	}
@@ -2060,7 +2059,7 @@ func TestSecurityRulePriorityFailsIfExhausted(t *testing.T) {
 	for i = consts.LoadBalancerMinimumPriority; i < consts.LoadBalancerMaximumPriority; i++ {
 		rules = append(rules, network.SecurityRule{
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-				Priority: to.Int32Ptr(i),
+				Priority: pointer.Int32(i),
 			},
 		})
 	}
@@ -2448,7 +2447,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T
 	sg := getTestSecurityGroup(az)
 	setMockSecurityGroup(az, ctrl, sg)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -2496,10 +2495,10 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 			Name: &expectedRuleName,
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				Protocol:                 network.SecurityRuleProtocolTCP,
-				SourcePortRange:          to.StringPtr("*"),
-				SourceAddressPrefix:      to.StringPtr("Internet"),
-				DestinationPortRange:     to.StringPtr("80"),
-				DestinationAddressPrefix: to.StringPtr(testIP2),
+				SourcePortRange:          pointer.String("*"),
+				SourceAddressPrefix:      pointer.String("Internet"),
+				DestinationPortRange:     pointer.String("80"),
+				DestinationAddressPrefix: pointer.String(testIP2),
 				Access:                   network.SecurityRuleAccessAllow,
 				Direction:                network.SecurityRuleDirectionInbound,
 			},
@@ -2507,7 +2506,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 	}
 	setMockSecurityGroup(az, ctrl, sg)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -2551,13 +2550,13 @@ func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2624,13 +2623,13 @@ func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCre
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2697,13 +2696,13 @@ func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRules
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2772,19 +2771,19 @@ func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSepara
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
 	}
@@ -2872,13 +2871,13 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
@@ -2886,7 +2885,7 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 	validateSecurityGroup(t, sg, svc1, svc2)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
@@ -2935,19 +2934,19 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
 	}
@@ -2955,7 +2954,7 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 	validateSecurityGroup(t, sg, svc1, svc2, svc3)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
@@ -3046,19 +3045,19 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 	sg := getTestSecurityGroup(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, to.StringPtr(getServiceLoadBalancerIP(&svc2)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc3: %q", err)
 	}
@@ -3066,13 +3065,13 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 	validateSecurityGroup(t, sg, svc1, svc2, svc3)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, to.StringPtr(getServiceLoadBalancerIP(&svc3)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc3: %q", err)
 	}
@@ -3147,7 +3146,7 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	for i, svc := range testServices {
 		svc := svc
 		setMockSecurityGroup(az, ctrl, sg)
-		sg, err = az.reconcileSecurityGroup(testClusterName, &testServices[i], to.StringPtr(getServiceLoadBalancerIP(&svc)), nil, true)
+		sg, err = az.reconcileSecurityGroup(testClusterName, &testServices[i], pointer.String(getServiceLoadBalancerIP(&svc)), nil, true)
 		if err != nil {
 			t.Errorf("Unexpected error adding svc%d: %q", i+1, err)
 		}
@@ -3240,13 +3239,13 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(getServiceLoadBalancerIP(&svc1)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc5, to.StringPtr(getServiceLoadBalancerIP(&svc5)), nil, false)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc5, pointer.String(getServiceLoadBalancerIP(&svc5)), nil, false)
 	if err != nil {
 		t.Errorf("Unexpected error removing svc5: %q", err)
 	}
@@ -3637,14 +3636,14 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 
 func TestFindSecurityRule(t *testing.T) {
 	sg := network.SecurityRule{
-		Name: to.StringPtr(testRuleName4),
+		Name: pointer.String(testRuleName4),
 		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 			Protocol:                   network.SecurityRuleProtocolTCP,
-			SourcePortRange:            to.StringPtr("*"),
-			SourceAddressPrefix:        to.StringPtr("Internet"),
-			DestinationPortRange:       to.StringPtr("80"),
-			DestinationAddressPrefix:   to.StringPtr(testIP1),
-			DestinationAddressPrefixes: to.StringSlicePtr([]string{}),
+			SourcePortRange:            pointer.String("*"),
+			SourceAddressPrefix:        pointer.String("Internet"),
+			DestinationPortRange:       pointer.String("80"),
+			DestinationAddressPrefix:   pointer.String(testIP1),
+			DestinationAddressPrefixes: &([]string{}),
 			Access:                     network.SecurityRuleAccessAllow,
 			Direction:                  network.SecurityRuleDirectionInbound,
 		},
@@ -3662,14 +3661,14 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when rule name doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr("not-the-right-name"),
+				Name: pointer.String("not-the-right-name"),
 			},
 			expected: false,
 		},
 		{
 			desc: "false should be returned when protocol doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol: network.SecurityRuleProtocolUDP,
 				},
@@ -3679,10 +3678,10 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourcePortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:        network.SecurityRuleProtocolUDP,
-					SourcePortRange: to.StringPtr("1.2.3.4/32"),
+					SourcePortRange: pointer.String("1.2.3.4/32"),
 				},
 			},
 			expected: false,
@@ -3690,11 +3689,11 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourceAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:            network.SecurityRuleProtocolUDP,
-					SourcePortRange:     to.StringPtr("*"),
-					SourceAddressPrefix: to.StringPtr("2.3.4.0/24"),
+					SourcePortRange:     pointer.String("*"),
+					SourceAddressPrefix: pointer.String("2.3.4.0/24"),
 				},
 			},
 			expected: false,
@@ -3702,12 +3701,12 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationPortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:             network.SecurityRuleProtocolUDP,
-					SourcePortRange:      to.StringPtr("*"),
-					SourceAddressPrefix:  to.StringPtr("Internet"),
-					DestinationPortRange: to.StringPtr("443"),
+					SourcePortRange:      pointer.String("*"),
+					SourceAddressPrefix:  pointer.String("Internet"),
+					DestinationPortRange: pointer.String("443"),
 				},
 			},
 			expected: false,
@@ -3715,13 +3714,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP2),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP2),
 				},
 			},
 			expected: false,
@@ -3729,13 +3728,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Access doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP1),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP1),
 					Access:                   network.SecurityRuleAccessDeny,
 					// Direction:                network.SecurityRuleDirectionInbound,
 				},
@@ -3745,13 +3744,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Direction doesn't match",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP1),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP1),
 					Access:                   network.SecurityRuleAccessAllow,
 					Direction:                network.SecurityRuleDirectionOutbound,
 				},
@@ -3761,13 +3760,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "true should be returned when everything matches but protocol is in different case",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocol("TCP"),
-					SourcePortRange:          to.StringPtr("*"),
-					SourceAddressPrefix:      to.StringPtr("Internet"),
-					DestinationPortRange:     to.StringPtr("80"),
-					DestinationAddressPrefix: to.StringPtr(testIP1),
+					SourcePortRange:          pointer.String("*"),
+					SourceAddressPrefix:      pointer.String("Internet"),
+					DestinationPortRange:     pointer.String("80"),
+					DestinationAddressPrefix: pointer.String(testIP1),
 					Access:                   network.SecurityRuleAccessAllow,
 					Direction:                network.SecurityRuleDirectionInbound,
 				},
@@ -3777,13 +3776,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "true should be returned when everything matches but DestinationAddressPrefixes is nil",
 			testRule: network.SecurityRule{
-				Name: to.StringPtr(testRuleName4),
+				Name: pointer.String(testRuleName4),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                   network.SecurityRuleProtocolTCP,
-					SourcePortRange:            to.StringPtr("*"),
-					SourceAddressPrefix:        to.StringPtr("Internet"),
-					DestinationPortRange:       to.StringPtr("80"),
-					DestinationAddressPrefix:   to.StringPtr(testIP1),
+					SourcePortRange:            pointer.String("*"),
+					SourceAddressPrefix:        pointer.String("Internet"),
+					DestinationPortRange:       pointer.String("80"),
+					DestinationAddressPrefix:   pointer.String(testIP1),
 					DestinationAddressPrefixes: nil,
 					Access:                     network.SecurityRuleAccessAllow,
 					Direction:                  network.SecurityRuleDirectionInbound,

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -24,12 +24,12 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
@@ -115,7 +115,7 @@ func parseTags(tags string, tagsMap map[string]string) map[string]*string {
 				klog.Warning("parseTags: empty key, ignoring this key-value pair")
 				continue
 			}
-			formatted[k] = to.StringPtr(v)
+			formatted[k] = pointer.String(v)
 		}
 	}
 
@@ -131,7 +131,7 @@ func parseTags(tags string, tagsMap map[string]string) map[string]*string {
 				klog.V(4).Infof("parseTags: found identical keys: %s from tags and %s from tagsMap (case-insensitive), %s will replace %s", k, key, key, k)
 				delete(formatted, k)
 			}
-			formatted[key] = to.StringPtr(value)
+			formatted[key] = pointer.String(value)
 		}
 	}
 
@@ -159,7 +159,7 @@ func (az *Cloud) reconcileTags(currentTagsOnResource, newTags map[string]*string
 		}
 
 		for _, systemTag := range systemTags {
-			systemTagsMap[systemTag] = to.StringPtr("")
+			systemTagsMap[systemTag] = pointer.String("")
 		}
 	}
 
@@ -170,7 +170,7 @@ func (az *Cloud) reconcileTags(currentTagsOnResource, newTags map[string]*string
 		if !found {
 			currentTagsOnResource[k] = v
 			changed = true
-		} else if !strings.EqualFold(to.String(v), to.String(currentTagsOnResource[key])) {
+		} else if !strings.EqualFold(pointer.StringDeref(v, ""), pointer.StringDeref(currentTagsOnResource[key], "")) {
 			currentTagsOnResource[key] = v
 			changed = true
 		}
@@ -304,11 +304,11 @@ func SliceEqual(s1, s2 []string) bool {
 func removeDuplicatedSecurityRules(rules []network.SecurityRule) []network.SecurityRule {
 	ruleNames := make(map[string]bool)
 	for i := len(rules) - 1; i >= 0; i-- {
-		if _, ok := ruleNames[to.String(rules[i].Name)]; ok {
-			klog.Warningf("Found duplicated rule %s, will be removed.", to.String(rules[i].Name))
+		if _, ok := ruleNames[pointer.StringDeref(rules[i].Name, "")]; ok {
+			klog.Warningf("Found duplicated rule %s, will be removed.", pointer.StringDeref(rules[i].Name, ""))
 			rules = append(rules[:i], rules[i+1:]...)
 		}
-		ruleNames[to.String(rules[i].Name)] = true
+		ruleNames[pointer.StringDeref(rules[i].Name, "")] = true
 	}
 	return rules
 }

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
@@ -101,75 +101,75 @@ func TestReconcileTags(t *testing.T) {
 		{
 			description: "reconcileTags should add missing tags and update existing tags",
 			currentTagsOnResource: map[string]*string{
-				"a": to.StringPtr("b"),
+				"a": pointer.String("b"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("c"),
-				"b": to.StringPtr("d"),
+				"a": pointer.String("c"),
+				"b": pointer.String("d"),
 			},
 			expectedTags: map[string]*string{
-				"a": to.StringPtr("c"),
-				"b": to.StringPtr("d"),
+				"a": pointer.String("c"),
+				"b": pointer.String("d"),
 			},
 			expectedChanged: true,
 		},
 		{
 			description: "reconcileTags should remove the tags that are not included in systemTags",
 			currentTagsOnResource: map[string]*string{
-				"a": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			systemTags: "a, b",
 			expectedTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			expectedChanged: true,
 		},
 		{
 			description: "reconcileTags should ignore the case of keys when comparing",
 			currentTagsOnResource: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("b"),
-				"C": to.StringPtr("d"),
+				"a": pointer.String("b"),
+				"C": pointer.String("d"),
 			},
 			expectedTags: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 		},
 		{
 			description: "reconcileTags should ignore the case of values when comparing",
 			currentTagsOnResource: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("B"),
-				"C": to.StringPtr("D"),
+				"a": pointer.String("B"),
+				"C": pointer.String("D"),
 			},
 			expectedTags: map[string]*string{
-				"A": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"A": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 		},
 		{
 			description: "reconcileTags should ignore the case of keys when checking systemTags",
 			currentTagsOnResource: map[string]*string{
-				"a": to.StringPtr("b"),
-				"c": to.StringPtr("d"),
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
 			},
 			newTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			systemTags: "A, b",
 			expectedTags: map[string]*string{
-				"a": to.StringPtr("c"),
+				"a": pointer.String("c"),
 			},
 			expectedChanged: true,
 		},
@@ -269,18 +269,18 @@ func TestRemoveDuplicatedSecurityRules(t *testing.T) {
 			description: "no duplicated rules",
 			rules: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 			},
 			expected: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 			},
 		},
@@ -288,21 +288,21 @@ func TestRemoveDuplicatedSecurityRules(t *testing.T) {
 			description: "duplicated rules",
 			rules: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 			},
 			expected: []network.SecurityRule{
 				{
-					Name: to.StringPtr("rule2"),
+					Name: pointer.String("rule2"),
 				},
 				{
-					Name: to.StringPtr("rule1"),
+					Name: pointer.String("rule1"),
 				},
 			},
 		},

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +34,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -248,7 +248,7 @@ func (ss *ScaleSet) GetPowerStatusByNodeName(name string) (powerState string, er
 	if vm.InstanceView != nil && vm.InstanceView.Statuses != nil {
 		statuses := *vm.InstanceView.Statuses
 		for _, status := range statuses {
-			state := to.String(status.Code)
+			state := pointer.StringDeref(status.Code, "")
 			if strings.HasPrefix(state, vmPowerStatePrefix) {
 				return strings.TrimPrefix(state, vmPowerStatePrefix), nil
 			}
@@ -281,7 +281,7 @@ func (ss *ScaleSet) GetProvisioningStateByNodeName(name string) (provisioningSta
 		return provisioningState, nil
 	}
 
-	return to.String(vm.VirtualMachineScaleSetVMProperties.ProvisioningState), nil
+	return pointer.StringDeref(vm.VirtualMachineScaleSetVMProperties.ProvisioningState, ""), nil
 }
 
 // getCachedVirtualMachineByInstanceID gets scaleSetVMInfo from cache.
@@ -470,7 +470,7 @@ func (ss *ScaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
 			return cloudprovider.Zone{}, fmt.Errorf("failed to parse zone %q: %w", zones, err)
 		}
 
-		failureDomain = ss.makeZone(to.String(vm.Location), zoneID)
+		failureDomain = ss.makeZone(pointer.StringDeref(vm.Location, ""), zoneID)
 	} else if vm.InstanceView != nil && vm.InstanceView.PlatformFaultDomain != nil {
 		// Availability zone is not used for the node, falling back to fault domain.
 		failureDomain = strconv.Itoa(int(*vm.InstanceView.PlatformFaultDomain))
@@ -483,7 +483,7 @@ func (ss *ScaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
 
 	return cloudprovider.Zone{
 		FailureDomain: strings.ToLower(failureDomain),
-		Region:        strings.ToLower(to.String(vm.Location)),
+		Region:        strings.ToLower(pointer.StringDeref(vm.Location, "")),
 	}, nil
 }
 
@@ -580,7 +580,7 @@ func (ss *ScaleSet) GetPrivateIPsByNodeName(nodeName string) ([]string, error) {
 // This returns the full identifier of the primary NIC for the given VM.
 func (ss *ScaleSet) getPrimaryInterfaceID(machine compute.VirtualMachineScaleSetVM) (string, error) {
 	if machine.NetworkProfile == nil || machine.NetworkProfile.NetworkInterfaces == nil {
-		return "", fmt.Errorf("failed to find the network interfaces for vm %s", to.String(machine.Name))
+		return "", fmt.Errorf("failed to find the network interfaces for vm %s", pointer.StringDeref(machine.Name, ""))
 	}
 
 	if len(*machine.NetworkProfile.NetworkInterfaces) == 1 {
@@ -588,12 +588,12 @@ func (ss *ScaleSet) getPrimaryInterfaceID(machine compute.VirtualMachineScaleSet
 	}
 
 	for _, ref := range *machine.NetworkProfile.NetworkInterfaces {
-		if to.Bool(ref.Primary) {
+		if pointer.BoolDeref(ref.Primary, false) {
 			return *ref.ID, nil
 		}
 	}
 
-	return "", fmt.Errorf("failed to find a primary nic for the vm. vmname=%q", to.String(machine.Name))
+	return "", fmt.Errorf("failed to find a primary nic for the vm. vmname=%q", pointer.StringDeref(machine.Name, ""))
 }
 
 // getVmssMachineID returns the full identifier of a vmss virtual machine.
@@ -657,7 +657,7 @@ func (ss *ScaleSet) listScaleSets(resourceGroup string) ([]string, error) {
 	ssNames := make([]string, 0)
 	for _, vmss := range allScaleSets {
 		name := *vmss.Name
-		if vmss.Sku != nil && to.Int64(vmss.Sku.Capacity) == 0 {
+		if vmss.Sku != nil && pointer.Int64Deref(vmss.Sku.Capacity, 0) == 0 {
 			klog.V(3).Infof("Capacity of VMSS %q is 0, skipping", name)
 			continue
 		}
@@ -1078,7 +1078,7 @@ func (ss *ScaleSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeNam
 	// Compose a new vmssVM with added backendPoolID.
 	newBackendPools = append(newBackendPools,
 		compute.SubResource{
-			ID: to.StringPtr(backendPoolID),
+			ID: pointer.String(backendPoolID),
 		})
 	primaryIPConfiguration.LoadBalancerBackendAddressPools = &newBackendPools
 	newVM := &compute.VirtualMachineScaleSetVM{
@@ -1247,7 +1247,7 @@ func (ss *ScaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 		// Compose a new vmss with added backendPoolID.
 		loadBalancerBackendAddressPools = append(loadBalancerBackendAddressPools,
 			compute.SubResource{
-				ID: to.StringPtr(backendPoolID),
+				ID: pointer.String(backendPoolID),
 			})
 		primaryIPConfig.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
 		newVMSS := compute.VirtualMachineScaleSet{
@@ -1537,32 +1537,32 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVMSS(backendPoolID, vmSetName st
 			} else if v, ok := value.(*compute.VirtualMachineScaleSet); ok {
 				vmss = v
 			}
-			klog.V(2).Infof("ensureBackendPoolDeletedFromVMSS: vmss (%s)", to.String(vmss.Name))
+			klog.V(2).Infof("ensureBackendPoolDeletedFromVMSS: vmss (%s)", pointer.StringDeref(vmss.Name, ""))
 
 			// When vmss is being deleted, CreateOrUpdate API would report "the vmss is being deleted" error.
 			// Since it is being deleted, we shouldn't send more CreateOrUpdate requests for it.
 			if vmss.ProvisioningState != nil && strings.EqualFold(*vmss.ProvisioningState, consts.VirtualMachineScaleSetsDeallocating) {
-				klog.V(3).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s being deleted, skipping", to.String(vmss.Name))
+				klog.V(3).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s being deleted, skipping", pointer.StringDeref(vmss.Name, ""))
 				return true
 			}
 			if vmss.VirtualMachineProfile == nil {
-				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: vmss %s has no VirtualMachineProfile, skipping", to.String(vmss.Name))
+				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: vmss %s has no VirtualMachineProfile, skipping", pointer.StringDeref(vmss.Name, ""))
 				return true
 			}
 			if vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations == nil {
-				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: cannot obtain the primary network interface configuration, of vmss %s", to.String(vmss.Name))
+				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: cannot obtain the primary network interface configuration, of vmss %s", pointer.StringDeref(vmss.Name, ""))
 				return true
 			}
 			vmssNIC := *vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-			primaryNIC, err := ss.getPrimaryNetworkInterfaceConfigurationForScaleSet(vmssNIC, to.String(vmss.Name))
+			primaryNIC, err := ss.getPrimaryNetworkInterfaceConfigurationForScaleSet(vmssNIC, pointer.StringDeref(vmss.Name, ""))
 			if err != nil {
-				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to get the primary network interface config of the VMSS %s: %v", to.String(vmss.Name), err)
+				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to get the primary network interface config of the VMSS %s: %v", pointer.StringDeref(vmss.Name, ""), err)
 				errorList = append(errorList, err)
 				return true
 			}
 			primaryIPConfig, err := getPrimaryIPConfigFromVMSSNetworkConfig(primaryNIC)
 			if err != nil {
-				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to the primary IP config from the VMSS %s's network config : %v", to.String(vmss.Name), err)
+				klog.Errorf("ensureBackendPoolDeletedFromVMSS: failed to the primary IP config from the VMSS %s's network config : %v", pointer.StringDeref(vmss.Name, ""), err)
 				errorList = append(errorList, err)
 				return true
 			}
@@ -1571,10 +1571,10 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromVMSS(backendPoolID, vmSetName st
 				loadBalancerBackendAddressPools = *primaryIPConfig.LoadBalancerBackendAddressPools
 			}
 			for _, loadBalancerBackendAddressPool := range loadBalancerBackendAddressPools {
-				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: loadBalancerBackendAddressPool (%s) on vmss (%s)", to.String(loadBalancerBackendAddressPool.ID), to.String(vmss.Name))
-				if strings.EqualFold(to.String(loadBalancerBackendAddressPool.ID), backendPoolID) {
-					klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s with backend pool %s, removing it", to.String(vmss.Name), backendPoolID)
-					vmssNamesMap[to.String(vmss.Name)] = true
+				klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: loadBalancerBackendAddressPool (%s) on vmss (%s)", pointer.StringDeref(loadBalancerBackendAddressPool.ID, ""), pointer.StringDeref(vmss.Name, ""))
+				if strings.EqualFold(pointer.StringDeref(loadBalancerBackendAddressPool.ID, ""), backendPoolID) {
+					klog.V(4).Infof("ensureBackendPoolDeletedFromVMSS: found vmss %s with backend pool %s, removing it", pointer.StringDeref(vmss.Name, ""), backendPoolID)
+					vmssNamesMap[pointer.StringDeref(vmss.Name, "")] = true
 				}
 			}
 
@@ -1750,15 +1750,15 @@ func (ss *ScaleSet) GetNodeCIDRMasksByProviderID(providerID string) (int, int, e
 
 	var ipv4Mask, ipv6Mask int
 	if v4, ok := vmss.Tags[consts.VMSetCIDRIPV4TagKey]; ok && v4 != nil {
-		ipv4Mask, err = strconv.Atoi(to.String(v4))
+		ipv4Mask, err = strconv.Atoi(pointer.StringDeref(v4, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", to.String(v4), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv4 mask size %s: %v", pointer.StringDeref(v4, ""), err)
 		}
 	}
 	if v6, ok := vmss.Tags[consts.VMSetCIDRIPV6TagKey]; ok && v6 != nil {
-		ipv6Mask, err = strconv.Atoi(to.String(v6))
+		ipv6Mask, err = strconv.Atoi(pointer.StringDeref(v6, ""))
 		if err != nil {
-			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", to.String(v6), err)
+			klog.Errorf("GetNodeCIDRMasksByProviderID: error when paring the value of the ipv6 mask size%s: %v", pointer.StringDeref(v6, ""), err)
 		}
 	}
 

--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -24,10 +24,10 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -219,13 +219,13 @@ func (ss *ScaleSet) newVMSSVirtualMachinesCache(resourceGroupName, vmssName, cac
 			vmssVMCacheEntry := &VMSSVirtualMachineEntry{
 				ResourceGroup:  resourceGroupName,
 				VMSSName:       vmssName,
-				InstanceID:     to.String(vm.InstanceID),
+				InstanceID:     pointer.StringDeref(vm.InstanceID, ""),
 				VirtualMachine: &vm,
 				LastUpdate:     time.Now().UTC(),
 			}
 			// set cache entry to nil when the VM is under deleting.
 			if vm.VirtualMachineScaleSetVMProperties != nil &&
-				strings.EqualFold(to.String(vm.VirtualMachineScaleSetVMProperties.ProvisioningState), string(compute.ProvisioningStateDeleting)) {
+				strings.EqualFold(pointer.StringDeref(vm.VirtualMachineScaleSetVMProperties.ProvisioningState, ""), string(compute.ProvisioningStateDeleting)) {
 				klog.V(4).Infof("VMSS virtualMachine %q is under deleting, setting its cache to nil", computerName)
 				vmssVMCacheEntry.VirtualMachine = nil
 			}
@@ -323,7 +323,7 @@ func (ss *ScaleSet) newAvailabilitySetNodesCache() (*azcache.TimedCache, error) 
 			}
 			for _, vm := range vms {
 				if vm.Name != nil {
-					vmNames.Insert(to.String(vm.Name))
+					vmNames.Insert(pointer.StringDeref(vm.Name, ""))
 					vmList = append(vmList, vm)
 				}
 			}

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -34,6 +33,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
@@ -58,7 +58,7 @@ const (
 func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv6 bool) compute.VirtualMachineScaleSet {
 	lbBackendpools := make([]compute.SubResource, 0)
 	for _, id := range lbBackendpoolIDs {
-		lbBackendpools = append(lbBackendpools, compute.SubResource{ID: to.StringPtr(id)})
+		lbBackendpools = append(lbBackendpools, compute.SubResource{ID: pointer.String(id)})
 	}
 	ipConfig := []compute.VirtualMachineScaleSetIPConfiguration{
 		{
@@ -79,7 +79,7 @@ func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv
 	expectedVMSS := compute.VirtualMachineScaleSet{
 		Name: &name,
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-			ProvisioningState: to.StringPtr("Running"),
+			ProvisioningState: pointer.String("Running"),
 			VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{
 				OsProfile: &compute.VirtualMachineScaleSetOSProfile{
 					ComputerNamePrefix: &namePrefix,
@@ -88,7 +88,7 @@ func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv
 					NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 						{
 							VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-								Primary:          to.BoolPtr(true),
+								Primary:          pointer.Bool(true),
 								IPConfigurations: &ipConfig,
 							},
 						},
@@ -132,23 +132,23 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 			{
 				ID: &interfaceID,
 				NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-					Primary: to.BoolPtr(true),
+					Primary: pointer.Bool(true),
 				},
 			},
 		}
 		ipConfigurations := []compute.VirtualMachineScaleSetIPConfiguration{
 			{
-				Name: to.StringPtr("ipconfig1"),
+				Name: pointer.String("ipconfig1"),
 				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-					Primary:                         to.BoolPtr(true),
-					LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: to.StringPtr(testLBBackendpoolID0)}},
+					Primary:                         pointer.Bool(true),
+					LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: pointer.String(testLBBackendpoolID0)}},
 				},
 			},
 		}
 		networkConfigurations := []compute.VirtualMachineScaleSetNetworkConfiguration{
 			{
-				Name: to.StringPtr("ipconfig1"),
-				ID:   to.StringPtr("fakeNetworkConfiguration"),
+				Name: pointer.String("ipconfig1"),
+				ID:   pointer.String("fakeNetworkConfiguration"),
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					IPConfigurations: &ipConfigurations,
 				},
@@ -156,15 +156,15 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 		}
 		if isIPv6 {
 			networkConfigurations = append(networkConfigurations, compute.VirtualMachineScaleSetNetworkConfiguration{
-				Name: to.StringPtr("ipconfig1v6"),
-				ID:   to.StringPtr("fakeNetworkConfigurationIPv6"),
+				Name: pointer.String("ipconfig1v6"),
+				ID:   pointer.String("fakeNetworkConfigurationIPv6"),
 				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 						{
-							Name: to.StringPtr("ipconfig1"),
+							Name: pointer.String("ipconfig1"),
 							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-								Primary:                         to.BoolPtr(false),
-								LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: to.StringPtr(testLBBackendpoolID0)}},
+								Primary:                         pointer.Bool(false),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: pointer.String(testLBBackendpoolID0)}},
 								PrivateIPAddressVersion:         compute.IPv6,
 							},
 						},
@@ -175,7 +175,7 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 
 		vmssVM := compute.VirtualMachineScaleSetVM{
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-				ProvisioningState: to.StringPtr(state),
+				ProvisioningState: pointer.String(state),
 				OsProfile: &compute.OSProfile{
 					ComputerName: &nodeName,
 				},
@@ -188,7 +188,7 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 				InstanceView: &compute.VirtualMachineScaleSetVMInstanceView{
 					PlatformFaultDomain: &faultDomain,
 					Statuses: &[]compute.InstanceViewStatus{
-						{Code: to.StringPtr(testVMPowerState)},
+						{Code: pointer.String(testVMPowerState)},
 					},
 				},
 			},
@@ -196,7 +196,7 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 			InstanceID: &instanceID,
 			Name:       &vmName,
 			Location:   &ss.Location,
-			Sku:        &compute.Sku{Name: to.StringPtr("sku")},
+			Sku:        &compute.Sku{Name: pointer.String("sku")},
 		}
 		if zone != "" {
 			zones := []string{zone}
@@ -205,16 +205,16 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 
 		// set interfaces.
 		expectedInterface = network.Interface{
-			Name: to.StringPtr("nic"),
+			Name: pointer.String("nic"),
 			ID:   &interfaceID,
 			InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
 				IPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
 						InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-							Primary:          to.BoolPtr(true),
-							PrivateIPAddress: to.StringPtr(fakePrivateIP),
+							Primary:          pointer.Bool(true),
+							PrivateIPAddress: pointer.String(fakePrivateIP),
 							PublicIPAddress: &network.PublicIPAddress{
-								ID: to.StringPtr(publicAddressID),
+								ID: pointer.String(publicAddressID),
 							},
 						},
 					},
@@ -224,9 +224,9 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 
 		// set public IPs.
 		expectedPIP = network.PublicIPAddress{
-			ID: to.StringPtr(publicAddressID),
+			ID: pointer.String(publicAddressID),
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-				IPAddress: to.StringPtr(fakePublicIP),
+				IPAddress: pointer.String(fakePublicIP),
 			},
 		}
 
@@ -697,7 +697,7 @@ func TestGetVMSS(t *testing.T) {
 		ss.cloud.VirtualMachineScaleSetsClient = mockVMSSClient
 
 		expected := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr(test.existedVMSSName),
+			Name: pointer.String(test.existedVMSSName),
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 			},
@@ -851,7 +851,7 @@ func TestGetProvisioningStateByNodeName(t *testing.T) {
 		expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, test.vmList, "", false)
 		mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
 		if test.provisioningState != "" {
-			expectedVMSSVMs[0].ProvisioningState = to.StringPtr(test.provisioningState)
+			expectedVMSSVMs[0].ProvisioningState = pointer.String(test.provisioningState)
 		} else {
 			expectedVMSSVMs[0].ProvisioningState = nil
 		}
@@ -888,7 +888,7 @@ func TestGetVmssVMByInstanceID(t *testing.T) {
 		assert.NoError(t, err, "unexpected error when creating test VMSS")
 
 		expectedVMSS := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr(testVMSSName),
+			Name: pointer.String(testVMSSName),
 			VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 			},
@@ -968,12 +968,12 @@ func TestGetPrimaryInterfaceID(t *testing.T) {
 			description: "GetPrimaryInterfaceID should return the ID of the primary NIC on the VMSS VM",
 			existedInterfaces: []compute.NetworkInterfaceReference{
 				{
-					ID: to.StringPtr("1"),
+					ID: pointer.String("1"),
 					NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-						Primary: to.BoolPtr(true),
+						Primary: pointer.Bool(true),
 					},
 				},
-				{ID: to.StringPtr("2")},
+				{ID: pointer.String("2")},
 			},
 			expectedID: "1",
 		},
@@ -981,15 +981,15 @@ func TestGetPrimaryInterfaceID(t *testing.T) {
 			description: "GetPrimaryInterfaceID should report an error if there's no primary NIC on the VMSS VM",
 			existedInterfaces: []compute.NetworkInterfaceReference{
 				{
-					ID: to.StringPtr("1"),
+					ID: pointer.String("1"),
 					NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 				{
-					ID: to.StringPtr("2"),
+					ID: pointer.String("2"),
 					NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 			},
@@ -1007,7 +1007,7 @@ func TestGetPrimaryInterfaceID(t *testing.T) {
 		assert.NoError(t, err, "unexpected error when creating test VMSS")
 
 		vm := compute.VirtualMachineScaleSetVM{
-			Name: to.StringPtr("vm"),
+			Name: pointer.String("vm"),
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 				NetworkProfile: &compute.NetworkProfile{
 					NetworkInterfaces: &test.existedInterfaces,
@@ -1105,15 +1105,15 @@ func TestGetPrimaryInterface(t *testing.T) {
 		expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, test.vmList, "", false)
 		if !test.hasPrimaryInterface {
 			networkInterfaces := *expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces
-			networkInterfaces[0].Primary = to.BoolPtr(false)
+			networkInterfaces[0].Primary = pointer.Bool(false)
 			networkInterfaces = append(networkInterfaces, compute.NetworkInterfaceReference{
-				NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: to.BoolPtr(false)},
+				NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: pointer.Bool(false)},
 			})
 			expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces = &networkInterfaces
 		}
 		if test.isInvalidNICID {
 			networkInterfaces := *expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces
-			networkInterfaces[0].ID = to.StringPtr("invalid/id/")
+			networkInterfaces[0].ID = pointer.String("invalid/id/")
 			expectedVMSSVMs[0].NetworkProfile.NetworkInterfaces = &networkInterfaces
 		}
 		mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
@@ -1303,27 +1303,27 @@ func TestListScaleSets(t *testing.T) {
 			description: "listScaleSets should return the correct scale sets",
 			existedScaleSets: []compute.VirtualMachineScaleSet{
 				{
-					Name: to.StringPtr("vmss-0"),
-					Sku:  &compute.Sku{Capacity: to.Int64Ptr(1)},
+					Name: pointer.String("vmss-0"),
+					Sku:  &compute.Sku{Capacity: pointer.Int64(1)},
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 						VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-1"),
+					Name: pointer.String("vmss-1"),
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 						VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-2"),
-					Sku:  &compute.Sku{Capacity: to.Int64Ptr(0)},
+					Name: pointer.String("vmss-2"),
+					Sku:  &compute.Sku{Capacity: pointer.Int64(0)},
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 						VirtualMachineProfile: &compute.VirtualMachineScaleSetVMProfile{},
 					},
 				},
 				{
-					Name: to.StringPtr("vmss-3"),
+					Name: pointer.String("vmss-3"),
 				},
 			},
 			expectedVMSSNames: []string{"vmss-0", "vmss-1"},
@@ -1363,8 +1363,8 @@ func TestListScaleSetVMs(t *testing.T) {
 		{
 			description: "listScaleSetVMs should return the correct vmss vms",
 			existedVMSSVMs: []compute.VirtualMachineScaleSetVM{
-				{Name: to.StringPtr("vmss-vm-000000")},
-				{Name: to.StringPtr("vmss-vm-000001")},
+				{Name: pointer.String("vmss-vm-000000")},
+				{Name: pointer.String("vmss-vm-000001")},
 			},
 		},
 		{
@@ -1458,7 +1458,7 @@ func TestGetAgentPoolScaleSets(t *testing.T) {
 		expectedVMSSVMs := []compute.VirtualMachineScaleSetVM{
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000000")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000000")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1466,7 +1466,7 @@ func TestGetAgentPoolScaleSets(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000001")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000001")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1474,7 +1474,7 @@ func TestGetAgentPoolScaleSets(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000002")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000002")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1592,7 +1592,7 @@ func TestGetVMSetNames(t *testing.T) {
 		expectedVMSSVMs := []compute.VirtualMachineScaleSetVM{
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000000")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000000")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1600,7 +1600,7 @@ func TestGetVMSetNames(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000001")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000001")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1608,7 +1608,7 @@ func TestGetVMSetNames(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000002")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000002")},
 					NetworkProfile: &compute.NetworkProfile{
 						NetworkInterfaces: &[]compute.NetworkInterfaceReference{},
 					},
@@ -1616,7 +1616,7 @@ func TestGetVMSetNames(t *testing.T) {
 			},
 			{
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					OsProfile: &compute.OSProfile{ComputerName: to.StringPtr("vmss-vm-000003")},
+					OsProfile: &compute.OSProfile{ComputerName: pointer.String("vmss-vm-000003")},
 				},
 			},
 		}
@@ -1642,7 +1642,7 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 	assert.NoError(t, err, "unexpected error when creating test VMSS")
 
 	networkConfigs := []compute.VirtualMachineScaleSetNetworkConfiguration{
-		{Name: to.StringPtr("config-0")},
+		{Name: pointer.String("config-0")},
 	}
 	config, err := ss.getPrimaryNetworkInterfaceConfigurationForScaleSet(networkConfigs, testVMSSName)
 	assert.Nil(t, err, "getPrimaryNetworkInterfaceConfigurationForScaleSet should return the correct network config")
@@ -1650,15 +1650,15 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 
 	networkConfigs = []compute.VirtualMachineScaleSetNetworkConfiguration{
 		{
-			Name: to.StringPtr("config-0"),
+			Name: pointer.String("config-0"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(false),
+				Primary: pointer.Bool(false),
 			},
 		},
 		{
-			Name: to.StringPtr("config-1"),
+			Name: pointer.String("config-1"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(true),
+				Primary: pointer.Bool(true),
 			},
 		},
 	}
@@ -1668,15 +1668,15 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 
 	networkConfigs = []compute.VirtualMachineScaleSetNetworkConfiguration{
 		{
-			Name: to.StringPtr("config-0"),
+			Name: pointer.String("config-0"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(false),
+				Primary: pointer.Bool(false),
 			},
 		},
 		{
-			Name: to.StringPtr("config-1"),
+			Name: pointer.String("config-1"),
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary: to.BoolPtr(false),
+				Primary: pointer.Bool(false),
 			},
 		},
 	}
@@ -1690,7 +1690,7 @@ func TestGetPrimaryIPConfigFromVMSSNetworkConfig(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 				},
 			},
 		},
@@ -1704,15 +1704,15 @@ func TestGetPrimaryIPConfigFromVMSSNetworkConfig(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 				{
-					Name: to.StringPtr("config-1"),
+					Name: pointer.String("config-1"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(true),
+						Primary: pointer.Bool(true),
 					},
 				},
 			},
@@ -1727,15 +1727,15 @@ func TestGetPrimaryIPConfigFromVMSSNetworkConfig(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 				{
-					Name: to.StringPtr("config-1"),
+					Name: pointer.String("config-1"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: to.BoolPtr(false),
+						Primary: pointer.Bool(false),
 					},
 				},
 			},
@@ -1758,13 +1758,13 @@ func TestGetConfigForScaleSetByIPFamily(t *testing.T) {
 		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
 						PrivateIPAddressVersion: compute.IPv4,
 					},
 				},
 				{
-					Name: to.StringPtr("config-0"),
+					Name: pointer.String("config-0"),
 					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
 						PrivateIPAddressVersion: compute.IPv6,
 					},
@@ -1852,25 +1852,25 @@ func TestEnsureHostInPool(t *testing.T) {
 			expectedVMSSName:          testVMSSName,
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &compute.VirtualMachineScaleSetVM{
-				Location: to.StringPtr("westus"),
+				Location: pointer.String("westus"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 							{
-								Name: to.StringPtr("ipconfig1"),
-								ID:   to.StringPtr("fakeNetworkConfiguration"),
+								Name: pointer.String("ipconfig1"),
+								ID:   pointer.String("fakeNetworkConfiguration"),
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 										{
-											Name: to.StringPtr("ipconfig1"),
+											Name: pointer.String("ipconfig1"),
 											VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-												Primary: to.BoolPtr(true),
+												Primary: pointer.Bool(true),
 												LoadBalancerBackendAddressPools: &[]compute.SubResource{
 													{
-														ID: to.StringPtr(testLBBackendpoolID0),
+														ID: pointer.String(testLBBackendpoolID0),
 													},
 													{
-														ID: to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb-internal/backendAddressPools/backendpool-1"),
+														ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb-internal/backendAddressPools/backendpool-1"),
 													},
 												},
 											},
@@ -2145,7 +2145,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 
 		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, test.setIPv6Config)
 		if test.isVMSSDeallocating {
-			expectedVMSS.ProvisioningState = to.StringPtr(consts.VirtualMachineScaleSetsDeallocating)
+			expectedVMSS.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
 		}
 		if test.isVMSSNilNICConfig {
 			expectedVMSS.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
@@ -2244,7 +2244,7 @@ func TestEnsureHostsInPool(t *testing.T) {
 		assert.NoError(t, err, test.description)
 
 		ss.LoadBalancerSku = consts.LoadBalancerSkuStandard
-		ss.ExcludeMasterFromStandardLB = to.BoolPtr(true)
+		ss.ExcludeMasterFromStandardLB = pointer.Bool(true)
 
 		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
 		mockVMSSClient := ss.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
@@ -2302,19 +2302,19 @@ func TestEnsureBackendPoolDeletedFromNode(t *testing.T) {
 			expectedVMSSName:          testVMSSName,
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &compute.VirtualMachineScaleSetVM{
-				Location: to.StringPtr("westus"),
+				Location: pointer.String("westus"),
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 							{
-								Name: to.StringPtr("ipconfig1"),
-								ID:   to.StringPtr("fakeNetworkConfiguration"),
+								Name: pointer.String("ipconfig1"),
+								ID:   pointer.String("fakeNetworkConfiguration"),
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
 										{
-											Name: to.StringPtr("ipconfig1"),
+											Name: pointer.String("ipconfig1"),
 											VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-												Primary:                         to.BoolPtr(true),
+												Primary:                         pointer.Bool(true),
 												LoadBalancerBackendAddressPools: &[]compute.SubResource{},
 											},
 										},
@@ -2419,7 +2419,7 @@ func TestEnsureBackendPoolDeletedFromVMSS(t *testing.T) {
 
 		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
 		if test.isVMSSDeallocating {
-			expectedVMSS.ProvisioningState = to.StringPtr(consts.VirtualMachineScaleSetsDeallocating)
+			expectedVMSS.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
 		}
 		if test.isVMSSNilNICConfig {
 			expectedVMSS.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
@@ -2464,25 +2464,25 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 			backendpoolID: testLBBackendpoolID0,
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(testLBBackendpoolID0),
+					ID: pointer.String(testLBBackendpoolID0),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: to.StringPtr("ip-1"),
-								ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+								Name: pointer.String("ip-1"),
+								ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
 							},
 							{
-								Name: to.StringPtr("ip-2"),
+								Name: pointer.String("ip-2"),
 							},
 							{
-								Name: to.StringPtr("ip-3"),
-								ID:   to.StringPtr("/invalid/id"),
+								Name: pointer.String("ip-3"),
+								ID:   pointer.String("/invalid/id"),
 							},
 						},
 					},
 				},
 				{
-					ID: to.StringPtr(testLBBackendpoolID1),
+					ID: pointer.String(testLBBackendpoolID1),
 				},
 			},
 			expectedVMSSVMPutTimes: 1,
@@ -2492,18 +2492,18 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 			backendpoolID: testLBBackendpoolID0,
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(testLBBackendpoolID0),
+					ID: pointer.String(testLBBackendpoolID0),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: to.StringPtr("ip-1"),
-								ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+								Name: pointer.String("ip-1"),
+								ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
 							},
 						},
 					},
 				},
 				{
-					ID: to.StringPtr(testLBBackendpoolID1),
+					ID: pointer.String(testLBBackendpoolID1),
 				},
 			},
 			expectedVMSSVMPutTimes: 1,
@@ -2515,18 +2515,18 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 			backendpoolID: testLBBackendpoolID0,
 			backendAddressPools: &[]network.BackendAddressPool{
 				{
-					ID: to.StringPtr(testLBBackendpoolID0),
+					ID: pointer.String(testLBBackendpoolID0),
 					BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 						BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 							{
-								Name: to.StringPtr("ip-1"),
-								ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/6/networkInterfaces/nic"),
+								Name: pointer.String("ip-1"),
+								ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/6/networkInterfaces/nic"),
 							},
 						},
 					},
 				},
 				{
-					ID: to.StringPtr(testLBBackendpoolID1),
+					ID: pointer.String(testLBBackendpoolID1),
 				},
 			},
 		},
@@ -2567,34 +2567,34 @@ func TestEnsureBackendPoolDeletedConcurrently(t *testing.T) {
 
 	backendAddressPools := &[]network.BackendAddressPool{
 		{
-			ID: to.StringPtr(testLBBackendpoolID0),
+			ID: pointer.String(testLBBackendpoolID0),
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						Name: to.StringPtr("ip-1"),
-						ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
+						Name: pointer.String("ip-1"),
+						ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
 					},
 				},
 			},
 		},
 		{
-			ID: to.StringPtr(testLBBackendpoolID1),
+			ID: pointer.String(testLBBackendpoolID1),
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						Name: to.StringPtr("ip-1"),
-						ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-1/virtualMachines/0/networkInterfaces/nic"),
+						Name: pointer.String("ip-1"),
+						ID:   pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-1/virtualMachines/0/networkInterfaces/nic"),
 					},
 				},
 			},
 		},
 		{
-			ID: to.StringPtr(testLBBackendpoolID2),
+			ID: pointer.String(testLBBackendpoolID2),
 			BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
 				BackendIPConfigurations: &[]network.InterfaceIPConfiguration{
 					{
-						Name: to.StringPtr("ip-1"),
-						ID:   to.StringPtr("/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
+						Name: pointer.String("ip-1"),
+						ID:   pointer.String("/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
 					},
 				},
 			},
@@ -2610,7 +2610,7 @@ func TestEnsureBackendPoolDeletedConcurrently(t *testing.T) {
 		vmssVMNetworkConfigs := expectedVMSSVMs[0].NetworkProfileConfiguration
 		vmssVMIPConfigs := (*vmssVMNetworkConfigs.NetworkInterfaceConfigurations)[0].VirtualMachineScaleSetNetworkConfigurationProperties.IPConfigurations
 		lbBackendpools := (*vmssVMIPConfigs)[0].LoadBalancerBackendAddressPools
-		*lbBackendpools = append(*lbBackendpools, compute.SubResource{ID: to.StringPtr(testLBBackendpoolID1)})
+		*lbBackendpools = append(*lbBackendpools, compute.SubResource{ID: pointer.String(testLBBackendpoolID1)})
 	}
 
 	mockVMClient := ss.cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -2664,8 +2664,8 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV4MaskSize: 24,
 			expectedIPV6MaskSize: 64,
@@ -2674,7 +2674,7 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should return the correct mask sizes even if some of the tags are not specified",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("24"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("24"),
 			},
 			expectedIPV4MaskSize: 24,
 		},
@@ -2682,8 +2682,8 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			description: "GetNodeCIDRMaksByProviderID should not fail even if some of the tag is invalid",
 			providerID:  "azure:///subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
 			tags: map[string]*string{
-				consts.VMSetCIDRIPV4TagKey: to.StringPtr("abc"),
-				consts.VMSetCIDRIPV6TagKey: to.StringPtr("64"),
+				consts.VMSetCIDRIPV4TagKey: pointer.String("abc"),
+				consts.VMSetCIDRIPV6TagKey: pointer.String("64"),
 			},
 			expectedIPV6MaskSize: 64,
 		},
@@ -2693,7 +2693,7 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedVMSS := compute.VirtualMachineScaleSet{
-				Name: to.StringPtr("vmss"),
+				Name: pointer.String("vmss"),
 				Tags: tc.tags,
 			}
 			mockVMSSClient := ss.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
@@ -2716,18 +2716,18 @@ func TestGetAgentPoolVMSetNamesMixedInstances(t *testing.T) {
 
 	existingVMs := []compute.VirtualMachine{
 		{
-			Name: to.StringPtr("vm-0"),
+			Name: pointer.String("vm-0"),
 			VirtualMachineProperties: &compute.VirtualMachineProperties{
 				AvailabilitySet: &compute.SubResource{
-					ID: to.StringPtr("vmas-0"),
+					ID: pointer.String("vmas-0"),
 				},
 			},
 		},
 		{
-			Name: to.StringPtr("vm-1"),
+			Name: pointer.String("vm-1"),
 			VirtualMachineProperties: &compute.VirtualMachineProperties{
 				AvailabilitySet: &compute.SubResource{
-					ID: to.StringPtr("vmas-1"),
+					ID: pointer.String("vmas-1"),
 				},
 			},
 		},
@@ -2826,16 +2826,16 @@ func TestScaleSet_VMSSBatchSize(t *testing.T) {
 		ss.Cloud.PutVMSSVMBatchSize = BatchSize
 
 		scaleSet := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr("foo"),
+			Name: pointer.String("foo"),
 			Tags: map[string]*string{
-				consts.VMSSTagForBatchOperation: to.StringPtr(""),
+				consts.VMSSTagForBatchOperation: pointer.String(""),
 			},
 		}
 		mockVMSSClient := ss.Cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
 		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).
 			Return([]compute.VirtualMachineScaleSet{scaleSet}, nil)
 
-		batchSize, err := ss.VMSSBatchSize(to.String(scaleSet.Name))
+		batchSize, err := ss.VMSSBatchSize(pointer.StringDeref(scaleSet.Name, ""))
 		assert.NoError(t, err)
 		assert.Equal(t, BatchSize, batchSize)
 	})
@@ -2848,13 +2848,13 @@ func TestScaleSet_VMSSBatchSize(t *testing.T) {
 		ss.Cloud.PutVMSSVMBatchSize = BatchSize
 
 		scaleSet := compute.VirtualMachineScaleSet{
-			Name: to.StringPtr("bar"),
+			Name: pointer.String("bar"),
 		}
 		mockVMSSClient := ss.Cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
 		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).
 			Return([]compute.VirtualMachineScaleSet{scaleSet}, nil)
 
-		batchSize, err := ss.VMSSBatchSize(to.String(scaleSet.Name))
+		batchSize, err := ss.VMSSBatchSize(pointer.StringDeref(scaleSet.Name, ""))
 		assert.NoError(t, err)
 		assert.Equal(t, 0, batchSize)
 	})

--- a/pkg/provider/azure_wrap.go
+++ b/pkg/provider/azure_wrap.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
@@ -232,7 +231,7 @@ func (az *Cloud) newVMCache() (*azcache.TimedCache, error) {
 		}
 
 		if vm.VirtualMachineProperties != nil &&
-			strings.EqualFold(to.String(vm.VirtualMachineProperties.ProvisioningState), string(compute.ProvisioningStateDeleting)) {
+			strings.EqualFold(pointer.StringDeref(vm.VirtualMachineProperties.ProvisioningState, ""), string(compute.ProvisioningStateDeleting)) {
 			klog.V(2).Infof("Virtual machine %q is under deleting", key)
 			return nil, nil
 		}

--- a/pkg/provider/azure_zones_test.go
+++ b/pkg/provider/azure_zones_test.go
@@ -27,12 +27,12 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/zoneclient/mockzoneclient"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -270,7 +270,7 @@ func TestGetZoneByProviderID(t *testing.T) {
 	mockVMClient := az.VirtualMachinesClient.(*mockvmclient.MockInterface)
 	mockVMClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "vm-0", gomock.Any()).Return(compute.VirtualMachine{
 		Zones:    &[]string{"1"},
-		Location: to.StringPtr("eastus"),
+		Location: pointer.String("eastus"),
 	}, nil)
 	zone, err = az.GetZoneByProviderID(context.Background(), testAvailabilitySetNodeProviderID)
 	assert.NoError(t, err)

--- a/pkg/util/deepcopy/deepcopy_test.go
+++ b/pkg/util/deepcopy/deepcopy_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 )
 
 type fakeStruct struct {
@@ -42,12 +42,12 @@ func TestCopyBasic(t *testing.T) {
 	zones := []string{"zone0", "zone1"}
 	var vmOriginal *compute.VirtualMachine = &compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			ProvisioningState: to.StringPtr("Failed"),
+			ProvisioningState: pointer.String("Failed"),
 		},
-		Name:  to.StringPtr("vmOriginal"),
+		Name:  pointer.String("vmOriginal"),
 		Zones: &zones,
 		Tags: map[string]*string{
-			"tag0": to.StringPtr("tagVal0"),
+			"tag0": pointer.String("tagVal0"),
 		},
 	}
 	vmCopied := Copy(vmOriginal).(*compute.VirtualMachine)
@@ -68,9 +68,9 @@ func TestCopyBasic(t *testing.T) {
 func TestCopyVMInSyncMap(t *testing.T) {
 	var vmOriginal *compute.VirtualMachine = &compute.VirtualMachine{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
-			ProvisioningState: to.StringPtr("Failed"),
+			ProvisioningState: pointer.String("Failed"),
 		},
-		Name: to.StringPtr("vmOriginal"),
+		Name: pointer.String("vmOriginal"),
 	}
 	vmCacheOriginal := &sync.Map{}
 	vmCacheOriginal.Store("vmOriginal", vmOriginal)
@@ -93,9 +93,9 @@ type vmssEntry struct {
 // TestCopyVMSSEntryInSyncMap tests object like vmssEntry in sync.Map.
 func TestCopyVMSSEntryInSyncMap(t *testing.T) {
 	vmssEntryOriginal := &vmssEntry{
-		Name: to.StringPtr("vmssEntryName"),
+		Name: pointer.String("vmssEntryName"),
 		VirtualMachineScaleSet: &compute.VirtualMachineScaleSet{
-			Name: to.StringPtr("vmssOriginal"),
+			Name: pointer.String("vmssOriginal"),
 		},
 	}
 	vmssCacheOriginal := &sync.Map{}

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 	"k8s.io/utils/strings/slices"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -294,7 +294,7 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		pip := defaultPublicIPAddress(ipName, tc.IPFamily == utils.IPv6)
 		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), pip)
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
 		utils.Logf("created pip with address %s", targetIP)
 
 		By("Creating a test load balancer service with floating IP disabled")
@@ -340,8 +340,8 @@ func validateUnsharedSecurityRuleExists(nsgs []aznetwork.SecurityGroup, ip strin
 			continue
 		}
 		for _, securityRule := range *nsg.SecurityRules {
-			utils.Logf("Checking security rule %q", to.String(securityRule.Name))
-			if strings.EqualFold(to.String(securityRule.DestinationAddressPrefix), ip) && strings.EqualFold(to.String(securityRule.DestinationPortRange), port) {
+			utils.Logf("Checking security rule %q", pointer.StringDeref(securityRule.Name, ""))
+			if strings.EqualFold(pointer.StringDeref(securityRule.DestinationAddressPrefix, ""), ip) && strings.EqualFold(pointer.StringDeref(securityRule.DestinationPortRange, ""), port) {
 				utils.Logf("Found target security rule")
 				return true
 			}
@@ -356,8 +356,8 @@ func validateSharedSecurityRuleExists(nsgs []aznetwork.SecurityGroup, ips []stri
 			continue
 		}
 		for _, securityRule := range *nsg.SecurityRules {
-			utils.Logf("Checking security rule %q", to.String(securityRule.Name))
-			if strings.EqualFold(to.String(securityRule.DestinationPortRange), port) {
+			utils.Logf("Checking security rule %q", pointer.StringDeref(securityRule.Name, ""))
+			if strings.EqualFold(pointer.StringDeref(securityRule.DestinationPortRange, ""), port) {
 				found := true
 				for _, ip := range ips {
 					if !utils.StringInSlice(ip, *securityRule.DestinationAddressPrefixes) {
@@ -381,11 +381,11 @@ func validateLoadBalancerSourceRangesRuleExists(nsgs []aznetwork.SecurityGroup, 
 			continue
 		}
 		for _, securityRule := range *nsg.SecurityRules {
-			utils.Logf("Checking security rule %q", to.String(securityRule.Name))
+			utils.Logf("Checking security rule %q", pointer.StringDeref(securityRule.Name, ""))
 			if securityRule.Access == aznetwork.SecurityRuleAccessAllow &&
-				strings.EqualFold(to.String(securityRule.DestinationAddressPrefix), ip) &&
-				strings.HasSuffix(to.String(securityRule.Name), ipRangesSuffix) &&
-				strings.EqualFold(to.String(securityRule.SourceAddressPrefix), sourceAddressPrefix) {
+				strings.EqualFold(pointer.StringDeref(securityRule.DestinationAddressPrefix, ""), ip) &&
+				strings.HasSuffix(pointer.StringDeref(securityRule.Name, ""), ipRangesSuffix) &&
+				strings.EqualFold(pointer.StringDeref(securityRule.SourceAddressPrefix, ""), sourceAddressPrefix) {
 				return true
 			}
 		}
@@ -400,11 +400,11 @@ func validateDenyAllSecurityRuleExists(nsgs []aznetwork.SecurityGroup, ip string
 			continue
 		}
 		for _, securityRule := range *nsg.SecurityRules {
-			utils.Logf("Checking security rule %q", to.String(securityRule.Name))
+			utils.Logf("Checking security rule %q", pointer.StringDeref(securityRule.Name, ""))
 			if securityRule.Access == aznetwork.SecurityRuleAccessDeny &&
-				strings.EqualFold(to.String(securityRule.DestinationAddressPrefix), ip) &&
-				strings.HasSuffix(to.String(securityRule.Name), "deny_all") &&
-				strings.EqualFold(to.String(securityRule.SourceAddressPrefix), "*") {
+				strings.EqualFold(pointer.StringDeref(securityRule.DestinationAddressPrefix, ""), ip) &&
+				strings.HasSuffix(pointer.StringDeref(securityRule.Name, ""), "deny_all") &&
+				strings.EqualFold(pointer.StringDeref(securityRule.SourceAddressPrefix, ""), "*") {
 				return true
 			}
 		}

--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
@@ -142,13 +142,13 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 	It("should support service annotation 'service.beta.kubernetes.io/azure-pls-ip-configuration-subnet'", func() {
 		subnetName := "pls-subnet"
 		subnet, isNew := createNewSubnet(tc, subnetName)
-		Expect(to.String(subnet.Name)).To(Equal(subnetName))
+		Expect(pointer.StringDeref(subnet.Name, "")).To(Equal(subnetName))
 		if isNew {
 			defer func() {
 				utils.Logf("cleaning up test subnet %s", subnetName)
 				vNet, err := tc.GetClusterVirtualNetwork()
 				Expect(err).NotTo(HaveOccurred())
-				err = tc.DeleteSubnet(to.String(vNet.Name), subnetName)
+				err = tc.DeleteSubnet(pointer.StringDeref(vNet.Name, ""), subnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}()
 		}

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
@@ -160,8 +160,8 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		Expect(err).NotTo(HaveOccurred())
-		targetIP := to.String(pip.IPAddress)
-		pipName := to.String(pip.Name)
+		targetIP := pointer.StringDeref(pip.IPAddress, "")
+		pipName := pointer.StringDeref(pip.Name, "")
 		utils.Logf("PIP %q to %q", pipName, targetIP)
 
 		By("Create a Service which will be deleted with the PIP")
@@ -332,7 +332,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 		By("creating a test resource group")
 		rg, cleanup := utils.CreateTestResourceGroup(tc)
-		defer cleanup(to.String(rg.Name))
+		defer cleanup(pointer.StringDeref(rg.Name, ""))
 
 		By("creating test PIP in the test resource group")
 		testPIPName := "testPIP-" + string(uuid.NewUUID())[0:4]
@@ -347,7 +347,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}()
 
 		annotation := map[string]string{
-			consts.ServiceAnnotationLoadBalancerResourceGroup: to.String(rg.Name),
+			consts.ServiceAnnotationLoadBalancerResourceGroup: pointer.StringDeref(rg.Name, ""),
 		}
 		By("Creating service " + serviceName + " in namespace " + ns.Name)
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
@@ -358,7 +358,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		//wait and get service's public IP Address
 		By("Waiting service to expose...")
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, to.String(pip.IPAddress))
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip.IPAddress, ""))
 		Expect(err).NotTo(HaveOccurred())
 
 		lb := getAzureLoadBalancerFromPIP(tc, *pip.IPAddress, *rg.Name, "")
@@ -387,17 +387,17 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		By("Checking tags on the corresponding public IP")
 		expectedTags := map[string]*string{
-			"a": to.StringPtr("b"),
-			"c": to.StringPtr("d"),
-			"e": to.StringPtr(""),
+			"a": pointer.String("b"),
+			"c": pointer.String("d"),
+			"e": pointer.String(""),
 		}
 		pips, err := tc.ListPublicIPs(tc.GetResourceGroup())
 		Expect(err).NotTo(HaveOccurred())
 		var targetPIP network.PublicIPAddress
 		for _, pip := range pips {
-			if strings.EqualFold(to.String(pip.IPAddress), ip) {
+			if strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), ip) {
 				targetPIP = pip
-				err := waitComparePIPTags(tc, expectedTags, to.String(pip.Name))
+				err := waitComparePIPTags(tc, expectedTags, pointer.StringDeref(pip.Name, ""))
 				Expect(err).NotTo(HaveOccurred())
 				break
 			}
@@ -412,12 +412,12 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		expectedTags = map[string]*string{
-			"a": to.StringPtr("c"),
-			"c": to.StringPtr("d"),
-			"e": to.StringPtr(""),
-			"x": to.StringPtr("y"),
+			"a": pointer.String("c"),
+			"c": pointer.String("d"),
+			"e": pointer.String(""),
+			"x": pointer.String("y"),
 		}
-		err = waitComparePIPTags(tc, expectedTags, to.String(targetPIP.Name))
+		err = waitComparePIPTags(tc, expectedTags, pointer.StringDeref(targetPIP.Name, ""))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -456,7 +456,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		By("Waiting for the service to expose")
 		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ip).To(Equal(to.String(pip1.IPAddress)))
+		Expect(ip).To(Equal(pointer.StringDeref(pip1.IPAddress, "")))
 
 		By("Updating the service to refer to the second service")
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
@@ -466,7 +466,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for service IP to be updated")
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, to.String(pip2.IPAddress))
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip2.IPAddress, ""))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -498,7 +498,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		By("Creating a service referring to the prefix")
 		{
 			annotation := map[string]string{
-				consts.ServiceAnnotationPIPPrefixID: to.String(prefix1.ID),
+				consts.ServiceAnnotationPIPPrefixID: pointer.StringDeref(prefix1.ID, ""),
 			}
 			service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
 			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
@@ -520,14 +520,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 			Expect(pip.IPAddress).NotTo(BeNil())
 			Expect(pip.PublicIPPrefix.ID).To(Equal(prefix1.ID))
-			Expect(ip).To(Equal(to.String(pip.IPAddress)))
+			Expect(ip).To(Equal(pointer.StringDeref(pip.IPAddress, "")))
 		}
 
 		By("Updating the service to refer to the second prefix")
 		{
 			service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			service.Annotations[consts.ServiceAnnotationPIPPrefixID] = to.String(prefix2.ID)
+			service.Annotations[consts.ServiceAnnotationPIPPrefixID] = pointer.StringDeref(prefix2.ID, "")
 			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -543,7 +543,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			Expect(pip.IPAddress).NotTo(BeNil())
 			Expect(pip.PublicIPPrefix.ID).To(Equal(prefix2.ID))
 
-			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, to.String(pip.IPAddress))
+			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip.IPAddress, ""))
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -655,7 +655,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			err = utils.DeletePIPWithRetry(tc, pipName, rg)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		pipAddr := to.String(pip.IPAddress)
+		pipAddr := pointer.StringDeref(pip.IPAddress, "")
 		utils.Logf("Created pip with address %s", pipAddr)
 
 		annotation := map[string]string{}
@@ -778,7 +778,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 		"app": serviceName,
 	}
 	ports := []v1.ServicePort{{
-		AppProtocol: to.StringPtr("Tcp"),
+		AppProtocol: pointer.String("Tcp"),
 		Port:        serverPort,
 		Name:        "port1",
 		TargetPort:  intstr.FromInt(serverPort),
@@ -786,7 +786,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 		Port:        serverPort + 1,
 		Name:        "port2",
 		TargetPort:  intstr.FromInt(serverPort),
-		AppProtocol: to.StringPtr("Tcp"),
+		AppProtocol: pointer.String("Tcp"),
 	},
 	}
 

--- a/tests/e2e/utils/azure_auth.go
+++ b/tests/e2e/utils/azure_auth.go
@@ -24,10 +24,10 @@ import (
 	azauth "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 )
 
 // Environmental variables for validating Azure resource status.
@@ -118,8 +118,8 @@ func (tc *AzureTestClient) assignRoleByID(scope, roleDefinitionID string) (resul
 		string(uuid.NewUUID()),
 		azauth.RoleAssignmentCreateParameters{
 			Properties: &azauth.RoleAssignmentProperties{
-				PrincipalID:      to.StringPtr(authconfig.AADClientID),
-				RoleDefinitionID: to.StringPtr(roleDefinitionID),
+				PrincipalID:      pointer.String(authconfig.AADClientID),
+				RoleDefinitionID: pointer.String(roleDefinitionID),
 			},
 		})
 }

--- a/tests/e2e/utils/container_registry_utils.go
+++ b/tests/e2e/utils/container_registry_utils.go
@@ -22,9 +22,9 @@ import (
 	"os/exec"
 
 	acr "github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/pointer"
 )
 
 // CreateContainerRegistry creates a test acr
@@ -37,8 +37,8 @@ func (tc *AzureTestClient) CreateContainerRegistry() (registry acr.Registry, err
 			Name: "Basic",
 			Tier: "SkuTierBasic",
 		},
-		Name:     to.StringPtr(acrName),
-		Location: to.StringPtr(location),
+		Name:     pointer.String(acrName),
+		Location: pointer.String(location),
 	}
 
 	Logf("Creating acr %s in resource group %s.", acrName, rgName)

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -28,11 +28,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
 )
 
 type IPFamily string
@@ -333,7 +333,7 @@ func WaitGetPIPByPrefix(
 			return false, nil
 		}
 
-		pipID := to.String((*prefix.PublicIPAddresses)[0].ID)
+		pipID := pointer.StringDeref((*prefix.PublicIPAddresses)[0].ID, "")
 		parts := strings.Split(pipID, "/")
 		pipName := parts[len(parts)-1]
 		pip, err = WaitGetPIP(cli, pipName)
@@ -402,9 +402,9 @@ func SelectAvailablePrivateIP(tc *AzureTestClient) (string, error) {
 		return "", err
 	}
 	if vNet.Subnets == nil || len(*vNet.Subnets) == 0 {
-		return "", fmt.Errorf("failed to find a subnet in vNet %s", to.String(vNet.Name))
+		return "", fmt.Errorf("failed to find a subnet in vNet %s", pointer.StringDeref(vNet.Name, ""))
 	}
-	subnet := to.String((*vNet.Subnets)[0].AddressPrefix)
+	subnet := pointer.StringDeref((*vNet.Subnets)[0].AddressPrefix, "")
 	if len(*vNet.Subnets) > 1 {
 		for _, sn := range *vNet.Subnets {
 			// if there is more than one subnet, select the first one we find.
@@ -432,7 +432,7 @@ func SelectAvailablePrivateIP(tc *AzureTestClient) (string, error) {
 	}
 	ip, _, err := net.ParseCIDR(subnet)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse subnet CIDR in vNet %s: %w", to.String(vNet.Name), err)
+		return "", fmt.Errorf("failed to parse subnet CIDR in vNet %s: %w", pointer.StringDeref(vNet.Name, ""), err)
 	}
 
 	baseIP := ip.To4()
@@ -444,7 +444,7 @@ func SelectAvailablePrivateIP(tc *AzureTestClient) (string, error) {
 	for i := 0; i <= 254; i++ {
 		baseIP[pos]++
 		IP := baseIP.String()
-		ret, err := vNetClient.CheckIPAddressAvailability(context.Background(), tc.GetResourceGroup(), to.String(vNet.Name), IP)
+		ret, err := vNetClient.CheckIPAddressAvailability(context.Background(), tc.GetResourceGroup(), pointer.StringDeref(vNet.Name, ""), IP)
 		if err != nil {
 			// just ignore
 			continue
@@ -463,7 +463,7 @@ func (azureTestClient *AzureTestClient) GetPublicIPFromAddress(resourceGroupName
 		return pip, err
 	}
 	for _, pip := range pipList {
-		if strings.EqualFold(to.String(pip.IPAddress), ipAddr) {
+		if strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), ipAddr) {
 			return pip, err
 		}
 	}

--- a/tests/e2e/utils/resource_group_utils.go
+++ b/tests/e2e/utils/resource_group_utils.go
@@ -21,17 +21,17 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/pointer"
 )
 
 // CreateTestResourceGroup create a test rg
 func CreateTestResourceGroup(tc *AzureTestClient) (*resources.Group, func(string)) {
 	gc := tc.createResourceGroupClient()
-	rgName := to.StringPtr("e2e-" + string(uuid.NewUUID())[0:4])
+	rgName := pointer.String("e2e-" + string(uuid.NewUUID())[0:4])
 	rg, err := gc.CreateOrUpdate(context.Background(), *rgName, createTestTemplate(tc, rgName))
 	Expect(err).NotTo(HaveOccurred())
 	By(fmt.Sprintf("resource group %s created", *rgName))
@@ -59,6 +59,6 @@ func WaitForDeleteResourceGroupCompletion(gc *resources.GroupsClient, future res
 func createTestTemplate(tc *AzureTestClient, name *string) resources.Group {
 	return resources.Group{
 		Name:     name,
-		Location: to.StringPtr(tc.location),
+		Location: pointer.String(tc.location),
 	}
 }

--- a/tests/e2e/utils/route_table_utils.go
+++ b/tests/e2e/utils/route_table_utils.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/utils/pointer"
 
 	providerazure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
@@ -47,7 +47,7 @@ func GetNodesInRouteTable(routeTable aznetwork.RouteTable) (map[string]interface
 
 	routeSet := make(map[string]interface{})
 	for _, route := range *routeTable.Routes {
-		routeSet[string(providerazure.MapRouteNameToNodeName(true, to.String(route.Name)))] = true
+		routeSet[string(providerazure.MapRouteNameToNodeName(true, pointer.StringDeref(route.Name, "")))] = true
 	}
 
 	return routeSet, nil

--- a/tests/e2e/utils/vmss_utils.go
+++ b/tests/e2e/utils/vmss_utils.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 
 	azcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-03-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
 )
 
 var (
@@ -76,7 +76,7 @@ func ScaleVMSS(tc *AzureTestClient, vmssName string, instanceCount int64) (err e
 		Location: vmss.Location,
 		Sku: &azcompute.Sku{
 			Name:     vmss.Sku.Name,
-			Capacity: to.Int64Ptr(instanceCount),
+			Capacity: pointer.Int64(instanceCount),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Cleanup: cherry-pick #2983 Use k8s utils pointer instead of Azure autorest/to to release-1.23

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
