### PR TITLE
fix: PerformancePlus setting issue

### DIFF
--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -727,7 +727,8 @@ func vmUpdateRequired(future *azure.Future, err error) bool {
 func getValidCreationData(subscriptionID, resourceGroup string, options *ManagedDiskOptions) (compute.CreationData, error) {
 	if options.SourceResourceID == "" {
 		return compute.CreationData{
-			CreateOption: compute.Empty,
+			CreateOption:    compute.Empty,
+			PerformancePlus: options.PerformancePlus,
 		}, nil
 	}
 
@@ -744,7 +745,8 @@ func getValidCreationData(subscriptionID, resourceGroup string, options *Managed
 		}
 	default:
 		return compute.CreationData{
-			CreateOption: compute.Empty,
+			CreateOption:    compute.Empty,
+			PerformancePlus: options.PerformancePlus,
 		}, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
PerformancePlus is not set correctly per https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/1893, this PR fixes the issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

<details>

```
  Normal   ExternalProvisioning  11s              persistentvolume-controller                                                             waiting for a volume to be created, either by external provisioner "disk.csi.azure.com" or manually created by system administrator
  Normal   Provisioning          3s (x3 over 7s)  disk.csi.azure.com_aks-acstor-38086987-vmss000002_4639910e-7ba7-4378-b573-e903bbb56d17  External provisioner is provisioning volume for claim "default/pvc-azuredisk5"
  Warning  ProvisioningFailed    3s (x3 over 6s)  disk.csi.azure.com_aks-acstor-38086987-vmss000002_4639910e-7ba7-4378-b573-e903bbb56d17  failed to provision volume with StorageClass "managed-csi": rpc error: code = Internal desc = Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
  "error": {
    "code": "BadRequest",
    "message": "The performancePlus flag can only be set on disks at least 512 GB in size."
  }
}


# az disk show --name pvc-87efdcc7-e4d9-4854-9717-d6ee67f35aa5 --resource-group MC_andy-aks126_andy-aks126_eastus2
{
  "burstingEnabled": null,
  "completionPercent": null,
  "creationData": {
    "createOption": "Empty",
    "galleryImageReference": null,
    "imageReference": null,
    "logicalSectorSize": null,
    "performancePlus": true,
    "securityDataUri": null,
    "sourceResourceId": null,
    "sourceUniqueId": null,
    "sourceUri": null,
    "storageAccountId": null,
    "uploadSizeBytes": null
  },
  "dataAccessAuthMode": null,
  "diskAccessId": null,
  "diskIopsReadOnly": null,
  "diskIopsReadWrite": 1500,
  "diskMBpsReadOnly": null,
  "diskMBpsReadWrite": 150,
  "diskSizeBytes": 550829555712,
  "diskSizeGb": 513,
```

</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: PerformancePlus setting issue
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: PerformancePlus setting issue
```
