### PR TITLE
[release-1.25] fix: change the expected tags in aks e2e test

### DIFF
--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -721,7 +721,6 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 		serviceDomainNamePrefix := testServiceName + string(uuid.NewUUID())
 		annotation := map[string]string{
 			consts.ServiceAnnotationDNSLabelName:                       serviceDomainNamePrefix,
-			consts.ServiceAnnotationAzurePIPTags:                       "Tag_1=t1, Tag_2=t2",
 			consts.ServiceAnnotationLoadBalancerIdleTimeout:            "20",
 			consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:    "HTTP",
 			consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath: "/healthtz",

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -390,59 +390,31 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 	})
 
 	It("should support service annotation `service.beta.kubernetes.io/azure-pip-tags`", func() {
-		By("Creating a service with custom tags")
-		annotation := map[string]string{
-			consts.ServiceAnnotationAzurePIPTags: "a=b,c= d,e =, =f",
+		if os.Getenv(utils.AKSTestCCM) != "" {
+			Skip("Skip this test case for AKS test")
 		}
-		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
-		service.GetAnnotations()
-		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting service to expose...")
-		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
-		Expect(err).NotTo(HaveOccurred())
-
-		defer func() {
-			By("Cleaning up test service")
-			err := utils.DeleteService(cs, ns.Name, serviceName)
-			Expect(err).NotTo(HaveOccurred())
-		}()
-
-		By("Checking tags on the corresponding public IP")
 		expectedTags := map[string]*string{
-			"a": pointer.String("b"),
-			"c": pointer.String("d"),
-			"e": pointer.String(""),
-		}
-		pips, err := tc.ListPublicIPs(tc.GetResourceGroup())
-		Expect(err).NotTo(HaveOccurred())
-		var targetPIP network.PublicIPAddress
-		for _, pip := range pips {
-			if strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), ip) {
-				targetPIP = pip
-				err := waitComparePIPTags(tc, expectedTags, pointer.StringDeref(pip.Name, ""))
-				Expect(err).NotTo(HaveOccurred())
-				break
-			}
-		}
-
-		By("Updating annotation and check tags again")
-		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		service.Annotations = map[string]string{
-			consts.ServiceAnnotationAzurePIPTags: "a=c,x=y",
-		}
-		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		expectedTags = map[string]*string{
 			"a": pointer.String("c"),
 			"c": pointer.String("d"),
 			"e": pointer.String(""),
 			"x": pointer.String("y"),
 		}
-		err = waitComparePIPTags(tc, expectedTags, pointer.StringDeref(targetPIP.Name, ""))
-		Expect(err).NotTo(HaveOccurred())
+
+		testPIPTagAnnotationWithTags(cs, tc, ns, serviceName, labels, ports, expectedTags)
+	})
+
+	It("should support service annotation `service.beta.kubernetes.io/azure-pip-tags` on aks clusters with systemTags set", func() {
+		if os.Getenv(utils.AKSTestCCM) == "" {
+			Skip("Skip this test case for non-AKS test")
+		}
+
+		expectedTags := map[string]*string{
+			"a": pointer.String("c"),
+			"x": pointer.String("y"),
+		}
+
+		testPIPTagAnnotationWithTags(cs, tc, ns, serviceName, labels, ports, expectedTags)
 	})
 
 	It("should support service annotation `service.beta.kubernetes.io/azure-pip-name`", func() {
@@ -1320,4 +1292,62 @@ func validateLoadBalancerBackendPools(tc *utils.AzureTestClient, vmssName string
 			Expect(matches[1]).To(Equal(vmssName))
 		}
 	}
+}
+
+func testPIPTagAnnotationWithTags(
+	cs clientset.Interface,
+	tc *utils.AzureTestClient,
+	ns *v1.Namespace,
+	serviceName string,
+	labels map[string]string,
+	ports []v1.ServicePort,
+	expectedTagsAfterUpdate map[string]*string,
+) {
+	By("Creating a service with custom tags")
+	annotation := map[string]string{
+		consts.ServiceAnnotationAzurePIPTags: "a=b,c= d,e =, =f",
+	}
+	service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
+	service.GetAnnotations()
+	_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Waiting service to expose...")
+	ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+	Expect(err).NotTo(HaveOccurred())
+
+	defer func() {
+		By("Cleaning up test service")
+		err := utils.DeleteService(cs, ns.Name, serviceName)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	By("Checking tags on the corresponding public IP")
+	expectedTags := map[string]*string{
+		"a": pointer.String("b"),
+		"c": pointer.String("d"),
+		"e": pointer.String(""),
+	}
+	pips, err := tc.ListPublicIPs(tc.GetResourceGroup())
+	Expect(err).NotTo(HaveOccurred())
+	var targetPIP network.PublicIPAddress
+	for _, pip := range pips {
+		if strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), ip) {
+			targetPIP = pip
+			err := waitComparePIPTags(tc, expectedTags, pointer.StringDeref(pip.Name, ""))
+			Expect(err).NotTo(HaveOccurred())
+			break
+		}
+	}
+
+	By("Updating annotation and check tags again")
+	service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	service.Annotations = map[string]string{
+		consts.ServiceAnnotationAzurePIPTags: "a=c,x=y",
+	}
+	_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	err = waitComparePIPTags(tc, expectedTagsAfterUpdate, pointer.StringDeref(targetPIP.Name, ""))
+	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

The test result differs for pip tags between capz and aks tests, because the aks enables systemTags. This PR creates a dedicated test case for aks, and skips the original one. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
