### PR TITLE
chore: upgrade credentialprovider-api-version to v1

### DIFF
--- a/cmd/acr-credential-provider/plugin_test.go
+++ b/cmd/acr-credential-provider/plugin_test.go
@@ -24,17 +24,17 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1"
+	v1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 )
 
 type fakePlugin struct {
 }
 
-func (f *fakePlugin) GetCredentials(ctx context.Context, image string, args []string) (*v1alpha1.CredentialProviderResponse, error) {
-	return &v1alpha1.CredentialProviderResponse{
-		CacheKeyType:  v1alpha1.RegistryPluginCacheKeyType,
+func (f *fakePlugin) GetCredentials(ctx context.Context, image string, args []string) (*v1.CredentialProviderResponse, error) {
+	return &v1.CredentialProviderResponse{
+		CacheKeyType:  v1.RegistryPluginCacheKeyType,
 		CacheDuration: &metav1.Duration{Duration: 10 * time.Minute},
-		Auth: map[string]v1alpha1.AuthConfig{
+		Auth: map[string]v1.AuthConfig{
 			"*.registry.io": {
 				Username: "user",
 				Password: "password",
@@ -52,26 +52,26 @@ func Test_runPlugin(t *testing.T) {
 	}{
 		{
 			name: "successful test case",
-			in:   bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","image":"test.registry.io/foobar"}`),
-			expectedOut: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","cacheKeyType":"Registry","cacheDuration":"10m0s","auth":{"*.registry.io":{"username":"user","password":"password"}}}
+			in:   bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1","image":"test.registry.io/foobar"}`),
+			expectedOut: []byte(`{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1","cacheKeyType":"Registry","cacheDuration":"10m0s","auth":{"*.registry.io":{"username":"user","password":"password"}}}
 `),
 			expectErr: false,
 		},
 		{
 			name:        "invalid kind",
-			in:          bytes.NewBufferString(`{"kind":"CredentialProviderFoo","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","image":"test.registry.io/foobar"}`),
+			in:          bytes.NewBufferString(`{"kind":"CredentialProviderFoo","apiVersion":"credentialprovider.kubelet.k8s.io/v1","image":"test.registry.io/foobar"}`),
 			expectedOut: nil,
 			expectErr:   true,
 		},
 		{
 			name:        "invalid apiVersion",
-			in:          bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"foo.k8s.io/v1alpha1","image":"test.registry.io/foobar"}`),
+			in:          bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"foo.k8s.io/v1","image":"test.registry.io/foobar"}`),
 			expectedOut: nil,
 			expectErr:   true,
 		},
 		{
 			name:        "empty image",
-			in:          bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1alpha1","image":""}`),
+			in:          bytes.NewBufferString(`{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1","image":""}`),
 			expectedOut: nil,
 			expectErr:   true,
 		},

--- a/site/content/en/topics/credential-provider.md
+++ b/site/content/en/topics/credential-provider.md
@@ -21,18 +21,17 @@ In order to switch the kubelet credential provider to out-of-tree, you'll have t
 ```yaml
 # cat /var/lib/kubelet/credential-provider-config.yaml
 kind: CredentialProviderConfig
-apiVersion: kubelet.config.k8s.io/v1alpha1
+apiVersion: kubelet.config.k8s.io/v1
 providers:
 - name: acr-credential-provider
-  apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+  apiVersion: credentialprovider.kubelet.k8s.io/v1
   defaultCacheDuration: 10m
   matchImages:
   - "*.azurecr.io"
   - "*.azurecr.cn"
   - "*.azurecr.de"
   - "*.azurecr.us"
-  - "*.azurecr.*" # Only required for custom Azure cloud.
   args:
-  - /etc/kubernetes/cloud-config/azure.json
+  - /etc/kubernetes/azure.json
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
chore: upgrade credentialprovider-api-version to v1

Per https://kubernetes.io/blog/2022/12/22/kubelet-credential-providers/, kubelet credential provider has been GA since v1.26 and the API version has been promoted to `credentialprovider.kubelet.k8s.io/v1`. For GA of [acr-credential-provider](https://github.com/kubernetes-sigs/cloud-provider-azure/tree/master/cmd/acr-credential-provider), we need to 

* Upgrade the API version to `credentialprovider.kubelet.k8s.io/v1`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3116

#### Special notes for your reviewer:
I have also manually verified on 1.26 node with following feature flag and config, external credential provider works, next will set up e2e test:

```
,KubeletCredentialProviders=true --image-credential-provider-bin-dir=/var/lib/kubelet/credential-provider --image-credential-provider-config=/var/lib/kubelet/credential-provider-config.yaml
 
# vi credential-provider-config.yaml
kind: CredentialProviderConfig
apiVersion: kubelet.config.k8s.io/v1
providers:
- name: acr-credential-provider
  apiVersion: credentialprovider.kubelet.k8s.io/v1
  defaultCacheDuration: 10m
  matchImages:
  - "*.azurecr.io"
  - "*.azurecr.cn"
  - "*.azurecr.de"
  - "*.azurecr.us"
  args:
  - /etc/kubernetes/azure.json
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
chore: upgrade credentialprovider-api-version to v1
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
chore: upgrade credentialprovider-api-version to v1
```
