### PR TITLE
Change MachinePool to use extenral cloud-provider

### DIFF
--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
@@ -362,7 +362,7 @@ spec:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
+        cloud-provider: external
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
   - bash -c /tmp/kubeadm-bootstrap.sh
@@ -474,7 +474,7 @@ spec:
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
         cloud-config: c:/k/azure.json
-        cloud-provider: azure
+        cloud-provider: external
         feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
@@ -364,7 +364,7 @@ spec:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
+        cloud-provider: external
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
   - bash -c /tmp/kubeadm-bootstrap.sh
@@ -479,7 +479,7 @@ spec:
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
         cloud-config: c:/k/azure.json
-        cloud-provider: azure
+        cloud-provider: external
         feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind bug
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When setting "cloud-provider: azure", the CAPZ will use in-tree kube-controller-manager rather than out-of-tree CCM and CNM. This will cause the ndoe providerID is set with wrong format for VMSS Flex VMs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
