### PR TITLE
[release-1.26][IPv6] Choose correct primary IP config

### DIFF
--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -56,6 +56,10 @@ var (
 	vmasIDRE           = regexp.MustCompile(`/subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Compute/availabilitySets/(.+)`)
 )
 
+const (
+	v6Suffix = "IPv6"
+)
+
 // returns the full identifier of an availabilitySet
 func (az *Cloud) getAvailabilitySetID(resourceGroup, availabilitySetName string) string {
 	return fmt.Sprintf(
@@ -270,6 +274,11 @@ func getBackendPoolName(clusterName string, service *v1.Service) string {
 	}
 
 	return clusterName
+}
+
+// ifBackendPoolIPv6 checks if a backend pool is of IPv6 according to name/ID.
+func isBackendPoolIPv6(name string) bool {
+	return strings.HasSuffix(name, fmt.Sprintf("-%s", v6Suffix))
 }
 
 func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protocol, port int32) string {

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -923,6 +923,22 @@ func TestGetBackendPoolName(t *testing.T) {
 	}
 }
 
+func TestIsBackendPoolIPv6(t *testing.T) {
+	testcases := []struct {
+		name           string
+		expectedIsIPv6 bool
+	}{
+		{"bp-IPv6", true},
+		{"bp-IPv4", false},
+		{"bp", false},
+		{"bp-ipv6", false},
+	}
+	for _, test := range testcases {
+		isIPv6 := isBackendPoolIPv6(test.name)
+		assert.Equal(t, test.expectedIsIPv6, isIPv6)
+	}
+}
+
 func TestGetStandardInstanceIDByNodeName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -47,13 +47,15 @@ import (
 )
 
 const (
-	fakePrivateIP        = "10.240.0.10"
-	fakePublicIP         = "10.10.10.10"
-	testVMSSName         = "vmss"
-	testVMPowerState     = "PowerState/Running"
-	testLBBackendpoolID0 = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-0"
-	testLBBackendpoolID1 = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-1"
-	testLBBackendpoolID2 = "/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-2"
+	fakePrivateIP          = "10.240.0.10"
+	fakePublicIP           = "10.10.10.10"
+	testVMSSName           = "vmss"
+	testVMPowerState       = "PowerState/Running"
+	testLBBackendpoolID0   = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-0"
+	testLBBackendpoolID0v6 = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-0" + "-" + v6Suffix
+	testLBBackendpoolID1   = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-1"
+	testLBBackendpoolID1v6 = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-1" + "-" + v6Suffix
+	testLBBackendpoolID2   = "/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-2"
 )
 
 func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv6 bool) compute.VirtualMachineScaleSet {
@@ -145,35 +147,29 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
 					Primary:                         pointer.Bool(true),
 					LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: pointer.String(testLBBackendpoolID0)}},
-				},
-			},
-		}
-		networkConfigurations := []compute.VirtualMachineScaleSetNetworkConfiguration{
-			{
-				Name: pointer.String("ipconfig1"),
-				ID:   pointer.String("fakeNetworkConfiguration"),
-				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-					IPConfigurations: &ipConfigurations,
+					PrivateIPAddressVersion:         compute.IPv4,
 				},
 			},
 		}
 		if isIPv6 {
-			networkConfigurations = append(networkConfigurations, compute.VirtualMachineScaleSetNetworkConfiguration{
-				Name: pointer.String("ipconfig1v6"),
-				ID:   pointer.String("fakeNetworkConfigurationIPv6"),
-				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
-						{
-							Name: pointer.String("ipconfig1"),
-							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-								Primary:                         pointer.Bool(false),
-								LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: pointer.String(testLBBackendpoolID0)}},
-								PrivateIPAddressVersion:         compute.IPv6,
-							},
-						},
-					},
+			ipConfigurations = append(ipConfigurations, compute.VirtualMachineScaleSetIPConfiguration{
+				Name: pointer.String("ipconfigv6"),
+				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+					Primary:                         pointer.Bool(false),
+					LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: pointer.String(testLBBackendpoolID0v6)}},
+					PrivateIPAddressVersion:         compute.IPv6,
 				},
 			})
+		}
+		networkConfigurations := []compute.VirtualMachineScaleSetNetworkConfiguration{
+			{
+				Name: pointer.String("vmss-nic"),
+				ID:   pointer.String("fakeNetworkConfiguration"),
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &ipConfigurations,
+					Primary:          pointer.Bool(true),
+				},
+			},
 		}
 
 		vmssVM := compute.VirtualMachineScaleSetVM{
@@ -1719,16 +1715,16 @@ func TestGetVMSetNames(t *testing.T) {
 	}
 }
 
-func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
+func TestGetPrimaryNetworkInterfaceConfiguration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	networkConfigs := []compute.VirtualMachineScaleSetNetworkConfiguration{
 		{Name: pointer.String("config-0")},
 	}
-	config, err := getPrimaryNetworkInterfaceConfigurationForScaleSet(networkConfigs, testVMSSName)
-	assert.Nil(t, err, "getPrimaryNetworkInterfaceConfigurationForScaleSet should return the correct network config")
-	assert.Equal(t, &networkConfigs[0], config, "getPrimaryNetworkInterfaceConfigurationForScaleSet should return the correct network config")
+	config, err := getPrimaryNetworkInterfaceConfiguration(networkConfigs, testVMSSName)
+	assert.Nil(t, err, "getPrimaryNetworkInterfaceConfiguration should return the correct network config")
+	assert.Equal(t, &networkConfigs[0], config, "getPrimaryNetworkInterfaceConfiguration should return the correct network config")
 
 	networkConfigs = []compute.VirtualMachineScaleSetNetworkConfiguration{
 		{
@@ -1744,9 +1740,9 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 			},
 		},
 	}
-	config, err = getPrimaryNetworkInterfaceConfigurationForScaleSet(networkConfigs, testVMSSName)
-	assert.Nil(t, err, "getPrimaryNetworkInterfaceConfigurationForScaleSet should return the correct network config")
-	assert.Equal(t, &networkConfigs[1], config, "getPrimaryNetworkInterfaceConfigurationForScaleSet should return the correct network config")
+	config, err = getPrimaryNetworkInterfaceConfiguration(networkConfigs, testVMSSName)
+	assert.Nil(t, err, "getPrimaryNetworkInterfaceConfiguration should return the correct network config")
+	assert.Equal(t, &networkConfigs[1], config, "getPrimaryNetworkInterfaceConfiguration should return the correct network config")
 
 	networkConfigs = []compute.VirtualMachineScaleSetNetworkConfiguration{
 		{
@@ -1762,103 +1758,403 @@ func TestGetPrimaryNetworkInterfaceConfigurationForScaleSet(t *testing.T) {
 			},
 		},
 	}
-	config, err = getPrimaryNetworkInterfaceConfigurationForScaleSet(networkConfigs, testVMSSName)
-	assert.Equal(t, fmt.Errorf("failed to find a primary network configuration for the scale set \"vmss\""), err, "getPrimaryNetworkInterfaceConfigurationForScaleSet should report an error if there is no primary nic")
-	assert.Nil(t, config, "getPrimaryNetworkInterfaceConfigurationForScaleSet should report an error if there is no primary nic")
+	config, err = getPrimaryNetworkInterfaceConfiguration(networkConfigs, testVMSSName)
+	assert.Equal(t, fmt.Errorf("failed to find a primary network configuration for the VMSS VM or VMSS \"vmss\""), err, "getPrimaryNetworkInterfaceConfiguration should report an error if there is no primary nic")
+	assert.Nil(t, config, "getPrimaryNetworkInterfaceConfiguration should report an error if there is no primary nic")
 }
 
 func TestGetPrimaryIPConfigFromVMSSNetworkConfig(t *testing.T) {
-	config := &compute.VirtualMachineScaleSetNetworkConfiguration{
-		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
-				{
-					Name: pointer.String("config-0"),
+	testcases := []struct {
+		desc             string
+		netConfig        *compute.VirtualMachineScaleSetNetworkConfiguration
+		backendPoolID    string
+		expectedIPConfig *compute.VirtualMachineScaleSetIPConfiguration
+		expectedErr      error
+	}{
+		{
+			desc: "only one IPv4 without primary (should not exist)",
+			netConfig: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+						},
+					},
+				},
+			},
+			backendPoolID: testLBBackendpoolID0,
+			expectedIPConfig: &compute.VirtualMachineScaleSetIPConfiguration{
+				Name: pointer.String("config-0"),
+			},
+		},
+		{
+			desc: "two IPv4 but one with primary",
+			netConfig: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			backendPoolID: testLBBackendpoolID0,
+			expectedIPConfig: &compute.VirtualMachineScaleSetIPConfiguration{
+				Name: pointer.String("config-1"),
+				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+					Primary: pointer.Bool(true),
+				},
+			},
+		},
+		{
+			desc: "multiple IPv4 without primary",
+			netConfig: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+							},
+						},
+					},
+				},
+			},
+			backendPoolID: testLBBackendpoolID0,
+			expectedErr:   fmt.Errorf("failed to find a primary IP configuration (IPv6=false) for the VMSS VM or VMSS \"vmss-config-0\""),
+		},
+		{
+			desc: "dualstack for IPv4",
+			netConfig: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								PrivateIPAddressVersion: compute.IPv4,
+								Primary:                 pointer.Bool(true),
+							},
+						},
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								PrivateIPAddressVersion: compute.IPv6,
+							},
+						},
+					},
+				},
+			},
+			backendPoolID: testLBBackendpoolID0,
+			expectedIPConfig: &compute.VirtualMachineScaleSetIPConfiguration{
+				Name: pointer.String("config-0"),
+				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+					PrivateIPAddressVersion: compute.IPv4,
+					Primary:                 pointer.Bool(true),
+				},
+			},
+		},
+		{
+			desc: "dualstack for IPv6",
+			netConfig: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								PrivateIPAddressVersion: compute.IPv4,
+								Primary:                 pointer.Bool(true),
+							},
+						},
+						{
+							Name: pointer.String("config-0-IPv6"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								PrivateIPAddressVersion: compute.IPv6,
+							},
+						},
+					},
+				},
+			},
+			backendPoolID: testLBBackendpoolID0v6,
+			expectedIPConfig: &compute.VirtualMachineScaleSetIPConfiguration{
+				Name: pointer.String("config-0-IPv6"),
+				VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+					PrivateIPAddressVersion: compute.IPv6,
 				},
 			},
 		},
 	}
 
-	ipConfig, err := getPrimaryIPConfigFromVMSSNetworkConfig(config)
-	assert.Nil(t, err, "getPrimaryIPConfigFromVMSSNetworkConfig should return the correct IP config")
-	assert.Equal(t, (*config.IPConfigurations)[0], *ipConfig, "getPrimaryIPConfigFromVMSSNetworkConfig should return the correct IP config")
-
-	config = &compute.VirtualMachineScaleSetNetworkConfiguration{
-		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
-				{
-					Name: pointer.String("config-0"),
-					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: pointer.Bool(false),
-					},
-				},
-				{
-					Name: pointer.String("config-1"),
-					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: pointer.Bool(true),
-					},
-				},
-			},
-		},
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ipConfig, err := getPrimaryIPConfigFromVMSSNetworkConfig(tc.netConfig, tc.backendPoolID, "vmss-config-0")
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedIPConfig, ipConfig)
+		})
 	}
-
-	ipConfig, err = getPrimaryIPConfigFromVMSSNetworkConfig(config)
-	assert.Nil(t, err, "getPrimaryIPConfigFromVMSSNetworkConfig should return the correct IP config")
-	assert.Equal(t, (*config.IPConfigurations)[1], *ipConfig, "getPrimaryIPConfigFromVMSSNetworkConfig should return the correct IP config")
-
-	config = &compute.VirtualMachineScaleSetNetworkConfiguration{
-		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
-				{
-					Name: pointer.String("config-0"),
-					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: pointer.Bool(false),
-					},
-				},
-				{
-					Name: pointer.String("config-1"),
-					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						Primary: pointer.Bool(false),
-					},
-				},
-			},
-		},
-	}
-
-	ipConfig, err = getPrimaryIPConfigFromVMSSNetworkConfig(config)
-	assert.Equal(t, err, fmt.Errorf("failed to find a primary IP configuration"), "getPrimaryIPConfigFromVMSSNetworkConfig should report an error if there is no primary IP config")
-	assert.Nil(t, ipConfig, "getPrimaryIPConfigFromVMSSNetworkConfig should report an error if there is no primary IP config")
 }
 
-func TestGetConfigForScaleSetByIPFamily(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	config := &compute.VirtualMachineScaleSetNetworkConfiguration{
-		VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-			IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
-				{
-					Name: pointer.String("config-0"),
-					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						PrivateIPAddressVersion: compute.IPv4,
-					},
-				},
-				{
-					Name: pointer.String("config-0"),
-					VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
-						PrivateIPAddressVersion: compute.IPv6,
+func TestDeleteBackendPoolFromIPConfig(t *testing.T) {
+	testcases := []struct {
+		desc               string
+		backendPoolID      string
+		primaryNIC         *compute.VirtualMachineScaleSetNetworkConfiguration
+		expectedPrimaryNIC *compute.VirtualMachineScaleSetNetworkConfiguration
+		expectedFound      bool
+		expectedErr        error
+	}{
+		{
+			desc:          "delete backend pool from ip config",
+			backendPoolID: "backendpool-0",
+			primaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(true),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{
+									{
+										ID: pointer.String("backendpool-0"),
+									},
+									{
+										ID: pointer.String("backendpool-1"),
+									},
+								},
+							},
+						},
 					},
 				},
 			},
+			expectedPrimaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(true),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{
+									{
+										ID: pointer.String("backendpool-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFound: true,
+		},
+		{
+			desc:          "backend pool not found",
+			backendPoolID: "backendpool-0",
+			primaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(true),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{
+									{
+										ID: pointer.String("backendpool-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPrimaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(true),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{
+									{
+										ID: pointer.String("backendpool-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedFound: false,
+		},
+		{
+			desc:          "delete backend pool from ip config IPv6",
+			backendPoolID: "backendpool-0-IPv6",
+			primaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(true),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{
+									{
+										ID: pointer.String("backendpool-1"),
+									},
+								},
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{
+									{
+										ID: pointer.String("backendpool-0-IPv6"),
+									},
+								},
+								PrivateIPAddressVersion: compute.IPv6,
+							},
+						},
+					},
+				},
+			},
+			expectedPrimaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(true),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{
+									{
+										ID: pointer.String("backendpool-1"),
+									},
+								},
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary:                         pointer.Bool(false),
+								LoadBalancerBackendAddressPools: &[]compute.SubResource{},
+								PrivateIPAddressVersion:         compute.IPv6,
+							},
+						},
+					},
+				},
+			},
+			expectedFound: true,
+		},
+		{
+			desc:          "primary IP config not found IPv4",
+			backendPoolID: "backendpool-0",
+			primaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+							},
+						},
+					},
+				},
+			},
+			expectedPrimaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary: pointer.Bool(false),
+							},
+						},
+					},
+				},
+			},
+			expectedFound: false,
+			expectedErr:   fmt.Errorf("failed to find a primary IP configuration (IPv6=false) for the VMSS VM or VMSS \"test-resource\""),
+		},
+		{
+			desc:          "primary IP config not found IPv6",
+			backendPoolID: "backendpool-0-IPv6",
+			primaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary:                 pointer.Bool(true),
+								PrivateIPAddressVersion: compute.IPv4,
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary:                 pointer.Bool(false),
+								PrivateIPAddressVersion: compute.IPv4,
+							},
+						},
+					},
+				},
+			},
+			expectedPrimaryNIC: &compute.VirtualMachineScaleSetNetworkConfiguration{
+				VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Name: pointer.String("config-0"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary:                 pointer.Bool(true),
+								PrivateIPAddressVersion: compute.IPv4,
+							},
+						},
+						{
+							Name: pointer.String("config-1"),
+							VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
+								Primary:                 pointer.Bool(false),
+								PrivateIPAddressVersion: compute.IPv4,
+							},
+						},
+					},
+				},
+			},
+			expectedFound: false,
+			expectedErr:   fmt.Errorf("failed to find a primary IP configuration (IPv6=true) for the VMSS VM or VMSS \"test-resource\""),
 		},
 	}
 
-	ipConfig, err := getConfigForScaleSetByIPFamily(config, "vmss-vm-000000", true)
-	assert.Nil(t, err, "getConfigForScaleSetByIPFamily should find the IPV6 config")
-	assert.Equal(t, (*config.IPConfigurations)[1], *ipConfig, "getConfigForScaleSetByIPFamily should find the IPV6 config")
-
-	ipConfig, err = getConfigForScaleSetByIPFamily(config, "vmss-vm-000000", false)
-	assert.Nil(t, err, "getConfigForScaleSetByIPFamily should find the IPV4 config")
-	assert.Equal(t, (*config.IPConfigurations)[0], *ipConfig, "getConfigForScaleSetByIPFamily should find the IPV4 config")
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			found, err := deleteBackendPoolFromIPConfig("test", tc.backendPoolID, "test-resource", tc.primaryNIC)
+			assert.Equal(t, tc.expectedFound, found)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedPrimaryNIC, tc.primaryNIC)
+		})
+	}
 }
 
 func TestEnsureHostInPool(t *testing.T) {
@@ -1936,7 +2232,7 @@ func TestEnsureHostInPool(t *testing.T) {
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 							{
-								Name: pointer.String("ipconfig1"),
+								Name: pointer.String("vmss-nic"),
 								ID:   pointer.String("fakeNetworkConfiguration"),
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
@@ -1952,9 +2248,11 @@ func TestEnsureHostInPool(t *testing.T) {
 														ID: pointer.String("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb-internal/backendAddressPools/backendpool-1"),
 													},
 												},
+												PrivateIPAddressVersion: compute.IPv4,
 											},
 										},
 									},
+									Primary: pointer.Bool(true),
 								},
 							},
 						},
@@ -2134,10 +2432,10 @@ func TestEnsureVMSSInPool(t *testing.T) {
 				},
 			},
 			isBasicLB:       false,
-			backendPoolID:   testLBBackendpoolID1,
+			backendPoolID:   testLBBackendpoolID1v6,
 			clusterIP:       "fd00::e68b",
 			expectedPutVMSS: false,
-			expectedErr:     fmt.Errorf("failed to find a IPconfiguration(IPv6=true) for the scale set VM \"\""),
+			expectedErr:     fmt.Errorf("failed to find a primary IP configuration (IPv6=true) for the VMSS VM or VMSS \"vmss\""),
 		},
 		{
 			description: "ensureVMSSInPool should update the VMSS correctly for IPv6",
@@ -2149,7 +2447,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 				},
 			},
 			isBasicLB:       false,
-			backendPoolID:   testLBBackendpoolID1,
+			backendPoolID:   testLBBackendpoolID1v6,
 			setIPv6Config:   true,
 			clusterIP:       "fd00::e68b",
 			expectedPutVMSS: true,
@@ -2202,7 +2500,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 			expectedGetInstanceID: "invalid",
 		},
 		{
-			description: "ensureVMSSInPool should report an error if failed to get instsance ID",
+			description: "ensureVMSSInPool should report an error if failed to get instance ID",
 			nodes: []*v1.Node{
 				{},
 			},
@@ -2215,41 +2513,43 @@ func TestEnsureVMSSInPool(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		ss, err := NewTestScaleSet(ctrl)
-		assert.NoError(t, err, test.description)
+		t.Run(test.description, func(t *testing.T) {
+			ss, err := NewTestScaleSet(ctrl)
+			assert.NoError(t, err, test.description)
 
-		if !test.isBasicLB {
-			ss.LoadBalancerSku = consts.LoadBalancerSkuStandard
-		}
+			if !test.isBasicLB {
+				ss.LoadBalancerSku = consts.LoadBalancerSkuStandard
+			}
 
-		expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, test.setIPv6Config)
-		if test.isVMSSDeallocating {
-			expectedVMSS.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
-		}
-		if test.isVMSSNilNICConfig {
-			expectedVMSS.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
-		}
-		mockVMSSClient := ss.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
-		mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-		vmssPutTimes := 0
-		if test.expectedPutVMSS {
-			vmssPutTimes = 1
-			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSS, nil)
-		}
-		mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil).Times(vmssPutTimes)
+			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, test.setIPv6Config)
+			if test.isVMSSDeallocating {
+				expectedVMSS.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
+			}
+			if test.isVMSSNilNICConfig {
+				expectedVMSS.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
+			}
+			mockVMSSClient := ss.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+			vmssPutTimes := 0
+			if test.expectedPutVMSS {
+				vmssPutTimes = 1
+				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSS, nil)
+			}
+			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil).Times(vmssPutTimes)
 
-		expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", test.setIPv6Config)
-		mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
-		mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", test.setIPv6Config)
+			mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 
-		if test.expectedGetInstanceID != "" {
-			mockVMSet := NewMockVMSet(ctrl)
-			mockVMSet.EXPECT().GetInstanceIDByNodeName(gomock.Any()).Return(test.expectedGetInstanceID, test.getInstanceIDErr)
-			ss.VMSet = mockVMSet
-		}
+			if test.expectedGetInstanceID != "" {
+				mockVMSet := NewMockVMSet(ctrl)
+				mockVMSet.EXPECT().GetInstanceIDByNodeName(gomock.Any()).Return(test.expectedGetInstanceID, test.getInstanceIDErr)
+				ss.VMSet = mockVMSet
+			}
 
-		err = ss.ensureVMSSInPool(&v1.Service{Spec: v1.ServiceSpec{ClusterIP: test.clusterIP}}, test.nodes, test.backendPoolID, test.vmSetName)
-		assert.Equal(t, test.expectedErr, err, test.description+", but an error occurs")
+			err = ss.ensureVMSSInPool(&v1.Service{Spec: v1.ServiceSpec{ClusterIP: test.clusterIP}}, test.nodes, test.backendPoolID, test.vmSetName)
+			assert.Equal(t, test.expectedErr, err, test.description+", but an error occurs")
+		})
 	}
 }
 
@@ -2344,7 +2644,7 @@ func TestEnsureHostsInPool(t *testing.T) {
 	}
 }
 
-func TestEnsureBackendPoolDeletedFromNode(t *testing.T) {
+func TestEnsureBackendPoolDeletedFromNodeCommon(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -2386,7 +2686,7 @@ func TestEnsureBackendPoolDeletedFromNode(t *testing.T) {
 					NetworkProfileConfiguration: &compute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: &[]compute.VirtualMachineScaleSetNetworkConfiguration{
 							{
-								Name: pointer.String("ipconfig1"),
+								Name: pointer.String("vmss-nic"),
 								ID:   pointer.String("fakeNetworkConfiguration"),
 								VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
 									IPConfigurations: &[]compute.VirtualMachineScaleSetIPConfiguration{
@@ -2395,9 +2695,11 @@ func TestEnsureBackendPoolDeletedFromNode(t *testing.T) {
 											VirtualMachineScaleSetIPConfigurationProperties: &compute.VirtualMachineScaleSetIPConfigurationProperties{
 												Primary:                         pointer.Bool(true),
 												LoadBalancerBackendAddressPools: &[]compute.SubResource{},
+												PrivateIPAddressVersion:         compute.IPv4,
 											},
 										},
 									},
+									Primary: pointer.Bool(true),
 								},
 							},
 						},
@@ -2408,26 +2710,28 @@ func TestEnsureBackendPoolDeletedFromNode(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		ss, err := NewTestScaleSet(ctrl)
-		assert.NoError(t, err, test.description)
+		t.Run(test.description, func(t *testing.T) {
+			ss, err := NewTestScaleSet(ctrl)
+			assert.NoError(t, err, test.description)
 
-		expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-		mockVMSSClient := ss.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
-		mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+			mockVMSSClient := ss.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]compute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-		expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
-		if test.isNilVMNetworkConfigs {
-			expectedVMSSVMs[0].NetworkProfileConfiguration.NetworkInterfaceConfigurations = nil
-		}
-		mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
-		mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
+			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
+			if test.isNilVMNetworkConfigs {
+				expectedVMSSVMs[0].NetworkProfileConfiguration.NetworkInterfaceConfigurations = nil
+			}
+			mockVMSSVMClient := ss.cloud.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(expectedVMSSVMs, nil).AnyTimes()
 
-		nodeResourceGroup, ssName, instanceID, vm, err := ss.ensureBackendPoolDeletedFromNode(test.nodeName, test.backendpoolID)
-		assert.Equal(t, test.expectedErr, err, test.description+", but an error occurs")
-		assert.Equal(t, test.expectedNodeResourceGroup, nodeResourceGroup, test.description)
-		assert.Equal(t, test.expectedVMSSName, ssName, test.description)
-		assert.Equal(t, test.expectedInstanceID, instanceID, test.description)
-		assert.Equal(t, test.expectedVMSSVM, vm, test.description)
+			nodeResourceGroup, ssName, instanceID, vm, err := ss.ensureBackendPoolDeletedFromNode(test.nodeName, test.backendpoolID)
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expectedNodeResourceGroup, nodeResourceGroup)
+			assert.Equal(t, test.expectedVMSSName, ssName)
+			assert.Equal(t, test.expectedInstanceID, instanceID)
+			assert.Equal(t, test.expectedVMSSVM, vm)
+		})
 	}
 }
 

--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -657,24 +657,13 @@ func (fs *FlexScaleSet) ensureVMSSFlexInPool(service *v1.Service, nodes []*v1.No
 			continue
 		}
 		vmssNIC := *vmssFlex.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-		primaryNIC, err := getPrimaryNetworkInterfaceConfigurationForScaleSet(vmssNIC, vmssFlexName)
+		primaryNIC, err := getPrimaryNetworkInterfaceConfiguration(vmssNIC, vmssFlexName)
 		if err != nil {
 			return err
 		}
-		var primaryIPConfig *compute.VirtualMachineScaleSetIPConfiguration
-		ipv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-		// Find primary network interface configuration.
-		if !fs.Cloud.ipv6DualStackEnabled && !ipv6 {
-			// Find primary IP configuration.
-			primaryIPConfig, err = getPrimaryIPConfigFromVMSSNetworkConfig(primaryNIC)
-			if err != nil {
-				return err
-			}
-		} else {
-			primaryIPConfig, err = getConfigForScaleSetByIPFamily(primaryNIC, "", ipv6)
-			if err != nil {
-				return err
-			}
+		primaryIPConfig, err := getPrimaryIPConfigFromVMSSNetworkConfig(primaryNIC, backendPoolID, vmssFlexName)
+		if err != nil {
+			return err
 		}
 
 		loadBalancerBackendAddressPools := []compute.SubResource{}
@@ -841,32 +830,16 @@ func (fs *FlexScaleSet) EnsureBackendPoolDeletedFromVMSets(vmssNamesMap map[stri
 			continue
 		}
 		vmssNIC := *vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-		primaryNIC, err := getPrimaryNetworkInterfaceConfigurationForScaleSet(vmssNIC, vmssName)
+		primaryNIC, err := getPrimaryNetworkInterfaceConfiguration(vmssNIC, vmssName)
 		if err != nil {
 			klog.Errorf("fs.EnsureBackendPoolDeletedFromVMSets: failed to get the primary network interface config of the VMSS %s: %v", vmssName, err)
 			errors = append(errors, err)
 			continue
 		}
-		primaryIPConfig, err := getPrimaryIPConfigFromVMSSNetworkConfig(primaryNIC)
+		found, err := deleteBackendPoolFromIPConfig("FlexSet.EnsureBackendPoolDeletedFromVMSets", backendPoolID, vmssName, primaryNIC)
 		if err != nil {
-			klog.Errorf("fs.EnsureBackendPoolDeletedFromVMSets: failed to the primary IP config from the VMSS %s's network config : %v", vmssName, err)
 			errors = append(errors, err)
 			continue
-		}
-		loadBalancerBackendAddressPools := []compute.SubResource{}
-		if primaryIPConfig.LoadBalancerBackendAddressPools != nil {
-			loadBalancerBackendAddressPools = *primaryIPConfig.LoadBalancerBackendAddressPools
-		}
-
-		var found bool
-		var newBackendPools []compute.SubResource
-		for i := len(loadBalancerBackendAddressPools) - 1; i >= 0; i-- {
-			curPool := loadBalancerBackendAddressPools[i]
-			if strings.EqualFold(backendPoolID, *curPool.ID) {
-				klog.V(10).Infof("fs.EnsureBackendPoolDeletedFromVMSets gets unwanted backend pool %q for VMSS %s", backendPoolID, vmssName)
-				found = true
-				newBackendPools = append(loadBalancerBackendAddressPools[:i], loadBalancerBackendAddressPools[i+1:]...)
-			}
 		}
 		if !found {
 			continue
@@ -874,7 +847,6 @@ func (fs *FlexScaleSet) EnsureBackendPoolDeletedFromVMSets(vmssNamesMap map[stri
 
 		vmssUpdaters = append(vmssUpdaters, func() error {
 			// Compose a new vmss with added backendPoolID.
-			primaryIPConfig.LoadBalancerBackendAddressPools = &newBackendPools
 			newVMSS := compute.VirtualMachineScaleSet{
 				Location: vmss.Location,
 				VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{

--- a/pkg/provider/azure_vmssflex_cache_test.go
+++ b/pkg/provider/azure_vmssflex_cache_test.go
@@ -129,6 +129,7 @@ func genreteTestVmssFlex(vmssFlexName string, testVmssFlexID string) compute.Vir
 													ID: pointer.String(testBackendPoolID0),
 												},
 											},
+											Primary: pointer.Bool(true),
 										},
 									},
 								},

--- a/pkg/provider/azure_vmssflex_test.go
+++ b/pkg/provider/azure_vmssflex_test.go
@@ -1624,7 +1624,7 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 			hasDefaultVMProfile:  true,
 			isNicConfigEmpty:     true,
 			vmssListCallingTimes: 1,
-			expectedErr:          fmt.Errorf("failed to find a primary network configuration for the scale set \"vmssflex1\""),
+			expectedErr:          fmt.Errorf("failed to find a primary network configuration for the VMSS VM or VMSS \"vmssflex1\""),
 		},
 		{
 			description: "EnsureBackendPoolDeletedFromVMSets should skip the vmss has empty IP config",
@@ -1637,7 +1637,7 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 			isNicConfigEmpty:     false,
 			isIPConfigEmpty:      true,
 			vmssListCallingTimes: 1,
-			expectedErr:          fmt.Errorf("failed to find a primary IP configuration"),
+			expectedErr:          fmt.Errorf("failed to find a primary IP configuration (IPv6=false) for the VMSS VM or VMSS \"vmssflex1\""),
 		},
 		{
 			description: "EnsureBackendPoolDeletedFromVMSets should skip the vmss if the backend pool is not in the vmss's backend pool list",
@@ -1663,41 +1663,42 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		fs, err := NewTestFlexScaleSet(ctrl)
-		assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
+		t.Run(tc.description, func(t *testing.T) {
+			fs, err := NewTestFlexScaleSet(ctrl)
+			assert.NoError(t, err, "unexpected error when creating test FlexScaleSet")
 
-		testVmssFlex := genreteTestVmssFlex("vmssflex1", testVmssFlex1ID)
+			testVmssFlex := genreteTestVmssFlex("vmssflex1", testVmssFlex1ID)
 
-		if tc.isVMSSDeallocating {
-			testVmssFlex.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
-		}
-		if !tc.hasDefaultVMProfile {
-			testVmssFlex.VirtualMachineProfile = nil
-		}
-		if tc.isNicConfigEmpty {
-			testVmssFlex.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = &[]compute.VirtualMachineScaleSetNetworkConfiguration{}
-		}
-		if tc.isIPConfigEmpty {
-			(*testVmssFlex.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations)[0].IPConfigurations = &[]compute.VirtualMachineScaleSetIPConfiguration{}
-		}
+			if tc.isVMSSDeallocating {
+				testVmssFlex.ProvisioningState = pointer.String(consts.VirtualMachineScaleSetsDeallocating)
+			}
+			if !tc.hasDefaultVMProfile {
+				testVmssFlex.VirtualMachineProfile = nil
+			}
+			if tc.isNicConfigEmpty {
+				testVmssFlex.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = &[]compute.VirtualMachineScaleSetNetworkConfiguration{}
+			}
+			if tc.isIPConfigEmpty {
+				(*testVmssFlex.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations)[0].IPConfigurations = &[]compute.VirtualMachineScaleSetIPConfiguration{}
+			}
 
-		vmssFlexList := []compute.VirtualMachineScaleSet{testVmssFlex}
+			vmssFlexList := []compute.VirtualMachineScaleSet{testVmssFlex}
 
-		mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
-		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(vmssFlexList, nil).Times(tc.vmssListCallingTimes)
-		mockVMSSClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(testVmssFlex1, nil).AnyTimes()
-		mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.vmssPutErr).AnyTimes()
+			mockVMSSClient := fs.cloud.VirtualMachineScaleSetsClient.(*mockvmssclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(vmssFlexList, nil).Times(tc.vmssListCallingTimes)
+			mockVMSSClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(testVmssFlex1, nil).AnyTimes()
+			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.vmssPutErr).AnyTimes()
 
-		err = fs.EnsureBackendPoolDeletedFromVMSets(tc.vmssNamesMap, tc.backendPoolID)
-		_, _ = fs.getVmssFlexByName("vmssflex1")
+			err = fs.EnsureBackendPoolDeletedFromVMSets(tc.vmssNamesMap, tc.backendPoolID)
+			_, _ = fs.getVmssFlexByName("vmssflex1")
 
-		if tc.expectedErr != nil {
-			assert.EqualError(t, err, tc.expectedErr.Error(), tc.description)
-		} else {
-			assert.NoError(t, err, tc.description)
-		}
+			if tc.expectedErr != nil {
+				assert.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
-
 }
 
 func TestEnsureBackendPoolDeletedFromNodeVmssFlex(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[IPv6] Choose correct primary IP config
Regardless of IPv6 only or dualstack clusters, IPv4 IP config is always primary. So for IPv6 backend
address pool, IP config's IP version needs consideration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[IPv6] Choose correct primary IP config. Regardless of IPv6 only or dualstack clusters, IPv4 IP config is always primary. So for IPv6 backend address pool, IP config's IP version needs consideration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
