### PR TITLE
Allow deprecated beta topology labels to be applied for those not ready to migrate

### DIFF
--- a/cmd/cloud-node-manager/app/config/config.go
+++ b/cmd/cloud-node-manager/app/config/config.go
@@ -81,4 +81,9 @@ type Config struct {
 	// WindowsService should be set to true if cloud-node-manager is running as a service on Windows.
 	// Its corresponding flag only gets registered in Windows builds
 	WindowsService bool
+
+	// EnableDeprecatedBetaTopologyLabels indicates whether the node should apply beta topology labels.
+	// If true, the node will apply beta topology labels.
+	// DEPRECATED: This flag will be removed in a future release.
+	EnableDeprecatedBetaTopologyLabels bool
 }

--- a/cmd/cloud-node-manager/app/nodemanager.go
+++ b/cmd/cloud-node-manager/app/nodemanager.go
@@ -137,7 +137,8 @@ func startControllers(ctx context.Context, c *cloudnodeconfig.Config, stopCh <-c
 		c.ClientBuilder.ClientOrDie("node-controller"),
 		nodeprovider.NewNodeProvider(ctx, c.UseInstanceMetadata, c.CloudConfigFilePath),
 		c.NodeStatusUpdateFrequency.Duration,
-		c.WaitForRoutes)
+		c.WaitForRoutes,
+		c.EnableDeprecatedBetaTopologyLabels)
 
 	go nodeController.Run(stopCh)
 

--- a/cmd/cloud-node-manager/app/options/options.go
+++ b/cmd/cloud-node-manager/app/options/options.go
@@ -86,6 +86,11 @@ type CloudNodeManagerOptions struct {
 	// WindowsService should be set to true if cloud-node-manager is running as a service on Windows.
 	// Its corresponding flag only gets registered in Windows builds
 	WindowsService bool
+
+	// EnableDeprecatedBetaTopologyLabels indicates whether the node should apply beta topology labels.
+	// If true, the node will apply beta topology labels.
+	// DEPRECATED: This flag will be removed in a future release.
+	EnableDeprecatedBetaTopologyLabels bool
 }
 
 // NewCloudNodeManagerOptions creates a new CloudNodeManagerOptions with a default config.
@@ -131,6 +136,7 @@ func (o *CloudNodeManagerOptions) Flags() cliflag.NamedFlagSets {
 	fs.BoolVar(&o.WaitForRoutes, "wait-routes", false, "Whether the nodes should wait for routes created on Azure route table. It should be set to true when using kubenet plugin.")
 	fs.BoolVar(&o.UseInstanceMetadata, "use-instance-metadata", true, "Should use Instance Metadata Service for fetching node information; if false will use ARM instead.")
 	fs.StringVar(&o.CloudConfigFilePath, "cloud-config", o.CloudConfigFilePath, "The path to the cloud config file to be used when using ARM to fetch node information.")
+	fs.BoolVar(&o.EnableDeprecatedBetaTopologyLabels, "enable-deprecated-beta-topology-labels", o.EnableDeprecatedBetaTopologyLabels, "DEPRECATED: This flag will be removed in a future release. If true, the node will apply beta topology labels.")
 	return fss
 }
 
@@ -192,6 +198,9 @@ func (o *CloudNodeManagerOptions) ApplyTo(c *cloudnodeconfig.Config, userAgent s
 	c.CloudConfigFilePath = o.CloudConfigFilePath
 
 	c.WindowsService = o.WindowsService
+
+	// Allow users to choose to apply beta topology labels until they are removed by all cloud providers.
+	c.EnableDeprecatedBetaTopologyLabels = o.EnableDeprecatedBetaTopologyLabels
 
 	return nil
 }

--- a/pkg/nodemanager/nodemanager.go
+++ b/pkg/nodemanager/nodemanager.go
@@ -63,17 +63,44 @@ type NodeProvider interface {
 	GetPlatformSubFaultDomain() (string, error)
 }
 
-// labelReconcileInfo lists Node labels to reconcile, and how to reconcile them.
+// labelReconcile holds information about a label to reconcile and how to reconcile it.
 // primaryKey and secondaryKey are keys of labels to reconcile.
 // - If both keys exist, but their values don't match. Use the value from the
 // primaryKey as the source of truth to reconcile.
 // - If ensureSecondaryExists is true, and the secondaryKey does not
 // exist, secondaryKey will be added with the value of the primaryKey.
-var labelReconcileInfo = []struct {
+type labelReconcile struct {
 	primaryKey            string
 	secondaryKey          string
 	ensureSecondaryExists bool
-}{}
+}
+
+// betaToplogyLabels lists beta topology labels that are deprecated and will
+// be removed in a future release.
+// For now we reconcile them optionally onto nodes.
+var betaToplogyLabels = []labelReconcile{
+	{
+		// Reconcile the beta and the GA zone label using the GA label as
+		// the source of truth
+		primaryKey:            v1.LabelZoneFailureDomainStable,
+		secondaryKey:          v1.LabelZoneFailureDomain,
+		ensureSecondaryExists: true,
+	},
+	{
+		// Reconcile the beta and the stable region label using the GA label as
+		// the source of truth
+		primaryKey:            v1.LabelZoneRegionStable,
+		secondaryKey:          v1.LabelZoneRegion,
+		ensureSecondaryExists: true,
+	},
+	{
+		// Reconcile the beta and the stable instance-type label using the GA label as
+		// the source of truth
+		primaryKey:            v1.LabelInstanceTypeStable,
+		secondaryKey:          v1.LabelInstanceType,
+		ensureSecondaryExists: true,
+	},
+}
 
 // UpdateNodeSpecBackoff is the back configure for node update.
 var UpdateNodeSpecBackoff = wait.Backoff{
@@ -103,6 +130,10 @@ type CloudNodeController struct {
 	recorder      record.EventRecorder
 
 	nodeStatusUpdateFrequency time.Duration
+
+	labelReconcileInfo []labelReconcile
+
+	enableBetaTopologyLabels bool
 }
 
 // NewCloudNodeController creates a CloudNodeController object
@@ -112,7 +143,7 @@ func NewCloudNodeController(
 	kubeClient clientset.Interface,
 	nodeProvider NodeProvider,
 	nodeStatusUpdateFrequency time.Duration,
-	waitForRoutes bool) *CloudNodeController {
+	waitForRoutes, enableBetaTopologyLabels bool) *CloudNodeController {
 
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"})
@@ -132,6 +163,12 @@ func NewCloudNodeController(
 		nodeProvider:              nodeProvider,
 		waitForRoutes:             waitForRoutes,
 		nodeStatusUpdateFrequency: nodeStatusUpdateFrequency,
+		enableBetaTopologyLabels:  enableBetaTopologyLabels,
+	}
+
+	// Only reconcile the beta toplogy labels when the feature flag is enabled.
+	if cnc.enableBetaTopologyLabels {
+		cnc.labelReconcileInfo = append(cnc.labelReconcileInfo, betaToplogyLabels...)
 	}
 
 	// Use shared informer to listen to add/update of nodes. Note that any nodes
@@ -190,7 +227,7 @@ func (cnc *CloudNodeController) reconcileNodeLabels(node *v1.Node) error {
 	}
 
 	labelsToUpdate := map[string]string{}
-	for _, r := range labelReconcileInfo {
+	for _, r := range cnc.labelReconcileInfo {
 		primaryValue, primaryExists := node.Labels[r.primaryKey]
 		secondaryValue, secondaryExists := node.Labels[r.secondaryKey]
 
@@ -445,51 +482,49 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Co
 	if instanceType, err := cnc.getInstanceTypeByName(ctx, node); err != nil {
 		return nil, err
 	} else if instanceType != "" {
-		klog.V(2).Infof("Adding node label from cloud provider: %s=%s", v1.LabelInstanceTypeStable, instanceType)
-		nodeModifiers = append(nodeModifiers, func(n *v1.Node) {
-			if n.Labels == nil {
-				n.Labels = map[string]string{}
-			}
-			n.Labels[v1.LabelInstanceTypeStable] = instanceType
-		})
+		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(v1.LabelInstanceTypeStable, instanceType))
+		if cnc.enableBetaTopologyLabels {
+			nodeModifiers = append(nodeModifiers, addCloudNodeLabel(v1.LabelInstanceType, instanceType))
+		}
 	}
+
 	zone, err := cnc.getZoneByName(ctx, node)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get zone from cloud provider: %w", err)
 	}
 	if zone.FailureDomain != "" {
-		klog.V(2).Infof("Adding node label from cloud provider: %s=%s", v1.LabelZoneFailureDomainStable, zone.FailureDomain)
-		nodeModifiers = append(nodeModifiers, func(n *v1.Node) {
-			if n.Labels == nil {
-				n.Labels = map[string]string{}
-			}
-			n.Labels[v1.LabelZoneFailureDomainStable] = zone.FailureDomain
-		})
+		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(v1.LabelZoneFailureDomainStable, zone.FailureDomain))
+		if cnc.enableBetaTopologyLabels {
+			nodeModifiers = append(nodeModifiers, addCloudNodeLabel(v1.LabelZoneFailureDomain, zone.FailureDomain))
+		}
 	}
 	if zone.Region != "" {
-		klog.V(2).Infof("Adding node label from cloud provider: %s=%s", v1.LabelZoneRegionStable, zone.Region)
-		nodeModifiers = append(nodeModifiers, func(n *v1.Node) {
-			if n.Labels == nil {
-				n.Labels = map[string]string{}
-			}
-			n.Labels[v1.LabelZoneRegionStable] = zone.Region
-		})
+		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(v1.LabelZoneRegionStable, zone.Region))
+		if cnc.enableBetaTopologyLabels {
+			nodeModifiers = append(nodeModifiers, addCloudNodeLabel(v1.LabelZoneRegion, zone.Region))
+		}
 	}
+
 	platformSubFaultDomain, err := cnc.getPlatformSubFaultDomain()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get platformSubFaultDomain: %w", err)
 	}
 	if platformSubFaultDomain != "" {
-		klog.V(2).Infof("Adding node label from cloud provider: %s=%s", consts.LabelPlatformSubFaultDomain, platformSubFaultDomain)
-		nodeModifiers = append(nodeModifiers, func(n *v1.Node) {
-			if n.Labels == nil {
-				n.Labels = map[string]string{}
-			}
-			n.Labels[consts.LabelPlatformSubFaultDomain] = platformSubFaultDomain
-		})
+		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(consts.LabelPlatformSubFaultDomain, platformSubFaultDomain))
 	}
 
 	return nodeModifiers, nil
+}
+
+// addCloudNodeLabel creates a nodeModifier that adds a label to a node.
+func addCloudNodeLabel(key, value string) func(*v1.Node) {
+	klog.V(2).Infof("Adding node label from cloud provider: %s=%s", key, value)
+	return func(node *v1.Node) {
+		if node.Labels == nil {
+			node.Labels = map[string]string{}
+		}
+		node.Labels[key] = value
+	}
 }
 
 func GetCloudTaint(taints []v1.Taint) *v1.Taint {

--- a/pkg/nodemanager/nodemanager_test.go
+++ b/pkg/nodemanager/nodemanager_test.go
@@ -19,7 +19,7 @@ package nodemanager
 import (
 	"context"
 	"errors"
-	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -190,6 +190,7 @@ func TestNodeInitialized(t *testing.T) {
 		fnh,
 		mockNP,
 		time.Second,
+		false,
 		false)
 
 	cloudNodeController.AddCloudNode(ctx, fnh.Existing[0])
@@ -268,7 +269,8 @@ func TestUpdateCloudNode(t *testing.T) {
 		fnh,
 		mockNP,
 		time.Second,
-		true)
+		true,
+		false)
 	eventBroadcaster.StartLogging(klog.Infof)
 
 	cloudNodeController.UpdateCloudNode(ctx, fnh.Existing[0], fnh.Existing[0])
@@ -319,6 +321,7 @@ func TestNodeIgnored(t *testing.T) {
 		fnh,
 		mockNP,
 		time.Second,
+		false,
 		false)
 	eventBroadcaster.StartLogging(klog.Infof)
 
@@ -333,83 +336,172 @@ func TestZoneInitialized(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	fnh := &testutil.FakeNodeHandler{
-		Existing: []*v1.Node{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "node0",
-					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-					Labels:            map[string]string{},
-				},
-				Status: v1.NodeStatus{
-					Conditions: []v1.NodeCondition{
-						{
-							Type:               v1.NodeReady,
-							Status:             v1.ConditionUnknown,
-							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+	t.Run("with stable zone labels", func(t *testing.T) {
+		fnh := &testutil.FakeNodeHandler{
+			Existing: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node0",
+						CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						Labels:            map[string]string{},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:               v1.NodeReady,
+								Status:             v1.ConditionUnknown,
+								LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							},
 						},
 					},
-				},
-				Spec: v1.NodeSpec{
-					Taints: []v1.Taint{
-						{
-							Key:    cloudproviderapi.TaintExternalCloudProvider,
-							Value:  "true",
-							Effect: v1.TaintEffectNoSchedule,
+					Spec: v1.NodeSpec{
+						Taints: []v1.Taint{
+							{
+								Key:    cloudproviderapi.TaintExternalCloudProvider,
+								Value:  "true",
+								Effect: v1.TaintEffectNoSchedule,
+							},
 						},
 					},
 				},
 			},
-		},
-		Clientset:      fake.NewSimpleClientset(&v1.PodList{}),
-		DeleteWaitChan: make(chan struct{}),
-	}
+			Clientset:      fake.NewSimpleClientset(&v1.PodList{}),
+			DeleteWaitChan: make(chan struct{}),
+		}
 
-	ctx := context.TODO()
-	factory := informers.NewSharedInformerFactory(fnh, 0)
-	mockNP := mocknodeprovider.NewMockNodeProvider(ctrl)
-	mockNP.EXPECT().InstanceID(ctx, types.NodeName("node0")).Return("node0", nil)
-	mockNP.EXPECT().InstanceType(ctx, types.NodeName("node0")).Return("Standard_D2_v3", nil)
-	mockNP.EXPECT().GetZone(ctx, gomock.Any()).Return(cloudprovider.Zone{
-		Region:        "eastus",
-		FailureDomain: "eastus-1",
-	}, nil)
-	mockNP.EXPECT().NodeAddresses(ctx, types.NodeName("node0")).Return([]v1.NodeAddress{
-		{
-			Type:    v1.NodeHostName,
-			Address: "node0.cloud.internal",
-		},
-		{
-			Type:    v1.NodeInternalIP,
-			Address: "10.0.0.1",
-		},
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "132.143.154.163",
-		},
-	}, nil).AnyTimes()
-	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
+		ctx := context.TODO()
+		factory := informers.NewSharedInformerFactory(fnh, 0)
+		mockNP := mocknodeprovider.NewMockNodeProvider(ctrl)
+		mockNP.EXPECT().InstanceID(ctx, types.NodeName("node0")).Return("node0", nil)
+		mockNP.EXPECT().InstanceType(ctx, types.NodeName("node0")).Return("Standard_D2_v3", nil)
+		mockNP.EXPECT().GetZone(ctx, gomock.Any()).Return(cloudprovider.Zone{
+			Region:        "eastus",
+			FailureDomain: "eastus-1",
+		}, nil)
+		mockNP.EXPECT().NodeAddresses(ctx, types.NodeName("node0")).Return([]v1.NodeAddress{
+			{
+				Type:    v1.NodeHostName,
+				Address: "node0.cloud.internal",
+			},
+			{
+				Type:    v1.NodeInternalIP,
+				Address: "10.0.0.1",
+			},
+			{
+				Type:    v1.NodeExternalIP,
+				Address: "132.143.154.163",
+			},
+		}, nil).AnyTimes()
+		mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
 
-	eventBroadcaster := record.NewBroadcaster()
-	cloudNodeController := &CloudNodeController{
-		kubeClient:   fnh,
-		nodeName:     "node0",
-		nodeProvider: mockNP,
-		nodeInformer: factory.Core().V1().Nodes(),
-		recorder:     eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
-	}
-	eventBroadcaster.StartLogging(klog.Infof)
+		eventBroadcaster := record.NewBroadcaster()
+		cloudNodeController := &CloudNodeController{
+			kubeClient:   fnh,
+			nodeName:     "node0",
+			nodeProvider: mockNP,
+			nodeInformer: factory.Core().V1().Nodes(),
+			recorder:     eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
+		}
+		eventBroadcaster.StartLogging(klog.Infof)
 
-	cloudNodeController.AddCloudNode(context.TODO(), fnh.Existing[0])
+		cloudNodeController.AddCloudNode(context.TODO(), fnh.Existing[0])
 
-	assert.Equal(t, 1, len(fnh.UpdatedNodes), "Node was not updated")
-	fmt.Println(fnh.UpdatedNodes[0].ObjectMeta.Labels)
-	assert.Equal(t, "eastus", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneRegionStable])
-	assert.Equal(t, "eastus-1", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneFailureDomainStable])
-	assert.Equal(t, "node0", fnh.UpdatedNodes[0].Name, "Node was not updated")
-	assert.Equal(t, 3, len(fnh.UpdatedNodes[0].ObjectMeta.Labels),
-		"Node label for Region and Zone were not set")
+		assert.Equal(t, 1, len(fnh.UpdatedNodes), "Node was not updated")
+		assert.Equal(t, "node0", fnh.UpdatedNodes[0].Name, "Node was not updated")
+		assert.Equal(t, 3, len(fnh.UpdatedNodes[0].ObjectMeta.Labels),
+			"Node label for Region and Zone were not set")
+		assert.Equal(t, "eastus", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneRegionStable],
+			"Node Region not correctly updated")
+		assert.Equal(t, "eastus-1", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneFailureDomainStable],
+			"Node FailureDomain not correctly updated")
+	})
+
+	t.Run("with beta zone labels", func(t *testing.T) {
+		fnh := &testutil.FakeNodeHandler{
+			Existing: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "node0",
+						CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						Labels:            map[string]string{},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:               v1.NodeReady,
+								Status:             v1.ConditionUnknown,
+								LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							},
+						},
+					},
+					Spec: v1.NodeSpec{
+						Taints: []v1.Taint{
+							{
+								Key:    cloudproviderapi.TaintExternalCloudProvider,
+								Value:  "true",
+								Effect: v1.TaintEffectNoSchedule,
+							},
+						},
+					},
+				},
+			},
+			Clientset:      fake.NewSimpleClientset(&v1.PodList{}),
+			DeleteWaitChan: make(chan struct{}),
+		}
+
+		ctx := context.TODO()
+		factory := informers.NewSharedInformerFactory(fnh, 0)
+		mockNP := mocknodeprovider.NewMockNodeProvider(ctrl)
+		mockNP.EXPECT().InstanceID(ctx, types.NodeName("node0")).Return("node0", nil)
+		mockNP.EXPECT().InstanceType(ctx, types.NodeName("node0")).Return("Standard_D2_v3", nil)
+		mockNP.EXPECT().GetZone(ctx, gomock.Any()).Return(cloudprovider.Zone{
+			Region:        "eastus",
+			FailureDomain: "eastus-1",
+		}, nil)
+		mockNP.EXPECT().NodeAddresses(ctx, types.NodeName("node0")).Return([]v1.NodeAddress{
+			{
+				Type:    v1.NodeHostName,
+				Address: "node0.cloud.internal",
+			},
+			{
+				Type:    v1.NodeInternalIP,
+				Address: "10.0.0.1",
+			},
+			{
+				Type:    v1.NodeExternalIP,
+				Address: "132.143.154.163",
+			},
+		}, nil).AnyTimes()
+		mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
+
+		eventBroadcaster := record.NewBroadcaster()
+		cloudNodeController := &CloudNodeController{
+			kubeClient:               fnh,
+			nodeName:                 "node0",
+			nodeProvider:             mockNP,
+			nodeInformer:             factory.Core().V1().Nodes(),
+			recorder:                 eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
+			enableBetaTopologyLabels: true,
+		}
+		eventBroadcaster.StartLogging(klog.Infof)
+
+		cloudNodeController.AddCloudNode(context.TODO(), fnh.Existing[0])
+
+		assert.Equal(t, 1, len(fnh.UpdatedNodes), "Node was not updated")
+		assert.Equal(t, "node0", fnh.UpdatedNodes[0].Name, "Node was not updated")
+		assert.Equal(t, 6, len(fnh.UpdatedNodes[0].ObjectMeta.Labels),
+			"Node label for Region and Zone were not set")
+		assert.Equal(t, "eastus", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneRegionStable],
+			"Node Region not correctly updated")
+		assert.Equal(t, "eastus-1", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneFailureDomainStable],
+			"Node FailureDomain not correctly updated")
+		assert.Equal(t, "eastus", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneRegion],
+			"Node Region not correctly updated")
+		assert.Equal(t, "eastus-1", fnh.UpdatedNodes[0].ObjectMeta.Labels[v1.LabelZoneFailureDomain],
+			"Node FailureDomain not correctly updated")
+	})
 }
 
 // This test checks that a node with the external cloud provider taint is cloudprovider initialized and
@@ -461,7 +553,10 @@ func TestAddCloudNode(t *testing.T) {
 	mockNP := mocknodeprovider.NewMockNodeProvider(ctrl)
 	mockNP.EXPECT().InstanceID(gomock.Any(), types.NodeName("node0")).Return("node0", nil)
 	mockNP.EXPECT().InstanceType(gomock.Any(), types.NodeName("node0")).Return("Standard_D2_v3", nil)
-
+	mockNP.EXPECT().GetZone(gomock.Any(), gomock.Any()).Return(cloudprovider.Zone{
+		Region:        "eastus",
+		FailureDomain: "eastus-1",
+	}, nil)
 	mockNP.EXPECT().NodeAddresses(gomock.Any(), types.NodeName("node0")).Return([]v1.NodeAddress{
 		{
 			Type:    v1.NodeHostName,
@@ -476,10 +571,6 @@ func TestAddCloudNode(t *testing.T) {
 			Address: "132.143.154.163",
 		},
 	}, nil).AnyTimes()
-	mockNP.EXPECT().GetZone(gomock.Any(), gomock.Any()).Return(cloudprovider.Zone{
-		Region:        "eastus",
-		FailureDomain: "eastus-1",
-	}, nil)
 	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
 
 	factory := informers.NewSharedInformerFactory(fnh, 0)
@@ -491,6 +582,7 @@ func TestAddCloudNode(t *testing.T) {
 		fnh,
 		mockNP,
 		time.Second,
+		false,
 		false)
 	factory.Start(ctx.Done())
 	cache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced)
@@ -550,6 +642,7 @@ func TestUpdateNodeAddresses(t *testing.T) {
 		fnh,
 		mockNP,
 		time.Second,
+		false,
 		false)
 	factory.Start(ctx.Done())
 	cache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced)
@@ -651,6 +744,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 		fnh,
 		mockNP,
 		time.Second,
+		false,
 		false)
 	eventBroadcaster.StartLogging(klog.Infof)
 
@@ -663,6 +757,123 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 	updatedNodes := fnh.GetUpdatedNodesCopy()
 	assert.Equal(t, 3, len(updatedNodes[0].Status.Addresses), "Node Addresses not correctly updated")
 	assert.Equal(t, "10.0.0.1", updatedNodes[0].Status.Addresses[0].Address, "Node Addresses not correctly updated")
+}
+
+func Test_reconcileNodeLabels(t *testing.T) {
+	testcases := []struct {
+		name           string
+		labels         map[string]string
+		expectedLabels map[string]string
+		expectedErr    error
+	}{
+		{
+			name:           "no labels",
+			labels:         map[string]string{},
+			expectedLabels: map[string]string{},
+			expectedErr:    nil,
+		},
+		{
+			name: "requires reconcile",
+			labels: map[string]string{
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelInstanceTypeStable:      "the-best-type",
+			},
+			expectedLabels: map[string]string{
+				v1.LabelZoneFailureDomain:       "foo",
+				v1.LabelZoneRegion:              "bar",
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelInstanceType:            "the-best-type",
+				v1.LabelInstanceTypeStable:      "the-best-type",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "doesn't require reconcile",
+			labels: map[string]string{
+				v1.LabelZoneFailureDomain:       "foo",
+				v1.LabelZoneRegion:              "bar",
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelInstanceType:            "the-best-type",
+				v1.LabelInstanceTypeStable:      "the-best-type",
+			},
+			expectedLabels: map[string]string{
+				v1.LabelZoneFailureDomain:       "foo",
+				v1.LabelZoneRegion:              "bar",
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelInstanceType:            "the-best-type",
+				v1.LabelInstanceTypeStable:      "the-best-type",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "require reconcile -- secondary labels are different from primary",
+			labels: map[string]string{
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelZoneFailureDomain:       "wrongfoo",
+				v1.LabelZoneRegion:              "wrongbar",
+				v1.LabelInstanceTypeStable:      "the-best-type",
+				v1.LabelInstanceType:            "the-wrong-type",
+			},
+			expectedLabels: map[string]string{
+				v1.LabelZoneFailureDomain:       "foo",
+				v1.LabelZoneRegion:              "bar",
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelInstanceType:            "the-best-type",
+				v1.LabelInstanceTypeStable:      "the-best-type",
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			testNode := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "node01",
+					Labels: test.labels,
+				},
+			}
+
+			clientset := fake.NewSimpleClientset(testNode)
+			factory := informers.NewSharedInformerFactory(clientset, 0)
+
+			cnc := &CloudNodeController{
+				kubeClient:   clientset,
+				nodeInformer: factory.Core().V1().Nodes(),
+				// Test using the beta toplogy labels.
+				labelReconcileInfo: betaToplogyLabels,
+			}
+
+			// activate node informer
+			factory.Core().V1().Nodes().Informer()
+			factory.Start(nil)
+			factory.WaitForCacheSync(nil)
+
+			err := cnc.reconcileNodeLabels(testNode)
+			if !errors.Is(err, test.expectedErr) {
+				t.Logf("actual err: %v", err)
+				t.Logf("expected err: %v", test.expectedErr)
+				t.Errorf("unexpected error")
+			}
+
+			actualNode, err := clientset.CoreV1().Nodes().Get(context.TODO(), "node01", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("error getting updated node: %v", err)
+			}
+
+			if !reflect.DeepEqual(actualNode.Labels, test.expectedLabels) {
+				t.Logf("actual node labels: %v", actualNode.Labels)
+				t.Logf("expected node labels: %v", test.expectedLabels)
+				t.Errorf("updated node did not match expected node")
+			}
+		})
+	}
 }
 
 // Tests that node address changes are detected correctly


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

#2653 removed the deprecated labels completely, however, other cloud providers have [not yet removed](https://github.com/kubernetes/cloud-provider/blob/9be8e26d3703a1461004f30951315283a88307e4/controllers/node/node_controller.go#L51-L86) these and there are a lot of people out there who are probably not ready to migrate. For example, the Azure Red Hat OpenShift offering has not announced removal of the labels and still supports the labels, even though Microsoft and AKS have removed them.

This PR introduces a softer change, allowing users to maintain the old behaviour should they wish to.

Commit wise, it does:
* Reverts 2653 to put things back to how they were
* Refactors the cloud node modifier code to clean that up ahead of later changes
* Switch priority from beta labels to GA labels, so that GA labels become the source of truth
* Adds `--deprecated-apply-beta-topology-labels` as a flag, off by default, that allows users to opt-in to the old behaviour

I think this should maintain the direction of the Azure provider, while allowing those who aren't yet ready to drop the labels, to continue using them until they have migrated.

My suggestion would be to keep these labels and this flag in-place until the wider cloud-provider community has sunset the labels completely and worked out the migration path for everyone.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2453 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The deprecated beta topology labels are no longer applied by default, to maintain the legacy behaviour use `--deprecated-apply-beta-topology-labels`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
