### PR TITLE
fix: storage account search default values

### DIFF
--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -251,11 +251,11 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 						return "", "", err
 					}
 					index = int(n.Int64())
-					klog.V(4).Infof("randomly pick one matching account, index: %d", index)
+					klog.V(4).Infof("randomly pick one matching account, index: %d, matching accounts: %s", index, accounts)
 				}
 				accountName = accounts[index].Name
 				createNewAccount = false
-				klog.V(4).Infof("found a matching account %s type %s location %s", accounts[0].Name, accounts[0].StorageType, accounts[0].Location)
+				klog.V(4).Infof("found a matching account %s type %s location %s", accounts[index].Name, accounts[index].StorageType, accounts[index].Location)
 			}
 		}
 
@@ -742,7 +742,7 @@ func isPrivateEndpointAsExpected(account storage.Account, accountOptions *Accoun
 }
 
 func isAllowBlobPublicAccessEqual(account storage.Account, accountOptions *AccountOptions) bool {
-	return pointer.BoolDeref(accountOptions.AllowBlobPublicAccess, false) == pointer.BoolDeref(account.AllowBlobPublicAccess, false)
+	return pointer.BoolDeref(accountOptions.AllowBlobPublicAccess, true) == pointer.BoolDeref(account.AllowBlobPublicAccess, true)
 }
 
 func isRequireInfrastructureEncryptionEqual(account storage.Account, accountOptions *AccountOptions) bool {
@@ -754,7 +754,7 @@ func isRequireInfrastructureEncryptionEqual(account storage.Account, accountOpti
 }
 
 func isAllowSharedKeyAccessEqual(account storage.Account, accountOptions *AccountOptions) bool {
-	return pointer.BoolDeref(accountOptions.AllowSharedKeyAccess, false) == pointer.BoolDeref(account.AllowSharedKeyAccess, false)
+	return pointer.BoolDeref(accountOptions.AllowSharedKeyAccess, true) == pointer.BoolDeref(account.AllowSharedKeyAccess, true)
 }
 
 func isAccessTierEqual(account storage.Account, accountOptions *AccountOptions) bool {

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -850,7 +850,7 @@ func TestIsAllowBlobPublicAccessEqual(t *testing.T) {
 				},
 			},
 			accountOptions: &AccountOptions{},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			account: storage.Account{
@@ -859,7 +859,7 @@ func TestIsAllowBlobPublicAccessEqual(t *testing.T) {
 			accountOptions: &AccountOptions{
 				AllowBlobPublicAccess: pointer.Bool(false),
 			},
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			account: storage.Account{
@@ -879,7 +879,7 @@ func TestIsAllowBlobPublicAccessEqual(t *testing.T) {
 			accountOptions: &AccountOptions{
 				AllowBlobPublicAccess: pointer.Bool(true),
 			},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			account: storage.Account{
@@ -913,7 +913,7 @@ func TestIsAllowSharedKeyAccessEqual(t *testing.T) {
 				},
 			},
 			accountOptions: &AccountOptions{},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			account: storage.Account{
@@ -922,7 +922,7 @@ func TestIsAllowSharedKeyAccessEqual(t *testing.T) {
 			accountOptions: &AccountOptions{
 				AllowSharedKeyAccess: pointer.Bool(false),
 			},
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			account: storage.Account{
@@ -942,7 +942,7 @@ func TestIsAllowSharedKeyAccessEqual(t *testing.T) {
 			accountOptions: &AccountOptions{
 				AllowSharedKeyAccess: pointer.Bool(true),
 			},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			account: storage.Account{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: account search default values
default values of AllowBlobPublicAccess and AllowSharedKeyAccess is true in storage API, this PR set the same default as storage API.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: storage account search default values
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: storage account search default values
```
