### PR TITLE
CCM should not panic when losing leader election lease

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -134,7 +134,8 @@ func NewCloudControllerManagerCommand() *cobra.Command {
 					Callbacks: leaderelection.LeaderCallbacks{
 						OnStartedLeading: RunWrapper(s, c, healthHandler),
 						OnStoppedLeading: func() {
-							panic("leaderelection lost")
+							klog.ErrorS(nil, "leaderelection lost")
+							klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 						},
 					},
 					WatchDog: electionChecker,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It is fairly normal in operation for the CCM to lose the lease, for example this could happen after a relatively short period of disruption to the API server connectivity. When it loses the connection, it should intentionally exit using an `os.Exit(1)` to prevent further execution.

Currently the code panics, which means you end up with a panic trace in the output, except, I would argue this shouldn't panic because it isn't a programmer error, there's no reason I would investigate the stack trace here.

Note, other providers use the core cloud-provider app and [exit in the way I'm suggesting here](https://github.com/kubernetes/cloud-provider/blob/4162b590014735c81ac6db5e3fbf7edaae3d4706/app/controllermanager.go#L258-L262).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

We monitor code panicking within our CI to look for genuine issues in the code that need investigation. A pod losing leader election is not a reason for us to investigate.

The code changes here will make sure that klog has time to dump any logs it has pending, and then exit, it should be pretty much equivalent in terms of exit behaviour to the current code in main, but without the need to use a panic.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CCM will now shut down gracefully when losing leader election, will no longer panic
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
