### PR TITLE
Add concurrent-node-syncs option

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -66,6 +66,7 @@ type CloudControllerManagerOptions struct {
 	KubeCloudShared    *cpoptions.KubeCloudSharedOptions
 	ServiceController  *cpoptions.ServiceControllerOptions
 	NodeIPAMController *NodeIPAMControllerOptions
+	NodeController     *cpoptions.NodeControllerOptions
 
 	SecureServing  *apiserveroptions.SecureServingOptionsWithLoopback
 	Authentication *apiserveroptions.DelegatingAuthenticationOptions
@@ -92,6 +93,9 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 		KubeCloudShared: cpoptions.NewKubeCloudSharedOptions(&componentConfig.KubeCloudShared),
 		ServiceController: &cpoptions.ServiceControllerOptions{
 			ServiceControllerConfiguration: &componentConfig.ServiceController,
+		},
+		NodeController: &cpoptions.NodeControllerOptions{
+			&componentConfig.NodeController,
 		},
 		NodeIPAMController:        defaultNodeIPAMControllerOptions(),
 		SecureServing:             apiserveroptions.NewSecureServingOptions().WithLoopback(),
@@ -137,6 +141,7 @@ func (o *CloudControllerManagerOptions) Flags(allControllers, disabledByDefaultC
 	o.KubeCloudShared.AddFlags(fss.FlagSet("generic"))
 	o.ServiceController.AddFlags(fss.FlagSet("service controller"))
 	o.NodeIPAMController.AddFlags(fss.FlagSet("node ipam controller"))
+	o.NodeController.AddFlags(fss.FlagSet("node controller"))
 
 	o.SecureServing.AddFlags(fss.FlagSet("secure serving"))
 	o.Authentication.AddFlags(fss.FlagSet("authentication"))
@@ -167,6 +172,9 @@ func (o *CloudControllerManagerOptions) ApplyTo(c *cloudcontrollerconfig.Config,
 		return err
 	}
 	if err = o.NodeIPAMController.ApplyTo(&c.NodeIPAMControllerConfig); err != nil {
+		return err
+	}
+	if err = o.NodeController.ApplyTo(&c.ComponentConfig.NodeController); err != nil {
 		return err
 	}
 	if err = o.SecureServing.ApplyTo(&c.SecureServing, &c.LoopbackClientConfig); err != nil {
@@ -234,6 +242,7 @@ func (o *CloudControllerManagerOptions) Validate(allControllers, disabledByDefau
 	errors = append(errors, o.KubeCloudShared.Validate()...)
 	errors = append(errors, o.ServiceController.Validate()...)
 	errors = append(errors, o.NodeIPAMController.Validate()...)
+	errors = append(errors, o.NodeController.Validate()...)
 	errors = append(errors, o.SecureServing.Validate()...)
 	errors = append(errors, o.Authentication.Validate()...)
 	errors = append(errors, o.Authorization.Validate()...)

--- a/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/cmd/cloud-controller-manager/app/options/options_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	cpconfig "k8s.io/cloud-provider/config"
+	nodeconfig "k8s.io/cloud-provider/controllers/node/config"
 	serviceconfig "k8s.io/cloud-provider/controllers/service/config"
 	cpoptions "k8s.io/cloud-provider/options"
 	componentbaseconfig "k8s.io/component-base/config"
@@ -97,6 +98,11 @@ func TestDefaultFlags(t *testing.T) {
 		NodeIPAMController: &NodeIPAMControllerOptions{
 			NodeIPAMControllerConfiguration: &config.NodeIPAMControllerConfiguration{
 				NodeCIDRMaskSize: consts.DefaultNodeCIDRMaskSize,
+			},
+		},
+		NodeController: &cpoptions.NodeControllerOptions{
+			NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{
+				ConcurrentNodeSyncs: 1,
 			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
@@ -244,6 +250,11 @@ func TestAddFlags(t *testing.T) {
 				NodeCIDRMaskSize: consts.DefaultNodeCIDRMaskSize,
 			},
 		},
+		NodeController: &cpoptions.NodeControllerOptions{
+			NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{
+				ConcurrentNodeSyncs: 1,
+			},
+		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
 			BindPort:    10001,
 			BindAddress: net.ParseIP("192.168.4.21"),
@@ -320,6 +331,16 @@ func TestValidate(t *testing.T) {
 			generateTestCloudControllerManagerOptions: func() *CloudControllerManagerOptions {
 				s, _ := NewCloudControllerManagerOptions()
 				s.ServiceController.ConcurrentServiceSyncs = 10
+				s.KubeCloudShared.CloudProvider.CloudConfigFile = "azure.json"
+				return s
+			},
+		},
+		{
+			desc:     "should return an error when concurrent node syncs a non-positive number",
+			expected: "concurrent-node-syncs must be a positive number",
+			generateTestCloudControllerManagerOptions: func() *CloudControllerManagerOptions {
+				s, _ := NewCloudControllerManagerOptions()
+				s.NodeController.ConcurrentNodeSyncs = 0
 				s.KubeCloudShared.CloudProvider.CloudConfigFile = "azure.json"
 				return s
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR:
- add concurrent-node-syncs option

Without this, ConcurrentNodeSyncs is always 0, as a result of which the node controller does not work.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
feat: add concurrent-node-syncs option
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
