### PR TITLE
[#3580] - Link to cloud provider config is broken on docs 'Deploy Cloud Controller Manager' page --fixed

### DIFF
--- a/site/content/en/install/azure-ccm.md
+++ b/site/content/en/install/azure-ccm.md
@@ -46,7 +46,7 @@ azure-cloud-controller-manager should be run as Deployment with multiple replica
 |Flag|Value|Remark|
 |---|---|---|
 |`--cloud-provider`|azure|cloud-provider should be set azure|
-|`--cloud-config`|/etc/kubernetes/cloud-config/azure.json|Path for [cloud provider config](../configs.md)|
+|`--cloud-config`|/etc/kubernetes/cloud-config/azure.json|Path for [cloud provider config](./configs.md)|
 |`--controllers`|*,-cloud-node | cloud node controller should be disabled|
 |`--configure-cloud-routes`| "false" for Azure CNI and "true" for other network plugins| Used for non-AzureCNI clusters |
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind documentation

#### What this PR does / why we need it:
This PR updates the `Deploy Cloud Controller Manager` page link. We need it to correct and maintain the documentation.

#### Which issue(s) this PR fixes:
[3580](https://github.com/kubernetes-sigs/cloud-provider-azure/issues/3580)

#### Special notes for your reviewer:
Sanity checks if the URL is opening for all browsers.

#### Does this PR introduce a user-facing change?
NONE