### PR TITLE
chore: set default loadBalancerSKU to Standard

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -706,6 +706,10 @@ func (az *Cloud) initCaches() (err error) {
 }
 
 func (az *Cloud) setLBDefaults(config *Config) error {
+	if config.LoadBalancerSku == "" {
+		config.LoadBalancerSku = consts.LoadBalancerSkuStandard
+	}
+
 	if strings.EqualFold(config.LoadBalancerSku, consts.LoadBalancerSkuStandard) {
 		// Do not add master nodes to standard LB by default.
 		if config.ExcludeMasterFromStandardLB == nil {

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -3917,3 +3917,13 @@ func TestFindSecurityRule(t *testing.T) {
 		assert.Equal(t, testCases[i].expected, found, testCases[i].desc)
 	}
 }
+
+func TestSetLBDefaults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	az := GetTestCloud(ctrl)
+
+	config := &Config{}
+	_ = az.setLBDefaults(config)
+	assert.Equal(t, config.LoadBalancerSku, consts.LoadBalancerSkuStandard)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

ClusterConfig defaults loadBalancerSku to `basic`: https://cloud-provider-azure.sigs.k8s.io/install/configs/#cluster-config.

> On 30 September 2025, Basic SKU public IP addresses will be retired in Azure. You can continue to use your existing Basic SKU public IP addresses until then, however, you'll no longer be able to create new ones after 31 March 2025.

Basic SKU is being retired. We should not be defaulting to basic for LB and public IP SKUs.

Standard SKU public IP addresses offer significant [improvements](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#sku), including:

- Access to a variety of other Azure products, including Standard Load Balancer, Azure Firewall, and NAT Gateway.
- Security by default—closed to inbound flows unless allowed by a network security group.
- Zone-redundant and zonal front ends for inbound and outbound traffic.

Even if the retirement date is 3 years away, we should consider making this change now as the default value should reflect the recommended best practices in Azure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2414

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
chore: set default loadBalancerSKU to Standard
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
