### PR TITLE
[release-1.26][e2e] Support dual-stack - utils

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -201,12 +201,18 @@ var (
 		false: "service.beta.kubernetes.io/azure-load-balancer-ipv4",
 		true:  "service.beta.kubernetes.io/azure-load-balancer-ipv6",
 	}
+	ServiceAnnotationPIPNameDualStack = map[bool]string{
+		false: "service.beta.kubernetes.io/azure-pip-name",
+		true:  "service.beta.kubernetes.io/azure-pip-name-ipv6",
+	}
+	ServiceAnnotationPIPPrefixIDDualStack = map[bool]string{
+		false: "service.beta.kubernetes.io/azure-pip-prefix-id",
+		true:  "service.beta.kubernetes.io/azure-pip-prefix-id-ipv6",
+	}
 )
 
 // load balancer
 const (
-	// PreConfiguredBackendPoolLoadBalancerTypesNone means that the load balancers are not pre-configured
-	PreConfiguredBackendPoolLoadBalancerTypesNone = ""
 	// PreConfiguredBackendPoolLoadBalancerTypesInternal means that the `internal` load balancers are pre-configured
 	PreConfiguredBackendPoolLoadBalancerTypesInternal = "internal"
 	// PreConfiguredBackendPoolLoadBalancerTypesExternal means that the `external` load balancers are pre-configured
@@ -352,6 +358,8 @@ const (
 	FrontendIPConfigNameMaxLength = 80
 	// LoadBalancerRuleNameMaxLength is the max length of the load balancing rule
 	LoadBalancerRuleNameMaxLength = 80
+	// IPFamilySuffixLength is the length of suffix length of IP family ("-IPv4", "-IPv6")
+	IPFamilySuffixLength = 5
 
 	// LoadBalancerBackendPoolConfigurationTypeNodeIPConfiguration is the lb backend pool config type node IP configuration
 	LoadBalancerBackendPoolConfigurationTypeNodeIPConfiguration = "nodeIPConfiguration"

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -92,12 +92,14 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 
 	It("should add the rule when expose a service", func() {
 		By("Creating a service and expose it")
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, map[string]string{}, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, map[string]string{}, ports)
 		defer func() {
 			By("Cleaning up")
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 
 		By("Validating ip exists in Security Group")
 		port := fmt.Sprintf("%d", serverPort)
@@ -142,7 +144,7 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		annotation := map[string]string{
 			consts.ServiceAnnotationSharedSecurityRule: "true",
 		}
-		ip1 := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips1 := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 
 		defer func() {
 			err := utils.DeleteService(cs, ns.Name, serviceName)
@@ -150,7 +152,7 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		}()
 
 		serviceName2 := serviceName + "-share"
-		ip2 := createAndExposeDefaultServiceWithAnnotation(cs, serviceName2, ns.Name, labels, annotation, ports)
+		ips2 := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName2, ns.Name, labels, annotation, ports)
 		defer func() {
 			By("Cleaning up")
 			err := utils.DeleteService(cs, ns.Name, serviceName2)
@@ -162,20 +164,13 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		nsgs, err := tc.GetClusterSecurityGroups()
 		Expect(err).NotTo(HaveOccurred())
 
-		ipList := []string{ip1, ip2}
+		ipList := append(ips1, ips2...)
 		Expect(validateSharedSecurityRuleExists(nsgs, ipList, port)).To(BeTrue(), "Security rule for service %s not exists", serviceName)
 
 		By("Validate automatically adjust or delete the rule, when service is deleted")
 		Expect(utils.DeleteService(cs, ns.Name, serviceName)).NotTo(HaveOccurred())
-		ipList = []string{ip2}
-
-		Eventually(func() (bool, error) {
-			nsgs, err = tc.GetClusterSecurityGroups()
-			if err != nil {
-				return false, err
-			}
-			return validateSharedSecurityRuleExists(nsgs, []string{ip2}, port) && !validateSharedSecurityRuleExists(nsgs, []string{ip1}, port), nil
-		}).WithContext(ctx).Should(BeTrue(), "Security rule should be modified to only contain service %s", serviceName2)
+		ipList = ips2
+		Expect(validateSharedSecurityRuleExists(nsgs, ipList, port)).To(BeTrue(), "Security rule should be modified to only contain service %s", serviceName2)
 
 		Expect(utils.DeleteService(cs, ns.Name, serviceName2)).NotTo(HaveOccurred())
 		Eventually(func() (bool, error) {
@@ -199,7 +194,7 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		utils.Logf("Successfully created LoadBalancer service " + serviceName + " in namespace " + ns.Name)
 
 		By("Waiting for the service to be exposed")
-		_, err = utils.WaitServiceExposure(cs, ns.Name, serviceName, "")
+		_, err = utils.WaitServiceExposure(cs, ns.Name, serviceName, []string{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating if the corresponding IP prefix existing in nsg")
@@ -236,8 +231,10 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the service to expose")
-		internalIP, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+		internalIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{})
 		Expect(err).NotTo(HaveOccurred())
+		Expect(len(internalIPs)).NotTo(BeZero())
+		internalIP := internalIPs[0]
 
 		By("Checking if there is a deny_all rule")
 		nsgs, err := tc.GetClusterSecurityGroups()
@@ -274,7 +271,9 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 
 		// Check Service connectivity with the deny-all-except-lb-range ExecAgnhostPod
 		By("Waiting for the service to expose")
-		internalIP, err = utils.WaitServiceExposureAndGetIP(cs, ns.Name, serviceName)
+		internalIPs, err = utils.WaitServiceExposureAndGetIPs(cs, ns.Name, serviceName)
+		Expect(len(internalIPs)).NotTo(BeZero())
+		internalIP = internalIPs[0]
 		for _, port := range service.Spec.Ports {
 			utils.Logf("checking the connectivity of addr %s:%d with protocol %v", internalIP, int(port.Port), port.Protocol)
 			err := utils.ValidateServiceConnectivity(ns.Name, agnhostPod, internalIP, int(port.Port), port.Protocol)
@@ -307,12 +306,11 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 			consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true",
 		}
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
-		service = updateServiceLBIP(service, false, targetIP)
+		service = updateServiceLBIPs(service, false, []string{targetIP})
 		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{targetIP})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ip).To(Equal(targetIP))
 
 		defer func() {
 			By("cleaning up")

--- a/tests/e2e/network/node.go
+++ b/tests/e2e/network/node.go
@@ -384,7 +384,9 @@ var _ = Describe("Azure nodes", func() {
 		Expect(ok).To(BeTrue())
 		Expect(nodeRG).NotTo(Equal(rgMaster))
 
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, map[string]string{}, ports)
+		publicIPs := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, map[string]string{}, ports)
+		Expect(len(publicIPs)).NotTo(BeZero())
+		publicIP := publicIPs[0]
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, rgMaster, rgMaster)
 
 		utils.Logf("finding NIC of the node %s, assuming it's in the same rg as master", nodeNotInRGMaster.Name)

--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -100,12 +100,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -128,12 +130,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -163,12 +167,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -187,12 +193,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -208,18 +216,22 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
-		selectedip, err := utils.SelectAvailablePrivateIP(tc)
+		selectedIPs, err := utils.SelectAvailablePrivateIPs(tc)
 		Expect(err).NotTo(HaveOccurred())
-		annotation[consts.ServiceAnnotationPLSIpConfigurationIPAddress] = selectedip
-		utils.Logf("Now update private link service's static ip to %s", selectedip)
+		Expect(len(selectedIPs)).NotTo(BeZero())
+		selectedIP := selectedIPs[0]
+		annotation[consts.ServiceAnnotationPLSIpConfigurationIPAddress] = selectedIP
+		utils.Logf("Now update private link service's static ip to %s", selectedIP)
 
 		service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -228,8 +240,10 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		ip, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+		ips, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{})
 		Expect(err).NotTo(HaveOccurred())
+		Expect(len(ips)).NotTo(BeZero())
+		ip = ips[0]
 
 		// wait and check pls is updated also
 		err = wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
@@ -237,7 +251,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 			return pls.IPConfigurations != nil &&
 				len(*pls.IPConfigurations) == 1 &&
 				(*pls.IPConfigurations)[0].PrivateIPAllocationMethod == network.Static &&
-				*(*pls.IPConfigurations)[0].PrivateIPAddress == selectedip, nil
+				*(*pls.IPConfigurations)[0].PrivateIPAddress == selectedIP, nil
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -255,12 +269,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -281,12 +297,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -308,12 +326,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -341,12 +361,14 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get Internal IP: %s", ip)
 
 		// get pls from azure client
@@ -368,11 +390,13 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 			consts.ServiceAnnotationPLSIpConfigurationIPAddressCount: strconv.Itoa(ipAddrCount),
 		}
 		svc1 := "service1"
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, svc1, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, svc1, ns.Name, labels, annotation, ports)
 		defer func() {
 			err := utils.DeleteService(cs, ns.Name, svc1)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Successfully created %s in namespace %s with IP %s", svc1, ns.Name, ip)
 
 		deployName0 := "pls-deploy0"
@@ -400,12 +424,12 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 			err = utils.DeleteService(cs, ns.Name, svc2)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		service2 = updateServiceLBIP(service2, true, ip)
+		service2 = updateServiceLBIPs(service2, true, ips)
 		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service2, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, svc2, ip)
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, svc2, ips)
 		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created %s in namespace %s with IP %s", svc2, ns.Name, ip)
+		utils.Logf("Successfully created %s in namespace %s with IPs %q", svc2, ns.Name, ips)
 
 		// get pls from azure client
 		pls := getPrivateLinkServiceFromIP(tc, ip, "", "", "")

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -149,7 +149,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			consts.ServiceAnnotationDNSLabelName: serviceDomainNamePrefix,
 		}
 		// create service with given annotation and wait it to expose
-		_ = createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		_ = createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
@@ -193,7 +193,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		By("Create a Service which will be deleted with the PIP")
 		oldServiceName := fmt.Sprintf("%s-old", serviceName)
 		service := utils.CreateLoadBalancerServiceManifest(oldServiceName, annotation, labels, nsName, ports)
-		service = updateServiceLBIP(service, false, targetIP)
+		service = updateServiceLBIPs(service, false, []string{targetIP})
 
 		// create service with given annotation and wait it to expose
 		_, err = cs.CoreV1().Services(nsName).Create(context.TODO(), service, metav1.CreateOptions{})
@@ -203,7 +203,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		Expect(err).NotTo(HaveOccurred())
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, nsName, oldServiceName, targetIP)
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, nsName, oldServiceName, []string{targetIP})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Delete the old Service")
@@ -247,7 +247,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 
 		// create service with given annotation and wait it to expose
-		_ = createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		_ = createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
@@ -300,17 +300,21 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		if newSubnetCIDR == nil {
 			By("Test subnet doesn't exist. Creating a new one...")
-			newSubnetCIDR, err = utils.GetNextSubnetCIDR(vNet, tc.IPFamily)
+			newSubnetCIDRs, err := utils.GetNextSubnetCIDRs(vNet, tc.IPFamily)
 			Expect(err).NotTo(HaveOccurred())
-			newSubnetCIDRStr := newSubnetCIDR.String()
-			By(fmt.Sprintf("Creating a subnet %q", newSubnetCIDRStr))
-			_, err = tc.CreateSubnet(vNet, &subnetName, &newSubnetCIDRStr, false)
+			newSubnetCIDRStrs := []string{}
+			for _, newSubnetCIDR := range newSubnetCIDRs {
+				newSubnetCIDRStrs = append(newSubnetCIDRStrs, newSubnetCIDR.String())
+			}
+			_, err = tc.CreateSubnet(vNet, &subnetName, &newSubnetCIDRStrs, false)
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				utils.Logf("cleaning up test subnet %s", subnetName)
 				err = tc.DeleteSubnet(*vNet.Name, subnetName)
 				Expect(err).NotTo(HaveOccurred())
 			}()
+			Expect(len(newSubnetCIDRs)).NotTo(BeZero())
+			newSubnetCIDR = newSubnetCIDRs[0]
 		}
 
 		annotation := map[string]string{
@@ -319,12 +323,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 		utils.Logf("Get External IP: %s", ip)
 
 		By("Validating external ip in target subnet")
@@ -342,12 +348,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			consts.ServiceAnnotationLoadBalancerInternal:                    "true",
 		}
 		// create service with given annotation and wait it to expose
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			utils.Logf("cleaning up test service %s", serviceName)
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 
 		lb := getAzureInternalLoadBalancerFromPrivateIP(tc, ip, "")
 
@@ -363,12 +371,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 
 		// create service with given annotation and wait it to expose
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		publicIPs := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			By("Cleaning up service")
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(publicIPs)).NotTo(BeZero())
+		publicIP := publicIPs[0]
 
 		// get lb from azure client
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
@@ -404,14 +414,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 		By("Creating service " + serviceName + " in namespace " + ns.Name)
 		service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
-		service = updateServiceLBIP(service, false, *pip.IPAddress)
+		service = updateServiceLBIPs(service, false, []string{*pip.IPAddress})
 		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		utils.Logf("Successfully created LoadBalancer service " + serviceName + " in namespace " + ns.Name)
 
 		//wait and get service's public IP Address
 		By("Waiting service to expose...")
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip.IPAddress, ""))
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{pointer.StringDeref(pip.IPAddress, "")})
 		Expect(err).NotTo(HaveOccurred())
 
 		lb := getAzureLoadBalancerFromPIP(tc, *pip.IPAddress, *rg.Name, "")
@@ -431,7 +441,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		annotation := map[string]string{
 			consts.ServiceAnnotationAdditionalPublicIPs: additionalPIP,
 		}
-		ip := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			By("cleaning up")
 			err := utils.DeleteService(cs, ns.Name, serviceName)
@@ -439,6 +449,8 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			err = utils.DeletePIPWithRetry(tc, ipName, "")
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
 
 		err = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
 			service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
@@ -538,9 +550,8 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the service to expose")
-		ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{pointer.StringDeref(pip1.IPAddress, "")})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ip).To(Equal(pointer.StringDeref(pip1.IPAddress, "")))
 
 		By("Updating the service to refer to the second service")
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
@@ -550,7 +561,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for service IP to be updated")
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip2.IPAddress, ""))
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{pointer.StringDeref(pip2.IPAddress, "")})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -595,8 +606,10 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 		By("Waiting for the service to expose")
 		{
-			ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+			ips, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips)).NotTo(BeZero())
+			ip := ips[0]
 
 			pip, err := utils.WaitGetPIPByPrefix(tc, prefix1Name, true)
 			Expect(err).NotTo(HaveOccurred())
@@ -626,7 +639,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			Expect(pip.IPAddress).NotTo(BeNil())
 			Expect(pip.PublicIPPrefix.ID).To(Equal(prefix2.ID))
 
-			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, pointer.StringDeref(pip.IPAddress, ""))
+			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{pointer.StringDeref(pip.IPAddress, "")})
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -643,12 +656,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 
 		// create service with given annotation and wait it to expose
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		publicIPs := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			By("Cleaning up service")
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(publicIPs)).NotTo(BeZero())
+		publicIP := publicIPs[0]
 		pipFrontendConfigID := getPIPFrontendConfigurationID(tc, publicIP, tc.GetResourceGroup(), "")
 		pipFrontendConfigIDSplit := strings.Split(pipFrontendConfigID, "/")
 		Expect(len(pipFrontendConfigIDSplit)).NotTo(Equal(0))
@@ -712,12 +727,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		})
 
 		// create service with given annotation and wait it to expose
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		publicIPs := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			By("Cleaning up service")
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(publicIPs)).NotTo(BeZero())
+		publicIP := publicIPs[0]
 		pipFrontendConfigID := getPIPFrontendConfigurationID(tc, publicIP, tc.GetResourceGroup(), "")
 		pipFrontendConfigIDSplit := strings.Split(pipFrontendConfigID, "/")
 		Expect(len(pipFrontendConfigIDSplit)).NotTo(Equal(0))
@@ -815,12 +832,14 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		}
 
 		By("Creating a Service")
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, annotation, ports)
+		publicIPs := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, annotation, ports)
 		defer func() {
 			By("Cleaning up service")
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(publicIPs)).NotTo(BeZero())
+		publicIP := publicIPs[0]
 
 		By("Check if the Service has the correct address")
 		Expect(publicIP).To(Equal(pipAddr))
@@ -1008,8 +1027,10 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 
 			//wait and get service's public IP Address
 			utils.Logf("Waiting service to expose...")
-			publicIP, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+			publicIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(len(publicIPs)).NotTo(BeZero())
+			publicIP := publicIPs[0]
 			// create service with given annotation and wait it to expose
 
 			defer func() {
@@ -1198,7 +1219,7 @@ func getAzureLoadBalancerFromPIP(tc *utils.AzureTestClient, pip, pipResourceGrou
 	return &lb
 }
 
-func createAndExposeDefaultServiceWithAnnotation(cs clientset.Interface, serviceName, nsName string, labels, annotation map[string]string, ports []v1.ServicePort) string {
+func createAndExposeDefaultServiceWithAnnotation(cs clientset.Interface, ipFamily utils.IPFamily, serviceName, nsName string, labels, annotation map[string]string, ports []v1.ServicePort) []string {
 	utils.Logf("Creating service " + serviceName + " in namespace " + nsName)
 	service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, nsName, ports)
 	_, err := cs.CoreV1().Services(nsName).Create(context.TODO(), service, metav1.CreateOptions{})
@@ -1207,10 +1228,10 @@ func createAndExposeDefaultServiceWithAnnotation(cs clientset.Interface, service
 
 	//wait and get service's IP Address
 	utils.Logf("Waiting service to expose...")
-	publicIP, err := utils.WaitServiceExposureAndValidateConnectivity(cs, nsName, serviceName, "")
+	publicIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ipFamily, nsName, serviceName, []string{})
 	Expect(err).NotTo(HaveOccurred())
 
-	return publicIP
+	return publicIPs
 }
 
 // createNginxDeploymentManifest returns a default deployment
@@ -1283,8 +1304,10 @@ func validateLoadBalancerBackendPools(tc *utils.AzureTestClient, vmssName string
 
 	//wait and get service's public IP Address
 	By("Waiting for service exposure")
-	publicIP, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns, serviceName, "")
+	publicIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns, serviceName, []string{})
 	Expect(err).NotTo(HaveOccurred())
+	Expect(len(publicIPs)).NotTo(BeZero())
+	publicIP := publicIPs[0]
 
 	// Invoking azure network client to get list of public IP Addresses
 	By("Getting public IPs in the resourceGroup " + resourceGroupName)
@@ -1374,8 +1397,9 @@ func testPIPTagAnnotationWithTags(
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Waiting service to expose...")
-	ip, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ns.Name, serviceName, "")
+	ips, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []string{})
 	Expect(err).NotTo(HaveOccurred())
+	Expect(len(ips)).To(Equal(1))
 
 	defer func() {
 		By("Cleaning up test service")
@@ -1393,7 +1417,7 @@ func testPIPTagAnnotationWithTags(
 	Expect(err).NotTo(HaveOccurred())
 	var targetPIP network.PublicIPAddress
 	for _, pip := range pips {
-		if strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), ip) {
+		if strings.EqualFold(pointer.StringDeref(pip.IPAddress, ""), ips[0]) {
 			targetPIP = pip
 			err := waitComparePIPTags(tc, expectedTags, pointer.StringDeref(pip.Name, ""))
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/network/standard_lb.go
+++ b/tests/e2e/network/standard_lb.go
@@ -92,7 +92,9 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 		}
 
 		rgName := tc.GetResourceGroup()
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, map[string]string{}, ports)
+		publicIPs := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, map[string]string{}, ports)
+		Expect(len(publicIPs)).NotTo(BeZero())
+		publicIP := publicIPs[0]
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, rgName, rgName)
 
 		nodeList, err := utils.GetAgentNodes(cs)
@@ -172,7 +174,9 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 		}
 
 		rgName := tc.GetResourceGroup()
-		publicIP := createAndExposeDefaultServiceWithAnnotation(cs, serviceName, ns.Name, labels, map[string]string{}, ports)
+		publicIPs := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, serviceName, ns.Name, labels, map[string]string{}, ports)
+		Expect(len(publicIPs)).NotTo(BeZero())
+		publicIP := publicIPs[0]
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, rgName, rgName)
 
 		Expect(lb.OutboundRules).NotTo(BeNil())

--- a/tests/e2e/utils/azure_test_client.go
+++ b/tests/e2e/utils/azure_test_client.go
@@ -146,12 +146,12 @@ func (tc *AzureTestClient) CreateSecurityGroupsClient() *aznetwork.SecurityGroup
 	return &aznetwork.SecurityGroupsClient{BaseClient: tc.networkClient}
 }
 
-// createPublicIPAddressesClient generates virtual network client with the same baseclient as azure test client
+// createPublicIPAddressesClient generates public IP addresses client with the same baseclient as azure test client
 func (tc *AzureTestClient) createPublicIPAddressesClient() *aznetwork.PublicIPAddressesClient {
 	return &aznetwork.PublicIPAddressesClient{BaseClient: tc.networkClient}
 }
 
-// createPublicIPPrefixesClient generates virtual network client with the same baseclient as azure test client
+// createPublicIPPrefixesClient generates public IP prefixes client with the same baseclient as azure test client
 func (tc *AzureTestClient) createPublicIPPrefixesClient() *aznetwork.PublicIPPrefixesClient {
 	return &aznetwork.PublicIPPrefixesClient{BaseClient: tc.networkClient}
 }

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -38,9 +38,17 @@ import (
 type IPFamily string
 
 var (
-	IPv4      IPFamily = "ipv4"
-	IPv6      IPFamily = "ipv6"
-	DualStack IPFamily = "dualstack"
+	IPv4      IPFamily = "IPv4"
+	IPv6      IPFamily = "IPv6"
+	DualStack IPFamily = "DualStack"
+
+	Suffixes = map[bool]string{
+		false: "-IPv4",
+		true:  "-IPv6",
+	}
+
+	// TODO: After dual-stack implementation finished, update here.
+	DualstackSupported = false
 )
 
 // getVirtualNetworkList returns the list of virtual networks in the cluster resource group.
@@ -53,6 +61,7 @@ func (azureTestClient *AzureTestClient) getVirtualNetworkList() (result aznetwor
 			if !IsRetryableAPIError(err) {
 				return false, err
 			}
+			Logf("error when listing virtual network list: %w", err)
 			return false, nil
 		}
 		return true, nil
@@ -81,11 +90,15 @@ func (azureTestClient *AzureTestClient) GetClusterVirtualNetwork() (virtualNetwo
 }
 
 // CreateSubnet creates a new subnet in the specified virtual network.
-func (azureTestClient *AzureTestClient) CreateSubnet(vnet aznetwork.VirtualNetwork, subnetName *string, prefix *string, waitUntilComplete bool) (network.Subnet, error) {
-	Logf("creating a new subnet %s, %s", *subnetName, *prefix)
+func (azureTestClient *AzureTestClient) CreateSubnet(vnet aznetwork.VirtualNetwork, subnetName *string, prefixes *[]string, waitUntilComplete bool) (network.Subnet, error) {
+	Logf("creating a new subnet %s, %v", *subnetName, *prefixes)
 	subnetParameter := (*vnet.Subnets)[0]
 	subnetParameter.Name = subnetName
-	subnetParameter.AddressPrefix = prefix
+	if len(*prefixes) == 1 {
+		subnetParameter.AddressPrefix = &(*prefixes)[0]
+	} else {
+		subnetParameter.AddressPrefixes = prefixes
+	}
 	subnetsClient := azureTestClient.createSubnetsClient()
 	_, err := subnetsClient.CreateOrUpdate(context.Background(), azureTestClient.GetResourceGroup(), *vnet.Name, *subnetName, subnetParameter)
 	var subnet network.Subnet
@@ -140,15 +153,15 @@ func (azureTestClient *AzureTestClient) DeleteSubnet(vnetName string, subnetName
 	})
 }
 
-// GetNextSubnetCIDR obtains a new ip address which has no overlap with existing subnets.
-func GetNextSubnetCIDR(vnet aznetwork.VirtualNetwork, ipFamily IPFamily) (*net.IPNet, error) {
+// GetNextSubnetCIDRs obtains a new ip address which has no overlap with existing subnets.
+func GetNextSubnetCIDRs(vnet aznetwork.VirtualNetwork, ipFamily IPFamily) ([]*net.IPNet, error) {
 	if len(*vnet.AddressSpace.AddressPrefixes) == 0 {
 		return nil, fmt.Errorf("vNet has no prefix")
 	}
 	// Because of Azure vNet limitation, underlying vNet is dual-stack for
 	// those single stack IPv6 clusters. Pods and Services are single stack
 	// IPv6 while Nodes and routes are dual-stack.
-	vnetCIDR := (*vnet.AddressSpace.AddressPrefixes)[0]
+	vnetCIDRs := []string{}
 	if ipFamily == IPv6 {
 		for i := range *vnet.AddressSpace.AddressPrefixes {
 			addrPrefix := (*vnet.AddressSpace.AddressPrefixes)[i]
@@ -157,9 +170,16 @@ func GetNextSubnetCIDR(vnet aznetwork.VirtualNetwork, ipFamily IPFamily) (*net.I
 				return nil, fmt.Errorf("failed to parse address prefix CIDR: %w", err)
 			}
 			if ip.To4() == nil {
-				vnetCIDR = addrPrefix
+				vnetCIDRs = append(vnetCIDRs, addrPrefix)
 				break
 			}
+		}
+	} else if ipFamily == IPv4 {
+		vnetCIDRs = append(vnetCIDRs, (*vnet.AddressSpace.AddressPrefixes)[0])
+	} else {
+		for i := range *vnet.AddressSpace.AddressPrefixes {
+			addrPrefix := (*vnet.AddressSpace.AddressPrefixes)[i]
+			vnetCIDRs = append(vnetCIDRs, addrPrefix)
 		}
 	}
 
@@ -174,7 +194,15 @@ func GetNextSubnetCIDR(vnet aznetwork.VirtualNetwork, ipFamily IPFamily) (*net.I
 		}
 		existSubnets = append(existSubnets, *subnet.AddressPrefixes...)
 	}
-	return getNextSubnet(vnetCIDR, existSubnets)
+	var nextSubnets []*net.IPNet
+	for _, vnetCIDR := range vnetCIDRs {
+		nextSubnet, err := getNextSubnet(vnetCIDR, existSubnets)
+		if err != nil {
+			return nextSubnets, err
+		}
+		nextSubnets = append(nextSubnets, nextSubnet)
+	}
+	return nextSubnets, nil
 }
 
 // isCIDRIPv6 checks if the provided CIDR is an IPv6 one.
@@ -239,7 +267,7 @@ func CreateLoadBalancerServiceManifest(name string, annotation map[string]string
 			Selector:       labels,
 			Ports:          ports,
 			Type:           "LoadBalancer",
-			IPFamilyPolicy: &ipFamilyPreferDS,
+			IPFamilyPolicy: &ipFamilyPreferDS, // TODO: This should be updated if there're single stack Service tests in dual-stack setup.
 		},
 	}
 }
@@ -402,57 +430,55 @@ func WaitGetPIP(azureTestClient *AzureTestClient, ipName string) (pip aznetwork.
 	return
 }
 
-// SelectAvailablePrivateIP selects a private IP address in Azure subnet.
-func SelectAvailablePrivateIP(tc *AzureTestClient) (string, error) {
-	vNet, err := tc.GetClusterVirtualNetwork()
-	vNetClient := tc.createVirtualNetworksClient()
-	if err != nil {
-		return "", err
-	}
-	if vNet.Subnets == nil || len(*vNet.Subnets) == 0 {
-		return "", fmt.Errorf("failed to find a subnet in vNet %s", pointer.StringDeref(vNet.Name, ""))
-	}
-	subnet := pointer.StringDeref((*vNet.Subnets)[0].AddressPrefix, "")
-	if len(*vNet.Subnets) > 1 {
-		for _, sn := range *vNet.Subnets {
-			// if there is more than one subnet, select the first one we find.
-			if !strings.Contains(*sn.Name, "controlplane") && !strings.Contains(*sn.Name, "control-plane") {
-				if tc.IPFamily == DualStack {
-					subnet = (*sn.AddressPrefixes)[0]
-				} else if tc.IPFamily == IPv4 {
-					subnet = *sn.AddressPrefix
-				} else {
-					for i := range *sn.AddressPrefixes {
-						addrPrefix := (*sn.AddressPrefixes)[i]
-						isIPv6, err := isCIDRIPv6(addrPrefix)
-						if err != nil {
-							return "", err
-						}
-						if isIPv6 {
-							subnet = addrPrefix
-							break
-						}
-					}
+func selectSubnets(ipFamily IPFamily, vNetSubnets *[]aznetwork.Subnet) ([]string, error) {
+	subnets := []string{}
+	for _, sn := range *vNetSubnets {
+		// if there is more than one subnet (non-control-plane), select the first one we find.
+		if strings.Contains(*sn.Name, "controlplane") || strings.Contains(*sn.Name, "control-plane") {
+			continue
+		}
+		if ipFamily == DualStack {
+			if len(*sn.AddressPrefixes) < 2 {
+				return []string{}, fmt.Errorf("failed to find correct sn.AddressPrefixes %q when IP family is dualstack", *sn.AddressPrefixes)
+			}
+			subnets = []string{(*sn.AddressPrefixes)[0], (*sn.AddressPrefixes)[1]}
+		} else if ipFamily == IPv4 {
+			subnets = []string{*sn.AddressPrefix}
+		} else {
+			for i := range *sn.AddressPrefixes {
+				addrPrefix := (*sn.AddressPrefixes)[i]
+				isIPv6, err := isCIDRIPv6(addrPrefix)
+				if err != nil {
+					return []string{}, err
 				}
-				break
+				if isIPv6 {
+					subnets = []string{addrPrefix}
+					break
+				}
 			}
 		}
+		break
 	}
+	return subnets, nil
+}
+
+func findIPInSubnet(vNetClient *aznetwork.VirtualNetworksClient, rg, subnet, vNetName string) (string, error) {
+	Logf("Handling subnet %s", subnet)
 	ip, _, err := net.ParseCIDR(subnet)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse subnet CIDR in vNet %s: %w", pointer.StringDeref(vNet.Name, ""), err)
+		return "", fmt.Errorf("failed to parse subnet CIDR in vNet %s: %w", vNetName, err)
 	}
 
 	baseIP := ip.To4()
 	pos := 3
-	if tc.IPFamily == IPv6 {
+	if ip.To4() == nil {
 		baseIP = ip.To16()
 		pos = 15
 	}
 	for i := 0; i <= 254; i++ {
 		baseIP[pos]++
 		IP := baseIP.String()
-		ret, err := vNetClient.CheckIPAddressAvailability(context.Background(), tc.GetResourceGroup(), pointer.StringDeref(vNet.Name, ""), IP)
+		ret, err := vNetClient.CheckIPAddressAvailability(context.Background(), rg, vNetName, IP)
 		if err != nil {
 			// just ignore
 			continue
@@ -462,6 +488,43 @@ func SelectAvailablePrivateIP(tc *AzureTestClient) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("find no availabePrivateIP in subnet CIDR %s", subnet)
+}
+
+// SelectAvailablePrivateIPs selects private IP addresses in Azure subnet.
+func SelectAvailablePrivateIPs(tc *AzureTestClient) ([]string, error) {
+	vNet, err := tc.GetClusterVirtualNetwork()
+	if err != nil {
+		return []string{}, err
+	}
+	if vNet.Subnets == nil || len(*vNet.Subnets) == 0 {
+		return []string{}, fmt.Errorf("failed to find a subnet in vNet %s", pointer.StringDeref(vNet.Name, ""))
+	}
+	subnets, err := selectSubnets(tc.IPFamily, vNet.Subnets)
+	if err != nil {
+		return []string{}, err
+	}
+
+	vNetClient := tc.createVirtualNetworksClient()
+	if err != nil {
+		return []string{}, err
+	}
+	privateIPs := []string{}
+	for _, subnet := range subnets {
+		ip, err := findIPInSubnet(vNetClient, tc.resourceGroup, subnet, pointer.StringDeref(vNet.Name, ""))
+		if err != nil {
+			return privateIPs, err
+		}
+		privateIPs = append(privateIPs, ip)
+	}
+
+	expectedPrivateIPCount := 1
+	if tc.IPFamily == DualStack {
+		expectedPrivateIPCount = 2
+	}
+	if len(privateIPs) != expectedPrivateIPCount {
+		return []string{}, fmt.Errorf("failed to find all availabePrivateIPs in subnet CIDRs %q, got privateIPs %q", subnets, privateIPs)
+	}
+	return privateIPs, nil
 }
 
 // GetPublicIPFromAddress finds public ip according to ip address
@@ -611,4 +674,23 @@ func GetClusterServiceIPFamily() (IPFamily, error) {
 		return IPv6, nil
 	}
 	return DualStack, nil
+}
+
+func IfIPFamiliesEnabled(ipFamily IPFamily) (v4Enabled bool, v6Enabled bool) {
+	if ipFamily == DualStack || ipFamily == IPv4 {
+		v4Enabled = true
+	}
+	if ipFamily == DualStack || ipFamily == IPv6 {
+		v6Enabled = true
+	}
+	return
+}
+
+// GetNameWithSuffix returns resource name with IP family suffix.
+// After dual-stack implementation is finished, this function returns name + suffix for all IP families.
+func GetNameWithSuffix(name, suffix string) string {
+	if DualstackSupported {
+		return name + suffix
+	}
+	return name
 }

--- a/tests/e2e/utils/network_utils_test.go
+++ b/tests/e2e/utils/network_utils_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+)
+
+func TestSelectSubnets(t *testing.T) {
+	testcases := []struct {
+		desc            string
+		ipFamily        IPFamily
+		vNetSubnets     *[]aznetwork.Subnet
+		expectedSubnets []string
+	}{
+		{
+			"only control-plane subnet",
+			IPv4,
+			&[]aznetwork.Subnet{
+				{Name: pointer.String("control-plane")},
+			},
+			[]string{},
+		},
+		{
+			"IPv4",
+			IPv4,
+			&[]aznetwork.Subnet{
+				{Name: pointer.String("subnet0"), SubnetPropertiesFormat: &aznetwork.SubnetPropertiesFormat{AddressPrefix: pointer.String("10.0.0.0/24")}},
+			},
+			[]string{"10.0.0.0/24"},
+		},
+		{
+			"IPv6",
+			IPv6,
+			&[]aznetwork.Subnet{
+				{
+					Name: pointer.String("subnet0"),
+					SubnetPropertiesFormat: &aznetwork.SubnetPropertiesFormat{
+						AddressPrefix:   pointer.String("10.0.0.0/24"),
+						AddressPrefixes: &[]string{"10.0.0.0/24", "2001::1/96"},
+					},
+				},
+			},
+			[]string{"2001::1/96"},
+		},
+		{
+			"DualStack",
+			DualStack,
+			&[]aznetwork.Subnet{
+				{
+					Name: pointer.String("subnet0"),
+					SubnetPropertiesFormat: &aznetwork.SubnetPropertiesFormat{
+						AddressPrefix:   pointer.String("10.0.0.0/24"),
+						AddressPrefixes: &[]string{"10.0.0.0/24", "2001::1/96"},
+					},
+				},
+			},
+			[]string{"10.0.0.0/24", "2001::1/96"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			subnets, err := selectSubnets(tc.ipFamily, tc.vNetSubnets)
+			assert.Nil(t, err)
+			assert.True(t, CompareStrings(subnets, tc.expectedSubnets))
+		})
+	}
+}

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -27,6 +27,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -187,4 +188,10 @@ func StringInSlice(s string, list []string) bool {
 		}
 	}
 	return false
+}
+
+func CompareStrings(s0, s1 []string) bool {
+	ss0 := sets.NewString(s0...)
+	ss1 := sets.NewString(s1...)
+	return ss0.Equal(ss1)
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[e2e] Support dual-stack - utils
* Support dual-stack in e2e utils functions and methods
* Adjust related e2e test code
* Define some dual-stack Service annotations

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
