### PR TITLE
Fix nodeAddressesChangeDetected() bug when dual-stack

### DIFF
--- a/pkg/nodemanager/nodemanager_test.go
+++ b/pkg/nodemanager/nodemanager_test.go
@@ -667,133 +667,155 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 
 // Tests that node address changes are detected correctly
 func TestNodeAddressesChangeDetected(t *testing.T) {
-	addressSet1 := []v1.NodeAddress{
+	testcases := []struct {
+		desc            string
+		addrSet1        []v1.NodeAddress
+		addrSet2        []v1.NodeAddress
+		expectedChanged bool
+	}{
 		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
+			desc: "IPs not changed",
+			addrSet1: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "fe::1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.163",
+				},
+			},
+			addrSet2: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "fe::1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.163",
+				},
+			},
+			expectedChanged: false,
 		},
 		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.163",
+			desc: "IPs changed",
+			addrSet1: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.164",
+				},
+			},
+			addrSet2: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.163",
+				},
+			},
+			expectedChanged: true,
 		},
-	}
-	addressSet2 := []v1.NodeAddress{
 		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
+			desc: "IPs and hostname changed set1",
+			addrSet1: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.164",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "hostname.aks.test",
+				},
+			},
+			addrSet2: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.164",
+				},
+			},
+			expectedChanged: true,
 		},
 		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.163",
+			desc: "IPs and hostname changed set2",
+			addrSet1: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.164",
+				},
+			},
+			addrSet2: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.164",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "hostname.aks.test",
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			desc: "IPs exchanged",
+			addrSet1: []v1.NodeAddress{
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "132.143.154.163",
+				},
+			},
+			addrSet2: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "132.143.154.163",
+				},
+			},
+			expectedChanged: true,
 		},
 	}
 
-	assert.False(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
-		"Node address changes are not detected correctly")
-
-	addressSet1 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.164",
-		},
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, tc.expectedChanged, nodeAddressesChangeDetected(tc.addrSet1, tc.addrSet2))
+		})
 	}
-	addressSet2 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.163",
-		},
-	}
-
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
-		"Node address changes are not detected correctly")
-
-	addressSet1 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.164",
-		},
-		{
-			Type:    v1.NodeHostName,
-			Address: "hostname.zone.region.aws.test",
-		},
-	}
-	addressSet2 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.164",
-		},
-	}
-
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
-		"Node address changes are not detected correctly")
-
-	addressSet1 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.164",
-		},
-	}
-	addressSet2 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.164",
-		},
-		{
-			Type:    v1.NodeHostName,
-			Address: "hostname.zone.region.aws.test",
-		},
-	}
-
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
-		"Node address changes are not detected correctly")
-
-	addressSet1 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "132.143.154.163",
-		},
-	}
-	addressSet2 = []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.163",
-		},
-	}
-
-	assert.True(t, nodeAddressesChangeDetected(addressSet1, addressSet2),
-		"Node address changes are not detected correctly")
 }
 
 // This test checks that a node with the external cloud provider taint is cloudprovider initialized


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix nodeAddressesChangeDetected() bug when dual-stack. In a dual-stack cluster, a Node has 2 internal IPs but current logic doesn't distinguish between these 2. As a result, CNM always assumes that NodeAddresses changed.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix nodeAddressesChangeDetected() bug when dual-stack. In a dual-stack cluster, a Node has 2 internal IPs but current logic doesn't distinguish between these 2. As a result, CNM always assumes that NodeAddresses changed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
