### PR TITLE
[e2e] Delete Service if WaitServiceExposureAndValidateConnectivity() fails

### DIFF
--- a/tests/e2e/utils/service_utils.go
+++ b/tests/e2e/utils/service_utils.go
@@ -31,6 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -100,21 +102,31 @@ func WaitServiceExposureAndGetIPs(cs clientset.Interface, namespace string, name
 }
 
 // WaitServiceExposureAndValidateConnectivity returns IPs of the service and check the connectivity if they are public IPs.
+// Service should have been created before calling this function.
 func WaitServiceExposureAndValidateConnectivity(cs clientset.Interface, ipFamily IPFamily, namespace string, name string, targetIPs []string) ([]string, error) {
 	var service *v1.Service
 	var err error
 	var ips []string
+
+	defer func() {
+		if err != nil {
+			deleteSvcErr := DeleteService(cs, namespace, name)
+			Expect(deleteSvcErr).NotTo(HaveOccurred())
+		}
+	}()
 
 	service, err = WaitServiceExposure(cs, namespace, name, targetIPs)
 	if err != nil {
 		return ips, err
 	}
 	if service == nil {
-		return ips, errors.New("the service is nil")
+		err = errors.New("the service is nil")
+		return ips, err
 	}
 
 	if len(service.Status.LoadBalancer.Ingress) == 0 {
-		return ips, errors.New("service.Status.LoadBalancer.Ingress is empty")
+		err = errors.New("service.Status.LoadBalancer.Ingress is empty")
+		return ips, err
 	}
 	ips = append(ips, service.Status.LoadBalancer.Ingress[0].IP)
 	if len(service.Status.LoadBalancer.Ingress) > 1 {
@@ -124,13 +136,14 @@ func WaitServiceExposureAndValidateConnectivity(cs clientset.Interface, ipFamily
 	// Create host exec Pod
 	result, err := CreateHostExecPod(cs, namespace, ExecAgnhostPod)
 	defer func() {
-		err := DeletePod(cs, namespace, ExecAgnhostPod)
-		if err != nil {
+		deletePodErr := DeletePod(cs, namespace, ExecAgnhostPod)
+		if deletePodErr != nil {
 			Logf("failed to delete ExecAgnhostPod, error: %v", err)
 		}
 	}()
 	if !result || err != nil {
-		return ips, fmt.Errorf("failed to create ExecAgnhostPod, result: %v, error: %w", result, err)
+		err = fmt.Errorf("failed to create ExecAgnhostPod, result: %v, error: %w", result, err)
+		return ips, err
 	}
 
 	// TODO: Check if other WaitServiceExposureAndValidateConnectivity() callers with internal Service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[e2e] Delete Service if WaitServiceExposureAndValidateConnectivity() fails
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4137

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
