### PR TITLE
[e2e] Improve autoscaling e2e

### DIFF
--- a/.pipelines/templates/autoscaling-multipool.json
+++ b/.pipelines/templates/autoscaling-multipool.json
@@ -9,7 +9,7 @@
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
-        "count": 1,
+        "count": 3,
         "mode" : "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
@@ -20,7 +20,7 @@
       },
       {
         "name": "agentpool2",
-        "count": 1,
+        "count": 3,
         "mode" : "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",

--- a/.pipelines/templates/autoscaling.json
+++ b/.pipelines/templates/autoscaling.json
@@ -9,7 +9,7 @@
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
-        "count": 1,
+        "count": 3,
         "mode" : "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",

--- a/tests/e2e/autoscaling/autoscaler.go
+++ b/tests/e2e/autoscaling/autoscaler.go
@@ -111,34 +111,9 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 			err := utils.DeleteNamespace(cs, ns.Name)
 			Expect(err).NotTo(HaveOccurred())
 
-			// TODO: Should not delete because old Nodes may be replaced by new ones
-			//delete extra nodes
-			nodes, err := utils.GetAgentNodes(cs)
-			Expect(err).NotTo(HaveOccurred())
-
-			nodesNotToBeDeleted := make([]string, 0)
-			for _, nodes := range initNodepoolNodeMap {
-				nodesNotToBeDeleted = append(nodesNotToBeDeleted, nodes...)
-			}
-
-			nodesToBeDeleted := make([]string, 0)
-			nodeToBeDeletedCount := 0
-			if len(nodes)-initNodeCount > 0 {
-				nodeToBeDeletedCount = len(nodes) - initNodeCount
-			}
-
-			for _, node := range nodes {
-				if nodeToBeDeletedCount == 0 {
-					break
-				}
-
-				if !utils.StringInSlice(node.Name, nodesNotToBeDeleted) {
-					nodesToBeDeleted = append(nodesToBeDeleted, node.Name)
-					nodeToBeDeletedCount--
-				}
-			}
-
-			err = utils.DeleteNodes(cs, nodesToBeDeleted)
+			// NOTICE: When scaling up and down, CAS creates a new instance and deletes an old one.
+			// So it is enough to just ensure the Node count equals VMSS VMs.
+			err = utils.WaitVMSSVMCountToEqualNodeCount(tc)
 			Expect(err).NotTo(HaveOccurred())
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[e2e] Improve autoscaling e2e
* More instances in VMSS to avoid deallocating to 0 instance
* AfterEach: Should not simply delete Nodes when before and after are different since only the total count matters
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
