### PR TITLE
fix: call availabilitySet.EnsureBackendPoolDeleted in scaleSet.Ensure…

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -143,6 +143,8 @@ const (
 
 	// GetNodeVmssFlexIDLockKey is the key for getting the lock for getNodeVmssFlexID function
 	GetNodeVmssFlexIDLockKey = "k8sGetNodeVmssFlexIDLockKey"
+	// VMManagementTypeLockKey is the key for getting the lock for getVMManagementType function
+	VMManagementTypeLockKey = "VMManagementType"
 
 	// AvailabilitySetNodesCacheTTLDefaultInSeconds is the TTL of the availabilitySet node cache
 	AvailabilitySetNodesCacheTTLDefaultInSeconds = 900

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -890,7 +890,7 @@ func TestInstanceMetadata(t *testing.T) {
 
 	t.Run("instance exists", func(t *testing.T) {
 		cloud := GetTestCloud(ctrl)
-		expectedVM := buildDefaultTestVirtualMachine("as", []string{"/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1"})
+		expectedVM := buildDefaultTestVirtualMachine("", "as", []string{"/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1"})
 		expectedVM.HardwareProfile = &compute.HardwareProfile{
 			VMSize: compute.BasicA0,
 		}

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -659,7 +659,7 @@ func TestGetStandardVMPrimaryInterfaceID(t *testing.T) {
 	}{
 		{
 			name:          "GetPrimaryInterfaceID should get the only NIC ID",
-			vm:            buildDefaultTestVirtualMachine("", []string{"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"}),
+			vm:            buildDefaultTestVirtualMachine("", "", []string{"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic"}),
 			expectedNicID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic",
 		},
 		{
@@ -1480,7 +1480,7 @@ func TestStandardEnsureHostInPool(t *testing.T) {
 			cloud.EnableMultipleStandardLoadBalancers = true
 		}
 
-		testVM := buildDefaultTestVirtualMachine(availabilitySetID, []string{test.nicID})
+		testVM := buildDefaultTestVirtualMachine("", availabilitySetID, []string{test.nicID})
 		testVM.Name = pointer.String(string(test.nodeName))
 		testNIC := buildDefaultTestInterface(false, []string{backendAddressPoolID})
 		testNIC.Name = pointer.String(test.nicName)
@@ -1622,7 +1622,7 @@ func TestStandardEnsureHostsInPool(t *testing.T) {
 		cloud.Config.ExcludeMasterFromStandardLB = pointer.Bool(true)
 		cloud.excludeLoadBalancerNodes = sets.NewString(test.excludeLBNodes...)
 
-		testVM := buildDefaultTestVirtualMachine(availabilitySetID, []string{test.nicID})
+		testVM := buildDefaultTestVirtualMachine("", availabilitySetID, []string{test.nicID})
 		testNIC := buildDefaultTestInterface(false, []string{backendAddressPoolID})
 		testNIC.Name = pointer.String(test.nicName)
 		testNIC.ID = pointer.String(test.nicID)
@@ -1880,7 +1880,7 @@ func TestStandardEnsureBackendPoolDeleted(t *testing.T) {
 					},
 				},
 			},
-			existingVM: buildDefaultTestVirtualMachine("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/as", []string{
+			existingVM: buildDefaultTestVirtualMachine("", "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/as", []string{
 				"/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/k8s-agentpool1-00000000-nic-1",
 			}),
 			existingNIC: buildDefaultTestInterface(true, []string{"/subscriptions/sub/resourceGroups/gh/providers/Microsoft.Network/loadBalancers/testCluster/backendAddressPools/testCluster"}),
@@ -1929,8 +1929,9 @@ func buildDefaultTestInterface(isPrimary bool, lbBackendpoolIDs []string) networ
 	return expectedNIC
 }
 
-func buildDefaultTestVirtualMachine(asID string, nicIDs []string) compute.VirtualMachine {
+func buildDefaultTestVirtualMachine(name, asID string, nicIDs []string) compute.VirtualMachine {
 	expectedVM := compute.VirtualMachine{
+		Name: pointer.String(name),
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			AvailabilitySet: &compute.SubResource{
 				ID: pointer.String(asID),
@@ -1952,7 +1953,7 @@ func TestStandardGetNodeNameByIPConfigurationID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	cloud := GetTestCloud(ctrl)
-	expectedVM := buildDefaultTestVirtualMachine("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL1-AVAILABILITYSET-00000000", []string{})
+	expectedVM := buildDefaultTestVirtualMachine("", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL1-AVAILABILITYSET-00000000", []string{})
 	expectedVM.Name = pointer.String("name")
 	mockVMClient := cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
 	mockVMClient.EXPECT().Get(gomock.Any(), "rg", "k8s-agentpool1-00000000-0", gomock.Any()).Return(expectedVM, nil)


### PR DESCRIPTION
…BackendPoolDeleted when using availability sets and vmType=vmss

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

fix: call availabilitySet.EnsureBackendPoolDeleted in scaleSet.EnsureBackendPoolDeleted when using availability sets and vmType=vmss

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: call availabilitySet.EnsureBackendPoolDeleted in scaleSet.EnsureBackendPoolDeleted when using availability sets and vmType=vmss
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
