### PR TITLE
[release-1.25] Cherry-pick 4217 4261 4272

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -1146,9 +1146,11 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 		switch {
 		case !isNodeManagedByCloudProvider:
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
+			klog.V(6).Infof("excluding Node %q from LoadBalancer because it is not managed by cloud provider", newNode.ObjectMeta.Name)
 
 		case hasExcludeBalancerLabel:
 			az.excludeLoadBalancerNodes.Insert(newNode.ObjectMeta.Name)
+			klog.V(6).Infof("excluding Node %q from LoadBalancer because it has exclude-from-external-load-balancers label", newNode.ObjectMeta.Name)
 
 		default:
 			// Nodes not falling into the three cases above are valid backends and
@@ -1162,7 +1164,7 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 				az.nodePrivateIPs[newNode.Name] = sets.NewString()
 			}
 
-			klog.V(4).Infof("adding IP address %s of the node %s", address, newNode.Name)
+			klog.V(6).Infof("adding IP address %s of the node %s", address, newNode.Name)
 			az.nodePrivateIPs[newNode.Name].Insert(address)
 		}
 	}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -134,14 +134,14 @@ func getPublicIPDomainNameLabel(service *v1.Service) (string, bool) {
 // reconcileService reconcile the LoadBalancer service. It returns LoadBalancerStatus on success.
 func (az *Cloud) reconcileService(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	serviceName := getServiceName(service)
+	resourceBaseName := az.GetLoadBalancerName(context.TODO(), "", service)
+	klog.V(2).Infof("reconcileService: Start reconciling Service %q with its resource basename %q", serviceName, resourceBaseName)
+
 	lb, err := az.reconcileLoadBalancer(clusterName, service, nodes, true /* wantLb */)
 	if err != nil {
 		klog.Errorf("reconcileLoadBalancer(%s) failed: %v", serviceName, err)
 		return nil, err
 	}
-
-	resourceBaseName := az.GetLoadBalancerName(context.TODO(), "", service)
-	klog.V(2).Infof("reconcileService: Start reconciling Service %q with its resource basename %q", serviceName, resourceBaseName)
 
 	lbStatus, fipConfig, err := az.getServiceLoadBalancerStatus(service, lb)
 	if err != nil {

--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -593,7 +593,7 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 			var nodeIPAddressesToBeDeleted []string
 			for nodeName := range bi.excludeLoadBalancerNodes {
 				for ip := range bi.nodePrivateIPs[nodeName] {
-					klog.V(2).Infof("bi.ReconcileBackendPools for service (%s): found unwanted node private IP %s, decoupling it from the LB %s", serviceName, ip, lbName)
+					klog.V(2).Infof("bi.ReconcileBackendPools for service (%s): found unwanted node private IP %s, decouple it from the LB %s", serviceName, ip, lbName)
 					nodeIPAddressesToBeDeleted = append(nodeIPAddressesToBeDeleted, ip)
 				}
 			}

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -1136,7 +1136,8 @@ func (as *availabilitySet) EnsureBackendPoolDeleted(service *v1.Service, backend
 			return false, fmt.Errorf("EnsureBackendPoolDeleted: failed to parse the VMAS ID %s: %w", vmasID, err)
 		}
 		// Only remove nodes belonging to specified vmSet to basic LB backends.
-		if !strings.EqualFold(vmasName, vmSetName) {
+		// If vmasID is empty, then it is standalone VM.
+		if vmasID != "" && !strings.EqualFold(vmasName, vmSetName) {
 			klog.V(2).Infof("EnsureBackendPoolDeleted: skipping the node %s belonging to another vm set %s", nodeName, vmasName)
 			continue
 		}

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -628,7 +629,9 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
 		if lb.Sku != nil && lb.Sku.Name == aznetwork.LoadBalancerSkuNameBasic {
 			// For a basic lb, not autoscaling pipeline
-			ipConfigs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].BackendIPConfigurations
+			idxes := getLBBackendPoolIndex(lb)
+			Expect(idxes).NotTo(BeZero())
+			ipConfigs := (*lb.BackendAddressPools)[idxes[0]].BackendIPConfigurations
 			Expect(ipConfigs).NotTo(BeNil())
 			lbBackendPoolIPConfigCount := len(*ipConfigs)
 			Expect(lbBackendPoolIPConfigCount).To(Equal(len(nodes)))
@@ -636,7 +639,9 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		} else {
 			// SLB: Here we use BackendPool IP instead of IP config because this works for both NIC based LB and IP based LB.
 			lbBackendPoolIPCount := 0
-			lbBackendPoolIPs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].LoadBalancerBackendAddresses
+			idxes := getLBBackendPoolIndex(lb)
+			Expect(idxes).NotTo(BeZero())
+			lbBackendPoolIPs := (*lb.BackendAddressPools)[idxes[0]].LoadBalancerBackendAddresses
 			Expect(lbBackendPoolIPs).NotTo(BeNil())
 			if utils.IsAutoscalingAKSCluster() {
 				for _, ip := range *lbBackendPoolIPs {
@@ -1066,44 +1071,62 @@ func waitForNodesInLBBackendPool(tc *utils.AzureTestClient, ip string, expectedN
 		lb := getAzureLoadBalancerFromPIP(tc, ip, tc.GetResourceGroup(), "")
 		if lb.Sku != nil && lb.Sku.Name == aznetwork.LoadBalancerSkuNameBasic {
 			// basic lb
-			lbBackendPoolIPConfigs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].BackendIPConfigurations
-			ipConfigNum := 0
-			if lbBackendPoolIPConfigs != nil {
-				ipConfigNum = len(*lbBackendPoolIPConfigs)
+			idxes := getLBBackendPoolIndex(lb)
+			if len(idxes) == 0 {
+				return false, errors.New("no backend pool found")
 			}
-			if expectedNum == ipConfigNum {
-				utils.Logf("Number of IP configs matches expected number %d. Success", expectedNum)
-				return true, nil
+			failed := false
+			for _, idx := range idxes {
+				bp := (*lb.BackendAddressPools)[idx]
+				lbBackendPoolIPConfigs := bp.BackendIPConfigurations
+				ipConfigNum := 0
+				if lbBackendPoolIPConfigs != nil {
+					ipConfigNum = len(*lbBackendPoolIPConfigs)
+				}
+				if expectedNum == ipConfigNum {
+					utils.Logf("Number of IP configs in the LB backend pool %q matches expected number %d. Success", *bp.Name, expectedNum)
+				} else {
+					utils.Logf("Number of IP configs: %d in the LB backend pool %q, expected %d, will retry soon", ipConfigNum, *bp.Name, expectedNum)
+					failed = true
+				}
 			}
-			utils.Logf("Number of IP configs: %d in the LB backend pool, expected %d, will retry soon", ipConfigNum, expectedNum)
-			return false, nil
+			return !failed, nil
 		}
 		// SLB
-		lbBackendPoolIPs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].LoadBalancerBackendAddresses
-		ipNum := 0
-		if lbBackendPoolIPs != nil {
-			if utils.IsAutoscalingAKSCluster() {
-				// Autoscaling tests don't include IP based LB.
-				for _, ip := range *lbBackendPoolIPs {
-					if ip.LoadBalancerBackendAddressPropertiesFormat == nil ||
-						ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration == nil {
-						return false, fmt.Errorf("LB backendPool address's NIC IP config ID is nil")
+		idxes := getLBBackendPoolIndex(lb)
+		if len(idxes) == 0 {
+			return false, errors.New("no backend pool found")
+		}
+		failed := false
+		for _, idx := range idxes {
+			bp := (*lb.BackendAddressPools)[idx]
+			lbBackendPoolIPs := bp.LoadBalancerBackendAddresses
+			ipNum := 0
+			if lbBackendPoolIPs != nil {
+				if utils.IsAutoscalingAKSCluster() {
+					// Autoscaling tests don't include IP based LB.
+					for _, ip := range *lbBackendPoolIPs {
+						if ip.LoadBalancerBackendAddressPropertiesFormat == nil ||
+							ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration == nil {
+							return false, fmt.Errorf("LB backendPool address's NIC IP config ID is nil")
+						}
+						ipConfigID := pointer.StringDeref(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration.ID, "")
+						if !strings.Contains(ipConfigID, utils.SystemPool) {
+							ipNum++
+						}
 					}
-					ipConfigID := pointer.StringDeref(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration.ID, "")
-					if !strings.Contains(ipConfigID, utils.SystemPool) {
-						ipNum++
-					}
+				} else {
+					ipNum = len(*lbBackendPoolIPs)
 				}
+			}
+			if ipNum == expectedNum {
+				utils.Logf("Number of IPs in the LB backend pool %q matches expected number %d. Success", *bp.Name, expectedNum)
 			} else {
-				ipNum = len(*lbBackendPoolIPs)
+				utils.Logf("Number of IPs: %d in the LB backend pool %q, expected %d, will retry soon", ipNum, *bp.Name, expectedNum)
+				failed = true
 			}
 		}
-		if ipNum == expectedNum {
-			utils.Logf("Number of IPs matches expected number %d. Success", expectedNum)
-			return true, nil
-		}
-		utils.Logf("Number of IPs: %d in the LB backend pool, expected %d, will retry soon", ipNum, expectedNum)
-		return false, nil
+		return !failed, nil
 	})
 }
 
@@ -1111,15 +1134,14 @@ func judgeInternal(service v1.Service) bool {
 	return service.Annotations[consts.ServiceAnnotationLoadBalancerInternal] == utils.TrueValue
 }
 
-func getLBBackendPoolIndex(lb *aznetwork.LoadBalancer) int {
-	if os.Getenv(utils.AKSTestCCM) != "" {
-		for index, backendPool := range *lb.BackendAddressPools {
-			if *backendPool.Name != "aksOutboundBackendPool" {
-				return index
-			}
+func getLBBackendPoolIndex(lb *aznetwork.LoadBalancer) []int {
+	idxes := []int{}
+	for index, backendPool := range *lb.BackendAddressPools {
+		if !strings.Contains(strings.ToLower(*backendPool.Name), "outboundbackendpool") {
+			idxes = append(idxes, index)
 		}
 	}
-	return 0
+	return idxes
 }
 
 func updateServiceLBIPs(service *v1.Service, isInternal bool, ips []string) (result *v1.Service) {

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -603,9 +603,12 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		By("Checking the number of the node pools")
 		nodes, err := utils.GetAgentNodes(cs)
 		Expect(err).NotTo(HaveOccurred())
-		initNodepoolNodeMap := utils.GetNodepoolNodeMap(&nodes)
-		if len(initNodepoolNodeMap) != 1 {
-			Skip("single node pool is needed in this scenario")
+		if os.Getenv(utils.AKSTestCCM) != "" {
+			// AKS
+			initNodepoolNodeMap := utils.GetNodepoolNodeMap(&nodes)
+			if len(initNodepoolNodeMap) != 1 {
+				Skip("single node pool is needed in this scenario")
+			}
 		}
 
 		By("Creating a service to trigger the LB reconcile")
@@ -613,34 +616,62 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		publicIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, []string{})
+		defer func() {
+			deleteSvcErr := utils.DeleteService(cs, ns.Name, testServiceName)
+			Expect(deleteSvcErr).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(publicIPs)).NotTo(BeZero())
 		publicIP := publicIPs[0]
 
 		By("Checking the initial node number in the LB backend pool")
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
-		lbBackendPoolIPConfigs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].BackendIPConfigurations
-		nodes, err = utils.GetAgentNodes(cs)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(len(*lbBackendPoolIPConfigs)).To(Equal(len(nodes)))
+		// Here we use BackendPool IP instead of IP config because this works for both NIC based LB and IP based LB.
+		lbBackendPoolIPCount := 0
+		lbBackendPoolIPs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].LoadBalancerBackendAddresses
+		Expect(lbBackendPoolIPs).NotTo(BeNil())
+		if utils.IsAutoscalingAKSCluster() {
+			for _, ip := range *lbBackendPoolIPs {
+				Expect(ip.LoadBalancerBackendAddressPropertiesFormat).NotTo(BeNil())
+				Expect(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration).NotTo(BeNil())
+				ipConfigID := pointer.StringDeref(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration.ID, "")
+				if !strings.Contains(ipConfigID, utils.SystemPool) {
+					lbBackendPoolIPCount++
+				}
+			}
+		} else {
+			lbBackendPoolIPCount = len(*lbBackendPoolIPs)
+		}
+		Expect(lbBackendPoolIPCount).To(Equal(len(nodes)))
+		utils.Logf("Initial node number in the LB backend pool is %d", lbBackendPoolIPCount)
+		nodeToLabel := nodes[0]
 
-		By("Labeling node")
-		node, err := utils.LabelNode(cs, &nodes[0], label, false)
+		By(fmt.Sprintf("Labeling node %q", nodeToLabel.Name))
+		node, err := utils.LabelNode(cs, &nodeToLabel, label, false)
+		defer func() {
+			node, err = utils.GetNode(cs, node.Name)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.LabelNode(cs, node, label, true)
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
+		addDummyAnnotationWithServiceName(cs, ns.Name, testServiceName)
 		var expectedCount int
 		if len(nodes) == 1 {
 			expectedCount = 1
 		} else {
 			expectedCount = len(nodes) - 1
 		}
+
 		err = waitForNodesInLBBackendPool(tc, publicIP, expectedCount)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Unlabeling node")
+		By(fmt.Sprintf("Unlabeling node %q", nodeToLabel.Name))
 		node, err = utils.GetNode(cs, node.Name)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = utils.LabelNode(cs, node, label, true)
 		Expect(err).NotTo(HaveOccurred())
+		addDummyAnnotationWithServiceName(cs, ns.Name, testServiceName)
 		err = waitForNodesInLBBackendPool(tc, publicIP, len(nodes))
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -891,18 +922,37 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 	})
 })
 
+func addDummyAnnotationWithServiceName(cs clientset.Interface, namespace string, serviceName string) {
+	service, err := cs.CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	addDummyAnnotationWithService(cs, namespace, service)
+}
+
+func addDummyAnnotationWithService(cs clientset.Interface, namespace string, service *v1.Service) {
+	utils.Logf("Adding a dummy annotation to trigger Service reconciliation")
+	Expect(service).NotTo(BeNil())
+	annotation := service.GetAnnotations()
+	if annotation == nil {
+		annotation = make(map[string]string)
+	}
+	// e2e test should not have 100+ dummy annotations.
+	for i := 0; i < 100; i++ {
+		if _, ok := annotation["dummy-annotation"+strconv.Itoa(i)]; !ok {
+			annotation["dummy-annotation"+strconv.Itoa(i)] = "dummy"
+			break
+		}
+	}
+	service = updateServiceAnnotation(service, annotation)
+	utils.Logf("Service's annotations: %v", annotation)
+	_, err := cs.CoreV1().Services(namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func updateServiceAndCompareEtags(tc *utils.AzureTestClient, cs clientset.Interface, ns *v1.Namespace, service *v1.Service, ip string, isInternal bool) {
 	utils.Logf("Retrieving etags from resources")
 	lbEtag, nsgEtag, pipEtag := getResourceEtags(tc, ip, cloudprovider.DefaultLoadBalancerName(service), isInternal)
 
-	utils.Logf("Adding a dummy annotation to trigger a second service reconciliation")
-	Expect(service).NotTo(BeNil())
-	annotation := service.GetAnnotations()
-	annotation["dummy-annotation"] = "dummy"
-	service = updateServiceAnnotation(service, annotation)
-	utils.Logf("service's annotations: %v", annotation)
-	_, err := cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	addDummyAnnotationWithService(cs, ns.Name, service)
 	ips, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, []string{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(ips)).NotTo(BeZero())
@@ -1005,15 +1055,30 @@ func getAzureInternalLoadBalancerFromPrivateIP(tc *utils.AzureTestClient, ip, lb
 func waitForNodesInLBBackendPool(tc *utils.AzureTestClient, ip string, expectedNum int) error {
 	return wait.PollImmediate(10*time.Second, 10*time.Minute, func() (done bool, err error) {
 		lb := getAzureLoadBalancerFromPIP(tc, ip, tc.GetResourceGroup(), "")
-		lbBackendPoolIPConfigs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].BackendIPConfigurations
-		ipConfigNum := 0
-		if lbBackendPoolIPConfigs != nil {
-			ipConfigNum = len(*lbBackendPoolIPConfigs)
+		lbBackendPoolIPs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].LoadBalancerBackendAddresses
+		ipNum := 0
+		if lbBackendPoolIPs != nil {
+			if utils.IsAutoscalingAKSCluster() {
+				// Autoscaling tests don't include IP based LB.
+				for _, ip := range *lbBackendPoolIPs {
+					if ip.LoadBalancerBackendAddressPropertiesFormat == nil ||
+						ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration == nil {
+						return false, fmt.Errorf("LB backendPool address's NIC IP config ID is nil")
+					}
+					ipConfigID := pointer.StringDeref(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration.ID, "")
+					if !strings.Contains(ipConfigID, utils.SystemPool) {
+						ipNum++
+					}
+				}
+			} else {
+				ipNum = len(*lbBackendPoolIPs)
+			}
 		}
-		if expectedNum == ipConfigNum {
+		if ipNum == expectedNum {
+			utils.Logf("Number of IPs matches expected number %d. Success", expectedNum)
 			return true, nil
 		}
-		utils.Logf("Number of IP configs: %d in the LB backend pool, will retry soon", ipConfigNum)
+		utils.Logf("Number of IPs: %d in the LB backend pool, expected %d, will retry soon", ipNum, expectedNum)
 		return false, nil
 	})
 }

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -626,24 +626,33 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 
 		By("Checking the initial node number in the LB backend pool")
 		lb := getAzureLoadBalancerFromPIP(tc, publicIP, tc.GetResourceGroup(), "")
-		// Here we use BackendPool IP instead of IP config because this works for both NIC based LB and IP based LB.
-		lbBackendPoolIPCount := 0
-		lbBackendPoolIPs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].LoadBalancerBackendAddresses
-		Expect(lbBackendPoolIPs).NotTo(BeNil())
-		if utils.IsAutoscalingAKSCluster() {
-			for _, ip := range *lbBackendPoolIPs {
-				Expect(ip.LoadBalancerBackendAddressPropertiesFormat).NotTo(BeNil())
-				Expect(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration).NotTo(BeNil())
-				ipConfigID := pointer.StringDeref(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration.ID, "")
-				if !strings.Contains(ipConfigID, utils.SystemPool) {
-					lbBackendPoolIPCount++
-				}
-			}
+		if lb.Sku != nil && lb.Sku.Name == aznetwork.LoadBalancerSkuNameBasic {
+			// For a basic lb, not autoscaling pipeline
+			ipConfigs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].BackendIPConfigurations
+			Expect(ipConfigs).NotTo(BeNil())
+			lbBackendPoolIPConfigCount := len(*ipConfigs)
+			Expect(lbBackendPoolIPConfigCount).To(Equal(len(nodes)))
+			utils.Logf("Initial node number in the LB backend pool is %d", lbBackendPoolIPConfigCount)
 		} else {
-			lbBackendPoolIPCount = len(*lbBackendPoolIPs)
+			// SLB: Here we use BackendPool IP instead of IP config because this works for both NIC based LB and IP based LB.
+			lbBackendPoolIPCount := 0
+			lbBackendPoolIPs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].LoadBalancerBackendAddresses
+			Expect(lbBackendPoolIPs).NotTo(BeNil())
+			if utils.IsAutoscalingAKSCluster() {
+				for _, ip := range *lbBackendPoolIPs {
+					Expect(ip.LoadBalancerBackendAddressPropertiesFormat).NotTo(BeNil())
+					Expect(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration).NotTo(BeNil())
+					ipConfigID := pointer.StringDeref(ip.LoadBalancerBackendAddressPropertiesFormat.NetworkInterfaceIPConfiguration.ID, "")
+					if !strings.Contains(ipConfigID, utils.SystemPool) {
+						lbBackendPoolIPCount++
+					}
+				}
+			} else {
+				lbBackendPoolIPCount = len(*lbBackendPoolIPs)
+			}
+			Expect(lbBackendPoolIPCount).To(Equal(len(nodes)))
+			utils.Logf("Initial node number in the LB backend pool is %d", lbBackendPoolIPCount)
 		}
-		Expect(lbBackendPoolIPCount).To(Equal(len(nodes)))
-		utils.Logf("Initial node number in the LB backend pool is %d", lbBackendPoolIPCount)
 		nodeToLabel := nodes[0]
 
 		By(fmt.Sprintf("Labeling node %q", nodeToLabel.Name))
@@ -1055,6 +1064,21 @@ func getAzureInternalLoadBalancerFromPrivateIP(tc *utils.AzureTestClient, ip, lb
 func waitForNodesInLBBackendPool(tc *utils.AzureTestClient, ip string, expectedNum int) error {
 	return wait.PollImmediate(10*time.Second, 10*time.Minute, func() (done bool, err error) {
 		lb := getAzureLoadBalancerFromPIP(tc, ip, tc.GetResourceGroup(), "")
+		if lb.Sku != nil && lb.Sku.Name == aznetwork.LoadBalancerSkuNameBasic {
+			// basic lb
+			lbBackendPoolIPConfigs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].BackendIPConfigurations
+			ipConfigNum := 0
+			if lbBackendPoolIPConfigs != nil {
+				ipConfigNum = len(*lbBackendPoolIPConfigs)
+			}
+			if expectedNum == ipConfigNum {
+				utils.Logf("Number of IP configs matches expected number %d. Success", expectedNum)
+				return true, nil
+			}
+			utils.Logf("Number of IP configs: %d in the LB backend pool, expected %d, will retry soon", ipConfigNum, expectedNum)
+			return false, nil
+		}
+		// SLB
 		lbBackendPoolIPs := (*lb.BackendAddressPools)[getLBBackendPoolIndex(lb)].LoadBalancerBackendAddresses
 		ipNum := 0
 		if lbBackendPoolIPs != nil {

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -771,6 +771,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			Expect(len(pipFrontendConfigIDSplit)).NotTo(Equal(0))
 			ids = append(ids, pipFrontendConfigIDSplit[len(pipFrontendConfigIDSplit)-1])
 		}
+		utils.Logf("PIP frontend config IDs %q", ids)
 
 		var lb *network.LoadBalancer
 		var targetProbes []*network.Probe
@@ -788,8 +789,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 				probeSplit := strings.Split(*probe.Name, "-")
 				Expect(len(probeSplit)).NotTo(Equal(0))
 				probeSplitID := probeSplit[0]
-				if len(probeSplit) > 1 &&
-					(probeSplit[len(probeSplit)-1] == "IPv4" || probeSplit[len(probeSplit)-1] == "IPv6") {
+				if probeSplit[len(probeSplit)-1] == "IPv6" {
 					probeSplitID += "-" + probeSplit[len(probeSplit)-1]
 				}
 				for _, id := range ids {
@@ -799,6 +799,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 				}
 			}
 
+			utils.Logf("targetProbes count %d, expectedTargetProbes count %d", len(targetProbes), expectedTargetProbesCount)
 			return len(targetProbes) == expectedTargetProbesCount, nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -813,11 +814,15 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 				utils.Logf("Validating health probe config intervalInSeconds")
 				Expect(*probe.IntervalInSeconds).To(Equal(int32(10)))
 			}
+			utils.Logf("Validating health probe config ProbeProtocolHTTP")
 			Expect(probe.Protocol).To(Equal(network.ProbeProtocolHTTP))
 		}
 
 		By("Changing ExternalTrafficPolicy of the service to Local")
-		expectedTargetProbesCount = 1
+		expectedTargetProbesLocalCount := 1
+		if tc.IPFamily == utils.DualStack {
+			expectedTargetProbesLocalCount = 2
+		}
 		var service *v1.Service
 		utils.Logf("Updating service " + serviceName + " in namespace " + ns.Name)
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -845,7 +850,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		})
 		Expect(retryErr).NotTo(HaveOccurred())
 
-		err = wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
+		err = wait.PollImmediate(5*time.Second, 300*time.Second, func() (bool, error) {
 			lb = getAzureLoadBalancerFromPIP(tc, publicIPs[0], tc.GetResourceGroup(), "")
 			targetProbes = []*network.Probe{}
 			for i := range *lb.LoadBalancerPropertiesFormat.Probes {
@@ -854,8 +859,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 				probeSplit := strings.Split(*probe.Name, "-")
 				Expect(len(probeSplit)).NotTo(Equal(0))
 				probeSplitID := probeSplit[0]
-				if len(probeSplit) > 1 &&
-					(probeSplit[len(probeSplit)-1] == "IPv4" || probeSplit[len(probeSplit)-1] == "IPv6") {
+				if probeSplit[len(probeSplit)-1] == "IPv6" {
 					probeSplitID += "-" + probeSplit[len(probeSplit)-1]
 				}
 				for _, id := range ids {
@@ -865,22 +869,28 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 				}
 			}
 
-			return len(targetProbes) == expectedTargetProbesCount, nil
+			utils.Logf("targetProbes count %d, expectedTargetProbesLocal count %d", len(targetProbes), expectedTargetProbesLocalCount)
+			if len(targetProbes) != expectedTargetProbesLocalCount {
+				return false, nil
+			}
+			By("Validating health probe configs")
+			for _, probe := range targetProbes {
+				utils.Logf("Validating health probe config numberOfProbes")
+				if probe.ProbeThreshold == nil || *probe.ProbeThreshold != int32(5) {
+					return false, nil
+				}
+				utils.Logf("Validating health probe config intervalInSeconds")
+				if probe.IntervalInSeconds == nil || *probe.IntervalInSeconds != int32(15) {
+					return false, nil
+				}
+				utils.Logf("Validating health probe config ProbeProtocolHTTP")
+				if !strings.EqualFold(string(probe.Protocol), string(network.ProbeProtocolHTTP)) {
+					return false, nil
+				}
+			}
+			return true, nil
 		})
 		Expect(err).NotTo(HaveOccurred())
-
-		By("Validating health probe configs")
-		for _, probe := range targetProbes {
-			if probe.ProbeThreshold != nil {
-				utils.Logf("Validating health probe config numberOfProbes")
-				Expect(*probe.ProbeThreshold).To(Equal(int32(5)))
-			}
-			if probe.IntervalInSeconds != nil {
-				utils.Logf("Validating health probe config intervalInSeconds")
-				Expect(*probe.IntervalInSeconds).To(Equal(int32(15)))
-			}
-			Expect(probe.Protocol).To(Equal(network.ProbeProtocolHTTP))
-		}
 	})
 
 	It("should generate health probe configs in multi-port scenario", func() {

--- a/tests/e2e/utils/azure_auth.go
+++ b/tests/e2e/utils/azure_auth.go
@@ -39,15 +39,6 @@ const (
 	ClusterLocationEnv        = "AZURE_LOCATION"
 	ClusterEnvironment        = "AZURE_ENVIRONMENT"
 	LoadBalancerSkuEnv        = "AZURE_LOADBALANCER_SKU"
-	// If "TEST_CCM" is true, the test is running on a CAPZ cluster.
-	CAPZTestCCM = "TEST_CCM"
-	// If "E2E_ON_AKS_CLUSTER" is true, the test is running on a AKS cluster.
-	AKSTestCCM     = "E2E_ON_AKS_CLUSTER"
-	AKSClusterType = "CLUSTER_TYPE"
-	// If "INGEST_TEST_RESULT" is true, the test result needs ingestion to kusto
-	IngestTestResult = "INGEST_TEST_RESULT"
-
-	TrueValue = "true"
 )
 
 // AzureAuthConfig holds auth related part of cloud config

--- a/tests/e2e/utils/consts.go
+++ b/tests/e2e/utils/consts.go
@@ -37,4 +37,16 @@ const (
 	TestSuiteLabelLB                 = "LB"
 	TestSuiteLabelMultiPorts         = "Multi-Ports"
 	TestSuiteLabelNSG                = "NSG"
+
+	// If "TEST_CCM" is true, the test is running on a CAPZ cluster.
+	CAPZTestCCM = "TEST_CCM"
+	// If "E2E_ON_AKS_CLUSTER" is true, the test is running on a AKS cluster.
+	AKSTestCCM     = "E2E_ON_AKS_CLUSTER"
+	AKSClusterType = "CLUSTER_TYPE"
+	// If "INGEST_TEST_RESULT" is true, the test result needs ingestion to kusto
+	IngestTestResult = "INGEST_TEST_RESULT"
+	// LB backendpool config type, may be nodeIP
+	LBBackendPoolConfigType = "LB_BACKEND_POOL_CONFIG_TYPE"
+
+	TrueValue = "true"
 )

--- a/tests/e2e/utils/node_utils.go
+++ b/tests/e2e/utils/node_utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -38,6 +39,11 @@ const (
 	nodeOSLabel               = "kubernetes.io/os"
 	typeLabel                 = "type"
 	agentpoolLabelKey         = "agentpool"
+
+	NodeModeLabel  = "kubernetes.azure.com/mode"
+	NodeModeSystem = "system"
+	NodeModeUser   = "user"
+	SystemPool     = "systempool"
 
 	// GPUResourceKey is the key of the GPU in the resource map of a node
 	GPUResourceKey = "nvidia.com/gpu"
@@ -262,7 +268,32 @@ func isVirtualKubeletNode(node *v1.Node) bool {
 	return false
 }
 
+// IsSystemPoolNode checks if the Node is of system pool when running tests in an AKS autoscaling cluster.
+func IsSystemPoolNode(node *v1.Node) bool {
+	if !IsAutoscalingAKSCluster() {
+		return false
+	}
+	if val, ok := node.Labels[NodeModeLabel]; ok && val == NodeModeSystem {
+		return true
+	}
+	return false
+}
+
+// IsAutoscalingAKSCluster checks if the cluster is an autoscaling AKS one.
+func IsAutoscalingAKSCluster() bool {
+	return os.Getenv(AKSTestCCM) != "" && strings.Contains(os.Getenv(AKSClusterType), "autoscaling")
+}
+
+// Before using the node config to update Node, some fields need to be cleaned.
+func cleanNodeConfigBeforeUpdate(node *v1.Node) {
+	node.CreationTimestamp = metav1.Time{}
+	node.ResourceVersion = ""
+	node.SetSelfLink("")
+	node.SetUID("")
+}
+
 func LabelNode(cs clientset.Interface, node *v1.Node, label string, isDelete bool) (*v1.Node, error) {
+	cleanNodeConfigBeforeUpdate(node)
 	if _, ok := node.Labels[label]; ok {
 		if isDelete {
 			delete(node.Labels, label)
@@ -272,9 +303,13 @@ func LabelNode(cs clientset.Interface, node *v1.Node, label string, isDelete boo
 		Logf("Found label %s on node %s, do nothing", label, node.Name)
 		return node, nil
 	}
-	node.Labels[label] = TrueValue
-	node, err := cs.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
-	return node, err
+	if !isDelete {
+		node.Labels[label] = TrueValue
+		node, err := cs.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+		return node, err
+	}
+	Logf("No such label %s on node %s, do nothing", label, node.Name)
+	return node, nil
 }
 
 func GetNodepoolNodeMap(nodes *[]v1.Node) map[string][]string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Fix ensureBackendPoolDeleted for standalone VM
* Trigger Service reconcile for exclude-from-external-load-balancers e2e test
* Refactor e2e
* Add logs for exclude-from-external-load-balancers
* Adjust exclude-from-lb test for basic-lb pipeline
* Fix IPv6/dual-stack EnsureBackendPoolDeleted() failure. IP config of IPv6 is not primary, it should not be skipped in EnsureBackendPoolDeleted(). Updated e2e code.
* Fix health probe e2e
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix ensureBackendPoolDeleted for standalone VM. Fix IPv6/dual-stack EnsureBackendPoolDeleted() failure. IP config of IPv6 is not primary, it should not be skipped in EnsureBackendPoolDeleted().
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
