### PR TITLE
[e2e][Autoscaling] Use user node pool

### DIFF
--- a/.pipelines/templates/autoscaling-multipool.json
+++ b/.pipelines/templates/autoscaling-multipool.json
@@ -8,8 +8,8 @@
     "dnsPrefix": "aks",
     "agentPoolProfiles": [
       {
-        "name": "agentpool1",
-        "count": 5,
+        "name": "systempool",
+        "count": 3,
         "mode" : "System",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
@@ -19,9 +19,20 @@
         "minCount": 3
       },
       {
-        "name": "agentpool2",
-        "count": 5,
-        "mode" : "System",
+        "name": "userpool1",
+        "count": 3,
+        "mode" : "User",
+        "vmSize": "Standard_DS2_v2",
+        "osType": "Linux",
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "enableAutoScaling": true,
+        "maxCount": 1000,
+        "minCount": 3
+      },
+      {
+        "name": "userpool2",
+        "count": 3,
+        "mode" : "User",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
         "availabilityProfile": "VirtualMachineScaleSets",

--- a/.pipelines/templates/autoscaling.json
+++ b/.pipelines/templates/autoscaling.json
@@ -8,9 +8,20 @@
     "dnsPrefix": "aks",
     "agentPoolProfiles": [
       {
-        "name": "agentpool1",
-        "count": 5,
+        "name": "systempool",
+        "count": 3,
         "mode" : "System",
+        "vmSize": "Standard_DS2_v2",
+        "osType": "Linux",
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "enableAutoScaling": true,
+        "maxCount": 1000,
+        "minCount": 3
+      },
+      {
+        "name": "userpool",
+        "count": 3,
+        "mode" : "User",
         "vmSize": "Standard_DS2_v2",
         "osType": "Linux",
         "availabilityProfile": "VirtualMachineScaleSets",

--- a/tests/e2e/autoscaling/autoscaler.go
+++ b/tests/e2e/autoscaling/autoscaler.go
@@ -130,6 +130,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		replicas := podCount + 1
 		deployment := createDeploymentManifest(basename+"-deployment", replicas, map[string]string{"app": basename}, podSize, false)
 		_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 
 		waitForScaleUpToComplete(cs, ns, initNodeCount+1)
@@ -141,12 +145,20 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		replicas := podCount + 1
 		deployment := createDeploymentManifest(basename+"-deployment", replicas, map[string]string{"app": basename + "-deployment"}, podSize, false)
 		_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 		waitForScaleUpToComplete(cs, ns, initNodeCount+1)
 
 		By("Deploying a StatefulSet")
 		statefulSetManifest := createStatefulSetWithPVCManifest(basename+"-statefulset", int32(2), map[string]string{"app": basename + "-statefulset"})
 		statefulSet, err := cs.AppsV1().StatefulSets(ns.Name).Create(context.TODO(), statefulSetManifest, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().StatefulSets(ns.Name).Delete(context.TODO(), statefulSet.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the StatefulSet to become ready")
@@ -210,6 +222,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		By("Saturating the free space")
 		deployment := createDeploymentManifest(basename+"-deployment", podCount, map[string]string{"app": basename + "-deployment"}, podSize, false)
 		_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 		err = utils.WaitPodsToBeReady(cs, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
@@ -219,6 +235,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		scaleUpPodSize := int64(float64(cpu.MilliValue()) / 1.8)
 		scaleUpDeployment := createDeploymentManifest(basename+"-deployment1", 10, map[string]string{"app": basename + "-deployment1"}, scaleUpPodSize, false)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), scaleUpDeployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), scaleUpDeployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 		waitForScaleUpToComplete(cs, ns, len(nodes)+10)
 
@@ -241,6 +261,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		By("Saturating the free space")
 		deployment := createDeploymentManifest(basename+"-deployment", podCount, map[string]string{"app": basename + "-deployment"}, podSize, false)
 		_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 		err = utils.WaitPodsToBeReady(cs, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
@@ -250,6 +274,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		scaleUpPodSize := int64(float64(cpu.MilliValue()) / 1.8)
 		scaleUpDeployment := createDeploymentManifest(basename+"-deployment1", 0, map[string]string{"app": basename + "-deployment1"}, scaleUpPodSize, false)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), scaleUpDeployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), scaleUpDeployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 
 		targetNodeCount := initNodeCount
@@ -280,6 +308,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		By("Saturating the free space")
 		deployment := createDeploymentManifest(basename+"-deployment", podCount, map[string]string{"app": basename + "-deployment"}, podSize, false)
 		_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 		err = utils.WaitPodsToBeReady(cs, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
@@ -289,6 +321,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		scaleUpPodSize := int64(float64(cpu.MilliValue()) / 1.8)
 		scaleUpDeployment := createDeploymentManifest(basename+"-deployment1", 0, map[string]string{"app": basename + "-deployment1"}, scaleUpPodSize, false)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), scaleUpDeployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), scaleUpDeployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 
 		targetNodeCount := initNodeCount
@@ -335,6 +371,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		replicas := podCount + 1
 		deployment := createDeploymentManifest(basename+"-deployment", replicas, map[string]string{"app": basename}, podSize, false)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 
 		waitForScaleUpToComplete(cs, ns, initNodeCount+1)
@@ -360,6 +400,10 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		replicas := initNodeCount + 1
 		deployment := createDeploymentManifest(basename+"-deployment", int32(replicas), map[string]string{"app": basename}, gpuCap, true)
 		_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
+		defer func() {
+			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), deployment.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 
 		waitForScaleUpToComplete(cs, ns, initNodeCount+1)
@@ -377,7 +421,7 @@ func waitForScaleUpToComplete(cs clientset.Interface, ns *v1.Namespace, targetNo
 
 func waitForScaleDownToComplete(cs clientset.Interface, ns *v1.Namespace, initNodeCount int, deployment *appsv1.Deployment) {
 	By("Waiting for a scale down operation to happen")
-	utils.Logf("Delete pods by setting the number of replicas in the deployment to 0")
+	utils.Logf("Delete pods by setting the number of replicas in the deployment %q to 0", deployment.Name)
 	replicas := int32(0)
 	deployment.Spec.Replicas = &replicas
 	_, err := cs.AppsV1().Deployments(ns.Name).Update(context.TODO(), deployment, metav1.UpdateOptions{})
@@ -396,6 +440,10 @@ func createPodSpec(requestCPU int64) (result v1.PodSpec) {
 				Name:  "container",
 				Image: "nginx:1.15",
 			},
+		},
+		NodeSelector: map[string]string{
+			// Use userpool only
+			utils.NodeModeLabel: utils.NodeModeUser,
 		},
 	}
 	if requestCPU != 0 {
@@ -417,6 +465,10 @@ func createGPUPodSpec(requestGPU int64) (result v1.PodSpec) {
 				Image: "nginx:1.15",
 			},
 		},
+		NodeSelector: map[string]string{
+			// Use userpool only
+			utils.NodeModeLabel: utils.NodeModeUser,
+		},
 	}
 	if requestGPU != 0 {
 		result.Containers[0].Resources = v1.ResourceRequirements{
@@ -433,6 +485,7 @@ func createGPUPodSpec(requestGPU int64) (result v1.PodSpec) {
 	return
 }
 
+// createDeploymentManifest creates Deployment for userpool only.
 func createDeploymentManifest(name string, replicas int32, label map[string]string, podSize int64, requestGPU bool) (result *appsv1.Deployment) {
 	var spec v1.PodSpec
 	if requestGPU {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[e2e][Autoscaling] Use user node pool. There're system pool NodeAffinity for coredns and metrics-server Deployments and using user node pool can avoid some Node deletion stuck problem.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
