### PR TITLE
[IPv6] Fix reconcileFrontendIPConfigs()

### DIFF
--- a/pkg/provider/azure_privatelinkservice_test.go
+++ b/pkg/provider/azure_privatelinkservice_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient"
-	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -337,18 +336,6 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			}
 			clusterName := testClusterName
 
-			if isInternal, ok := test.annotations[consts.ServiceAnnotationLoadBalancerInternal]; !ok || isInternal != "true" {
-				existingPIPS := []network.PublicIPAddress{
-					{
-						ID: pointer.String("pipID"),
-						PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-							PublicIPAddressVersion: network.IPv4,
-						},
-					},
-				}
-				mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
-				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(existingPIPS, nil).Times(1)
-			}
 			mockSubnetsClient := az.SubnetsClient.(*mocksubnetclient.MockInterface)
 			mockPLSsClient := az.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
 			if test.expectedSubnetGet {

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -1167,6 +1167,9 @@ func TestIsBackendPoolIPv6(t *testing.T) {
 	for _, test := range testcases {
 		isIPv6 := isBackendPoolIPv6(test.name)
 		assert.Equal(t, test.expectedIsIPv6, isIPv6)
+
+		isIPv6ManagedResource := managedResourceHasIPv6Suffix(test.name)
+		assert.Equal(t, test.expectedIsIPv6, isIPv6ManagedResource)
 	}
 }
 
@@ -1829,13 +1832,13 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 	defer ctrl.Finish()
 
 	testCases := []struct {
-		desc         string
-		existingPIPs []network.PublicIPAddress
-		fip          network.FrontendIPConfiguration
-		service      *v1.Service
-		isOwned      bool
-		isPrimary    bool
-		expectedErr  error
+		desc                 string
+		existingPIPs         []network.PublicIPAddress
+		fip                  network.FrontendIPConfiguration
+		service              *v1.Service
+		isOwned              bool
+		isPrimary            bool
+		expectedFIPIPVersion network.IPVersion
 	}{
 		{
 			desc: "serviceOwnsFrontendIP should detect the primary service",
@@ -1886,6 +1889,34 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "1.2.3.4"},
 				},
 			},
+		},
+		{
+			desc: "serviceOwnsFrontendIP should return correct FIP IP version",
+			existingPIPs: []network.PublicIPAddress{
+				{
+					ID: pointer.String("pip"),
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress:              pointer.String("4.3.2.1"),
+						PublicIPAddressVersion: network.IPv4,
+					},
+				},
+			},
+			fip: network.FrontendIPConfiguration{
+				Name: pointer.String("auid"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &network.PublicIPAddress{
+						ID: pointer.String("pip"),
+					},
+				},
+			},
+			service: &v1.Service{
+				ObjectMeta: meta.ObjectMeta{
+					UID:         types.UID("secondary"),
+					Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "4.3.2.1"},
+				},
+			},
+			expectedFIPIPVersion: network.IPv4,
+			isOwned:              true,
 		},
 		{
 			desc: "serviceOwnsFrontendIP should return false if there is a mismatch between the PIP's ID and " +
@@ -2060,8 +2091,10 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 				mockPIPsClient := cloud.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
 				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPIPs, nil).MaxTimes(2)
 			}
-			isOwned, isPrimary, err := cloud.serviceOwnsFrontendIP(test.fip, test.service)
-			assert.Equal(t, test.expectedErr, err)
+			isOwned, isPrimary, fipIPVersion := cloud.serviceOwnsFrontendIP(test.fip, test.service)
+			if test.expectedFIPIPVersion != "" {
+				assert.Equal(t, test.expectedFIPIPVersion, fipIPVersion)
+			}
 			assert.Equal(t, test.isOwned, isOwned)
 			assert.Equal(t, test.isPrimary, isPrimary)
 		})

--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -45,6 +45,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 	var cs clientset.Interface
 	var ns *v1.Namespace
 	var tc *utils.AzureTestClient
+	var isDeploymentCreated bool
 
 	labels := map[string]string{
 		"app": serviceName,
@@ -77,14 +78,17 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		deployment := createServerDeploymentManifest(serviceName, labels)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		isDeploymentCreated = true
 	})
 
 	AfterEach(func() {
 		if ns != nil && cs != nil {
-			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			if isDeploymentCreated {
+				err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
 
-			err = utils.DeleteNamespace(cs, ns.Name)
+			err := utils.DeleteNamespace(cs, ns.Name)
 			Expect(err).NotTo(HaveOccurred())
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[IPv6] Fix reconcileFrontendIPConfigs(). Current logic handles lb.FrontendIPConfigurations according to Service's IP family, which is incorrect. For an IPv6 cluster, there're still some IPv4 FIPs due to Azure limitation, which will be removed. For an IPv4 cluster, all resources are of IPv4, which is not affected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4038

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[IPv6] Fix reconcileFrontendIPConfigs(). Current logic handles lb.FrontendIPConfigurations according to Service's IP family, which is incorrect. For an IPv6 cluster, there're still some IPv4 FIPs due to Azure limitation, which will be removed. For an IPv4 cluster, all resources are of IPv4, which is not affected.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
