### PR TITLE
Deprecate numberOfProbes and adopt ProbeThreshold to address a probe issue in nrp

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2244,7 +2244,7 @@ func (az *Cloud) buildHealthProbeRulesForPort(serviceManifest *v1.Service, port 
 		return nil, fmt.Errorf("total probe should be less than 120, please adjust interval and number of probe accordingly")
 	}
 	properties.IntervalInSeconds = probeInterval
-	properties.NumberOfProbes = numberOfProbes
+	properties.ProbeThreshold = numberOfProbes
 	probe := &network.Probe{
 		Name:                  &lbrule,
 		ProbePropertiesFormat: properties,
@@ -2280,7 +2280,7 @@ func (az *Cloud) getExpectedLBRules(
 				Protocol:          network.ProbeProtocolHTTP,
 				Port:              pointer.Int32(podPresencePort),
 				IntervalInSeconds: pointer.Int32(consts.HealthProbeDefaultProbeInterval),
-				NumberOfProbes:    pointer.Int32(consts.HealthProbeDefaultNumOfProbe),
+				ProbeThreshold:    pointer.Int32(consts.HealthProbeDefaultNumOfProbe),
 			},
 		}
 		expectedProbes = append(expectedProbes, *nodeEndpointHealthprobe)
@@ -3243,7 +3243,7 @@ func findProbe(probes []network.Probe, probe network.Probe) bool {
 			strings.EqualFold(string(existingProbe.Protocol), string(probe.Protocol)) &&
 			strings.EqualFold(pointer.StringDeref(existingProbe.RequestPath, ""), pointer.StringDeref(probe.RequestPath, "")) &&
 			pointer.Int32Deref(existingProbe.IntervalInSeconds, 0) == pointer.Int32Deref(probe.IntervalInSeconds, 0) &&
-			pointer.Int32Deref(existingProbe.NumberOfProbes, 0) == pointer.Int32Deref(probe.NumberOfProbes, 0) {
+			pointer.Int32Deref(existingProbe.ProbeThreshold, 0) == pointer.Int32Deref(probe.ProbeThreshold, 0) {
 			return true
 		}
 	}

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -2654,7 +2654,7 @@ func getTestProbe(protocol, path string, interval, servicePort, probePort, numOf
 			Protocol:          network.ProbeProtocol(protocol),
 			Port:              probePort,
 			IntervalInSeconds: interval,
-			NumberOfProbes:    numOfProbe,
+			ProbeThreshold:    numOfProbe,
 		},
 	}
 	if (strings.EqualFold(protocol, "Http") || strings.EqualFold(protocol, "Https")) && len(strings.TrimSpace(path)) > 0 {
@@ -2799,7 +2799,7 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 						Port:              pointer.Int32(10080),
 						Protocol:          network.ProbeProtocolTCP,
 						IntervalInSeconds: pointer.Int32(5),
-						NumberOfProbes:    pointer.Int32(2),
+						ProbeThreshold:    pointer.Int32(2),
 					},
 				},
 			},
@@ -3072,7 +3072,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 				RequestPath:       pointer.String("/healthz"),
 				Protocol:          network.ProbeProtocolHTTP,
 				IntervalInSeconds: pointer.Int32(5),
-				NumberOfProbes:    pointer.Int32(2),
+				ProbeThreshold:    pointer.Int32(2),
 			},
 		},
 	}
@@ -3100,7 +3100,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 				Port:              pointer.Int32(10080),
 				Protocol:          network.ProbeProtocolTCP,
 				IntervalInSeconds: pointer.Int32(5),
-				NumberOfProbes:    pointer.Int32(2),
+				ProbeThreshold:    pointer.Int32(2),
 			},
 		},
 	}

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -844,8 +844,8 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		var numberOfProbes *int32
 		var intervalInSeconds *int32
 		for _, probe := range targetProbes {
-			if probe.NumberOfProbes != nil {
-				numberOfProbes = probe.NumberOfProbes
+			if probe.ProbeThreshold != nil {
+				numberOfProbes = probe.ProbeThreshold
 			}
 			if probe.IntervalInSeconds != nil {
 				intervalInSeconds = probe.IntervalInSeconds
@@ -917,8 +917,8 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		var numberOfProbes *int32
 		var intervalInSeconds *int32
 		for _, probe := range targetProbes {
-			if probe.NumberOfProbes != nil {
-				numberOfProbes = probe.NumberOfProbes
+			if probe.ProbeThreshold != nil {
+				numberOfProbes = probe.ProbeThreshold
 			}
 			if probe.IntervalInSeconds != nil {
 				intervalInSeconds = probe.IntervalInSeconds


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Deprecate numberOfProbes and adopt ProbeThreshold to address a probe issue in nrp
Because numberofprobes never works and it is mentioned in https://learn.microsoft.com/en-us/azure/load-balancer/whats-new#known-issues
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deprecate numberOfProbes and adopt ProbeThreshold in network api to address a probe issue in nrp
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
