### PR TITLE
build: Excludes previous release tag commit when generating release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,49 +154,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${GITHUB_REF_NAME#[vV]}"
-          VERSION_MAJOR="${VERSION%%\.*}"
-          VERSION_MINOR="${VERSION#*.}"
-          VERSION_MINOR="${VERSION_MINOR%.*}"
-          VERSION_PATCH="${VERSION##*.}"
-
-          BRANCH=release-${VERSION_MAJOR}.${VERSION_MINOR}
-          if [[ ! `git show-ref ${BRANCH}` ]]; then
-            BRANCH=master
-          fi
-
-          if [[ "${VERSION_PATCH}" = "0" ]]; then
-            # when release a new minor version, generate release note from the last minor version
-            START_TAG=v${VERSION_MAJOR}.$((VERSION_MINOR-1)).0
-          else
-            START_TAG=v${VERSION_MAJOR}.${VERSION_MINOR}.$((VERSION_PATCH-1))
-          fi
-          START_SHA=$(git rev-parse ${START_TAG})
-          END_TAG=${GITHUB_REF_NAME}
-          END_SHA=$(git rev-parse ${END_TAG})
-
-          echo "BRANCH=${BRANCH}"
-          echo "START_TAG=${START_TAG} START_SHA=${START_SHA}"
-          echo "END_TAG=${END_TAG} END_SHA=${END_SHA}"
-
-          GO111MODULE=on go install k8s.io/release/cmd/release-notes@latest
-
-
-          release-notes --repo=cloud-provider-azure \
-          	--org=kubernetes-sigs \
-          	--branch=${BRANCH} \
-          	--start-sha=${START_SHA} \
-          	--end-sha=${END_SHA} \
-          	--markdown-links=true \
-          	--required-author='' \
-          	--output=release-notes.md
-
-          # Generate release note for site
-          # Prepend site header
-          SITE_RELEASE_NOTE=site/content/en/blog/releases/${{github.ref_name}}.md
-          SITE_HEAD="---\ntitle: "v${VERSION}"\nlinkTitle: "v${VERSION}"\ndate: $(date '+%Y-%m-%d')\ndescription: Cloud Provider Azure v${VERSION}\n---\n\n"
-          cp release-notes.md ${SITE_RELEASE_NOTE}
-          sed -i "1i${SITE_HEAD}" ${SITE_RELEASE_NOTE}
+          ./hack/generate-release-note.sh ${GITHUB_REF_NAME} release-notes.md true
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RELEASE=$1
+OUTPUT=${2:-release-notes.md}
+UPDATE_SITE=${3:-false}
+
+install_cli() {
+  if ! [[ -x "$(command -v release-notes)" ]]; then
+    echo "CLI release-notes not found, installing..."
+    GO111MODULE=on go install k8s.io/release/cmd/release-notes@latest
+  else
+    echo "CLI release-notes found, skip installing. If you want to upgrade, run 'GO111MODULE=on go install k8s.io/release/cmd/release-notes@latest'"
+  fi
+}
+
+generate() {
+  FROM_TAG=$1
+  TO_TAG=$2
+  BRANCH=$3
+  FROM_COMMIT=$(git rev-list --no-merges ${FROM_TAG}..${TO_TAG} | tail -1) # exclude the ${FROM_TAG} commit
+  TO_COMMIT=$(git rev-parse ${TO_TAG})
+
+  echo "Generating release notes for ${FROM_TAG}..${TO_TAG} (${FROM_COMMIT}..${TO_COMMIT}) on branch ${BRANCH}"
+
+  rm -f ${OUTPUT}
+  release-notes --repo=cloud-provider-azure \
+    --org=kubernetes-sigs \
+    --branch=${BRANCH} \
+    --start-sha=${FROM_COMMIT} \
+    --end-sha=${TO_COMMIT} \
+    --markdown-links=true \
+    --required-author='' \
+    --output=${OUTPUT}
+
+  read -r -d '' HEAD <<EOF
+Full Changelog: [${FROM_TAG}..${TO_TAG}](https://github.com/kubernetes-sigs/cloud-provider-azure/compare/${FROM_TAG}...${TO_TAG})
+EOF
+
+  echo -e "${HEAD}\n\n$(cat ${OUTPUT})" > ${OUTPUT}
+
+  if [[ "${UPDATE_SITE}" = "true" ]]; then
+    echo "Generating site content for ${TO_TAG}: site/content/en/blog/releases/${TO_TAG}.md"
+    read -r -d '' SITE_HEAD <<EOF
+---
+title: ${TO_TAG}
+linkTitle: ${TO_TAG}
+date: $(date '+%Y-%m-%d')
+description: Cloud Provider Azure ${TO_TAG}
+---
+EOF
+    echo -e "${SITE_HEAD}\n$(cat ${OUTPUT})" > site/content/en/blog/releases/${TO_TAG}.md
+  fi
+}
+
+help() {
+  echo "Usage: $0 <release> [output] [update_site]"
+  echo "  release: release tag, e.g. v1.21.0."
+  echo "  output: output file, default to release-notes.md."
+  echo "  update_site: update site content, default to false."
+  echo "  GITHUB_TOKEN: The GitHub token to use for API requests. (required environment variable)"
+  echo "Example: $0 v1.21.0"
+  echo "Example: $0 v1.21.0 release-notes.md true"
+}
+
+main() {
+  if [[ -z "${RELEASE}" || -z "${GITHUB_TOKEN}" ]]; then
+    help
+    exit 1
+  fi
+
+  install_cli
+
+  VERSION="${RELEASE#[vV]}"
+  VERSION_MAJOR="${VERSION%%\.*}"
+  VERSION_MINOR="${VERSION#*.}"
+  VERSION_MINOR="${VERSION_MINOR%.*}"
+  VERSION_PATCH="${VERSION##*.}"
+  BRANCH=release-${VERSION_MAJOR}.${VERSION_MINOR}
+
+  # when release a new minor version, generate release note from the last minor version
+  # example:
+  #   when release v1.21.0, generate release note from v1.20.0 (v1.20.0..v1.21.0)
+  #   when release v1.21.3, generate release note from v1.21.2 (v1.21.2..v1.21.3)
+  if [[ "${VERSION_PATCH}" = "0" ]]; then
+    START_TAG=v${VERSION_MAJOR}.$((VERSION_MINOR-1)).0
+  else
+    START_TAG=v${VERSION_MAJOR}.${VERSION_MINOR}.$((VERSION_PATCH-1))
+  fi
+  END_TAG=${RELEASE}
+
+  generate ${START_TAG} ${END_TAG} ${BRANCH}
+}
+
+main

--- a/site/content/en/blog/releases/v1.23.28.md
+++ b/site/content/en/blog/releases/v1.23.28.md
@@ -1,18 +1,16 @@
 ---
 title: v1.23.28
 linkTitle: v1.23.28
-date: 2023-02-09
+date: 2023-02-13
 description: Cloud Provider Azure v1.23.28
 ---
-
+Full Changelog: [v1.23.27..v1.23.28](https://github.com/kubernetes-sigs/cloud-provider-azure/compare/v1.23.27...v1.23.28)
 
 ## Changes by Kind
 
 ### Bug or Regression
 
 - Fix: remove vmss vm from cache when invalidate the cache ([#3299](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3299), [@nilo19](https://github.com/nilo19))
-- Fix: skip removing nics from lb if there will be no nics in the backend pool
-  update network api to 2022-07-01 to support backend pool level virtual network id ([#3244](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3244), [@nilo19](https://github.com/nilo19))
 
 ## Dependencies
 

--- a/site/content/en/blog/releases/v1.24.15.md
+++ b/site/content/en/blog/releases/v1.24.15.md
@@ -1,18 +1,16 @@
 ---
 title: v1.24.15
 linkTitle: v1.24.15
-date: 2023-02-09
+date: 2023-02-13
 description: Cloud Provider Azure v1.24.15
 ---
-
+Full Changelog: [v1.24.14..v1.24.15](https://github.com/kubernetes-sigs/cloud-provider-azure/compare/v1.24.14...v1.24.15)
 
 ## Changes by Kind
 
 ### Bug or Regression
 
 - Fix: remove vmss vm from cache when invalidate the cache ([#3300](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3300), [@nilo19](https://github.com/nilo19))
-- Fix: skip removing nics from lb if there will be no nics in the backend pool
-  update network api to 2022-07-01 to support backend pool level virtual network id ([#3245](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3245), [@nilo19](https://github.com/nilo19))
 
 ## Dependencies
 
@@ -20,7 +18,6 @@ description: Cloud Provider Azure v1.24.15
 _Nothing has changed._
 
 ### Changed
-- github.com/onsi/ginkgo/v2: [v2.7.1 → v2.8.0](https://github.com/onsi/ginkgo/v2/compare/v2.7.1...v2.8.0)
 - golang.org/x/sys: v0.4.0 → v0.5.0
 
 ### Removed

--- a/site/content/en/blog/releases/v1.25.9.md
+++ b/site/content/en/blog/releases/v1.25.9.md
@@ -1,18 +1,16 @@
 ---
 title: v1.25.9
 linkTitle: v1.25.9
-date: 2023-02-09
+date: 2023-02-13
 description: Cloud Provider Azure v1.25.9
 ---
-
+Full Changelog: [v1.25.8..v1.25.9](https://github.com/kubernetes-sigs/cloud-provider-azure/compare/v1.25.8...v1.25.9)
 
 ## Changes by Kind
 
 ### Bug or Regression
 
 - Fix: remove vmss vm from cache when invalidate the cache ([#3301](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3301), [@nilo19](https://github.com/nilo19))
-- Fix: skip removing nics from lb if there will be no nics in the backend pool
-  update network api to 2022-07-01 to support backend pool level virtual network id ([#3246](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3246), [@nilo19](https://github.com/nilo19))
 
 ## Dependencies
 
@@ -20,7 +18,6 @@ description: Cloud Provider Azure v1.25.9
 _Nothing has changed._
 
 ### Changed
-- github.com/onsi/ginkgo/v2: [v2.7.1 → v2.8.0](https://github.com/onsi/ginkgo/v2/compare/v2.7.1...v2.8.0)
 - golang.org/x/sys: v0.4.0 → v0.5.0
 
 ### Removed

--- a/site/content/en/blog/releases/v1.26.5.md
+++ b/site/content/en/blog/releases/v1.26.5.md
@@ -1,18 +1,16 @@
 ---
 title: v1.26.5
 linkTitle: v1.26.5
-date: 2023-02-09
+date: 2023-02-13
 description: Cloud Provider Azure v1.26.5
 ---
-
+Full Changelog: [v1.26.4..v1.26.5](https://github.com/kubernetes-sigs/cloud-provider-azure/compare/v1.26.4...v1.26.5)
 
 ## Changes by Kind
 
 ### Bug or Regression
 
 - Fix: remove vmss vm from cache when invalidate the cache ([#3302](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3302), [@nilo19](https://github.com/nilo19))
-- Fix: skip removing nics from lb if there will be no nics in the backend pool
-  update network api to 2022-07-01 to support backend pool level virtual network id ([#3247](https://github.com/kubernetes-sigs/cloud-provider-azure/pull/3247), [@nilo19](https://github.com/nilo19))
 
 ## Dependencies
 
@@ -20,7 +18,6 @@ description: Cloud Provider Azure v1.26.5
 _Nothing has changed._
 
 ### Changed
-- github.com/onsi/ginkgo/v2: [v2.7.1 → v2.8.0](https://github.com/onsi/ginkgo/v2/compare/v2.7.1...v2.8.0)
 - golang.org/x/sys: v0.4.0 → v0.5.0
 
 ### Removed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

1. Fix the misuse of `end-sha` argument of `release-notes` CLI.
2. Regenerate `v1.26.5` release note.
3. Add script to generate release note:
```shell
# Print usage
$ ./hack/generate-release-note.sh
Usage: hack/generate-release-note.sh <release> [output] [update_site]
  release: release tag, e.g. v1.21.0.
  output: output file, default to release-notes.md.
  update_site: update site content, default to false.
  GITHUB_TOKEN: The GitHub token to use for API requests. (required environment variable)
Example: hack/generate-release-note.sh v1.21.0
Example: hack/generate-release-note.sh v1.21.0 release-notes.md true

# Example:
# Generate v1.26.5 release note to ./release-notes.md
# And it will update the site doc (with site header): site/content/en/blog/releases/v1.26.5.md
$ ./hack/generate-release-note.sh v1.26.5 release-notes.md true
```

A [sample build](https://github.com/lodrem/cloud-provider-azure/actions/runs/4161844764/jobs/7200295157) in my local repo.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3325 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
