### PR TITLE
track2 sdk:add GetVirtualMachineScaleSetNetworkInterface for interface client

### DIFF
--- a/pkg/azclient/client-gen/cmd/typescaffold/type_scaffold.go
+++ b/pkg/azclient/client-gen/cmd/typescaffold/type_scaffold.go
@@ -152,8 +152,8 @@ func main() {
 				fmt.Printf("failed to create dir %s\n", err.Error())
 				return
 			}
-			if _, err = os.Lstat(fileName + "/custom.go"); err == nil {
-				fmt.Printf("customization file %s already exists, skip\n", fileName+"/custom.go")
+			if _, err = os.Lstat(fileName + "/interface.go"); err == nil {
+				fmt.Printf("interface file %s already exists, skip\n", fileName+"/interface.go")
 				return
 			}
 			err = os.WriteFile(fileName+"/interface.go", formattedContent, 0600)

--- a/pkg/azclient/interfaceclient/interface.go
+++ b/pkg/azclient/interfaceclient/interface.go
@@ -18,6 +18,8 @@ limitations under the License.
 package interfaceclient
 
 import (
+	"context"
+
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v3"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
@@ -25,6 +27,8 @@ import (
 
 // +azure:client:verbs=get;createorupdate;delete;list,resource=Interface,packageName=github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v3,packageAlias=armnetwork,clientName=InterfacesClient,expand=true,rateLimitKey=interfaceRateLimit
 type Interface interface {
+	// GetVirtualMachineScaleSetNetworkInterface gets a network.Interface of VMSS VM.
+	GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceOptions) (armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse, error)
 	utils.GetWithExpandFunc[armnetwork.Interface]
 	utils.CreateOrUpdateFunc[armnetwork.Interface]
 	utils.DeleteFunc[armnetwork.Interface]

--- a/pkg/azclient/interfaceclient/mock_interfaceclient/interface.go
+++ b/pkg/azclient/interfaceclient/mock_interfaceclient/interface.go
@@ -95,6 +95,21 @@ func (mr *MockInterfaceMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterface)(nil).Get), arg0, arg1, arg2, arg3)
 }
 
+// GetVirtualMachineScaleSetNetworkInterface mocks base method.
+func (m *MockInterface) GetVirtualMachineScaleSetNetworkInterface(arg0 context.Context, arg1, arg2, arg3, arg4 string, arg5 *armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceOptions) (armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVirtualMachineScaleSetNetworkInterface", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVirtualMachineScaleSetNetworkInterface indicates an expected call of GetVirtualMachineScaleSetNetworkInterface.
+func (mr *MockInterfaceMockRecorder) GetVirtualMachineScaleSetNetworkInterface(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachineScaleSetNetworkInterface", reflect.TypeOf((*MockInterface)(nil).GetVirtualMachineScaleSetNetworkInterface), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
 // List mocks base method.
 func (m *MockInterface) List(arg0 context.Context, arg1 string) ([]*armnetwork.Interface, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
add GetVirtualMachineScaleSetNetworkInterface for interface client
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
