### PR TITLE
[WIP] feat: implement Non Graceful node shutdown feature in CCM

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -1195,9 +1195,14 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 			}
 		} else {
 			if !taints.TaintExists(newNode.Spec.Taints, &nodeOutOfServiceTaint) && az.KubeClient != nil {
-				klog.V(2).Infof("node %s is not in ready state, adding taint %s to the node", newNode.Name, v1.TaintNodeOutOfService)
-				if err := cloudnodeutil.AddOrUpdateTaintOnNode(az.KubeClient, newNode.Name, &nodeOutOfServiceTaint); err != nil {
-					klog.Errorf("failed to add taint %s to the node %s", v1.TaintNodeOutOfService, newNode.Name)
+				shutdown, err := az.InstanceShutdown(context.Background(), newNode)
+				if err == nil && shutdown {
+					klog.V(2).Infof("node %s is now in shutdown state, adding taint %s to the node", newNode.Name, v1.TaintNodeOutOfService)
+					if err := cloudnodeutil.AddOrUpdateTaintOnNode(az.KubeClient, newNode.Name, &nodeOutOfServiceTaint); err != nil {
+						klog.Errorf("failed to add taint %s to the node %s", v1.TaintNodeOutOfService, newNode.Name)
+					}
+				} else {
+					klog.Warningf("node %s is not ready, while it's not in shutdown state: %v", newNode.Name, err)
 				}
 			}
 		}

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -4041,3 +4041,54 @@ func TestSetLBDefaults(t *testing.T) {
 	_ = az.setLBDefaults(config)
 	assert.Equal(t, config.LoadBalancerSku, consts.LoadBalancerSkuStandard)
 }
+
+func TestIsNodeReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *v1.Node
+		expected bool
+	}{
+		{
+			node:     nil,
+			expected: false,
+		},
+		{
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			node: &v1.Node{
+				Status: v1.NodeStatus{},
+			},
+			expected: false,
+		},
+		{
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:   v1.NodeMemoryPressure,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		if got := isNodeReady(test.node); got != test.expected {
+			t.Errorf("isNodeReady() = %v, want %v", got, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
feat: implement Non Graceful node shutdown feature in CCM (beta feature from k8s 1.26)
https://kubernetes.io/docs/concepts/architecture/nodes/#non-graceful-node-shutdown

When node is not ready, this PR would add taint `node.kubernetes.io/out-of-service` to the node and when node is ready, this PR would remove `node.kubernetes.io/out-of-service` from the node, this could solve the issue: statefulset pod with volume mount could never be terminated successfully when node is shutdown or become not ready state.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3269

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat: implement Non Graceful node shutdown feature in CCM
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
feat: implement Non Graceful node shutdown feature in CCM
```
