### PR TITLE
update to debian bullseye, buster EOL soon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # syntax=docker/dockerfile:1
 
-FROM --platform=linux/amd64 golang:1.20.5-buster@sha256:eb3f9ac805435c1b2c965d63ce460988e1000058e1f67881324746362baf9572 AS builder
+FROM --platform=linux/amd64 golang:1.20-bullseye@sha256:e88f338421aa37d614c3cf0fea40a978a943b5cc1b1b34ecff3cb7e1a6e79090 AS builder
 
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH=amd64

--- a/Makefile
+++ b/Makefile
@@ -122,12 +122,6 @@ $(BIN_DIR)/azure-acr-credential-provider.exe: $(PKG_CONFIG) $(wildcard cmd/acr-c
 ##@ Images
 ## --------------------------------------
 
-.PHONY: docker-pull-prerequisites
-docker-pull-prerequisites: ## Pull prerequisite images.
-	docker pull docker/dockerfile:1
-	docker pull docker.io/library/golang:buster
-	docker pull gcr.io/distroless/static:latest
-
 buildx-setup:
 	$(DOCKER_BUILDX) inspect img-builder > /dev/null 2>&1 || $(DOCKER_BUILDX) create --name img-builder --use
 	# enable qemu for arm64 build
@@ -136,7 +130,7 @@ buildx-setup:
 	docker run --rm --privileged tonistiigi/binfmt --install all
 
 .PHONY: build-ccm-image
-build-ccm-image: buildx-setup docker-pull-prerequisites ## Build controller-manager image.
+build-ccm-image: buildx-setup ## Build controller-manager image.
 	$(DOCKER_BUILDX) build \
 		--pull \
 		--output=type=$(OUTPUT_TYPE) \
@@ -150,7 +144,7 @@ build-ccm-image: buildx-setup docker-pull-prerequisites ## Build controller-mana
 		--sbom=false
 
 .PHONY: build-node-image-linux
-build-node-image-linux: buildx-setup docker-pull-prerequisites ## Build node-manager image.
+build-node-image-linux: buildx-setup ## Build node-manager image.
 	$(DOCKER_BUILDX) build \
 		--pull \
 		--output=type=$(OUTPUT_TYPE) \

--- a/cloud-node-manager.Dockerfile
+++ b/cloud-node-manager.Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.20.5-buster AS builder
+FROM --platform=linux/amd64 golang:1.20-bullseye@sha256:e88f338421aa37d614c3cf0fea40a978a943b5cc1b1b34ecff3cb7e1a6e79090 AS builder
 
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH=amd64

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.5-buster
+FROM golang:1.20-bullseye@sha256:e88f338421aa37d614c3cf0fea40a978a943b5cc1b1b34ecff3cb7e1a6e79090
 
 WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
 

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -140,7 +140,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		// 1. Create a Service with managed PIP and check connectivity with DNS
 		// 2. Delete the Service
 		// 3. Create a Service with user assigned PIP
-		// 4. Delete the Servcie and check tags
+		// 4. Delete the Service and check tags
 		// 5. Create a Service with different name
 		// 6. Update the Service with new tag
 		By("Create a Service with managed PIP")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Debian buster has been EOL for a while and its LTS is soon to be over. Reference:

- https://wiki.debian.org/DebianReleases

This PR updates Dockerfile references to build from buster + 1 --> bullseye.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
build images from debian bullseye
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
