### PR TITLE
[release-1.27] Cherrypick FIP, NSG dualstack change

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -193,6 +193,7 @@ const (
 	BackoffJitterDefault = 1.0
 )
 
+// IP family variables
 const (
 	IPVersionIPv6 bool = true
 	IPVersionIPv4 bool = false

--- a/pkg/consts/helpers.go
+++ b/pkg/consts/helpers.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/net"
 )
 
 // IsK8sServiceHasHAModeEnabled return if HA Mode is enabled in kubernetes service annotations
@@ -34,10 +33,6 @@ func IsK8sServiceHasHAModeEnabled(service *v1.Service) bool {
 // IsK8sServiceUsingInternalLoadBalancer return if service is using an internal load balancer.
 func IsK8sServiceUsingInternalLoadBalancer(service *v1.Service) bool {
 	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationLoadBalancerInternal, TrueAnnotationValue)
-}
-
-func IsK8sServiceInternalIPv6(service *v1.Service) bool {
-	return IsK8sServiceUsingInternalLoadBalancer(service) && net.IsIPv6String(service.Spec.ClusterIP)
 }
 
 // IsK8sServiceDisableLoadBalancerFloatingIP return if floating IP in load balancer is disabled in kubernetes service annotations

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -811,10 +811,7 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 	serviceName := getServiceName(service)
 	for _, ipConfiguration := range *lb.FrontendIPConfigurations {
 		ipConfiguration := ipConfiguration
-		owns, isPrimaryService, err := az.serviceOwnsFrontendIP(ipConfiguration, service)
-		if err != nil {
-			return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to filter frontend IP configs with error: %w", serviceName, pointer.StringDeref(lb.Name, ""), err)
-		}
+		owns, isPrimaryService, _ := az.serviceOwnsFrontendIP(ipConfiguration, service)
 		if owns {
 			klog.V(2).Infof("get(%s): lb(%s) - found frontend IP config, primary service: %v", serviceName, pointer.StringDeref(lb.Name, ""), isPrimaryService)
 
@@ -1399,30 +1396,32 @@ func (az *Cloud) isFrontendIPChanged(
 	lbFrontendIPConfigName string,
 	subnet *network.Subnet,
 ) (bool, error) {
-	isServiceOwnsFrontendIP, isPrimaryService, err := az.serviceOwnsFrontendIP(config, service)
-	if err != nil {
-		return false, err
-	}
+	isServiceOwnsFrontendIP, isPrimaryService, fipIPVersion := az.serviceOwnsFrontendIP(config, service)
 	if isServiceOwnsFrontendIP && isPrimaryService && !strings.EqualFold(pointer.StringDeref(config.Name, ""), lbFrontendIPConfigName) {
 		return true, nil
 	}
 	if !strings.EqualFold(pointer.StringDeref(config.Name, ""), lbFrontendIPConfigName) {
 		return false, nil
 	}
-	isInternal := requiresInternalLoadBalancer(service)
-	isIPv6, err := az.isFIPIPv6(service, &config, isInternal)
-	if err != nil {
-		return false, err
+	pipRG := az.getPublicIPAddressResourceGroup(service)
+	var isIPv6 bool
+	var err error
+	if fipIPVersion != "" {
+		isIPv6 = fipIPVersion == network.IPv6
+	} else {
+		if isIPv6, err = az.isFIPIPv6(service, pipRG, &config); err != nil {
+			return false, err
+		}
 	}
 	loadBalancerIP := getServiceLoadBalancerIP(service, isIPv6)
+	isInternal := requiresInternalLoadBalancer(service)
 	if isInternal {
 		// Judge subnet
 		subnetName := getInternalSubnet(service)
 		if subnetName != nil {
-			if err := az.fillSubnet(subnet, *subnetName); err != nil {
-				return false, err
+			if subnet == nil {
+				return false, fmt.Errorf("isFrontendIPChanged: Unexpected nil subnet")
 			}
-
 			if config.Subnet != nil && !strings.EqualFold(pointer.StringDeref(config.Subnet.ID, ""), pointer.StringDeref(subnet.ID, "")) {
 				return true, nil
 			}
@@ -1433,8 +1432,7 @@ func (az *Cloud) isFrontendIPChanged(
 	if err != nil {
 		return false, err
 	}
-	pipResourceGroup := az.getPublicIPAddressResourceGroup(service)
-	pip, existsPip, err := az.getPublicIPAddress(pipResourceGroup, pipName, azcache.CacheReadTypeDefault)
+	pip, existsPip, err := az.getPublicIPAddress(pipRG, pipName, azcache.CacheReadTypeDefault)
 	if err != nil {
 		return false, err
 	}
@@ -1555,31 +1553,31 @@ func findMatchedOutboundRuleFIPConfig(fipConfigID *string, outboundRuleFIPConfig
 	return found
 }
 
-func (az *Cloud) findFrontendIPConfigOfService(
+func (az *Cloud) findFrontendIPConfigsOfService(
 	fipConfigs *[]network.FrontendIPConfiguration,
 	service *v1.Service,
-	isInternal bool,
-	isIPv6 bool,
-) (*network.FrontendIPConfiguration, error) {
+) (map[bool]*network.FrontendIPConfiguration, error) {
+	fipsOfServiceMap := map[bool]*network.FrontendIPConfiguration{}
+	pipRG := az.getPublicIPAddressResourceGroup(service)
 	for _, config := range *fipConfigs {
 		config := config
-		fipIsIPv6, err := az.isFIPIPv6(service, &config, isInternal)
-		if err != nil {
-			return nil, err
-		}
-		if fipIsIPv6 != isIPv6 {
-			continue
-		}
-		owns, _, err := az.serviceOwnsFrontendIP(config, service)
-		if err != nil {
-			return nil, err
-		}
+		owns, _, fipIPVersion := az.serviceOwnsFrontendIP(config, service)
 		if owns {
-			return &config, nil
+			var fipIsIPv6 bool
+			var err error
+			if fipIPVersion != "" {
+				fipIsIPv6 = fipIPVersion == network.IPv6
+			} else {
+				if fipIsIPv6, err = az.isFIPIPv6(service, pipRG, &config); err != nil {
+					return nil, err
+				}
+			}
+
+			fipsOfServiceMap[fipIsIPv6] = &config
 		}
 	}
 
-	return nil, nil
+	return fipsOfServiceMap, nil
 }
 
 // reconcileLoadBalancer ensures load balancer exists and the frontend ip config is setup.
@@ -1647,7 +1645,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 
 	// update probes/rules
-	isInternal := requiresInternalLoadBalancer(service)
+	pipRG := az.getPublicIPAddressResourceGroup(service)
 	for _, ownedFIPConfig := range ownedFIPConfigs {
 		if ownedFIPConfig == nil {
 			continue
@@ -1656,9 +1654,15 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 			return nil, fmt.Errorf("reconcileLoadBalancer for service (%s)(%t): nil ID for frontend IP config", serviceName, wantLb)
 		}
 
-		isIPv6, err := az.isFIPIPv6(service, ownedFIPConfig, isInternal)
-		if err != nil {
-			return nil, err
+		var isIPv6 bool
+		var err error
+		_, _, fipIPVersion := az.serviceOwnsFrontendIP(*ownedFIPConfig, service)
+		if fipIPVersion != "" {
+			isIPv6 = fipIPVersion == network.IPv6
+		} else {
+			if isIPv6, err = az.isFIPIPv6(service, pipRG, ownedFIPConfig); err != nil {
+				return nil, err
+			}
 		}
 		lbFrontendIPConfigIDs[isIPv6] = *ownedFIPConfig.ID
 	}
@@ -1865,52 +1869,12 @@ func (az *Cloud) reconcileLBRules(lb *network.LoadBalancer, service *v1.Service,
 	return dirtyRules
 }
 
-func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Service, lb *network.LoadBalancer, lbStatus *v1.LoadBalancerStatus, wantLb bool, lbFrontendIPConfigName map[bool]string) ([]*network.FrontendIPConfiguration, []network.FrontendIPConfiguration, bool, error) {
-	ownedFIPConfigs := []*network.FrontendIPConfiguration{}
-	toDeleteConfigs := []network.FrontendIPConfiguration{}
-	lbFrontEndIPConfigNewConfigs := []network.FrontendIPConfiguration{}
-	changedTotal := false
-	var subnet network.Subnet
-	handleFrontendIPConfig := func(isIPv6 bool) error {
-		ownedFIPConfig, toDeleteConfigsSingleStack, changed, newConfigs, err := az.reconcileFrontendIPConfigsSingleStack(clusterName, service, lb, lbStatus, wantLb, isIPv6, lbFrontendIPConfigName[isIPv6], &subnet)
-		if err != nil {
-			return err
-		}
-
-		if changed {
-			lbFrontEndIPConfigNewConfigs = append(lbFrontEndIPConfigNewConfigs, newConfigs...)
-			changedTotal = true
-		}
-		ownedFIPConfigs = append(ownedFIPConfigs, ownedFIPConfig)
-		toDeleteConfigs = append(toDeleteConfigs, toDeleteConfigsSingleStack...)
-		return nil
-	}
-	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
-	if v4Enabled {
-		if err := handleFrontendIPConfig(false); err != nil {
-			return ownedFIPConfigs, toDeleteConfigs, changedTotal, err
-		}
-	}
-	if v6Enabled {
-		if err := handleFrontendIPConfig(true); err != nil {
-			return ownedFIPConfigs, toDeleteConfigs, changedTotal, err
-		}
-	}
-	if changedTotal {
-		lb.FrontendIPConfigurations = &lbFrontEndIPConfigNewConfigs
-	}
-	return ownedFIPConfigs, toDeleteConfigs, changedTotal, nil
-}
-
-func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
-	clusterName string,
+func (az *Cloud) reconcileFrontendIPConfigs(clusterName string,
 	service *v1.Service,
 	lb *network.LoadBalancer,
 	status *v1.LoadBalancerStatus,
-	wantLb, isIPv6 bool,
-	lbFrontendIPConfigName string,
-	subnet *network.Subnet,
-) (*network.FrontendIPConfiguration, []network.FrontendIPConfiguration, bool, []network.FrontendIPConfiguration, error) {
+	wantLb bool,
+	lbFrontendIPConfigNames map[bool]string) ([]*network.FrontendIPConfiguration, []network.FrontendIPConfiguration, bool, error) {
 	var err error
 	lbName := *lb.Name
 	serviceName := getServiceName(service)
@@ -1919,30 +1883,18 @@ func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
 	var newConfigs []network.FrontendIPConfiguration
 	var toDeleteConfigs []network.FrontendIPConfiguration
 	if lb.FrontendIPConfigurations != nil {
-		for i := range *lb.FrontendIPConfigurations {
-			fip := (*lb.FrontendIPConfigurations)[i]
-			fipIsIPv6, err := az.isFIPIPv6(service, &fip, isInternal)
-			if err != nil {
-				return nil, toDeleteConfigs, false, newConfigs, err
-			}
-			if fipIsIPv6 == isIPv6 {
-				newConfigs = append(newConfigs, fip)
-			}
-		}
+		newConfigs = *lb.FrontendIPConfigurations
 	}
 
-	var ownedFIPConfig *network.FrontendIPConfiguration
+	var ownedFIPConfigs []*network.FrontendIPConfiguration
 	if !wantLb {
 		for i := len(newConfigs) - 1; i >= 0; i-- {
 			config := newConfigs[i]
-			isServiceOwnsFrontendIP, _, err := az.serviceOwnsFrontendIP(config, service)
-			if err != nil {
-				return nil, toDeleteConfigs, false, newConfigs, err
-			}
+			isServiceOwnsFrontendIP, _, _ := az.serviceOwnsFrontendIP(config, service)
 			if isServiceOwnsFrontendIP {
 				unsafe, err := az.isFrontendIPConfigUnsafeToDelete(lb, service, config.ID)
 				if err != nil {
-					return nil, toDeleteConfigs, false, newConfigs, err
+					return nil, toDeleteConfigs, false, err
 				}
 
 				// If the frontend IP configuration is not being referenced by:
@@ -1970,18 +1922,47 @@ func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
 		var (
 			previousZone *[]string
 			isFipChanged bool
+			subnet       network.Subnet
+			existsSubnet bool
 		)
+
+		if isInternal {
+			subnetName := getInternalSubnet(service)
+			if subnetName == nil {
+				subnetName = &az.SubnetName
+			}
+			subnet, existsSubnet, err = az.getSubnet(az.VnetName, *subnetName)
+			if err != nil {
+				return nil, toDeleteConfigs, false, err
+			}
+			if !existsSubnet {
+				return nil, toDeleteConfigs, false, fmt.Errorf("ensure(%s): lb(%s) - failed to get subnet: %s/%s", serviceName, lbName, az.VnetName, *subnetName)
+			}
+		}
+
+		pipRG := az.getPublicIPAddressResourceGroup(service)
+
 		for i := len(newConfigs) - 1; i >= 0; i-- {
 			config := newConfigs[i]
-			isServiceOwnsFrontendIP, _, _ := az.serviceOwnsFrontendIP(config, service)
+			isServiceOwnsFrontendIP, _, fipIPVersion := az.serviceOwnsFrontendIP(config, service)
 			if !isServiceOwnsFrontendIP {
 				klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): the frontend IP configuration %s does not belong to the service", serviceName, pointer.StringDeref(config.Name, ""))
 				continue
 			}
 			klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): checking owned frontend IP configuration %s", serviceName, pointer.StringDeref(config.Name, ""))
-			isFipChanged, err = az.isFrontendIPChanged(clusterName, config, service, lbFrontendIPConfigName, subnet)
+			var isIPv6 bool
+			var err error
+			if fipIPVersion != "" {
+				isIPv6 = fipIPVersion == network.IPv6
+			} else {
+				if isIPv6, err = az.isFIPIPv6(service, pipRG, &config); err != nil {
+					return nil, toDeleteConfigs, false, err
+				}
+			}
+
+			isFipChanged, err = az.isFrontendIPChanged(clusterName, config, service, lbFrontendIPConfigNames[isIPv6], &subnet)
 			if err != nil {
-				return nil, toDeleteConfigs, false, newConfigs, err
+				return nil, toDeleteConfigs, false, err
 			}
 			if isFipChanged {
 				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - dropping", serviceName, wantLb, *config.Name)
@@ -1990,31 +1971,24 @@ func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
 				dirtyConfigs = true
 				previousZone = config.Zones
 			}
-			break
 		}
 
-		ownedFIPConfig, err = az.findFrontendIPConfigOfService(&newConfigs, service, isInternal, isIPv6)
+		ownedFIPConfigMap, err := az.findFrontendIPConfigsOfService(&newConfigs, service)
 		if err != nil {
-			return nil, toDeleteConfigs, false, newConfigs, err
+			return nil, toDeleteConfigs, false, err
+		}
+		for _, config := range ownedFIPConfigMap {
+			ownedFIPConfigs = append(ownedFIPConfigs, config)
 		}
 
-		if ownedFIPConfig == nil {
-			klog.V(4).Infof("ensure(%s): lb(%s) - creating a new frontend IP config", serviceName, lbName)
+		addNewFIPOfService := func(isIPv6 bool) error {
+			klog.V(4).Infof("ensure(%s): lb(%s) - creating a new frontend IP config (isIPv6=%t)", serviceName, lbName, isIPv6)
 
 			// construct FrontendIPConfigurationPropertiesFormat
 			var fipConfigurationProperties *network.FrontendIPConfigurationPropertiesFormat
 			if isInternal {
-				subnetName := getInternalSubnet(service)
-				if subnetName == nil {
-					subnetName = &az.SubnetName
-				}
-				if err := az.fillSubnet(subnet, *subnetName); err != nil {
-					return nil, toDeleteConfigs, false, newConfigs, fmt.Errorf("ensure(%s): lb(%s) - %w", serviceName, lbName, err)
-				}
-
 				configProperties := network.FrontendIPConfigurationPropertiesFormat{
-					Subnet:                  subnet,
-					PrivateIPAddressVersion: network.IPv4,
+					Subnet: &subnet,
 				}
 
 				if isIPv6 {
@@ -2026,7 +2000,7 @@ func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
 				ingressIPInSubnet := func(ingresses []v1.LoadBalancerIngress) bool {
 					for _, ingress := range ingresses {
 						ingressIP := ingress.IP
-						if (net.ParseIP(ingressIP).To4() == nil) == isIPv6 && ipInSubnet(ingressIP, subnet) {
+						if (net.ParseIP(ingressIP).To4() == nil) == isIPv6 && ipInSubnet(ingressIP, &subnet) {
 							privateIP = ingressIP
 							break
 						}
@@ -2050,12 +2024,12 @@ func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
 			} else {
 				pipName, shouldPIPExisted, err := az.determinePublicIPName(clusterName, service, isIPv6)
 				if err != nil {
-					return nil, toDeleteConfigs, false, newConfigs, err
+					return err
 				}
 				domainNameLabel, found := getPublicIPDomainNameLabel(service)
 				pip, err := az.ensurePublicIPExists(service, pipName, domainNameLabel, clusterName, shouldPIPExisted, found, isIPv6)
 				if err != nil {
-					return nil, toDeleteConfigs, false, newConfigs, err
+					return err
 				}
 				fipConfigurationProperties = &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{ID: pip.ID},
@@ -2063,24 +2037,41 @@ func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
 			}
 
 			newConfig := network.FrontendIPConfiguration{
-				Name:                                    pointer.String(lbFrontendIPConfigName),
-				ID:                                      pointer.String(fmt.Sprintf(consts.FrontendIPConfigIDTemplate, az.getNetworkResourceSubscriptionID(), az.ResourceGroup, *lb.Name, lbFrontendIPConfigName)),
+				Name:                                    pointer.String(lbFrontendIPConfigNames[isIPv6]),
+				ID:                                      pointer.String(fmt.Sprintf(consts.FrontendIPConfigIDTemplate, az.getNetworkResourceSubscriptionID(), az.ResourceGroup, pointer.StringDeref(lb.Name, ""), lbFrontendIPConfigNames[isIPv6])),
 				FrontendIPConfigurationPropertiesFormat: fipConfigurationProperties,
 			}
 
 			if isInternal {
-				if err := az.getFrontendZones(&newConfig, previousZone, isFipChanged, serviceName, lbFrontendIPConfigName); err != nil {
+				if err := az.getFrontendZones(&newConfig, previousZone, isFipChanged, serviceName, lbFrontendIPConfigNames[isIPv6]); err != nil {
 					klog.Errorf("reconcileLoadBalancer for service (%s)(%t): failed to getFrontendZones: %s", serviceName, wantLb, err.Error())
-					return nil, toDeleteConfigs, false, newConfigs, err
+					return err
 				}
 			}
 			newConfigs = append(newConfigs, newConfig)
-			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, lbFrontendIPConfigName)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, lbFrontendIPConfigNames[isIPv6])
 			dirtyConfigs = true
+			return nil
+		}
+
+		v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
+		if v4Enabled && ownedFIPConfigMap[false] == nil {
+			if err := addNewFIPOfService(false); err != nil {
+				return nil, toDeleteConfigs, false, err
+			}
+		}
+		if v6Enabled && ownedFIPConfigMap[true] == nil {
+			if err := addNewFIPOfService(true); err != nil {
+				return nil, toDeleteConfigs, false, err
+			}
 		}
 	}
 
-	return ownedFIPConfig, toDeleteConfigs, dirtyConfigs, newConfigs, err
+	if dirtyConfigs {
+		lb.FrontendIPConfigurations = &newConfigs
+	}
+
+	return ownedFIPConfigs, toDeleteConfigs, dirtyConfigs, err
 }
 
 func (az *Cloud) getFrontendZones(

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/netip"
 	"reflect"
 	"sort"
@@ -1390,7 +1391,14 @@ func getDomainNameLabel(pip *network.PublicIPAddress) string {
 	return pointer.StringDeref(pip.PublicIPAddressPropertiesFormat.DNSSettings.DomainNameLabel, "")
 }
 
-func (az *Cloud) isFrontendIPChanged(clusterName string, config network.FrontendIPConfiguration, service *v1.Service, lbFrontendIPConfigName string) (bool, error) {
+// subnet is reused to reduce API calls when dualstack.
+func (az *Cloud) isFrontendIPChanged(
+	clusterName string,
+	config network.FrontendIPConfiguration,
+	service *v1.Service,
+	lbFrontendIPConfigName string,
+	subnet *network.Subnet,
+) (bool, error) {
 	isServiceOwnsFrontendIP, isPrimaryService, err := az.serviceOwnsFrontendIP(config, service)
 	if err != nil {
 		return false, err
@@ -1401,20 +1409,20 @@ func (az *Cloud) isFrontendIPChanged(clusterName string, config network.Frontend
 	if !strings.EqualFold(pointer.StringDeref(config.Name, ""), lbFrontendIPConfigName) {
 		return false, nil
 	}
-	isIPv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-	loadBalancerIP := getServiceLoadBalancerIP(service, isIPv6)
 	isInternal := requiresInternalLoadBalancer(service)
+	isIPv6, err := az.isFIPIPv6(service, &config, isInternal)
+	if err != nil {
+		return false, err
+	}
+	loadBalancerIP := getServiceLoadBalancerIP(service, isIPv6)
 	if isInternal {
 		// Judge subnet
-		subnetName := subnet(service)
+		subnetName := getInternalSubnet(service)
 		if subnetName != nil {
-			subnet, existsSubnet, err := az.getSubnet(az.VnetName, *subnetName)
-			if err != nil {
+			if err := az.fillSubnet(subnet, *subnetName); err != nil {
 				return false, err
 			}
-			if !existsSubnet {
-				return false, fmt.Errorf("failed to get subnet")
-			}
+
 			if config.Subnet != nil && !strings.EqualFold(pointer.StringDeref(config.Subnet.ID, ""), pointer.StringDeref(subnet.ID, "")) {
 				return true, nil
 			}
@@ -1550,9 +1558,18 @@ func findMatchedOutboundRuleFIPConfig(fipConfigID *string, outboundRuleFIPConfig
 func (az *Cloud) findFrontendIPConfigOfService(
 	fipConfigs *[]network.FrontendIPConfiguration,
 	service *v1.Service,
+	isInternal bool,
+	isIPv6 bool,
 ) (*network.FrontendIPConfiguration, error) {
 	for _, config := range *fipConfigs {
 		config := config
+		fipIsIPv6, err := az.isFIPIPv6(service, &config, isInternal)
+		if err != nil {
+			return nil, err
+		}
+		if fipIsIPv6 != isIPv6 {
+			continue
+		}
 		owns, _, err := az.serviceOwnsFrontendIP(config, service)
 		if err != nil {
 			return nil, err
@@ -1587,12 +1604,15 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 
 	lbName := *lb.Name
-	isIPv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-	lbBackendPoolID := az.getBackendPoolID(lbName, getBackendPoolName(clusterName, isIPv6))
+	lbResourceGroup := az.getLoadBalancerResourceGroup()
+	lbBackendPoolIDs := az.getBackendPoolIDs(clusterName, lbName)
 	klog.V(2).Infof("reconcileLoadBalancer for service(%s): lb(%s/%s) wantLb(%t) resolved load balancer name",
-		serviceName, az.getLoadBalancerResourceGroup(), lbName, wantLb)
-	defaultLBFrontendIPConfigName := az.getDefaultFrontendIPConfigName(service)
-	defaultLBFrontendIPConfigID := az.getFrontendIPConfigID(lbName, defaultLBFrontendIPConfigName)
+		serviceName, lbResourceGroup, lbName, wantLb)
+	lbFrontendIPConfigNames := az.getFrontendIPConfigNames(service)
+	lbFrontendIPConfigIDs := map[bool]string{
+		consts.IPVersionIPv4: az.getFrontendIPConfigID(lbName, lbFrontendIPConfigNames[consts.IPVersionIPv4]),
+		consts.IPVersionIPv6: az.getFrontendIPConfigID(lbName, lbFrontendIPConfigNames[consts.IPVersionIPv6]),
+	}
 	dirtyLb := false
 
 	// reconcile the load balancer's backend pool configuration.
@@ -1618,7 +1638,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 
 	// reconcile the load balancer's frontend IP configurations.
-	ownedFIPConfig, toDeleteConfigs, changed, err := az.reconcileFrontendIPConfigs(clusterName, service, lb, lbStatus, wantLb, defaultLBFrontendIPConfigName)
+	ownedFIPConfigs, toDeleteConfigs, changed, err := az.reconcileFrontendIPConfigs(clusterName, service, lb, lbStatus, wantLb, lbFrontendIPConfigNames)
 	if err != nil {
 		return lb, err
 	}
@@ -1627,26 +1647,47 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 
 	// update probes/rules
-	if ownedFIPConfig != nil {
-		if ownedFIPConfig.ID != nil {
-			defaultLBFrontendIPConfigID = *ownedFIPConfig.ID
-		} else {
+	isInternal := requiresInternalLoadBalancer(service)
+	for _, ownedFIPConfig := range ownedFIPConfigs {
+		if ownedFIPConfig == nil {
+			continue
+		}
+		if ownedFIPConfig.ID == nil {
 			return nil, fmt.Errorf("reconcileLoadBalancer for service (%s)(%t): nil ID for frontend IP config", serviceName, wantLb)
 		}
-	}
 
-	if wantLb {
-		err = az.checkLoadBalancerResourcesConflicts(lb, defaultLBFrontendIPConfigID, service)
+		isIPv6, err := az.isFIPIPv6(service, ownedFIPConfig, isInternal)
 		if err != nil {
 			return nil, err
 		}
+		lbFrontendIPConfigIDs[isIPv6] = *ownedFIPConfig.ID
 	}
 
 	var expectedProbes []network.Probe
 	var expectedRules []network.LoadBalancingRule
-	if wantLb {
-		expectedProbes, expectedRules, err = az.getExpectedLBRules(service, defaultLBFrontendIPConfigID, lbBackendPoolID, lbName)
+	getExpectedLBRule := func(isIPv6 bool) error {
+		expectedProbesSingleStack, expectedRulesSingleStack, err := az.getExpectedLBRules(service, lbFrontendIPConfigIDs[isIPv6], lbBackendPoolIDs[isIPv6], lbName, isIPv6)
 		if err != nil {
+			return err
+		}
+		expectedProbes = append(expectedProbes, expectedProbesSingleStack...)
+		expectedRules = append(expectedRules, expectedRulesSingleStack...)
+		return nil
+	}
+	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
+	if wantLb && v4Enabled {
+		if err = az.checkLoadBalancerResourcesConflicts(lb, lbFrontendIPConfigIDs[false], service); err != nil {
+			return nil, err
+		}
+		if err := getExpectedLBRule(false); err != nil {
+			return nil, err
+		}
+	}
+	if wantLb && v6Enabled {
+		if err = az.checkLoadBalancerResourcesConflicts(lb, lbFrontendIPConfigIDs[true], service); err != nil {
+			return nil, err
+		}
+		if err := getExpectedLBRule(true); err != nil {
 			return nil, err
 		}
 	}
@@ -1718,12 +1759,11 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 			_ = az.lbCache.Delete(lbName)
 		}()
 
-		if lb.LoadBalancerPropertiesFormat != nil && lb.BackendAddressPools != nil {
-			backendPools := *lb.BackendAddressPools
-			for _, backendPool := range backendPools {
+		if lb.LoadBalancerPropertiesFormat != nil && lb.LoadBalancerPropertiesFormat.BackendAddressPools != nil {
+			for _, backendPool := range *lb.LoadBalancerPropertiesFormat.BackendAddressPools {
 				isIPv6 := isBackendPoolIPv6(pointer.StringDeref(backendPool.Name, ""))
 				if strings.EqualFold(pointer.StringDeref(backendPool.Name, ""), getBackendPoolName(clusterName, isIPv6)) {
-					if err := az.LoadBalancerBackendPool.EnsureHostsInPool(service, nodes, lbBackendPoolID, vmSetName, clusterName, lbName, backendPool); err != nil {
+					if err := az.LoadBalancerBackendPool.EnsureHostsInPool(service, nodes, lbBackendPoolIDs[isIPv6], vmSetName, clusterName, lbName, backendPool); err != nil {
 						return nil, err
 					}
 				}
@@ -1825,7 +1865,52 @@ func (az *Cloud) reconcileLBRules(lb *network.LoadBalancer, service *v1.Service,
 	return dirtyRules
 }
 
-func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Service, lb *network.LoadBalancer, status *v1.LoadBalancerStatus, wantLb bool, defaultLBFrontendIPConfigName string) (*network.FrontendIPConfiguration, []network.FrontendIPConfiguration, bool, error) {
+func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Service, lb *network.LoadBalancer, lbStatus *v1.LoadBalancerStatus, wantLb bool, lbFrontendIPConfigName map[bool]string) ([]*network.FrontendIPConfiguration, []network.FrontendIPConfiguration, bool, error) {
+	ownedFIPConfigs := []*network.FrontendIPConfiguration{}
+	toDeleteConfigs := []network.FrontendIPConfiguration{}
+	lbFrontEndIPConfigNewConfigs := []network.FrontendIPConfiguration{}
+	changedTotal := false
+	var subnet network.Subnet
+	handleFrontendIPConfig := func(isIPv6 bool) error {
+		ownedFIPConfig, toDeleteConfigsSingleStack, changed, newConfigs, err := az.reconcileFrontendIPConfigsSingleStack(clusterName, service, lb, lbStatus, wantLb, isIPv6, lbFrontendIPConfigName[isIPv6], &subnet)
+		if err != nil {
+			return err
+		}
+
+		if changed {
+			lbFrontEndIPConfigNewConfigs = append(lbFrontEndIPConfigNewConfigs, newConfigs...)
+			changedTotal = true
+		}
+		ownedFIPConfigs = append(ownedFIPConfigs, ownedFIPConfig)
+		toDeleteConfigs = append(toDeleteConfigs, toDeleteConfigsSingleStack...)
+		return nil
+	}
+	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
+	if v4Enabled {
+		if err := handleFrontendIPConfig(false); err != nil {
+			return ownedFIPConfigs, toDeleteConfigs, changedTotal, err
+		}
+	}
+	if v6Enabled {
+		if err := handleFrontendIPConfig(true); err != nil {
+			return ownedFIPConfigs, toDeleteConfigs, changedTotal, err
+		}
+	}
+	if changedTotal {
+		lb.FrontendIPConfigurations = &lbFrontEndIPConfigNewConfigs
+	}
+	return ownedFIPConfigs, toDeleteConfigs, changedTotal, nil
+}
+
+func (az *Cloud) reconcileFrontendIPConfigsSingleStack(
+	clusterName string,
+	service *v1.Service,
+	lb *network.LoadBalancer,
+	status *v1.LoadBalancerStatus,
+	wantLb, isIPv6 bool,
+	lbFrontendIPConfigName string,
+	subnet *network.Subnet,
+) (*network.FrontendIPConfiguration, []network.FrontendIPConfiguration, bool, []network.FrontendIPConfiguration, error) {
 	var err error
 	lbName := *lb.Name
 	serviceName := getServiceName(service)
@@ -1834,7 +1919,16 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 	var newConfigs []network.FrontendIPConfiguration
 	var toDeleteConfigs []network.FrontendIPConfiguration
 	if lb.FrontendIPConfigurations != nil {
-		newConfigs = *lb.FrontendIPConfigurations
+		for i := range *lb.FrontendIPConfigurations {
+			fip := (*lb.FrontendIPConfigurations)[i]
+			fipIsIPv6, err := az.isFIPIPv6(service, &fip, isInternal)
+			if err != nil {
+				return nil, toDeleteConfigs, false, newConfigs, err
+			}
+			if fipIsIPv6 == isIPv6 {
+				newConfigs = append(newConfigs, fip)
+			}
+		}
 	}
 
 	var ownedFIPConfig *network.FrontendIPConfiguration
@@ -1843,12 +1937,12 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			config := newConfigs[i]
 			isServiceOwnsFrontendIP, _, err := az.serviceOwnsFrontendIP(config, service)
 			if err != nil {
-				return nil, toDeleteConfigs, false, err
+				return nil, toDeleteConfigs, false, newConfigs, err
 			}
 			if isServiceOwnsFrontendIP {
 				unsafe, err := az.isFrontendIPConfigUnsafeToDelete(lb, service, config.ID)
 				if err != nil {
-					return nil, toDeleteConfigs, false, err
+					return nil, toDeleteConfigs, false, newConfigs, err
 				}
 
 				// If the frontend IP configuration is not being referenced by:
@@ -1885,9 +1979,9 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 				continue
 			}
 			klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): checking owned frontend IP configuration %s", serviceName, pointer.StringDeref(config.Name, ""))
-			isFipChanged, err = az.isFrontendIPChanged(clusterName, config, service, defaultLBFrontendIPConfigName)
+			isFipChanged, err = az.isFrontendIPChanged(clusterName, config, service, lbFrontendIPConfigName, subnet)
 			if err != nil {
-				return nil, toDeleteConfigs, false, err
+				return nil, toDeleteConfigs, false, newConfigs, err
 			}
 			if isFipChanged {
 				klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - dropping", serviceName, wantLb, *config.Name)
@@ -1899,9 +1993,9 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			break
 		}
 
-		ownedFIPConfig, err = az.findFrontendIPConfigOfService(&newConfigs, service)
+		ownedFIPConfig, err = az.findFrontendIPConfigOfService(&newConfigs, service, isInternal, isIPv6)
 		if err != nil {
-			return nil, toDeleteConfigs, false, err
+			return nil, toDeleteConfigs, false, newConfigs, err
 		}
 
 		if ownedFIPConfig == nil {
@@ -1910,36 +2004,42 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			// construct FrontendIPConfigurationPropertiesFormat
 			var fipConfigurationProperties *network.FrontendIPConfigurationPropertiesFormat
 			if isInternal {
-				subnetName := subnet(service)
+				subnetName := getInternalSubnet(service)
 				if subnetName == nil {
 					subnetName = &az.SubnetName
 				}
-				subnet, existsSubnet, err := az.getSubnet(az.VnetName, *subnetName)
-				if err != nil {
-					return nil, toDeleteConfigs, false, err
-				}
-
-				if !existsSubnet {
-					return nil, toDeleteConfigs, false, fmt.Errorf("ensure(%s): lb(%s) - failed to get subnet: %s/%s", serviceName, lbName, az.VnetName, *subnetName)
+				if err := az.fillSubnet(subnet, *subnetName); err != nil {
+					return nil, toDeleteConfigs, false, newConfigs, fmt.Errorf("ensure(%s): lb(%s) - %w", serviceName, lbName, err)
 				}
 
 				configProperties := network.FrontendIPConfigurationPropertiesFormat{
-					Subnet: &subnet,
+					Subnet:                  subnet,
+					PrivateIPAddressVersion: network.IPv4,
 				}
 
-				isIPv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
 				if isIPv6 {
 					configProperties.PrivateIPAddressVersion = network.IPv6
 				}
 
 				loadBalancerIP := getServiceLoadBalancerIP(service, isIPv6)
+				privateIP := ""
+				ingressIPInSubnet := func(ingresses []v1.LoadBalancerIngress) bool {
+					for _, ingress := range ingresses {
+						ingressIP := ingress.IP
+						if (net.ParseIP(ingressIP).To4() == nil) == isIPv6 && ipInSubnet(ingressIP, subnet) {
+							privateIP = ingressIP
+							break
+						}
+					}
+					return privateIP != ""
+				}
 				if loadBalancerIP != "" {
 					configProperties.PrivateIPAllocationMethod = network.Static
 					configProperties.PrivateIPAddress = &loadBalancerIP
-				} else if status != nil && len(status.Ingress) > 0 && ipInSubnet(status.Ingress[0].IP, &subnet) {
-					klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): keep the original private IP %s", serviceName, status.Ingress[0].IP)
+				} else if status != nil && len(status.Ingress) > 0 && ingressIPInSubnet(status.Ingress) {
+					klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): keep the original private IP %s", serviceName, privateIP)
 					configProperties.PrivateIPAllocationMethod = network.Static
-					configProperties.PrivateIPAddress = pointer.String(status.Ingress[0].IP)
+					configProperties.PrivateIPAddress = pointer.String(privateIP)
 				} else {
 					// We'll need to call GetLoadBalancer later to retrieve allocated IP.
 					klog.V(4).Infof("reconcileFrontendIPConfigs for service (%s): dynamically allocate the private IP", serviceName)
@@ -1948,15 +2048,14 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 
 				fipConfigurationProperties = &configProperties
 			} else {
-				isIPv6 := utilnet.IsIPv6String(service.Spec.ClusterIP) // TODO: dualstack support
 				pipName, shouldPIPExisted, err := az.determinePublicIPName(clusterName, service, isIPv6)
 				if err != nil {
-					return nil, toDeleteConfigs, false, err
+					return nil, toDeleteConfigs, false, newConfigs, err
 				}
 				domainNameLabel, found := getPublicIPDomainNameLabel(service)
 				pip, err := az.ensurePublicIPExists(service, pipName, domainNameLabel, clusterName, shouldPIPExisted, found, isIPv6)
 				if err != nil {
-					return nil, toDeleteConfigs, false, err
+					return nil, toDeleteConfigs, false, newConfigs, err
 				}
 				fipConfigurationProperties = &network.FrontendIPConfigurationPropertiesFormat{
 					PublicIPAddress: &network.PublicIPAddress{ID: pip.ID},
@@ -1964,28 +2063,24 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string, service *v1.Serv
 			}
 
 			newConfig := network.FrontendIPConfiguration{
-				Name:                                    pointer.String(defaultLBFrontendIPConfigName),
-				ID:                                      pointer.String(fmt.Sprintf(consts.FrontendIPConfigIDTemplate, az.getNetworkResourceSubscriptionID(), az.ResourceGroup, *lb.Name, defaultLBFrontendIPConfigName)),
+				Name:                                    pointer.String(lbFrontendIPConfigName),
+				ID:                                      pointer.String(fmt.Sprintf(consts.FrontendIPConfigIDTemplate, az.getNetworkResourceSubscriptionID(), az.ResourceGroup, *lb.Name, lbFrontendIPConfigName)),
 				FrontendIPConfigurationPropertiesFormat: fipConfigurationProperties,
 			}
 
 			if isInternal {
-				if err := az.getFrontendZones(&newConfig, previousZone, isFipChanged, serviceName, defaultLBFrontendIPConfigName); err != nil {
+				if err := az.getFrontendZones(&newConfig, previousZone, isFipChanged, serviceName, lbFrontendIPConfigName); err != nil {
 					klog.Errorf("reconcileLoadBalancer for service (%s)(%t): failed to getFrontendZones: %s", serviceName, wantLb, err.Error())
-					return nil, toDeleteConfigs, false, err
+					return nil, toDeleteConfigs, false, newConfigs, err
 				}
 			}
 			newConfigs = append(newConfigs, newConfig)
-			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, defaultLBFrontendIPConfigName)
+			klog.V(2).Infof("reconcileLoadBalancer for service (%s)(%t): lb frontendconfig(%s) - adding", serviceName, wantLb, lbFrontendIPConfigName)
 			dirtyConfigs = true
 		}
 	}
 
-	if dirtyConfigs {
-		lb.FrontendIPConfigurations = &newConfigs
-	}
-
-	return ownedFIPConfig, toDeleteConfigs, dirtyConfigs, err
+	return ownedFIPConfig, toDeleteConfigs, dirtyConfigs, newConfigs, err
 }
 
 func (az *Cloud) getFrontendZones(
@@ -2123,7 +2218,8 @@ func (az *Cloud) getExpectedLBRules(
 	service *v1.Service,
 	lbFrontendIPConfigID string,
 	lbBackendPoolID string,
-	lbName string) ([]network.Probe, []network.LoadBalancingRule, error) {
+	lbName string,
+	isIPv6 bool) ([]network.Probe, []network.LoadBalancingRule, error) {
 
 	var expectedRules []network.LoadBalancingRule
 	var expectedProbes []network.Probe
@@ -2135,7 +2231,7 @@ func (az *Cloud) getExpectedLBRules(
 	var nodeEndpointHealthprobe *network.Probe
 	if servicehelpers.NeedsHealthCheck(service) && !(consts.IsPLSEnabled(service.Annotations) && consts.IsPLSProxyProtocolEnabled(service.Annotations)) {
 		podPresencePath, podPresencePort := servicehelpers.GetServiceHealthCheckPathPort(service)
-		lbRuleName := az.getLoadBalancerRuleName(service, v1.ProtocolTCP, podPresencePort, utilnet.IsIPv6String(service.Spec.ClusterIP))
+		lbRuleName := az.getLoadBalancerRuleName(service, v1.ProtocolTCP, podPresencePort, isIPv6)
 		probeInterval, numberOfProbes, err := az.getHealthProbeConfigProbeIntervalAndNumOfProbe(service, podPresencePort)
 		if err != nil {
 			return nil, nil, err
@@ -2159,7 +2255,7 @@ func (az *Cloud) getExpectedLBRules(
 		az.useStandardLoadBalancer() &&
 		consts.IsK8sServiceHasHAModeEnabled(service) {
 
-		lbRuleName := az.getloadbalancerHAmodeRuleName(service, utilnet.IsIPv6String(service.Spec.ClusterIP))
+		lbRuleName := az.getloadbalancerHAmodeRuleName(service, isIPv6)
 		klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
 
 		props, err := az.getExpectedHAModeLoadBalancingRuleProperties(service, lbFrontendIPConfigID, lbBackendPoolID)
@@ -2199,7 +2295,7 @@ func (az *Cloud) getExpectedLBRules(
 		// generate lb rule for each port defined in svc object
 
 		for _, port := range service.Spec.Ports {
-			lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port, utilnet.IsIPv6String(service.Spec.ClusterIP))
+			lbRuleName := az.getLoadBalancerRuleName(service, port.Protocol, port.Port, isIPv6)
 			klog.V(2).Infof("getExpectedLBRules lb name (%s) rule name (%s)", lbName, lbRuleName)
 			isNoLBRuleRequired, err := consts.IsLBRuleOnK8sServicePortDisabled(service.Annotations, port.Port)
 			if err != nil {
@@ -3187,6 +3283,7 @@ func findRule(rules []network.LoadBalancingRule, rule network.LoadBalancingRule,
 
 // equalLoadBalancingRulePropertiesFormat checks whether the provided LoadBalancingRulePropertiesFormat are equal.
 // Note: only fields used in reconcileLoadBalancer are considered.
+// s: existing, t: target
 func equalLoadBalancingRulePropertiesFormat(s *network.LoadBalancingRulePropertiesFormat, t *network.LoadBalancingRulePropertiesFormat, wantLB bool) bool {
 	if s == nil || t == nil {
 		return false
@@ -3303,7 +3400,7 @@ func requiresInternalLoadBalancer(service *v1.Service) bool {
 	return false
 }
 
-func subnet(service *v1.Service) *string {
+func getInternalSubnet(service *v1.Service) *string {
 	if requiresInternalLoadBalancer(service) {
 		if l, found := service.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet]; found && strings.TrimSpace(l) != "" {
 			return &l
@@ -3410,6 +3507,7 @@ func serviceOwnsPublicIP(service *v1.Service, pip *network.PublicIPAddress, clus
 		clusterTag := getClusterFromPIPClusterTags(pip.Tags)
 
 		// if there is no service tag on the pip, it is user-created pip
+		isIPv6 := pip.PublicIPAddressVersion == network.IPv6
 		if serviceTag == "" {
 			return isServiceSelectPIP(service, pip, isIPv6), true
 		}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -83,13 +83,13 @@ func (az *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, servic
 		return nil, az.existsPip(clusterName, service), err
 	}
 
-	_, status, existsLb, err := az.getServiceLoadBalancer(service, clusterName, nil, false, existingLBs)
+	_, status, _, existsLb, err := az.getServiceLoadBalancer(service, clusterName, nil, false, existingLBs)
 	if err != nil || existsLb {
 		return status, existsLb || az.existsPip(clusterName, service), err
 	}
 
 	flippedService := flipServiceInternalAnnotation(service)
-	_, status, existsLb, err = az.getServiceLoadBalancer(flippedService, clusterName, nil, false, existingLBs)
+	_, status, _, existsLb, err = az.getServiceLoadBalancer(flippedService, clusterName, nil, false, existingLBs)
 	if err != nil || existsLb {
 		return status, existsLb || az.existsPip(clusterName, service), err
 	}
@@ -124,7 +124,7 @@ func (az *Cloud) reconcileService(ctx context.Context, clusterName string, servi
 		return nil, err
 	}
 
-	lbStatus, fipConfig, err := az.getServiceLoadBalancerStatus(service, lb)
+	lbStatus, lbIPsPrimaryPIPs, fipConfigs, err := az.getServiceLoadBalancerStatus(service, lb)
 	if err != nil {
 		klog.Errorf("getServiceLoadBalancerStatus(%s) failed: %v", serviceName, err)
 		if !errors.Is(err, ErrorNotVmssInstance) {
@@ -132,25 +132,21 @@ func (az *Cloud) reconcileService(ctx context.Context, clusterName string, servi
 		}
 	}
 
-	var serviceIP *string
-	if lbStatus != nil && len(lbStatus.Ingress) > 0 {
-		serviceIP = &lbStatus.Ingress[0].IP
-	}
-
-	klog.V(2).Infof("reconcileService: reconciling security group for service %q with IP %q, wantLb = true", serviceName, logSafe(serviceIP))
-	if _, err := az.reconcileSecurityGroup(clusterName, service, serviceIP, lb.Name, true /* wantLb */); err != nil {
+	serviceIPs := lbIPsPrimaryPIPs
+	klog.V(2).Infof("reconcileService: reconciling security group for service %q with IPs %q, wantLb = true", serviceName, serviceIPs)
+	if _, err := az.reconcileSecurityGroup(clusterName, service, &serviceIPs, lb.Name, true /* wantLb */); err != nil {
 		klog.Errorf("reconcileSecurityGroup(%s) failed: %#v", serviceName, err)
 		return nil, err
 	}
 
-	if fipConfig != nil {
+	for _, fipConfig := range fipConfigs {
 		if err := az.reconcilePrivateLinkService(clusterName, service, fipConfig, true /* wantPLS */); err != nil {
 			klog.Errorf("reconcilePrivateLinkService(%s) failed: %#v", serviceName, err)
 			return nil, err
 		}
 	}
 
-	updateService := updateServiceLoadBalancerIP(service, pointer.StringDeref(serviceIP, ""))
+	updateService := updateServiceLoadBalancerIPs(service, lbIPsPrimaryPIPs)
 	flippedService := flipServiceInternalAnnotation(updateService)
 	if _, err := az.reconcileLoadBalancer(clusterName, flippedService, nil, false /* wantLb */); err != nil {
 		klog.Errorf("reconcileLoadBalancer(%s) failed: %#v", serviceName, err)
@@ -278,13 +274,13 @@ func (az *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName stri
 		klog.V(5).InfoS("EnsureLoadBalancerDeleted Finish", "service", serviceName, "cluster", clusterName, "service_spec", service, "error", err)
 	}()
 
-	serviceIPToCleanup, err := az.findServiceIPAddress(ctx, clusterName, service)
+	_, _, lbIPsPrimaryPIPs, _, err := az.getServiceLoadBalancer(service, clusterName, nil, false, []network.LoadBalancer{})
 	if err != nil && !retry.HasStatusForbiddenOrIgnoredError(err) {
 		return err
 	}
-
-	klog.V(2).Infof("EnsureLoadBalancerDeleted: reconciling security group for service %q with IP %q, wantLb = false", serviceName, serviceIPToCleanup)
-	_, err = az.reconcileSecurityGroup(clusterName, service, &serviceIPToCleanup, nil, false /* wantLb */)
+	serviceIPsToCleanup := lbIPsPrimaryPIPs
+	klog.V(2).Infof("EnsureLoadBalancerDeleted: reconciling security group for service %q with IPs %q, wantLb = false", serviceName, serviceIPsToCleanup)
+	_, err = az.reconcileSecurityGroup(clusterName, service, &serviceIPsToCleanup, nil, false /* wantLb */)
 	if err != nil {
 		return err
 	}
@@ -300,8 +296,7 @@ func (az *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName stri
 		return err
 	}
 
-	_, err = az.reconcilePublicIPs(clusterName, service, "", false /* wantLb */)
-	if err != nil {
+	if _, err = az.reconcilePublicIPs(clusterName, service, "", false /* wantLb */); err != nil {
 		return err
 	}
 
@@ -370,15 +365,17 @@ func (az *Cloud) shouldChangeLoadBalancer(service *v1.Service, currLBName, clust
 	return true
 }
 
-func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadBalancer, existingLBs []network.LoadBalancer, fip *network.FrontendIPConfiguration, clusterName string, service *v1.Service) error {
+func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadBalancer, existingLBs []network.LoadBalancer, fips []*network.FrontendIPConfiguration, clusterName string, service *v1.Service) error {
 	if lb == nil || lb.LoadBalancerPropertiesFormat == nil || lb.FrontendIPConfigurations == nil {
 		return nil
 	}
 	fipConfigs := *lb.FrontendIPConfigurations
 	for i, fipConfig := range fipConfigs {
-		if strings.EqualFold(pointer.StringDeref(fipConfig.Name, ""), pointer.StringDeref(fip.Name, "")) {
-			fipConfigs = append(fipConfigs[:i], fipConfigs[i+1:]...)
-			break
+		for _, fip := range fips {
+			if strings.EqualFold(pointer.StringDeref(fipConfig.Name, ""), pointer.StringDeref(fip.Name, "")) {
+				fipConfigs = append(fipConfigs[:i], fipConfigs[i+1:]...)
+				break
+			}
 		}
 	}
 	lb.FrontendIPConfigurations = &fipConfigs
@@ -387,8 +384,10 @@ func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadB
 	if lb.LoadBalancingRules != nil {
 		lbRules := *lb.LoadBalancingRules
 		for i := len(lbRules) - 1; i >= 0; i-- {
-			if strings.Contains(pointer.StringDeref(lbRules[i].Name, ""), pointer.StringDeref(fip.Name, "")) {
-				lbRules = append(lbRules[:i], lbRules[i+1:]...)
+			for _, fip := range fips {
+				if strings.Contains(pointer.StringDeref(lbRules[i].Name, ""), pointer.StringDeref(fip.Name, "")) {
+					lbRules = append(lbRules[:i], lbRules[i+1:]...)
+				}
 			}
 		}
 		lb.LoadBalancingRules = &lbRules
@@ -396,32 +395,41 @@ func (az *Cloud) removeFrontendIPConfigurationFromLoadBalancer(lb *network.LoadB
 	if lb.Probes != nil {
 		lbProbes := *lb.Probes
 		for i := len(lbProbes) - 1; i >= 0; i-- {
-			if strings.Contains(pointer.StringDeref(lbProbes[i].Name, ""), pointer.StringDeref(fip.Name, "")) {
-				lbProbes = append(lbProbes[:i], lbProbes[i+1:]...)
+			for _, fip := range fips {
+				if strings.Contains(pointer.StringDeref(lbProbes[i].Name, ""), pointer.StringDeref(fip.Name, "")) {
+					lbProbes = append(lbProbes[:i], lbProbes[i+1:]...)
+				}
 			}
 		}
 		lb.Probes = &lbProbes
 	}
 
-	// clean up any private link service associated with the frontEndIPConfig
-	err := az.reconcilePrivateLinkService(clusterName, service, fip, false /* wantPLS */)
-	if err != nil {
-		klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to clean up PLS: %v", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name, err)
-		return err
+	// PLS does not support IPv6 so there will not be additional API calls.
+	for _, fip := range fips {
+		// clean up any private link service associated with the frontEndIPConfig
+		if err := az.reconcilePrivateLinkService(clusterName, service, fip, false /* wantPLS */); err != nil {
+			klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to clean up PLS: %v", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name, err)
+			return err
+		}
 	}
 
+	fipNames := []string{}
+	for _, fip := range fips {
+		fipNames = append(fipNames, pointer.StringDeref(fip.Name, ""))
+	}
+	logPrefix := fmt.Sprintf("removeFrontendIPConfigurationFromLoadBalancer(%s, %q, %s, %s)", pointer.StringDeref(lb.Name, ""), fipNames, clusterName, service.Name)
 	if len(fipConfigs) == 0 {
-		klog.V(2).Infof("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): deleting load balancer because there is no remaining frontend IP configurations", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name)
+		klog.V(2).Infof("%s: deleting load balancer because there is no remaining frontend IP configurations", logPrefix)
 		err := az.cleanOrphanedLoadBalancer(lb, existingLBs, service, clusterName)
 		if err != nil {
-			klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to cleanupOrphanedLoadBalancer: %v", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name, err)
+			klog.Errorf("%s: failed to cleanupOrphanedLoadBalancer: %v", logPrefix, err)
 			return err
 		}
 	} else {
-		klog.V(2).Infof("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): updating the load balancer", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name)
+		klog.V(2).Infof("%s: updating the load balancer", logPrefix)
 		err := az.CreateOrUpdateLB(service, *lb)
 		if err != nil {
-			klog.Errorf("removeFrontendIPConfigurationFromLoadBalancer(%s, %s, %s, %s): failed to CreateOrUpdateLB: %v", pointer.StringDeref(lb.Name, ""), pointer.StringDeref(fip.Name, ""), clusterName, service.Name, err)
+			klog.Errorf("%s: failed to CreateOrUpdateLB: %v", logPrefix, err)
 			return err
 		}
 		_ = az.lbCache.Delete(pointer.StringDeref(lb.Name, ""))
@@ -433,9 +441,15 @@ func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs
 	lbName := pointer.StringDeref(lb.Name, "")
 	serviceName := getServiceName(service)
 	isBackendPoolPreConfigured := az.isBackendPoolPreConfigured(service)
-	isIPv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-	lbBackendPoolName := getBackendPoolName(clusterName, isIPv6)
-	lbBackendPoolID := az.getBackendPoolID(lbName, lbBackendPoolName)
+	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
+	lbBackendPoolIDs := az.getBackendPoolIDs(clusterName, lbName)
+	lbBackendPoolIDsToDelete := []string{}
+	if v4Enabled {
+		lbBackendPoolIDsToDelete = append(lbBackendPoolIDsToDelete, lbBackendPoolIDs[consts.IPVersionIPv4])
+	}
+	if v6Enabled {
+		lbBackendPoolIDsToDelete = append(lbBackendPoolIDsToDelete, lbBackendPoolIDs[consts.IPVersionIPv6])
+	}
 	if isBackendPoolPreConfigured {
 		klog.V(2).Infof("cleanOrphanedLoadBalancer(%s, %s, %s): ignore cleanup of dirty lb because the lb is pre-configured", lbName, serviceName, clusterName)
 	} else {
@@ -462,8 +476,7 @@ func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs
 			lb.BackendAddressPools = nil
 		}
 
-		deleteErr := az.safeDeleteLoadBalancer(*lb, clusterName, vmSetName, service)
-		if deleteErr != nil {
+		if deleteErr := az.safeDeleteLoadBalancer(*lb, clusterName, vmSetName, service); deleteErr != nil {
 			klog.Warningf("cleanOrphanedLoadBalancer(%s, %s, %s): failed to DeleteLB: %v", lbName, serviceName, clusterName, deleteErr)
 
 			rgName, vmssName, parseErr := retry.GetVMSSMetadataByRawError(deleteErr)
@@ -487,14 +500,12 @@ func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs
 			}
 
 			vmssNamesMap := map[string]bool{vmssName: true}
-			err := az.VMSet.EnsureBackendPoolDeletedFromVMSets(vmssNamesMap, []string{lbBackendPoolID})
-			if err != nil {
+			if err := az.VMSet.EnsureBackendPoolDeletedFromVMSets(vmssNamesMap, lbBackendPoolIDsToDelete); err != nil {
 				klog.Errorf("cleanOrphanedLoadBalancer(%s, %s, %s): failed to EnsureBackendPoolDeletedFromVMSets: %v", lbName, serviceName, clusterName, err)
 				return err
 			}
 
-			deleteErr := az.DeleteLB(service, lbName)
-			if deleteErr != nil {
+			if deleteErr := az.DeleteLB(service, lbName); deleteErr != nil {
 				klog.Errorf("cleanOrphanedLoadBalancer(%s, %s, %s): failed delete lb for the second time, stop retrying: %v", lbName, serviceName, clusterName, deleteErr)
 				return deleteErr.Error()
 			}
@@ -506,16 +517,21 @@ func (az *Cloud) cleanOrphanedLoadBalancer(lb *network.LoadBalancer, existingLBs
 
 // safeDeleteLoadBalancer deletes the load balancer after decoupling it from the vmSet
 func (az *Cloud) safeDeleteLoadBalancer(lb network.LoadBalancer, clusterName, vmSetName string, service *v1.Service) *retry.Error {
-	isIPv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-	lbBackendPoolID := az.getBackendPoolID(pointer.StringDeref(lb.Name, ""), getBackendPoolName(clusterName, isIPv6))
-	_, err := az.VMSet.EnsureBackendPoolDeleted(service, []string{lbBackendPoolID}, vmSetName, lb.BackendAddressPools, true)
-	if err != nil {
+	lbBackendPoolIDs := az.getBackendPoolIDs(clusterName, pointer.StringDeref(lb.Name, ""))
+	lbBackendPoolIDsToDelete := []string{}
+	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
+	if v4Enabled {
+		lbBackendPoolIDsToDelete = append(lbBackendPoolIDsToDelete, lbBackendPoolIDs[consts.IPVersionIPv4])
+	}
+	if v6Enabled {
+		lbBackendPoolIDsToDelete = append(lbBackendPoolIDsToDelete, lbBackendPoolIDs[consts.IPVersionIPv6])
+	}
+	if _, err := az.VMSet.EnsureBackendPoolDeleted(service, lbBackendPoolIDsToDelete, vmSetName, lb.BackendAddressPools, true); err != nil {
 		return retry.NewError(false, fmt.Errorf("safeDeleteLoadBalancer: failed to EnsureBackendPoolDeleted: %w", err))
 	}
 
 	klog.V(2).Infof("safeDeleteLoadBalancer: deleting LB %s", pointer.StringDeref(lb.Name, ""))
-	rerr := az.DeleteLB(service, pointer.StringDeref(lb.Name, ""))
-	if rerr != nil {
+	if rerr := az.DeleteLB(service, pointer.StringDeref(lb.Name, "")); rerr != nil {
 		return rerr
 	}
 	_ = az.lbCache.Delete(pointer.StringDeref(lb.Name, ""))
@@ -613,7 +629,7 @@ func (az *Cloud) reconcileSharedLoadBalancer(service *v1.Service, clusterName st
 // In case the selected load balancer does not exist it returns network.LoadBalancer struct
 // with added metadata (such as name, location) and existsLB set to FALSE.
 // By default - cluster default LB is returned.
-func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string, nodes []*v1.Node, wantLb bool, existingLBs []network.LoadBalancer) (lb *network.LoadBalancer, status *v1.LoadBalancerStatus, exists bool, err error) {
+func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string, nodes []*v1.Node, wantLb bool, existingLBs []network.LoadBalancer) (lb *network.LoadBalancer, status *v1.LoadBalancerStatus, lbIPsPrimaryPIPs []string, exists bool, err error) {
 	isInternal := requiresInternalLoadBalancer(service)
 	var defaultLB *network.LoadBalancer
 	primaryVMSetName := az.VMSet.GetPrimaryVMSetName()
@@ -624,7 +640,7 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 	if len(existingLBs) == 0 {
 		existingLBs, err = az.ListLB(service)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, nil, false, err
 		}
 	}
 
@@ -652,7 +668,7 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 			}
 			cleanedLB, err := az.LoadBalancerBackendPool.CleanupVMSetFromBackendPoolByCondition(&existingLB, service, nodes, clusterName, shouldRemoveVMSetFromSLB)
 			if err != nil {
-				return nil, nil, false, err
+				return nil, nil, nil, false, err
 			}
 			existingLB = *cleanedLB
 			existingLBs[i] = *cleanedLB
@@ -663,28 +679,33 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 		if isInternalLoadBalancer(&existingLB) != isInternal {
 			continue
 		}
-		var fipConfig *network.FrontendIPConfiguration
-		status, fipConfig, err = az.getServiceLoadBalancerStatus(service, &existingLB)
+
+		var fipConfigs []*network.FrontendIPConfiguration
+		status, lbIPsPrimaryPIPs, fipConfigs, err = az.getServiceLoadBalancerStatus(service, &existingLB)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, nil, false, err
 		}
 		if status == nil {
 			// service is not on this load balancer
 			continue
 		}
-		klog.V(4).Infof("getServiceLoadBalancer(%s, %s, %v): current lb ip: %s", service.Name, clusterName, wantLb, status.Ingress[0].IP)
+		klog.V(4).Infof("getServiceLoadBalancer(%s, %s, %v): current lb IPs: %q", service.Name, clusterName, wantLb, lbIPsPrimaryPIPs)
 
 		// select another load balancer instead of returning
 		// the current one if the change is needed
 		if wantLb && az.shouldChangeLoadBalancer(service, pointer.StringDeref(existingLB.Name, ""), clusterName) {
-			if err := az.removeFrontendIPConfigurationFromLoadBalancer(&existingLB, existingLBs, fipConfig, clusterName, service); err != nil {
-				klog.Errorf("getServiceLoadBalancer(%s, %s, %v): failed to remove frontend IP configuration from load balancer: %v", service.Name, clusterName, wantLb, err)
-				return nil, nil, false, err
+			fipConfigNames := []string{}
+			for _, fipConfig := range fipConfigs {
+				fipConfigNames = append(fipConfigNames, pointer.StringDeref(fipConfig.Name, ""))
+			}
+			if err := az.removeFrontendIPConfigurationFromLoadBalancer(&existingLB, existingLBs, fipConfigs, clusterName, service); err != nil {
+				klog.Errorf("getServiceLoadBalancer(%s, %s, %v): failed to remove frontend IP configurations %q from load balancer: %v", service.Name, clusterName, wantLb, fipConfigNames, err)
+				return nil, nil, nil, false, err
 			}
 			break
 		}
 
-		return &existingLB, status, true, nil
+		return &existingLB, status, lbIPsPrimaryPIPs, true, nil
 	}
 
 	// Service does not have a load balancer, select one.
@@ -695,10 +716,10 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 		// select new load balancer for service
 		selectedLB, exists, err := az.selectLoadBalancer(clusterName, service, &existingLBs, nodes)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, nil, false, err
 		}
 
-		return selectedLB, status, exists, err
+		return selectedLB, status, lbIPsPrimaryPIPs, exists, err
 	}
 
 	// create a default LB with meta data if not present
@@ -721,7 +742,7 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 		}
 	}
 
-	return defaultLB, nil, false, nil
+	return defaultLB, nil, nil, false, nil
 }
 
 // selectLoadBalancer selects load balancer for the service in the cluster.
@@ -798,19 +819,25 @@ func (az *Cloud) selectLoadBalancer(clusterName string, service *v1.Service, exi
 	return selectedLB, existsLb, nil
 }
 
-func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.LoadBalancer) (status *v1.LoadBalancerStatus, fipConfig *network.FrontendIPConfiguration, err error) {
+// getServiceLoadBalancerStatus returns LB status for the Service.
+// Before DualStack support, old logic takes the first ingress IP as non-additional one
+// and the second one as additional one. With DualStack support, the second IP may be
+// the IP of another IP family so the new logic returns two variables.
+func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.LoadBalancer) (status *v1.LoadBalancerStatus, lbIPsPrimaryPIPs []string, fipConfigs []*network.FrontendIPConfiguration, err error) {
 	if lb == nil {
 		klog.V(10).Info("getServiceLoadBalancerStatus: lb is nil")
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	if lb.FrontendIPConfigurations == nil || len(*lb.FrontendIPConfigurations) == 0 {
 		klog.V(10).Info("getServiceLoadBalancerStatus: lb.FrontendIPConfigurations is nil")
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
+
 	isInternal := requiresInternalLoadBalancer(service)
 	serviceName := getServiceName(service)
-	for _, ipConfiguration := range *lb.FrontendIPConfigurations {
-		ipConfiguration := ipConfiguration
+	lbIngresses := []v1.LoadBalancerIngress{}
+	for i := range *lb.FrontendIPConfigurations {
+		ipConfiguration := (*lb.FrontendIPConfigurations)[i]
 		owns, isPrimaryService, _ := az.serviceOwnsFrontendIP(ipConfiguration, service)
 		if owns {
 			klog.V(2).Infof("get(%s): lb(%s) - found frontend IP config, primary service: %v", serviceName, pointer.StringDeref(lb.Name, ""), isPrimaryService)
@@ -820,19 +847,19 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 				lbIP = ipConfiguration.PrivateIPAddress
 			} else {
 				if ipConfiguration.PublicIPAddress == nil {
-					return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress is Nil", serviceName, *lb.Name)
+					return nil, nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress is Nil", serviceName, *lb.Name)
 				}
 				pipID := ipConfiguration.PublicIPAddress.ID
 				if pipID == nil {
-					return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress ID is Nil", serviceName, *lb.Name)
+					return nil, nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress ID is Nil", serviceName, *lb.Name)
 				}
 				pipName, err := getLastSegment(*pipID, "/")
 				if err != nil {
-					return nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress Name from ID(%s)", serviceName, *lb.Name, *pipID)
+					return nil, nil, nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress Name from ID(%s)", serviceName, *lb.Name, *pipID)
 				}
 				pip, existsPip, err := az.getPublicIPAddress(az.getPublicIPAddressResourceGroup(service), pipName, azcache.CacheReadTypeDefault)
 				if err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 				if existsPip {
 					lbIP = pip.IPAddress
@@ -841,25 +868,28 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 
 			klog.V(2).Infof("getServiceLoadBalancerStatus gets ingress IP %q from frontendIPConfiguration %q for service %q", pointer.StringDeref(lbIP, ""), pointer.StringDeref(ipConfiguration.Name, ""), serviceName)
 
-			// set additional public IPs to LoadBalancerStatus, so that kube-proxy would create their iptables rules.
-			lbIngress := []v1.LoadBalancerIngress{{IP: pointer.StringDeref(lbIP, "")}}
-			additionalIPs, err := getServiceAdditionalPublicIPs(service)
-			if err != nil {
-				return &v1.LoadBalancerStatus{Ingress: lbIngress}, &ipConfiguration, err
-			}
-			if len(additionalIPs) > 0 {
-				for _, pip := range additionalIPs {
-					lbIngress = append(lbIngress, v1.LoadBalancerIngress{
-						IP: pip,
-					})
-				}
-			}
-
-			return &v1.LoadBalancerStatus{Ingress: lbIngress}, &ipConfiguration, nil
+			lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{IP: pointer.StringDeref(lbIP, "")})
+			lbIPsPrimaryPIPs = append(lbIPsPrimaryPIPs, pointer.StringDeref(lbIP, ""))
+			fipConfigs = append(fipConfigs, &ipConfiguration)
 		}
 	}
+	if len(lbIngresses) == 0 {
+		return nil, nil, nil, nil
+	}
 
-	return nil, nil, nil
+	// set additional public IPs to LoadBalancerStatus, so that kube-proxy would create their iptables rules.
+	additionalIPs, err := getServiceAdditionalPublicIPs(service)
+	if err != nil {
+		return &v1.LoadBalancerStatus{Ingress: lbIngresses}, lbIPsPrimaryPIPs, fipConfigs, err
+	}
+	if len(additionalIPs) > 0 {
+		for _, pip := range additionalIPs {
+			lbIngresses = append(lbIngresses, v1.LoadBalancerIngress{
+				IP: pip,
+			})
+		}
+	}
+	return &v1.LoadBalancerStatus{Ingress: lbIngresses}, lbIPsPrimaryPIPs, fipConfigs, nil
 }
 
 func (az *Cloud) determinePublicIPName(clusterName string, service *v1.Service, isIPv6 bool) (string, bool, error) {
@@ -982,39 +1012,14 @@ func flipServiceInternalAnnotation(service *v1.Service) *v1.Service {
 	return copyService
 }
 
-func updateServiceLoadBalancerIP(service *v1.Service, serviceIP string) *v1.Service {
+func updateServiceLoadBalancerIPs(service *v1.Service, serviceIPs []string) *v1.Service {
 	copyService := service.DeepCopy()
-	if len(serviceIP) > 0 && copyService != nil {
-		setServiceLoadBalancerIP(copyService, serviceIP)
+	if copyService != nil {
+		for _, serviceIP := range serviceIPs {
+			setServiceLoadBalancerIP(copyService, serviceIP)
+		}
 	}
 	return copyService
-}
-
-func (az *Cloud) findServiceIPAddress(ctx context.Context, clusterName string, service *v1.Service) (string, error) {
-	isIPv6 := utilnet.IsIPv6String(service.Spec.ClusterIP)
-	lbIP := getServiceLoadBalancerIP(service, isIPv6)
-	if len(lbIP) > 0 {
-		return lbIP, nil
-	}
-
-	if len(service.Status.LoadBalancer.Ingress) > 0 && len(service.Status.LoadBalancer.Ingress[0].IP) > 0 {
-		return service.Status.LoadBalancer.Ingress[0].IP, nil
-	}
-
-	_, lbStatus, existsLb, err := az.getServiceLoadBalancer(service, clusterName, nil, false, []network.LoadBalancer{})
-	if err != nil {
-		return "", err
-	}
-	if !existsLb {
-		klog.V(2).Infof("Expected to find an IP address for service %s but did not. Assuming it has been removed", service.Name)
-		return "", nil
-	}
-	if len(lbStatus.Ingress) < 1 {
-		klog.V(2).Infof("Expected to find an IP address for service %s but it had no ingresses. Assuming it has been removed", service.Name)
-		return "", nil
-	}
-
-	return lbStatus.Ingress[0].IP, nil
 }
 
 func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domainNameLabel, clusterName string, shouldPIPExisted, foundDNSLabelAnnotation, isIPv6 bool) (*network.PublicIPAddress, error) {
@@ -1080,7 +1085,7 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		}
 	} else {
 		if shouldPIPExisted {
-			return nil, fmt.Errorf("PublicIP from annotation azure-pip-name=%s for service %s doesn't exist", pipName, serviceName)
+			return nil, fmt.Errorf("PublicIP from annotation azure-pip-name(-IPv6)=%s for service %s doesn't exist", pipName, serviceName)
 		}
 
 		changed = true
@@ -1595,7 +1600,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		return nil, err
 	}
 
-	lb, lbStatus, _, err := az.getServiceLoadBalancer(service, clusterName, nodes, wantLb, existingLBs)
+	lb, lbStatus, _, _, err := az.getServiceLoadBalancer(service, clusterName, nodes, wantLb, existingLBs)
 	if err != nil {
 		klog.Errorf("reconcileLoadBalancer: failed to get load balancer for service %q, error: %v", serviceName, err)
 		return nil, err
@@ -1683,7 +1688,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		if err = az.checkLoadBalancerResourcesConflicts(lb, lbFrontendIPConfigIDs[false], service); err != nil {
 			return nil, err
 		}
-		if err := getExpectedLBRule(false); err != nil {
+		if err := getExpectedLBRule(consts.IPVersionIPv4); err != nil {
 			return nil, err
 		}
 	}
@@ -1691,7 +1696,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 		if err = az.checkLoadBalancerResourcesConflicts(lb, lbFrontendIPConfigIDs[true], service); err != nil {
 			return nil, err
 		}
-		if err := getExpectedLBRule(true); err != nil {
+		if err := getExpectedLBRule(consts.IPVersionIPv6); err != nil {
 			return nil, err
 		}
 	}
@@ -1703,7 +1708,6 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	if changed := az.reconcileLBRules(lb, service, serviceName, wantLb, expectedRules); changed {
 		dirtyLb = true
 	}
-
 	if changed := az.ensureLoadBalancerTagged(lb); changed {
 		dirtyLb = true
 	}
@@ -1982,7 +1986,8 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string,
 		}
 
 		addNewFIPOfService := func(isIPv6 bool) error {
-			klog.V(4).Infof("ensure(%s): lb(%s) - creating a new frontend IP config (isIPv6=%t)", serviceName, lbName, isIPv6)
+			klog.V(4).Infof("ensure(%s): lb(%s) - creating a new frontend IP config %q (isIPv6=%t)",
+				serviceName, lbName, lbFrontendIPConfigNames[isIPv6], isIPv6)
 
 			// construct FrontendIPConfigurationPropertiesFormat
 			var fipConfigurationProperties *network.FrontendIPConfigurationPropertiesFormat
@@ -2400,7 +2405,7 @@ func (az *Cloud) getExpectedLoadBalancingRulePropertiesForPort(
 
 	// Azure ILB does not support secondary IPs as floating IPs on the LB. Therefore, floating IP needs to be turned
 	// off and the rule should point to the nodeIP:nodePort.
-	if consts.IsK8sServiceInternalIPv6(service) {
+	if consts.IsK8sServiceUsingInternalLoadBalancer(service) && isBackendPoolIPv6(lbBackendPoolID) {
 		props.BackendPort = pointer.Int32(servicePort.NodePort)
 		props.EnableFloatingIP = pointer.Bool(false)
 	}
@@ -2422,7 +2427,7 @@ func (az *Cloud) getExpectedHAModeLoadBalancingRuleProperties(
 
 // This reconciles the Network Security Group similar to how the LB is reconciled.
 // This entails adding required, missing SecurityRules and removing stale rules.
-func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service, lbIP *string, lbName *string, wantLb bool) (*network.SecurityGroup, error) {
+func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service, lbIPs *[]string, lbName *string, wantLb bool) (*network.SecurityGroup, error) {
 	serviceName := getServiceName(service)
 	klog.V(5).Infof("reconcileSecurityGroup(%s): START clusterName=%q", serviceName, clusterName)
 
@@ -2440,16 +2445,26 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		return nil, err
 	}
 
-	destinationIPAddress := ""
-	if wantLb && lbIP == nil {
+	if wantLb && lbIPs == nil {
 		return nil, fmt.Errorf("no load balancer IP for setting up security rules for service %s", service.Name)
 	}
-	if lbIP != nil {
-		destinationIPAddress = *lbIP
+
+	destinationIPAddresses := map[bool][]string{}
+	if lbIPs != nil {
+		for _, ip := range *lbIPs {
+			if net.ParseIP(ip).To4() != nil {
+				destinationIPAddresses[false] = append(destinationIPAddresses[false], ip)
+			} else {
+				destinationIPAddresses[true] = append(destinationIPAddresses[true], ip)
+			}
+		}
 	}
 
-	if destinationIPAddress == "" {
-		destinationIPAddress = "*"
+	if len(destinationIPAddresses[false]) == 0 {
+		destinationIPAddresses[false] = []string{"*"}
+	}
+	if len(destinationIPAddresses[true]) == 0 {
+		destinationIPAddresses[true] = []string{"*"}
 	}
 
 	disableFloatingIP := false
@@ -2457,7 +2472,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		disableFloatingIP = true
 	}
 
-	backendIPAddresses := make([]string, 0)
+	backendIPAddresses := map[bool][]string{}
 	if wantLb && disableFloatingIP {
 		lb, exist, err := az.getAzureLoadBalancer(pointer.StringDeref(lbName, ""), azcache.CacheReadTypeDefault)
 		if err != nil {
@@ -2466,21 +2481,18 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		if !exist {
 			return nil, fmt.Errorf("unable to get lb %s", pointer.StringDeref(lbName, ""))
 		}
-		backendPrivateIPv4s, backendPrivateIPv6s := az.LoadBalancerBackendPool.GetBackendPrivateIPs(clusterName, service, lb)
-		backendIPAddresses = backendPrivateIPv4s
-		if utilnet.IsIPv6String(*lbIP) {
-			backendIPAddresses = backendPrivateIPv6s
-		}
+		backendIPAddresses[false], backendIPAddresses[true] = az.LoadBalancerBackendPool.GetBackendPrivateIPs(clusterName, service, lb)
 	}
 
 	additionalIPs, err := getServiceAdditionalPublicIPs(service)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get additional public IPs, error=%w", err)
 	}
-
-	destinationIPAddresses := []string{destinationIPAddress}
-	if destinationIPAddress != "*" {
-		destinationIPAddresses = append(destinationIPAddresses, additionalIPs...)
+	for _, ip := range additionalIPs {
+		isIPv6 := net.ParseIP(ip).To4() == nil
+		if len(destinationIPAddresses[isIPv6]) != 1 || destinationIPAddresses[isIPv6][0] != "*" {
+			destinationIPAddresses[isIPv6] = append(destinationIPAddresses[isIPv6], ip)
+		}
 	}
 
 	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(service)
@@ -2492,21 +2504,40 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		delete(sourceRanges, consts.DefaultLoadBalancerSourceRanges)
 	}
 
-	var sourceAddressPrefixes []string
+	sourceAddressPrefixes := map[bool][]string{}
 	if (sourceRanges == nil || servicehelpers.IsAllowAll(sourceRanges)) && len(serviceTags) == 0 {
 		if !requiresInternalLoadBalancer(service) || len(service.Spec.LoadBalancerSourceRanges) > 0 {
-			sourceAddressPrefixes = []string{"Internet"}
+			sourceAddressPrefixes[false] = []string{"Internet"}
+			sourceAddressPrefixes[true] = []string{"Internet"}
 		}
 	} else {
 		for _, ip := range sourceRanges {
-			sourceAddressPrefixes = append(sourceAddressPrefixes, ip.String())
+			if ip == nil {
+				continue
+			}
+			isIPv6 := net.ParseIP(ip.IP.String()).To4() == nil
+			sourceAddressPrefixes[isIPv6] = append(sourceAddressPrefixes[isIPv6], ip.String())
 		}
-		sourceAddressPrefixes = append(sourceAddressPrefixes, serviceTags...)
+		sourceAddressPrefixes[false] = append(sourceAddressPrefixes[false], serviceTags...)
+		sourceAddressPrefixes[true] = append(sourceAddressPrefixes[true], serviceTags...)
 	}
 
-	expectedSecurityRules, err := az.getExpectedSecurityRules(wantLb, ports, sourceAddressPrefixes, service, destinationIPAddresses, sourceRanges, backendIPAddresses, disableFloatingIP)
-	if err != nil {
-		return nil, err
+	expectedSecurityRules := []network.SecurityRule{}
+	handleSecurityRules := func(isIPv6 bool) error {
+		expectedSecurityRulesSingleStack, err := az.getExpectedSecurityRules(wantLb, ports, sourceAddressPrefixes[isIPv6], service, destinationIPAddresses[isIPv6], sourceRanges, backendIPAddresses[isIPv6], disableFloatingIP, isIPv6)
+		expectedSecurityRules = append(expectedSecurityRules, expectedSecurityRulesSingleStack...)
+		return err
+	}
+	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
+	if v4Enabled {
+		if err := handleSecurityRules(false); err != nil {
+			return nil, err
+		}
+	}
+	if v6Enabled {
+		if err := handleSecurityRules(true); err != nil {
+			return nil, err
+		}
 	}
 
 	// update security rules
@@ -2535,7 +2566,14 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	return &sg, nil
 }
 
-func (az *Cloud) reconcileSecurityRules(sg network.SecurityGroup, service *v1.Service, serviceName string, wantLb bool, expectedSecurityRules []network.SecurityRule, ports []v1.ServicePort, sourceAddressPrefixes []string, destinationIPAddresses []string) (bool, []network.SecurityRule, error) {
+func (az *Cloud) reconcileSecurityRules(sg network.SecurityGroup,
+	service *v1.Service,
+	serviceName string,
+	wantLb bool,
+	expectedSecurityRules []network.SecurityRule,
+	ports []v1.ServicePort,
+	sourceAddressPrefixes, destinationIPAddresses map[bool][]string,
+) (bool, []network.SecurityRule, error) {
 	dirtySg := false
 	var updatedRules []network.SecurityRule
 	if sg.SecurityGroupPropertiesFormat != nil && sg.SecurityGroupPropertiesFormat.SecurityRules != nil {
@@ -2567,46 +2605,57 @@ func (az *Cloud) reconcileSecurityRules(sg network.SecurityGroup, service *v1.Se
 
 	// update security rules: if the service uses a shared rule and is being deleted,
 	// then remove it from the shared rule
-	if useSharedSecurityRule(service) && !wantLb {
-		for _, port := range ports {
-			for _, sourceAddressPrefix := range sourceAddressPrefixes {
-				sharedRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefix, utilnet.IsIPv6String(service.Spec.ClusterIP))
-				sharedIndex, sharedRule, sharedRuleFound := findSecurityRuleByName(updatedRules, sharedRuleName)
-				if !sharedRuleFound {
-					klog.V(4).Infof("Didn't find shared rule %s for service %s", sharedRuleName, service.Name)
-					continue
-				}
-				shouldDeleteNSGRule := false
-				if sharedRule.DestinationAddressPrefixes == nil || len(*sharedRule.DestinationAddressPrefixes) == 0 {
-					shouldDeleteNSGRule = true
-				} else {
-					existingPrefixes := *sharedRule.DestinationAddressPrefixes
-					for _, destinationIPAddress := range destinationIPAddresses {
-						addressIndex, found := findIndex(existingPrefixes, destinationIPAddress)
-						if !found {
-							klog.Warningf("Didn't find destination address %v in shared rule %s for service %s", destinationIPAddress, sharedRuleName, service.Name)
-							continue
-						}
-						if len(existingPrefixes) == 1 {
-							shouldDeleteNSGRule = true
-							break //shared nsg rule has only one entry and entry owned by deleted svc has been found. skip the rest of the entries
-						} else {
-							newDestinations := append(existingPrefixes[:addressIndex], existingPrefixes[addressIndex+1:]...)
-							sharedRule.DestinationAddressPrefixes = &newDestinations
-							updatedRules[sharedIndex] = sharedRule
-						}
-						dirtySg = true
+	handleRule := func(isIPv6 bool) {
+		if useSharedSecurityRule(service) && !wantLb {
+			for _, port := range ports {
+				for _, sourceAddressPrefix := range sourceAddressPrefixes[isIPv6] {
+					sharedRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefix, isIPv6)
+					sharedIndex, sharedRule, sharedRuleFound := findSecurityRuleByName(updatedRules, sharedRuleName)
+					if !sharedRuleFound {
+						klog.V(4).Infof("Didn't find shared rule %s for service %s", sharedRuleName, service.Name)
+						continue
 					}
-				}
+					shouldDeleteNSGRule := false
+					if sharedRule.SecurityRulePropertiesFormat == nil ||
+						sharedRule.SecurityRulePropertiesFormat.DestinationAddressPrefixes == nil ||
+						len(*sharedRule.SecurityRulePropertiesFormat.DestinationAddressPrefixes) == 0 {
+						shouldDeleteNSGRule = true
+					} else {
+						existingPrefixes := *sharedRule.DestinationAddressPrefixes
+						for _, destinationIPAddress := range destinationIPAddresses[isIPv6] {
+							addressIndex, found := findIndex(existingPrefixes, destinationIPAddress)
+							if !found {
+								klog.Warningf("Didn't find destination address %v in shared rule %s for service %s", destinationIPAddress, sharedRuleName, service.Name)
+								continue
+							}
+							if len(existingPrefixes) == 1 {
+								shouldDeleteNSGRule = true
+								break //shared nsg rule has only one entry and entry owned by deleted svc has been found. skip the rest of the entries
+							} else {
+								newDestinations := append(existingPrefixes[:addressIndex], existingPrefixes[addressIndex+1:]...)
+								sharedRule.DestinationAddressPrefixes = &newDestinations
+								updatedRules[sharedIndex] = sharedRule
+							}
+							dirtySg = true
+						}
+					}
 
-				if shouldDeleteNSGRule {
-					klog.V(4).Infof("shared rule will be deleted because last service %s which refers this rule is deleted.", service.Name)
-					updatedRules = append(updatedRules[:sharedIndex], updatedRules[sharedIndex+1:]...)
-					dirtySg = true
-					continue
+					if shouldDeleteNSGRule {
+						klog.V(4).Infof("shared rule will be deleted because last service %s which refers this rule is deleted.", service.Name)
+						updatedRules = append(updatedRules[:sharedIndex], updatedRules[sharedIndex+1:]...)
+						dirtySg = true
+						continue
+					}
 				}
 			}
 		}
+	}
+	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
+	if v4Enabled {
+		handleRule(consts.IPVersionIPv4)
+	}
+	if v6Enabled {
+		handleRule(consts.IPVersionIPv6)
 	}
 
 	// update security rules: prepare rules for consolidation
@@ -2655,10 +2704,11 @@ func (az *Cloud) reconcileSecurityRules(sg network.SecurityGroup, service *v1.Se
 	for _, r := range updatedRules {
 		klog.V(10).Infof("Updated security rule while processing %s: %s:%s -> %s:%s", service.Name, logSafe(r.SourceAddressPrefix), logSafe(r.SourcePortRange), logSafeCollection(r.DestinationAddressPrefix, r.DestinationAddressPrefixes), logSafe(r.DestinationPortRange))
 	}
+
 	return dirtySg, updatedRules, nil
 }
 
-func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, sourceAddressPrefixes []string, service *v1.Service, destinationIPAddresses []string, sourceRanges utilnet.IPNetSet, backendIPAddresses []string, disableFloatingIP bool) ([]network.SecurityRule, error) {
+func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, sourceAddressPrefixes []string, service *v1.Service, destinationIPAddresses []string, sourceRanges utilnet.IPNetSet, backendIPAddresses []string, disableFloatingIP, isIPv6 bool) ([]network.SecurityRule, error) {
 	expectedSecurityRules := []network.SecurityRule{}
 
 	if wantLb {
@@ -2675,7 +2725,7 @@ func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, s
 			}
 			for j := range sourceAddressPrefixes {
 				ix := i*len(sourceAddressPrefixes) + j
-				securityRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefixes[j], utilnet.IsIPv6String(service.Spec.ClusterIP))
+				securityRuleName := az.getSecurityRuleName(service, port, sourceAddressPrefixes[j], isIPv6)
 				nsgRule := network.SecurityRule{
 					Name: pointer.String(securityRuleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
@@ -2712,7 +2762,7 @@ func (az *Cloud) getExpectedSecurityRules(wantLb bool, ports []v1.ServicePort, s
 				if err != nil {
 					return nil, err
 				}
-				securityRuleName := az.getSecurityRuleName(service, port, "deny_all", utilnet.IsIPv6String(service.Spec.ClusterIP))
+				securityRuleName := az.getSecurityRuleName(service, port, "deny_all", isIPv6)
 				nsgRule := network.SecurityRule{
 					Name: pointer.String(securityRuleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
@@ -2747,7 +2797,7 @@ func (az *Cloud) shouldUpdateLoadBalancer(clusterName string, service *v1.Servic
 		return false, fmt.Errorf("shouldUpdateLoadBalancer: failed to list managed load balancers: %w", err)
 	}
 
-	_, _, existsLb, _ := az.getServiceLoadBalancer(service, clusterName, nodes, false, existingManagedLBs)
+	_, _, _, existsLb, _ := az.getServiceLoadBalancer(service, clusterName, nodes, false, existingManagedLBs)
 	return existsLb && service.ObjectMeta.DeletionTimestamp == nil && service.Spec.Type == v1.ServiceTypeLoadBalancer, nil
 }
 
@@ -3120,6 +3170,9 @@ func (az *Cloud) getPublicIPUpdates(
 			}
 		}
 
+		if pip.Name == nil {
+			return false, nil, false, nil, fmt.Errorf("PIP name is empty: %v", pip)
+		}
 		pipName := *pip.Name
 
 		// If we've been told to use a specific public ip by the client, let's track whether or not it actually existed

--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -767,6 +767,7 @@ func newBackendPool(lb *network.LoadBalancer, isBackendPoolPreConfigured bool, p
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{},
 	})
 
+	// Always returns false
 	return isBackendPoolPreConfigured
 }
 

--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -85,14 +85,8 @@ func isLBBackendPoolsExisting(lbBackendPoolNames map[bool]string, bpName *string
 func (bc *backendPoolTypeNodeIPConfig) CleanupVMSetFromBackendPoolByCondition(slb *network.LoadBalancer, service *v1.Service, nodes []*v1.Node, clusterName string, shouldRemoveVMSetFromSLB func(string) bool) (*network.LoadBalancer, error) {
 	v4Enabled, v6Enabled := getIPFamiliesEnabled(service)
 
-	lbBackendPoolNames := map[bool]string{
-		consts.IPVersionIPv4: getBackendPoolName(clusterName, consts.IPVersionIPv4),
-		consts.IPVersionIPv6: getBackendPoolName(clusterName, consts.IPVersionIPv6),
-	}
-	lbBackendPoolIDs := map[bool]string{
-		consts.IPVersionIPv4: bc.getBackendPoolID(pointer.StringDeref(slb.Name, ""), lbBackendPoolNames[consts.IPVersionIPv4]),
-		consts.IPVersionIPv6: bc.getBackendPoolID(pointer.StringDeref(slb.Name, ""), lbBackendPoolNames[consts.IPVersionIPv6]),
-	}
+	lbBackendPoolNames := getBackendPoolNames(clusterName)
+	lbBackendPoolIDs := bc.getBackendPoolIDs(clusterName, pointer.StringDeref(slb.Name, ""))
 	newBackendPools := make([]network.BackendAddressPool, 0)
 	if slb.LoadBalancerPropertiesFormat != nil && slb.BackendAddressPools != nil {
 		newBackendPools = *slb.BackendAddressPools
@@ -175,14 +169,8 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 	lbName := *lb.Name
 
 	serviceName := getServiceName(service)
-	lbBackendPoolNames := map[bool]string{
-		false: getBackendPoolName(clusterName, false),
-		true:  getBackendPoolName(clusterName, true),
-	}
-	lbBackendPoolIDs := map[bool]string{
-		false: bc.getBackendPoolID(lbName, lbBackendPoolNames[false]),
-		true:  bc.getBackendPoolID(lbName, lbBackendPoolNames[true]),
-	}
+	lbBackendPoolNames := getBackendPoolNames(clusterName)
+	lbBackendPoolIDs := bc.getBackendPoolIDs(clusterName, lbName)
 	vmSetName := bc.mapLoadBalancerNameToVMSet(lbName, clusterName)
 	isBackendPoolPreConfigured := bc.isBackendPoolPreConfigured(service)
 
@@ -347,10 +335,7 @@ func getBackendIPConfigurationsToBeDeleted(
 
 func (bc *backendPoolTypeNodeIPConfig) GetBackendPrivateIPs(clusterName string, service *v1.Service, lb *network.LoadBalancer) ([]string, []string) {
 	serviceName := getServiceName(service)
-	lbBackendPoolNames := map[bool]string{
-		false: getBackendPoolName(clusterName, false),
-		true:  getBackendPoolName(clusterName, true),
-	}
+	lbBackendPoolNames := getBackendPoolNames(clusterName)
 	if lb.LoadBalancerPropertiesFormat == nil || lb.LoadBalancerPropertiesFormat.BackendAddressPools == nil {
 		return nil, nil
 	}
@@ -509,10 +494,7 @@ func (bi *backendPoolTypeNodeIP) EnsureHostsInPool(service *v1.Service, nodes []
 }
 
 func (bi *backendPoolTypeNodeIP) CleanupVMSetFromBackendPoolByCondition(slb *network.LoadBalancer, service *v1.Service, nodes []*v1.Node, clusterName string, shouldRemoveVMSetFromSLB func(string) bool) (*network.LoadBalancer, error) {
-	lbBackendPoolNames := map[bool]string{
-		false: getBackendPoolName(clusterName, false),
-		true:  getBackendPoolName(clusterName, true),
-	}
+	lbBackendPoolNames := getBackendPoolNames(clusterName)
 	newBackendPools := make([]network.BackendAddressPool, 0)
 	if slb.LoadBalancerPropertiesFormat != nil && slb.BackendAddressPools != nil {
 		newBackendPools = *slb.BackendAddressPools
@@ -580,15 +562,9 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 	foundBackendPools := map[bool]bool{}
 	lbName := *lb.Name
 	serviceName := getServiceName(service)
-	lbBackendPoolNames := map[bool]string{
-		false: getBackendPoolName(clusterName, false),
-		true:  getBackendPoolName(clusterName, true),
-	}
+	lbBackendPoolNames := getBackendPoolNames(clusterName)
 	vmSetName := bi.mapLoadBalancerNameToVMSet(lbName, clusterName)
-	lbBackendPoolIDs := map[bool]string{
-		false: bi.getBackendPoolID(pointer.StringDeref(lb.Name, ""), lbBackendPoolNames[false]),
-		true:  bi.getBackendPoolID(pointer.StringDeref(lb.Name, ""), lbBackendPoolNames[true]),
-	}
+	lbBackendPoolIDs := bi.getBackendPoolIDs(clusterName, pointer.StringDeref(lb.Name, ""))
 	isBackendPoolPreConfigured := bi.isBackendPoolPreConfigured(service)
 
 	mc := metrics.NewMetricContext("services", "migrate_to_ip_based_backend_pool", bi.ResourceGroup, bi.getNetworkResourceSubscriptionID(), serviceName)
@@ -742,10 +718,7 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 
 func (bi *backendPoolTypeNodeIP) GetBackendPrivateIPs(clusterName string, service *v1.Service, lb *network.LoadBalancer) ([]string, []string) {
 	serviceName := getServiceName(service)
-	lbBackendPoolNames := map[bool]string{
-		false: getBackendPoolName(clusterName, false),
-		true:  getBackendPoolName(clusterName, true),
-	}
+	lbBackendPoolNames := getBackendPoolNames(clusterName)
 	if lb.LoadBalancerPropertiesFormat == nil || lb.LoadBalancerPropertiesFormat.BackendAddressPools == nil {
 		return nil, nil
 	}

--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -89,10 +89,9 @@ func (bc *backendPoolTypeNodeIPConfig) CleanupVMSetFromBackendPoolByCondition(sl
 		consts.IPVersionIPv4: getBackendPoolName(clusterName, consts.IPVersionIPv4),
 		consts.IPVersionIPv6: getBackendPoolName(clusterName, consts.IPVersionIPv6),
 	}
-	lbResourceGroup := bc.getLoadBalancerResourceGroup()
 	lbBackendPoolIDs := map[bool]string{
-		consts.IPVersionIPv4: bc.getBackendPoolID(pointer.StringDeref(slb.Name, ""), lbResourceGroup, lbBackendPoolNames[consts.IPVersionIPv4]),
-		consts.IPVersionIPv6: bc.getBackendPoolID(pointer.StringDeref(slb.Name, ""), lbResourceGroup, lbBackendPoolNames[consts.IPVersionIPv6]),
+		consts.IPVersionIPv4: bc.getBackendPoolID(pointer.StringDeref(slb.Name, ""), lbBackendPoolNames[consts.IPVersionIPv4]),
+		consts.IPVersionIPv6: bc.getBackendPoolID(pointer.StringDeref(slb.Name, ""), lbBackendPoolNames[consts.IPVersionIPv6]),
 	}
 	newBackendPools := make([]network.BackendAddressPool, 0)
 	if slb.LoadBalancerPropertiesFormat != nil && slb.BackendAddressPools != nil {
@@ -181,8 +180,8 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 		true:  getBackendPoolName(clusterName, true),
 	}
 	lbBackendPoolIDs := map[bool]string{
-		false: bc.getBackendPoolID(lbName, bc.getLoadBalancerResourceGroup(), lbBackendPoolNames[false]),
-		true:  bc.getBackendPoolID(lbName, bc.getLoadBalancerResourceGroup(), lbBackendPoolNames[true]),
+		false: bc.getBackendPoolID(lbName, lbBackendPoolNames[false]),
+		true:  bc.getBackendPoolID(lbName, lbBackendPoolNames[true]),
 	}
 	vmSetName := bc.mapLoadBalancerNameToVMSet(lbName, clusterName)
 	isBackendPoolPreConfigured := bc.isBackendPoolPreConfigured(service)
@@ -587,8 +586,8 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 	}
 	vmSetName := bi.mapLoadBalancerNameToVMSet(lbName, clusterName)
 	lbBackendPoolIDs := map[bool]string{
-		false: bi.getBackendPoolID(pointer.StringDeref(lb.Name, ""), bi.getLoadBalancerResourceGroup(), lbBackendPoolNames[false]),
-		true:  bi.getBackendPoolID(pointer.StringDeref(lb.Name, ""), bi.getLoadBalancerResourceGroup(), lbBackendPoolNames[true]),
+		false: bi.getBackendPoolID(pointer.StringDeref(lb.Name, ""), lbBackendPoolNames[false]),
+		true:  bi.getBackendPoolID(pointer.StringDeref(lb.Name, ""), lbBackendPoolNames[true]),
 	}
 	isBackendPoolPreConfigured := bi.isBackendPoolPreConfigured(service)
 

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1653,7 +1653,7 @@ func TestGetServiceTags(t *testing.T) {
 	}
 }
 
-func TestGetServiceLoadBalancer(t *testing.T) {
+func TestGetServiceLoadBalancerCommon(t *testing.T) {
 	testCases := []struct {
 		desc           string
 		sku            string
@@ -1821,7 +1821,7 @@ func TestGetServiceLoadBalancer(t *testing.T) {
 			}
 			az.LoadBalancerSku = test.sku
 			service := test.service
-			lb, status, exists, err := az.getServiceLoadBalancer(&service, testClusterName,
+			lb, status, _, exists, err := az.getServiceLoadBalancer(&service, testClusterName,
 				clusterResources.nodes, test.wantLB, []network.LoadBalancer{})
 			assert.Equal(t, test.expectedLB, lb)
 			assert.Equal(t, test.expectedStatus, status)
@@ -1854,7 +1854,7 @@ func TestGetServiceLoadBalancerWithExtendedLocation(t *testing.T) {
 	mockLBsClient.EXPECT().List(gomock.Any(), "rg").Return(nil, nil)
 	az.LoadBalancerClient = mockLBsClient
 
-	lb, status, exists, err := az.getServiceLoadBalancer(&service, testClusterName,
+	lb, status, _, exists, err := az.getServiceLoadBalancer(&service, testClusterName,
 		clusterResources.nodes, false, []network.LoadBalancer{})
 	assert.Equal(t, expectedLB, lb, "GetServiceLoadBalancer shall return a default LB with expected location.")
 	assert.Nil(t, status, "GetServiceLoadBalancer: Status should be nil for default LB.")
@@ -1879,7 +1879,7 @@ func TestGetServiceLoadBalancerWithExtendedLocation(t *testing.T) {
 	mockLBsClient.EXPECT().List(gomock.Any(), "rg").Return(nil, nil)
 	az.LoadBalancerClient = mockLBsClient
 
-	lb, status, exists, err = az.getServiceLoadBalancer(&service, testClusterName,
+	lb, status, _, exists, err = az.getServiceLoadBalancer(&service, testClusterName,
 		clusterResources.nodes, true, []network.LoadBalancer{})
 	assert.Equal(t, expectedLB, lb, "GetServiceLoadBalancer shall return a new LB with expected location.")
 	assert.Nil(t, status, "GetServiceLoadBalancer: Status should be nil for new LB.")
@@ -2312,7 +2312,7 @@ func TestDeterminePublicIPName(t *testing.T) {
 	}
 }
 
-func TestReconcileLoadBalancerRule(t *testing.T) {
+func TestReconcileLoadBalancerRuleCommon(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -2328,14 +2328,14 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 	}{
 		{
 			desc:            "getExpectedLBRules shall return corresponding probe and lbRule(blb)",
-			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{}, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{}, 80),
 			loadBalancerSku: "basic",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getDefaultTestRules(false),
 		},
 		{
 			desc:            "getExpectedLBRules shall return tcp probe on non supported protocols when basic lb sku is used",
-			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{}, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{}, 80),
 			loadBalancerSku: "basic",
 			probeProtocol:   "Mongodb",
 			expectedRules:   getDefaultTestRules(false),
@@ -2343,7 +2343,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc:            "getExpectedLBRules shall return tcp probe on https protocols when basic lb sku is used",
-			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{}, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{}, 80),
 			loadBalancerSku: "basic",
 			probeProtocol:   "Https",
 			expectedRules:   getDefaultTestRules(false),
@@ -2351,20 +2351,20 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc:            "getExpectedLBRules shall return error (slb with external mode and SCTP)",
-			service:         getTestService("test1", v1.ProtocolSCTP, map[string]string{}, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolSCTP, map[string]string{}, 80),
 			loadBalancerSku: "standard",
 			expectedErr:     true,
 		},
 		{
 			desc:            "getExpectedLBRules shall return corresponding probe and lbRule(slb with tcp reset)",
-			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			loadBalancerSku: "standard",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
 			desc:            "getExpectedLBRules shall respect the probe protocol and path configuration in the config file",
-			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Http",
 			probePath:       "/healthy",
@@ -2373,7 +2373,7 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc:            "getExpectedLBRules shall respect the probe protocol and path configuration in the config file",
-			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Https",
 			probePath:       "/healthy1",
@@ -2386,50 +2386,53 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 				consts.ServiceAnnotationLoadBalancerInternal: "true",
 			}, true, 80),
 			loadBalancerSku: "standard",
-			expectedProbes:  getDefaultTestProbes("Tcp", ""),
-			expectedRules:   getDefaultInternalIPv6Rules(true),
+			expectedProbes: map[bool][]network.Probe{
+				// Use false as IPv6 param but it is a IPv6 probe.
+				true: {getTestProbe("Tcp", "", pointer.Int32(5), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(2), false)},
+			},
+			expectedRules: getDefaultInternalIPv6Rules(true),
 		},
 		{
 			desc: "getExpectedLBRules shall return corresponding probe and lbRule (slb with HA enabled)",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
 				consts.ServiceAnnotationLoadBalancerInternal:                    "true",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules: map[bool][]network.LoadBalancingRule{
-				consts.IPVersionIPv4: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv4),
-				consts.IPVersionIPv6: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv6),
+				consts.IPVersionIPv4: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv4, true),
+				consts.IPVersionIPv6: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv6, true),
 			},
 		},
 		{
 			desc: "getExpectedLBRules shall return corresponding probe and lbRule (slb with HA mode and SCTP)",
-			service: getTestService("test1", v1.ProtocolSCTP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolSCTP, map[string]string{
 				consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
 				consts.ServiceAnnotationLoadBalancerInternal:                    "true",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			expectedRules: map[bool][]network.LoadBalancingRule{
-				consts.IPVersionIPv4: getHATestRules(true, false, v1.ProtocolSCTP, consts.IPVersionIPv4),
-				consts.IPVersionIPv6: getHATestRules(true, false, v1.ProtocolSCTP, consts.IPVersionIPv6),
+				consts.IPVersionIPv4: getHATestRules(true, false, v1.ProtocolSCTP, consts.IPVersionIPv4, true),
+				consts.IPVersionIPv6: getHATestRules(true, false, v1.ProtocolSCTP, consts.IPVersionIPv6, true),
 			},
 		},
 		{
 			desc: "getExpectedLBRules shall return corresponding probe and lbRule (slb with HA enabled multi-ports services)",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
 				consts.ServiceAnnotationLoadBalancerInternal:                    "true",
-			}, false, 80, 8080),
+			}, 80, 8080),
 			loadBalancerSku: "standard",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules: map[bool][]network.LoadBalancingRule{
-				consts.IPVersionIPv4: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv4),
-				consts.IPVersionIPv6: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv6),
+				consts.IPVersionIPv4: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv4, true),
+				consts.IPVersionIPv6: getHATestRules(true, true, v1.ProtocolTCP, consts.IPVersionIPv6, true),
 			},
 		},
 		{
 			desc:            "getExpectedLBRules should leave probe path empty when using TCP probe",
-			service:         getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
@@ -2437,9 +2440,9 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should return tcp probe when invalid protocol is defined",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsRequestPath): "/healthy1",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "TCP1",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
@@ -2447,9 +2450,9 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should return tcp probe when invalid protocol is defined",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsRequestPath): "/healthy1",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "basic",
 			probeProtocol:   "TCP1",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
@@ -2457,39 +2460,39 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsRequestPath): "/healthy1",
 				consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:                              "https",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			expectedProbes:  getDefaultTestProbes("Https", "/healthy1"),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
 			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsRequestPath): "/healthy1",
 				consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:                              "http",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			expectedProbes:  getDefaultTestProbes("Http", "/healthy1"),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
 			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsRequestPath): "/healthy1",
 				consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:                              "tcp",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			expectedProbes:  getDefaultTestProbes("Tcp", ""),
 			expectedRules:   getDefaultTestRules(true),
 		},
 		{
 			desc: "getExpectedLBRules should return correct rule when deprecated annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsRequestPath): "/healthy1",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Https",
 			expectedProbes:  getDefaultTestProbes("Https", "/healthy1"),
@@ -2497,10 +2500,10 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should overwrite value defined in deprecated annotation when deprecated annotations and probe path are defined",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.ServiceAnnotationLoadBalancerHealthProbeRequestPath:                           "/healthy1",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsRequestPath): "/healthy2",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Https",
 			expectedProbes:  getDefaultTestProbes("Https", "/healthy2"),
@@ -2508,32 +2511,32 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should return error when probe interval * num > 120",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "10",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "20",
 				consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:                                "https",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedErr:     true,
 		},
 		{
 			desc: "getExpectedLBRules should return error when probe interval * num ==  120",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "10",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "20",
 				consts.ServiceAnnotationLoadBalancerHealthProbeProtocol:                                "tcp",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedErr:     true,
 		},
 		{
 			desc: "getExpectedLBRules should return correct rule when health probe annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "20",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "5",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Https",
 			probePath:       "/healthy1",
@@ -2542,10 +2545,10 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should return correct rule when health probe annotations are added,default path should be /",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "20",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "5",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Http",
 			expectedProbes:  getTestProbes("Http", "/", pointer.Int32(20), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(5)),
@@ -2553,10 +2556,10 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should return correct rule when tcp health probe annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "20",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "5",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedProbes:  getTestProbes("Tcp", "", pointer.Int32(20), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(5)),
@@ -2564,47 +2567,47 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "20",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "5a",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedErr:     true,
 		},
 		{
 			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "1",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "5",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedErr:     true,
 		},
 		{
 			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "10",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "1",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedErr:     true,
 		},
 		{
 			desc: "getExpectedLBRules should return error when invalid tcp health probe annotations are added",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "10",
 				consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "20",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Tcp",
 			expectedErr:     true,
 		},
 		{
 			desc:            "getExpectedLBRules should return correct rule when floating ip annotations are added",
-			service:         getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, false, 80),
+			service:         getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, 80),
 			loadBalancerSku: "basic",
 			expectedRules: map[bool][]network.LoadBalancingRule{
 				consts.IPVersionIPv4: {getFloatingIPTestRule(false, false, 80, consts.IPVersionIPv4)},
@@ -2614,27 +2617,27 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should prioritize port specific probe protocol over defaults",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_80_health-probe_protocol": "HtTp",
-			}, false, 80),
+			}, 80),
 			expectedRules:  getDefaultTestRules(false),
 			expectedProbes: getDefaultTestProbes("Http", "/"),
 		},
 		{
 			desc: "getExpectedLBRules should prioritize port specific probe protocol over appProtocol",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_80_health-probe_protocol": "HtTp",
-			}, false, 80),
+			}, 80),
 			probeProtocol:  "Mongodb",
 			expectedRules:  getDefaultTestRules(false),
 			expectedProbes: getDefaultTestProbes("Http", "/"),
 		},
 		{
 			desc: "getExpectedLBRules should prioritize port specific probe protocol over deprecated annotation",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_80_health-probe_protocol":             "HtTpS",
 				"service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol": "TcP",
-			}, false, 80),
+			}, 80),
 			loadBalancerSku: "standard",
 			probeProtocol:   "Https",
 			expectedRules:   getDefaultTestRules(true),
@@ -2642,18 +2645,18 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should default to Tcp on invalid port specific probe protocol",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_80_health-probe_protocol": "FooBar",
-			}, false, 80),
+			}, 80),
 			probeProtocol:  "Http",
 			expectedRules:  getDefaultTestRules(false),
 			expectedProbes: getDefaultTestProbes("Tcp", ""),
 		},
 		{
 			desc: "getExpectedLBRules should support customize health probe port in multi-port service",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_8000_health-probe_port": "port-tcp-80",
-			}, false, 80, 8000),
+			}, 80, 8000),
 			expectedRules: map[bool][]network.LoadBalancingRule{
 				consts.IPVersionIPv4: {getTestRule(false, 80, consts.IPVersionIPv4), getTestRule(false, 8000, consts.IPVersionIPv4)},
 				consts.IPVersionIPv6: {getTestRule(false, 80, consts.IPVersionIPv6), getTestRule(false, 8000, consts.IPVersionIPv6)},
@@ -2671,9 +2674,9 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should support customize health probe port in multi-port service",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_8000_health-probe_port": "80",
-			}, false, 80, 8000),
+			}, 80, 8000),
 			expectedRules: map[bool][]network.LoadBalancingRule{
 				consts.IPVersionIPv4: {
 					getTestRule(false, 80, consts.IPVersionIPv4),
@@ -2697,9 +2700,9 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should not generate probe rule when no health probe rule is specified.",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_8000_no_probe_rule": "true",
-			}, false, 80, 8000),
+			}, 80, 8000),
 			expectedRules: map[bool][]network.LoadBalancingRule{
 				consts.IPVersionIPv4: {
 					getTestRule(false, 80, consts.IPVersionIPv4),
@@ -2729,9 +2732,9 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		},
 		{
 			desc: "getExpectedLBRules should not generate lb rule and health probe rule when no lb rule is specified.",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 				"service.beta.kubernetes.io/port_8000_no_lb_rule": "true",
-			}, false, 80, 8000),
+			}, 80, 8000),
 			expectedRules: map[bool][]network.LoadBalancingRule{
 				consts.IPVersionIPv4: {
 					getTestRule(false, 80, consts.IPVersionIPv4),
@@ -2767,11 +2770,11 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 		expectedErr     bool
 	}{
 		desc: "getExpectedLBRules should expected rules when timeout are added",
-		service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+		service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{
 			consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsProbeInterval): "10",
 			consts.BuildHealthProbeAnnotationKeyForPort(80, consts.HealthProbeParamsNumOfProbe):    "10",
 			consts.ServiceAnnotationLoadBalancerIdleTimeout:                                        "5",
-		}, false, 80),
+		}, 80),
 		loadBalancerSku: "standard",
 		probeProtocol:   "Tcp",
 		expectedProbes:  getTestProbes("Tcp", "", pointer.Int32(10), pointer.Int32(80), pointer.Int32(10080), pointer.Int32(10)),
@@ -2869,7 +2872,6 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			az := GetTestCloud(ctrl)
 			az.Config.LoadBalancerSku = test.loadBalancerSku
 			service := test.service
-			service.Spec.IPFamilies = []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}
 			firstPort := service.Spec.Ports[0]
 			probeProtocol := test.probeProtocol
 			if test.probeProtocol != "" {
@@ -2878,25 +2880,39 @@ func TestReconcileLoadBalancerRule(t *testing.T) {
 			if test.probePath != "" {
 				service.Annotations[consts.BuildHealthProbeAnnotationKeyForPort(firstPort.Port, consts.HealthProbeParamsRequestPath)] = test.probePath
 			}
-			probeV4, lbruleV4, errV4 := az.getExpectedLBRules(&service,
-				"frontendIPConfigID", "backendPoolID", "lbname", false)
-			probeV6, lbruleV6, errV6 := az.getExpectedLBRules(&service,
-				"frontendIPConfigID-IPv6", "backendPoolID-IPv6", "lbname", true)
-			if test.expectedErr {
-				assert.Error(t, errV4)
-				assert.Error(t, errV6)
-			} else {
-				assert.Equal(t, test.expectedProbes[false], probeV4)
-				assert.Equal(t, test.expectedProbes[true], probeV6)
-				assert.Equal(t, test.expectedRules[false], lbruleV4)
-				assert.Equal(t, test.expectedRules[true], lbruleV6)
-				assert.NoError(t, errV4)
-				assert.NoError(t, errV6)
+			v4Enabled, v6Enabled := getIPFamiliesEnabled(&service)
+			if v4Enabled {
+				probe, lbrule, err := az.getExpectedLBRules(&service,
+					"frontendIPConfigID", "backendPoolID", "lbname", consts.IPVersionIPv4)
+				if test.expectedErr {
+					assert.Error(t, err)
+				} else {
+					assert.Equal(t, test.expectedProbes[consts.IPVersionIPv4], probe)
+					assert.Equal(t, test.expectedRules[consts.IPVersionIPv4], lbrule)
+					assert.NoError(t, err)
+				}
+			}
+			isDualStack := v4Enabled && v6Enabled
+			if v6Enabled {
+				lbFrontendIPConfigID, lbBackendPoolID := "frontendIPConfigID", "backendPoolID-IPv6"
+				if isDualStack {
+					lbFrontendIPConfigID = "frontendIPConfigID-IPv6"
+				}
+				probe, lbrule, err := az.getExpectedLBRules(&service,
+					lbFrontendIPConfigID, lbBackendPoolID, "lbname", consts.IPVersionIPv6)
+				if test.expectedErr {
+					assert.Error(t, err)
+				} else {
+					assert.Equal(t, test.expectedProbes[consts.IPVersionIPv6], probe)
+					assert.Equal(t, test.expectedRules[consts.IPVersionIPv6], lbrule)
+					assert.NoError(t, err)
+				}
 			}
 		})
 	}
 }
 
+// getDefaultTestRules returns dualstack rules.
 func getDefaultTestRules(enableTCPReset bool) map[bool][]network.LoadBalancingRule {
 	return map[bool][]network.LoadBalancingRule{
 		consts.IPVersionIPv4: {getTestRule(enableTCPReset, 80, consts.IPVersionIPv4)},
@@ -2904,17 +2920,18 @@ func getDefaultTestRules(enableTCPReset bool) map[bool][]network.LoadBalancingRu
 	}
 }
 
+// getDefaultInternalIPv6Rules returns a rule for IPv6 single stack.
 func getDefaultInternalIPv6Rules(enableTCPReset bool) map[bool][]network.LoadBalancingRule {
-	rulesDualStack := getDefaultTestRules(true)
-	for _, rules := range rulesDualStack {
-		for _, rule := range rules {
-			rule.EnableFloatingIP = pointer.Bool(false)
-			rule.BackendPort = pointer.Int32(getBackendPort(*rule.FrontendPort))
-		}
+	rule := getTestRule(true, 80, false)
+	rule.EnableFloatingIP = pointer.Bool(false)
+	rule.BackendPort = pointer.Int32(getBackendPort(*rule.FrontendPort))
+	rule.BackendAddressPool.ID = pointer.String("backendPoolID-IPv6")
+	return map[bool][]network.LoadBalancingRule{
+		true: {rule},
 	}
-	return rulesDualStack
 }
 
+// getTestRule returns a rule for dualStack.
 func getTestRule(enableTCPReset bool, port int32, isIPv6 bool) network.LoadBalancingRule {
 	suffix := ""
 	if isIPv6 {
@@ -2948,14 +2965,19 @@ func getTestRule(enableTCPReset bool, port int32, isIPv6 bool) network.LoadBalan
 	return expectedRules
 }
 
-func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol, isIPv6 bool) []network.LoadBalancingRule {
+func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol, isIPv6, isInternal bool) []network.LoadBalancingRule {
 	suffix := ""
+	enableFloatingIP := true
 	if isIPv6 {
 		suffix = "-" + v6Suffix
+		if isInternal {
+			enableFloatingIP = false
+		}
 	}
+
 	expectedRules := []network.LoadBalancingRule{
 		{
-			Name: pointer.String(fmt.Sprintf("atest1-%s-80", string(protocol)) + suffix),
+			Name: pointer.String(fmt.Sprintf("atest1-%s-80%s", string(protocol), suffix)),
 			LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 				Protocol: network.TransportProtocol("All"),
 				FrontendIPConfiguration: &network.SubResource{
@@ -2967,7 +2989,7 @@ func getHATestRules(enableTCPReset, hasProbe bool, protocol v1.Protocol, isIPv6 
 				LoadDistribution:     "Default",
 				FrontendPort:         pointer.Int32(0),
 				BackendPort:          pointer.Int32(0),
-				EnableFloatingIP:     pointer.Bool(true),
+				EnableFloatingIP:     pointer.Bool(enableFloatingIP),
 				DisableOutboundSnat:  pointer.Bool(false),
 				IdleTimeoutInMinutes: pointer.Int32(4),
 				EnableTCPReset:       pointer.Bool(true),
@@ -3918,20 +3940,20 @@ func TestGetServiceLoadBalancerStatus(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			status, _, err := az.getServiceLoadBalancerStatus(test.service, test.lb)
+			status, _, _, err := az.getServiceLoadBalancerStatus(test.service, test.lb)
 			assert.Equal(t, test.expectedStatus, status)
 			assert.Equal(t, test.expectedError, err != nil)
 		})
 	}
 }
 
-func TestReconcileSecurityGroup(t *testing.T) {
+func TestReconcileSecurityGroupCommon(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	testCases := []struct {
 		desc          string
-		lbIP          *string
+		lbIPs         *[]string
 		lbName        *string
 		service       v1.Service
 		existingSgs   map[string]network.SecurityGroup
@@ -3952,25 +3974,25 @@ func TestReconcileSecurityGroup(t *testing.T) {
 		},
 		{
 			desc:          "reconcileSecurityGroup shall report error if no such sg can be found",
-			service:       getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			service:       getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			expectedError: true,
 		},
 		{
-			desc:          "reconcileSecurityGroup shall report error if wantLb is true and lbIP is nil",
-			service:       getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			desc:          "reconcileSecurityGroup shall report error if wantLb is true and lbIPs is nil",
+			service:       getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			wantLb:        true,
 			existingSgs:   map[string]network.SecurityGroup{"nsg": {}},
 			expectedError: true,
 		},
 		{
 			desc:        "reconcileSecurityGroup shall remain the existingSgs intact if nothing needs to be modified",
-			service:     getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			service:     getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {}},
 			expectedSg:  &network.SecurityGroup{},
 		},
 		{
-			desc:    "reconcileSecurityGroup shall delete unwanted sg if wantLb is false and lbIP is nil",
-			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			desc:    "reconcileSecurityGroup shall delete unwanted sg if wantLb is false and lbIPs is nil",
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
@@ -3997,7 +4019,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 		},
 		{
 			desc:    "reconcileSecurityGroup shall delete unwanted sgs and create needed ones",
-			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
@@ -4014,7 +4036,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 					},
 				},
 			}},
-			lbIP:   pointer.String("1.1.1.1"),
+			lbIPs:  &[]string{"1.1.1.1", "fd00::eef0"},
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
 				Name: pointer.String("nsg"),
@@ -4033,18 +4055,31 @@ func TestReconcileSecurityGroup(t *testing.T) {
 								Direction:                network.SecurityRuleDirection("Inbound"),
 							},
 						},
+						{
+							Name: pointer.String("atest1-TCP-80-Internet-IPv6"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								Protocol:                 network.SecurityRuleProtocol("Tcp"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("Internet"),
+								DestinationAddressPrefix: pointer.String("fd00::eef0"),
+								Access:                   network.SecurityRuleAccess("Allow"),
+								Priority:                 pointer.Int32(501),
+								Direction:                network.SecurityRuleDirection("Inbound"),
+							},
+						},
 					},
 				},
 			},
 		},
 		{
-			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix for IPv6",
+			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix for IPv6 only",
 			service: getTestService("test1", v1.ProtocolTCP, nil, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   pointer.String("fd00::eef0"),
+			lbIPs:  &[]string{"fd00::eef0"},
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
 				Name: pointer.String("nsg"),
@@ -4068,13 +4103,56 @@ func TestReconcileSecurityGroup(t *testing.T) {
 			},
 		},
 		{
-			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix with additional public IPs",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAdditionalPublicIPs: "2.3.4.5"}, true, 80),
+			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix for Dual-stack",
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, nil, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   pointer.String("1.2.3.4"),
+			lbIPs:  &[]string{"1.1.1.1", "fd00::eef0"},
+			wantLb: true,
+			expectedSg: &network.SecurityGroup{
+				Name: pointer.String("nsg"),
+				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
+					SecurityRules: &[]network.SecurityRule{
+						{
+							Name: pointer.String("atest1-TCP-80-Internet"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								Protocol:                 network.SecurityRuleProtocol("Tcp"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("Internet"),
+								DestinationAddressPrefix: pointer.String("1.1.1.1"),
+								Access:                   network.SecurityRuleAccess("Allow"),
+								Priority:                 pointer.Int32(500),
+								Direction:                network.SecurityRuleDirection("Inbound"),
+							},
+						},
+						{
+							Name: pointer.String("atest1-TCP-80-Internet-IPv6"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								Protocol:                 network.SecurityRuleProtocol("Tcp"),
+								SourcePortRange:          pointer.String("*"),
+								DestinationPortRange:     pointer.String("80"),
+								SourceAddressPrefix:      pointer.String("Internet"),
+								DestinationAddressPrefix: pointer.String("fd00::eef0"),
+								Access:                   network.SecurityRuleAccess("Allow"),
+								Priority:                 pointer.Int32(501),
+								Direction:                network.SecurityRuleDirection("Inbound"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:    "reconcileSecurityGroup shall create sgs with correct destinationPrefix with additional public IPs",
+			service: getTestServiceDualStack("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAdditionalPublicIPs: "2.3.4.5,fd00::eef1"}, 80),
+			existingSgs: map[string]network.SecurityGroup{"nsg": {
+				Name:                          pointer.String("nsg"),
+				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
+			}},
+			lbIPs:  &[]string{"1.2.3.4", "fd00::eef0"},
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
 				Name: pointer.String("nsg"),
@@ -4093,15 +4171,28 @@ func TestReconcileSecurityGroup(t *testing.T) {
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
+						{
+							Name: pointer.String("atest1-TCP-80-Internet-IPv6"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								Protocol:                   network.SecurityRuleProtocol("Tcp"),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String("80"),
+								SourceAddressPrefix:        pointer.String("Internet"),
+								DestinationAddressPrefixes: &([]string{"fd00::eef0", "fd00::eef1"}),
+								Access:                     network.SecurityRuleAccess("Allow"),
+								Priority:                   pointer.Int32(501),
+								Direction:                  network.SecurityRuleDirection("Inbound"),
+							},
+						},
 					},
 				},
 			},
 		},
 		{
 			desc:    "reconcileSecurityGroup shall not create unwanted security rules if there is service tags",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAllowedServiceTag: "tag"}, true, 80),
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationAllowedServiceTag: "tag"}, false, 80),
 			wantLb:  true,
-			lbIP:    pointer.String("1.1.1.1"),
+			lbIPs:   &[]string{"1.1.1.1"},
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
@@ -4141,12 +4232,12 @@ func TestReconcileSecurityGroup(t *testing.T) {
 		},
 		{
 			desc:    "reconcileSecurityGroup shall create shared sgs for service with azure-shared-securityrule annotations",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, true, 80),
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   pointer.String("1.2.3.4"),
+			lbIPs:  &[]string{"1.2.3.4"},
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
 				Name: pointer.String("nsg"),
@@ -4171,7 +4262,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 		},
 		{
 			desc:    "reconcileSecurityGroup shall delete shared sgs for service with azure-shared-securityrule annotations",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, true, 80),
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
@@ -4192,7 +4283,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 					},
 				},
 			}},
-			lbIP:   pointer.String("1.2.3.4"),
+			lbIPs:  &[]string{"1.2.3.4"},
 			wantLb: false,
 			expectedSg: &network.SecurityGroup{
 				Name: pointer.String("nsg"),
@@ -4203,7 +4294,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 		},
 		{
 			desc:    "reconcileSecurityGroup shall delete shared sgs destination for service with azure-shared-securityrule annotations",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, true, 80),
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"}, false, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name: pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
@@ -4224,7 +4315,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 					},
 				},
 			}},
-			lbIP:   pointer.String("1.2.3.4"),
+			lbIPs:  &[]string{"1.2.3.4"},
 			wantLb: false,
 			expectedSg: &network.SecurityGroup{
 				Name: pointer.String("nsg"),
@@ -4254,7 +4345,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   pointer.String("1.2.3.4"),
+			lbIPs:  &[]string{"1.2.3.4"},
 			lbName: pointer.String("lb"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
@@ -4280,12 +4371,12 @@ func TestReconcileSecurityGroup(t *testing.T) {
 		},
 		{
 			desc:    "reconcileSecurityGroup shall create sgs with only IPv6 destination addresses for IPv6 services with floating IP disabled",
-			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, false, 80),
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true"}, true, 80),
 			existingSgs: map[string]network.SecurityGroup{"nsg": {
 				Name:                          pointer.String("nsg"),
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
 			}},
-			lbIP:   pointer.String("1234::5"),
+			lbIPs:  &[]string{"1234::5"},
 			lbName: pointer.String("lb"),
 			wantLb: true,
 			expectedSg: &network.SecurityGroup{
@@ -4331,7 +4422,7 @@ func TestReconcileSecurityGroup(t *testing.T) {
 				mockLBClient.EXPECT().Get(gomock.Any(), "rg", *test.lbName, gomock.Any()).Return(network.LoadBalancer{}, nil)
 			}
 			service := test.service
-			sg, err := az.reconcileSecurityGroup("testCluster", &service, test.lbIP, test.lbName, test.wantLb)
+			sg, err := az.reconcileSecurityGroup("testCluster", &service, test.lbIPs, test.lbName, test.wantLb)
 			assert.Equal(t, test.expectedSg, sg)
 			assert.Equal(t, test.expectedError, err != nil)
 		})
@@ -4351,7 +4442,7 @@ func TestReconcileSecurityGroupLoadBalancerSourceRanges(t *testing.T) {
 			SecurityRules: &[]network.SecurityRule{},
 		},
 	}
-	lbIP := pointer.String("1.1.1.1")
+	lbIPs := &[]string{"1.1.1.1"}
 	expectedSg := network.SecurityGroup{
 		Name: pointer.String("nsg"),
 		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
@@ -4388,7 +4479,7 @@ func TestReconcileSecurityGroupLoadBalancerSourceRanges(t *testing.T) {
 	mockSGClient := az.SecurityGroupsClient.(*mocksecuritygroupclient.MockInterface)
 	mockSGClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any()).Return(existingSg, nil)
 	mockSGClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	sg, err := az.reconcileSecurityGroup("testCluster", &service, lbIP, nil, true)
+	sg, err := az.reconcileSecurityGroup("testCluster", &service, lbIPs, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSg, *sg)
 }
@@ -5128,7 +5219,7 @@ func compareStrings(s0, s1 []string) bool {
 	return ss0.Equal(ss1)
 }
 
-func TestEnsurePublicIPExists(t *testing.T) {
+func TestEnsurePublicIPExistsCommon(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -5472,7 +5563,8 @@ func TestEnsurePublicIPExists(t *testing.T) {
 				{
 					Name: pointer.String("pip1"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-						IPAddress: pointer.String("1.2.3.4"),
+						PublicIPAddressVersion: network.IPv4,
+						IPAddress:              pointer.String("1.2.3.4"),
 					},
 					Tags: map[string]*string{"a": pointer.String("b")},
 				},
@@ -6425,7 +6517,7 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerDelete(t *testing.T) {
 		mockPLSClient := cloud.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
 		mockPLSClient.EXPECT().List(gomock.Any(), "rg").Return(expectedPLS, nil).MaxTimes(1)
 		existingLBs := []network.LoadBalancer{{Name: pointer.String("lb")}}
-		err := cloud.removeFrontendIPConfigurationFromLoadBalancer(&lb, existingLBs, fip, "testCluster", &service)
+		err := cloud.removeFrontendIPConfigurationFromLoadBalancer(&lb, existingLBs, []*network.FrontendIPConfiguration{fip}, "testCluster", &service)
 		assert.NoError(t, err)
 	})
 }
@@ -6456,7 +6548,7 @@ func TestRemoveFrontendIPConfigurationFromLoadBalancerUpdate(t *testing.T) {
 		expectedPLS := make([]network.PrivateLinkService, 0)
 		mockPLSClient := cloud.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
 		mockPLSClient.EXPECT().List(gomock.Any(), "rg").Return(expectedPLS, nil).MaxTimes(1)
-		err := cloud.removeFrontendIPConfigurationFromLoadBalancer(&lb, []network.LoadBalancer{}, fip, "testCluster", &service)
+		err := cloud.removeFrontendIPConfigurationFromLoadBalancer(&lb, []network.LoadBalancer{}, []*network.FrontendIPConfiguration{fip}, "testCluster", &service)
 		assert.NoError(t, err)
 	})
 }
@@ -6652,8 +6744,8 @@ func TestReconcileZonesForFrontendIPConfigs(t *testing.T) {
 			isDualStack := isServiceDualStack(&service)
 			defaultLBFrontendIPConfigName := cloud.getDefaultFrontendIPConfigName(&service)
 			lbFrontendIPConfigNames := map[bool]string{
-				false: getResourceByIPFamily(defaultLBFrontendIPConfigName, isDualStack, false),
-				true:  getResourceByIPFamily(defaultLBFrontendIPConfigName, isDualStack, true),
+				consts.IPVersionIPv4: getResourceByIPFamily(defaultLBFrontendIPConfigName, isDualStack, consts.IPVersionIPv4),
+				consts.IPVersionIPv6: getResourceByIPFamily(defaultLBFrontendIPConfigName, isDualStack, consts.IPVersionIPv6),
 			}
 			_, _, dirty, err := cloud.reconcileFrontendIPConfigs("testCluster", &service, &lb, tc.status, true, lbFrontendIPConfigNames)
 			if tc.expectedErr == nil {

--- a/pkg/provider/azure_privatelinkservice_test.go
+++ b/pkg/provider/azure_privatelinkservice_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -317,31 +318,54 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			expectedPLSDelete: true,
 		},
 	}
-	for i, test := range testCases {
-		az := GetTestCloud(ctrl)
-		service := getTestServiceWithAnnotation("test", test.annotations, false, 80)
-		fipConfig := &network.FrontendIPConfiguration{
-			Name: pointer.String("fipConfig"),
-			ID:   pointer.String("fipConfigID"),
-		}
-		clusterName := testClusterName
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			az := GetTestCloud(ctrl)
+			service := getTestServiceWithAnnotation("test", test.annotations, false, 80)
+			fipConfig := &network.FrontendIPConfiguration{
+				Name: pointer.String("fipConfig"),
+				ID:   pointer.String("fipConfigID"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &network.PublicIPAddress{
+						ID: pointer.String("pipID"),
+						PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+							PublicIPAddressVersion: network.IPv4,
+						},
+					},
+					PrivateIPAddressVersion: network.IPv4,
+				},
+			}
+			clusterName := testClusterName
 
-		mockSubnetsClient := az.SubnetsClient.(*mocksubnetclient.MockInterface)
-		mockPLSsClient := az.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
-		if test.expectedSubnetGet {
-			mockSubnetsClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", "").Return(*test.existingSubnet, nil).MaxTimes(2)
-		}
-		if test.expectedPLSList {
-			mockPLSsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPLSList, nil).MaxTimes(1)
-		}
-		if test.expectedPLSCreate {
-			mockPLSsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", pointer.StringDeref(test.expectedPLS.Name, ""), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		}
-		if test.expectedPLSDelete {
-			mockPLSsClient.EXPECT().Delete(gomock.Any(), "rg", "testpls").Return(nil).Times(1)
-		}
-		err := az.reconcilePrivateLinkService(clusterName, &service, fipConfig, test.wantPLS)
-		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+			if isInternal, ok := test.annotations[consts.ServiceAnnotationLoadBalancerInternal]; !ok || isInternal != "true" {
+				existingPIPS := []network.PublicIPAddress{
+					{
+						ID: pointer.String("pipID"),
+						PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+							PublicIPAddressVersion: network.IPv4,
+						},
+					},
+				}
+				mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
+				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(existingPIPS, nil).Times(1)
+			}
+			mockSubnetsClient := az.SubnetsClient.(*mocksubnetclient.MockInterface)
+			mockPLSsClient := az.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
+			if test.expectedSubnetGet {
+				mockSubnetsClient.EXPECT().Get(gomock.Any(), "rg", "vnet", "subnet", "").Return(*test.existingSubnet, nil).MaxTimes(2)
+			}
+			if test.expectedPLSList {
+				mockPLSsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPLSList, nil).MaxTimes(1)
+			}
+			if test.expectedPLSCreate {
+				mockPLSsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", pointer.StringDeref(test.expectedPLS.Name, ""), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			}
+			if test.expectedPLSDelete {
+				mockPLSsClient.EXPECT().Delete(gomock.Any(), "rg", "testpls").Return(nil).Times(1)
+			}
+			err := az.reconcilePrivateLinkService(clusterName, &service, fipConfig, test.wantPLS)
+			assert.Equal(t, test.expectedError, err != nil)
+		})
 	}
 }
 

--- a/pkg/provider/azure_privatelinkservice_test.go
+++ b/pkg/provider/azure_privatelinkservice_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/privatelinkserviceclient/mockprivatelinkserviceclient"
-	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/publicipclient/mockpublicipclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/subnetclient/mocksubnetclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -337,18 +336,6 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			}
 			clusterName := testClusterName
 
-			if isInternal, ok := test.annotations[consts.ServiceAnnotationLoadBalancerInternal]; !ok || isInternal != "true" {
-				existingPIPS := []network.PublicIPAddress{
-					{
-						ID: pointer.String("pipID"),
-						PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
-							PublicIPAddressVersion: network.IPv4,
-						},
-					},
-				}
-				mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
-				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(existingPIPS, nil).Times(1)
-			}
 			mockSubnetsClient := az.SubnetsClient.(*mocksubnetclient.MockInterface)
 			mockPLSsClient := az.PrivateLinkServiceClient.(*mockprivatelinkserviceclient.MockInterface)
 			if test.expectedSubnetGet {

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -74,7 +74,11 @@ func (az *Cloud) getAvailabilitySetID(resourceGroup, availabilitySetName string)
 }
 
 // returns the full identifier of a loadbalancer frontendipconfiguration.
-func (az *Cloud) getFrontendIPConfigID(lbName, rgName, fipConfigName string) string {
+func (az *Cloud) getFrontendIPConfigID(lbName, fipConfigName string) string {
+	return az.getFrontendIPConfigIDWithRG(lbName, az.getLoadBalancerResourceGroup(), fipConfigName)
+}
+
+func (az *Cloud) getFrontendIPConfigIDWithRG(lbName, rgName, fipConfigName string) string {
 	return fmt.Sprintf(
 		consts.FrontendIPConfigIDTemplate,
 		az.getNetworkResourceSubscriptionID(),
@@ -84,7 +88,11 @@ func (az *Cloud) getFrontendIPConfigID(lbName, rgName, fipConfigName string) str
 }
 
 // returns the full identifier of a loadbalancer backendpool.
-func (az *Cloud) getBackendPoolID(lbName, rgName, backendPoolName string) string {
+func (az *Cloud) getBackendPoolID(lbName, backendPoolName string) string {
+	return az.getBackendPoolIDWithRG(lbName, az.getLoadBalancerResourceGroup(), backendPoolName)
+}
+
+func (az *Cloud) getBackendPoolIDWithRG(lbName, rgName, backendPoolName string) string {
 	return fmt.Sprintf(
 		consts.BackendPoolIDTemplate,
 		az.getNetworkResourceSubscriptionID(),
@@ -94,7 +102,11 @@ func (az *Cloud) getBackendPoolID(lbName, rgName, backendPoolName string) string
 }
 
 // returns the full identifier of a loadbalancer probe.
-func (az *Cloud) getLoadBalancerProbeID(lbName, rgName, lbRuleName string) string {
+func (az *Cloud) getLoadBalancerProbeID(lbName, lbRuleName string) string {
+	return az.getLoadBalancerProbeIDWithRG(lbName, az.getLoadBalancerResourceGroup(), lbRuleName)
+}
+
+func (az *Cloud) getLoadBalancerProbeIDWithRG(lbName, rgName, lbRuleName string) string {
 	return fmt.Sprintf(
 		consts.LoadBalancerProbeIDTemplate,
 		az.getNetworkResourceSubscriptionID(),

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -1169,7 +1169,7 @@ func TestGetBackendPoolNames(t *testing.T) {
 			name:              "GetBackendPoolNames should return 2 backend pool names",
 			service:           getTestService("test1", v1.ProtocolTCP, nil, true, 80),
 			clusterName:       "azure",
-			expectedPoolNames: map[bool]string{false: "azure", true: "azure-IPv6"},
+			expectedPoolNames: map[bool]string{consts.IPVersionIPv4: "azure", consts.IPVersionIPv6: "azure-IPv6"},
 		},
 	}
 	for _, test := range testcases {

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -39,7 +40,6 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
-	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
@@ -57,13 +57,22 @@ import (
 
 const (
 	testClusterName = "testCluster"
-	testIP1         = "192.168.77.88"
-	testIP2         = "192.168.33.44"
-	testIP3         = "192.168.99.11"
-	testRuleName    = "shared-TCP-80-Internet"
-	testRuleName2   = "shared-TCP-4444-Internet"
-	testRuleName3   = "shared-TCP-8888-Internet"
-	testRuleName4   = "TCP-80-Internet"
+)
+
+var (
+	testIPs = []map[bool]string{
+		{false: "192.168.77.88", true: "fe::1"},
+		{false: "192.168.33.44", true: "fe::2"},
+		{false: "192.168.99.11", true: "fe::3"},
+		{false: "192.168.22.33", true: "fe::4"},
+	}
+
+	testRuleNames = []map[bool]string{
+		{false: "shared-TCP-80-Internet", true: "shared-TCP-80-Internet-IPv6"},
+		{false: "shared-TCP-4444-Internet", true: "shared-TCP-4444-Internet-IPv6"},
+		{false: "shared-TCP-8888-Internet", true: "shared-TCP-8888-Internet-IPv6"},
+		{false: "TCP-80-Internet", true: "TCP-80-Internet-IPv6"},
+	}
 )
 
 // Test flipServiceInternalAnnotation
@@ -125,23 +134,43 @@ func TestAddPort(t *testing.T) {
 	validateLoadBalancer(t, lb, svc)
 }
 
-func TestLoadBalancerInternalServiceModeSelection(t *testing.T) {
-	testLoadBalancerServiceDefaultModeSelection(t, true)
-	testLoadBalancerServiceAutoModeSelection(t, true)
-	testLoadBalancerServicesSpecifiedSelection(t, true)
-	testLoadBalancerMaxRulesServices(t, true)
-	testLoadBalancerServiceAutoModeDeleteSelection(t, true)
+func TestLoadBalancerSelection(t *testing.T) {
+	testcases := []struct {
+		desc       string
+		isInternal bool
+	}{
+		{
+			desc:       "internal",
+			isInternal: true,
+		},
+		{
+			desc:       "external",
+			isInternal: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Run("defaultModeSelection", func(t *testing.T) {
+				testLoadBalancerServiceDefaultModeSelection(t, tc.isInternal)
+			})
+			t.Run("autoModeSelection", func(t *testing.T) {
+				testLoadBalancerServiceAutoModeSelection(t, tc.isInternal)
+			})
+			t.Run("specifiedSelection", func(t *testing.T) {
+				testLoadBalancerServicesSpecifiedSelection(t, tc.isInternal)
+			})
+			t.Run("maxRulesServices", func(t *testing.T) {
+				testLoadBalancerMaxRulesServices(t, tc.isInternal)
+			})
+			t.Run("autoModeDeleteSelection", func(t *testing.T) {
+				testLoadBalancerServiceAutoModeDeleteSelection(t, tc.isInternal)
+			})
+		})
+	}
 }
 
-func TestLoadBalancerExternalServiceModeSelection(t *testing.T) {
-	testLoadBalancerServiceDefaultModeSelection(t, false)
-	testLoadBalancerServiceAutoModeSelection(t, false)
-	testLoadBalancerServicesSpecifiedSelection(t, false)
-	testLoadBalancerMaxRulesServices(t, false)
-	testLoadBalancerServiceAutoModeDeleteSelection(t, false)
-}
-
-func setMockEnvDualStack(az *Cloud, ctrl *gomock.Controller, expectedInterfaces []network.Interface, expectedVirtualMachines []compute.VirtualMachine, serviceCount int) {
+func setMockEnvDualStack(az *Cloud, ctrl *gomock.Controller, expectedInterfaces []network.Interface, expectedVirtualMachines []compute.VirtualMachine, serviceCount int, services ...v1.Service) {
 	mockInterfacesClient := mockinterfaceclient.NewMockInterface(ctrl)
 	az.InterfacesClient = mockInterfacesClient
 	for i := range expectedInterfaces {
@@ -158,7 +187,7 @@ func setMockEnvDualStack(az *Cloud, ctrl *gomock.Controller, expectedInterfaces 
 
 	setMockPublicIPs(az, ctrl, serviceCount, true, true)
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az, services...)
 	setMockSecurityGroup(az, ctrl, sg)
 }
 
@@ -177,13 +206,7 @@ func setMockEnv(az *Cloud, ctrl *gomock.Controller, expectedInterfaces []network
 		mockVirtualMachinesClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("vm-%d", i), gomock.Any()).Return(expectedVirtualMachines[i], nil).AnyTimes()
 	}
 
-	if len(services) > 0 {
-		v4Enabled, v6Enabled := getIPFamiliesEnabled(&services[0])
-		setMockPublicIPs(az, ctrl, serviceCount, v4Enabled, v6Enabled)
-	} else {
-		// Default is IPv4 only.
-		setMockPublicIPs(az, ctrl, serviceCount, true, false)
-	}
+	setMockPublicIPs(az, ctrl, serviceCount, true, false)
 
 	sg := getTestSecurityGroup(az, services...)
 	setMockSecurityGroup(az, ctrl, sg)
@@ -432,6 +455,7 @@ func setMockLBs(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadB
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 					PrivateIPAllocationMethod: "Dynamic",
 					PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+					PrivateIPAddressVersion:   network.IPv4,
 				},
 			},
 		}
@@ -451,6 +475,7 @@ func setMockLBs(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadB
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 				PrivateIPAllocationMethod: "Dynamic",
 				PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+				PrivateIPAddressVersion:   network.IPv4,
 			},
 		}
 		if isInternal {
@@ -578,26 +603,20 @@ func testLoadBalancerServiceAutoModeSelection(t *testing.T, isInternal bool) {
 		az.PrivateLinkServiceClient = mockPLSClient
 
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
-		if err != nil {
-			t.Errorf("Unexpected error: %q", err)
-		}
-		if lbStatus == nil {
-			t.Errorf("Unexpected error: %s", svcName)
-		}
+		assert.Nil(t, err)
+		assert.NotNil(t, lbStatus, svc.Name)
 
 		// expected is MIN(index, availabilitySetCount)
 		expectedNumOfLB := int(math.Min(float64(index), float64(availabilitySetCount)))
 		ctx, cancel := getContextWithCancel()
 		defer cancel()
-		result, _ := az.LoadBalancerClient.List(ctx, az.Config.ResourceGroup)
-		lbCount := len(result)
-		if lbCount != expectedNumOfLB {
-			t.Errorf("Unexpected number of LB's: Expected (%d) Found (%d)", expectedNumOfLB, lbCount)
-		}
+		lbs, _ := az.LoadBalancerClient.List(ctx, az.Config.ResourceGroup)
+		lbCount := len(lbs)
+		assert.Equal(t, expectedNumOfLB, lbCount)
 
 		maxRules := 0
 		minRules := serviceCount
-		for _, lb := range result {
+		for _, lb := range lbs {
 			ruleCount := len(*lb.LoadBalancingRules)
 			if ruleCount < minRules {
 				minRules = ruleCount
@@ -890,19 +909,20 @@ func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	svc1 := getTestService("serviceea", v1.ProtocolTCP, nil, false, 80)
+	svc1 := getTestServiceDualStack("serviceea", v1.ProtocolTCP, nil, 80)
 	setServiceLoadBalancerIP(&svc1, "192.168.0.0")
+	setServiceLoadBalancerIP(&svc1, "fdf8:f535:82e4::53")
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 	setMockSecurityGroup(az, ctrl, sg)
 
 	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
-	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(""), nil, true)
+	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{""}, nil, true)
 	assert.Nil(t, err)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
+	lbIPs := []string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, &lbIPs, nil, true)
 	assert.Nil(t, err)
-	validateSecurityGroup(t, sg, svc1)
+	validateSecurityGroupDualStack(t, az, sg, svc1)
 }
 
 func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
@@ -910,16 +930,16 @@ func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, false, 80)
+	svc1 := getTestServiceDualStack("servicea", v1.ProtocolTCP, nil, 80)
 	setServiceLoadBalancerIP(&svc1, "")
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 	setMockSecurityGroup(az, ctrl, sg)
 
-	dynamicallyAssignedIP := "192.168.0.0"
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(dynamicallyAssignedIP), nil, true)
+	dynamicallyAssignedIPs := []string{"192.168.0.0", "fdf8:f535:82e4::53"}
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &dynamicallyAssignedIPs, nil, true)
 	assert.Nil(t, err)
-	validateSecurityGroup(t, sg, svc1)
+	validateSecurityGroupDualStack(t, az, sg, svc1)
 }
 
 // Test addition of services on an internal LB using both default and explicit subnets.
@@ -1375,22 +1395,24 @@ func TestReconcileSecurityGroupNewServiceAddsPort(t *testing.T) {
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	getTestSecurityGroup(az)
-	svc1 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
+	getTestSecurityGroupDualStack(az)
+	svc1 := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
-	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
+	lbStatus, _, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
-	assert.Nil(t, err)
+	assert.Equal(t, 2, len(lbStatus.Ingress))
+	lbIPs := []string{lbStatus.Ingress[0].IP, lbStatus.Ingress[1].IP}
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &lbIPs, nil, true /* wantLb */)
+	assert.NoError(t, err)
 
-	validateSecurityGroup(t, sg, svc1)
+	validateSecurityGroupDualStack(t, az, sg, svc1)
 }
 
 func TestReconcileSecurityGroupNewInternalServiceAddsPort(t *testing.T) {
@@ -1412,11 +1434,10 @@ func TestReconcileSecurityGroupNewInternalServiceAddsPort(t *testing.T) {
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
-	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
+	lbStatus, _, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{lbStatus.Ingress[0].IP}, nil, true /* wantLb */)
 	assert.Nil(t, err)
-
-	validateSecurityGroup(t, sg, svc1)
+	validateSecurityGroup(t, az, sg, svc1)
 }
 
 func TestReconcileSecurityGroupRemoveService(t *testing.T) {
@@ -1424,16 +1445,16 @@ func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	service1 := getTestService("service1", v1.ProtocolTCP, nil, false, 81)
-	service2 := getTestService("service2", v1.ProtocolTCP, nil, false, 82)
+	service1 := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 81)
+	service2 := getTestServiceDualStack("service2", v1.ProtocolTCP, nil, 82)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 2, service1, service2)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 2, service1, service2)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(pointer.String(testClusterName),
+		getTestLoadBalancerDualStack(pointer.String(testClusterName),
 			pointer.String(az.ResourceGroup),
 			pointer.String(testClusterName),
 			pointer.String("aservice1"),
@@ -1447,15 +1468,18 @@ func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &service1, clusterResources.nodes, true)
 	_, _ = az.reconcileLoadBalancer(testClusterName, &service2, clusterResources.nodes, true)
 
-	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&service1, lb)
+	lbStatus, _, _, err := az.getServiceLoadBalancerStatus(&service1, lb)
+	assert.NoError(t, err)
+	assert.NotNil(t, lbStatus)
 
-	sg := getTestSecurityGroup(az, service1, service2)
-	validateSecurityGroup(t, sg, service1, service2)
+	sg := getTestSecurityGroupDualStack(az, service1, service2)
+	validateSecurityGroupDualStack(t, az, sg, service1, service2)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &service1, &lbStatus.Ingress[0].IP, nil, false /* wantLb */)
+	assert.Equal(t, 2, len(lbStatus.Ingress))
+	sg, err = az.reconcileSecurityGroup(testClusterName, &service1, &[]string{lbStatus.Ingress[0].IP, lbStatus.Ingress[1].IP}, nil, false /* wantLb */)
 	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, service2)
+	validateSecurityGroupDualStack(t, az, sg, service2)
 }
 
 func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
@@ -1463,33 +1487,34 @@ func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	svc := getTestService("service1", v1.ProtocolTCP, nil, false, 80, 443)
+	svc := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80, 443)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	getTestSecurityGroup(az, svc)
-	svcUpdated := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
+	getTestSecurityGroupDualStack(az, svc)
+	svcUpdated := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80)
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
-		getTestLoadBalancer(pointer.String(testClusterName),
+		getTestLoadBalancerDualStack(pointer.String(testClusterName),
 			pointer.String(az.ResourceGroup),
 			pointer.String(testClusterName),
 			pointer.String("aservice1"),
 			svc,
 			"Standard"), nil).AnyTimes()
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true)
-	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc, lb)
+	lbStatus, _, _, _ := az.getServiceLoadBalancerStatus(&svc, lb)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svcUpdated, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
+	assert.Equal(t, 2, len(lbStatus.Ingress))
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svcUpdated, &[]string{lbStatus.Ingress[0].IP, lbStatus.Ingress[1].IP}, nil, true /* wantLb */)
 	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svcUpdated)
+	validateSecurityGroupDualStack(t, az, sg, svcUpdated)
 }
 
 func TestReconcileSecurityWithSourceRanges(t *testing.T) {
@@ -1497,28 +1522,31 @@ func TestReconcileSecurityWithSourceRanges(t *testing.T) {
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	svc := getTestService("service1", v1.ProtocolTCP, nil, false, 80, 443)
+	svc := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80, 443)
 	svc.Spec.LoadBalancerSourceRanges = []string{
 		"192.168.0.0/24",
 		"10.0.0.0/32",
+		"fe00::/64",
+		"ee00::/64",
 	}
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	getTestSecurityGroup(az, svc)
+	getTestSecurityGroupDualStack(az, svc)
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true)
-	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc, lb)
+	lbStatus, _, _, _ := az.getServiceLoadBalancerStatus(&svc, lb)
 
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
+	assert.Equal(t, 2, len(lbStatus.Ingress))
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, &[]string{lbStatus.Ingress[0].IP, lbStatus.Ingress[1].IP}, nil, true /* wantLb */)
 	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svc)
+	validateSecurityGroupDualStack(t, az, sg, svc)
 }
 
 func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
@@ -1526,14 +1554,14 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 	cachedSG := *sg
 	cachedSG.Etag = pointer.String("1111111-0000-0000-0000-000000000000")
 	az.nsgCache.Set(pointer.StringDeref(sg.Name, ""), &cachedSG)
 
-	svc1 := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
+	svc1 := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 	mockSGsClient := mocksecuritygroupclient.NewMockInterface(ctrl)
 	az.SecurityGroupsClient = mockSGsClient
 	mockSGsClient.EXPECT().Get(gomock.Any(), az.SecurityGroupResourceGroup, az.SecurityGroupName, gomock.Any()).Return(cachedSG, nil).AnyTimes()
@@ -1544,7 +1572,7 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 	mockSGsClient.EXPECT().CreateOrUpdate(gomock.Any(), az.SecurityGroupResourceGroup, az.SecurityGroupName, gomock.Any(), gomock.Any()).Return(expectedError).AnyTimes()
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, true)
 	mockLBClient := az.LoadBalancerClient.(*mockloadbalancerclient.MockInterface)
 	mockLBClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, "testCluster", gomock.Any()).Return(
 		getTestLoadBalancer(pointer.String(testClusterName),
@@ -1559,9 +1587,9 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
-	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
+	lbStatus, _, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
 
-	newSG, err := az.reconcileSecurityGroup(testClusterName, &svc1, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
+	newSG, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{lbStatus.Ingress[0].IP}, nil, true /* wantLb */)
 	assert.Nil(t, newSG)
 	assert.Error(t, err)
 
@@ -1884,22 +1912,31 @@ func getServiceSourceRanges(service *v1.Service) []string {
 	return service.Spec.LoadBalancerSourceRanges
 }
 
-func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGroup {
+func getTestSecurityGroupCommon(az *Cloud, v4Enabled, v6Enabled bool, services ...v1.Service) *network.SecurityGroup {
 	rules := []network.SecurityRule{}
-
 	for i, service := range services {
 		for _, port := range service.Spec.Ports {
-			sources := getServiceSourceRanges(&services[i])
-			for _, src := range sources {
-				isIPv6 := utilnet.IsIPv6String(services[i].Spec.ClusterIP)
-				ruleName := az.getSecurityRuleName(&services[i], port, src, isIPv6)
-				rules = append(rules, network.SecurityRule{
+			getRule := func(svc *v1.Service, port v1.ServicePort, src string, isIPv6 bool) network.SecurityRule {
+				ruleName := az.getSecurityRuleName(svc, port, src, isIPv6)
+				return network.SecurityRule{
 					Name: pointer.String(ruleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						SourceAddressPrefix:  pointer.String(src),
 						DestinationPortRange: pointer.String(fmt.Sprintf("%d", port.Port)),
 					},
-				})
+				}
+			}
+
+			sources := getServiceSourceRanges(&services[i])
+			for _, src := range sources {
+				if v4Enabled {
+					rule := getRule(&services[i], port, src, false)
+					rules = append(rules, rule)
+				}
+				if v6Enabled {
+					rule := getRule(&services[i], port, src, true)
+					rules = append(rules, rule)
+				}
 			}
 		}
 	}
@@ -1913,6 +1950,14 @@ func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGr
 	}
 
 	return &sg
+}
+
+func getTestSecurityGroupDualStack(az *Cloud, services ...v1.Service) *network.SecurityGroup {
+	return getTestSecurityGroupCommon(az, true, true, services...)
+}
+
+func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGroup {
+	return getTestSecurityGroupCommon(az, true, false, services...)
 }
 
 func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, services ...v1.Service) {
@@ -1929,10 +1974,11 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 		svcIPFamilyCount = len(services[0].Spec.IPFamilies)
 	}
 	for i, svc := range services {
+		isInternal := requiresInternalLoadBalancer(&services[i])
 		if len(svc.Spec.Ports) > 0 {
 			expectedFrontendIPCount += svcIPFamilyCount
 			expectedSubnetName := ""
-			if requiresInternalLoadBalancer(&services[i]) {
+			if isInternal {
 				expectedSubnetName = svc.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet]
 				if expectedSubnetName == "" {
 					expectedSubnetName = az.SubnetName
@@ -1961,10 +2007,17 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 				foundRule := false
 				for _, actualRule := range *loadBalancer.LoadBalancingRules {
 					if strings.EqualFold(*actualRule.Name, wantedRuleName) &&
-						*actualRule.FrontendPort == wantedRule.Port &&
-						*actualRule.BackendPort == wantedRule.Port {
-						foundRule = true
-						break
+						*actualRule.FrontendPort == wantedRule.Port {
+						if isInternal {
+							if (!isIPv6 && *actualRule.BackendPort == wantedRule.Port) ||
+								(isIPv6 && *actualRule.BackendPort == wantedRule.NodePort) {
+								foundRule = true
+								break
+							}
+						} else if *actualRule.BackendPort == wantedRule.Port {
+							foundRule = true
+							break
+						}
 					}
 				}
 				if !foundRule {
@@ -2098,17 +2151,11 @@ func validatePublicIP(t *testing.T, publicIP *network.PublicIPAddress, service *
 	}
 
 	serviceName := getServiceName(service)
-	if serviceName != *(publicIP.Tags[consts.ServiceTagKey]) {
-		t.Errorf("Expected publicIP resource has matching tags[%s]", consts.ServiceTagKey)
-	}
-
-	if publicIP.Tags[consts.ClusterNameKey] == nil {
-		t.Fatalf("Expected publicIP resource does not have tags[%s]", consts.ClusterNameKey)
-	}
-
-	if *(publicIP.Tags[consts.ClusterNameKey]) != testClusterName {
-		t.Errorf("Expected publicIP resource has matching tags[%s]", consts.ClusterNameKey)
-	}
+	assert.Equalf(t, serviceName, pointer.StringDeref(publicIP.Tags[consts.ServiceTagKey], ""),
+		"Expected publicIP resource has matching tags[%s]", consts.ServiceTagKey)
+	assert.NotNilf(t, publicIP.Tags[consts.ClusterNameKey], "Expected publicIP resource does not have tags[%s]", consts.ClusterNameKey)
+	assert.Equalf(t, testClusterName, pointer.StringDeref(publicIP.Tags[consts.ClusterNameKey], ""),
+		"Expected publicIP resource has matching tags[%s]", consts.ClusterNameKey)
 
 	// We cannot use Service LoadBalancerIP to compare with
 	// Public IP's IPAddress
@@ -2167,84 +2214,112 @@ func securityRuleMatches(serviceSourceRange string, servicePort v1.ServicePort, 
 	return nil
 }
 
-func validateSecurityGroup(t *testing.T, securityGroup *network.SecurityGroup, services ...v1.Service) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	az := GetTestCloud(ctrl)
-	seenRules := make(map[string]string)
-	for i, svc := range services {
+func validateSecurityGroupCommon(t *testing.T, az *Cloud, securityGroup *network.SecurityGroup, v4Enabled, v6Enabled bool, services ...v1.Service) {
+	expectedRules := make(map[string]bool)
+	for _, svc := range services {
 		svc := svc
 		for _, wantedRule := range svc.Spec.Ports {
-			sources := getServiceSourceRanges(&services[i])
+			sources := getServiceSourceRanges(&svc)
 			for _, source := range sources {
-				isIPv6 := utilnet.IsIPv6String(services[i].Spec.ClusterIP)
-				wantedRuleName := az.getSecurityRuleName(&services[i], wantedRule, source, isIPv6)
-				seenRules[wantedRuleName] = wantedRuleName
-				foundRule := false
-				for _, actualRule := range *securityGroup.SecurityRules {
-					if strings.EqualFold(*actualRule.Name, wantedRuleName) {
-						err := securityRuleMatches(source, wantedRule, getServiceLoadBalancerIP(&svc, isIPv6), actualRule)
-						if err != nil {
-							t.Errorf("Found matching security rule %q but properties were incorrect: %v", wantedRuleName, err)
+				checkRule := func(svc *v1.Service, wantedRule v1.ServicePort, source string, isIPv6 bool) {
+					sourceIP, _, err := net.ParseCIDR(source)
+					// err == nil means source is a valid CIDR.
+					if err == nil && sourceIP.To4() == nil != isIPv6 {
+						return
+					}
+					wantedRuleName := az.getSecurityRuleName(svc, wantedRule, source, isIPv6)
+					expectedRules[wantedRuleName] = true
+
+					foundRule := false
+					for _, actualRule := range *securityGroup.SecurityRules {
+						if strings.EqualFold(*actualRule.Name, wantedRuleName) {
+							if err := securityRuleMatches(source, wantedRule, getServiceLoadBalancerIP(svc, isIPv6), actualRule); err != nil {
+								t.Errorf("Found matching security rule %q but properties were incorrect: %v", wantedRuleName, err)
+							}
+							foundRule = true
+							break
 						}
-						foundRule = true
-						break
+					}
+					if !foundRule {
+						t.Errorf("Expected security group rule but didn't find it: %q", wantedRuleName)
 					}
 				}
-				if !foundRule {
-					t.Errorf("Expected security group rule but didn't find it: %q", wantedRuleName)
+
+				if v4Enabled {
+					checkRule(&svc, wantedRule, source, false)
+				}
+				if v6Enabled {
+					checkRule(&svc, wantedRule, source, true)
 				}
 			}
 		}
 	}
 
+	actualRules := []string{}
+	for _, rule := range *securityGroup.SecurityRules {
+		actualRules = append(actualRules, *rule.Name)
+	}
 	lenRules := len(*securityGroup.SecurityRules)
-	expectedRuleCount := len(seenRules)
-	if lenRules != expectedRuleCount {
-		t.Errorf("Expected the loadbalancer to have %d rules. Found %d.\n", expectedRuleCount, lenRules)
-	}
+	expectedRuleCount := len(expectedRules)
+	assert.Equalf(t, expectedRuleCount, lenRules, "Expected rules: %v, actual ones: %v", expectedRules, actualRules)
 }
 
-func TestSecurityRulePriorityPicksNextAvailablePriority(t *testing.T) {
-	rules := []network.SecurityRule{}
+func validateSecurityGroupDualStack(t *testing.T, az *Cloud, securityGroup *network.SecurityGroup, services ...v1.Service) {
+	validateSecurityGroupCommon(t, az, securityGroup, true, true, services...)
+}
 
-	var expectedPriority int32 = consts.LoadBalancerMinimumPriority + 50
+func validateSecurityGroup(t *testing.T, az *Cloud, securityGroup *network.SecurityGroup, services ...v1.Service) {
+	validateSecurityGroupCommon(t, az, securityGroup, true, false, services...)
+}
 
-	var i int32
-	for i = consts.LoadBalancerMinimumPriority; i < expectedPriority; i++ {
-		rules = append(rules, network.SecurityRule{
+func TestGetNextAvailablePriority(t *testing.T) {
+	rules50, rulesTooMany := []network.SecurityRule{}, []network.SecurityRule{}
+	for i := int32(consts.LoadBalancerMinimumPriority); i < consts.LoadBalancerMinimumPriority+50; i++ {
+		rules50 = append(rules50, network.SecurityRule{
+			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+				Priority: pointer.Int32(i),
+			},
+		})
+	}
+	for i := int32(consts.LoadBalancerMinimumPriority); i < consts.LoadBalancerMaximumPriority; i++ {
+		rulesTooMany = append(rulesTooMany, network.SecurityRule{
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				Priority: pointer.Int32(i),
 			},
 		})
 	}
 
-	priority, err := getNextAvailablePriority(rules)
-	if err != nil {
-		t.Errorf("Unexpectected error: %q", err)
+	testcases := []struct {
+		desc             string
+		rules            []network.SecurityRule
+		lastPriority     int32
+		expectErr        bool
+		expectedPriority int32
+	}{
+		{
+			desc:             "50 rules",
+			rules:            rules50,
+			lastPriority:     consts.LoadBalancerMinimumPriority - 1,
+			expectedPriority: consts.LoadBalancerMinimumPriority + 50,
+		},
+		{
+			desc:         "too many rules",
+			rules:        rulesTooMany,
+			lastPriority: consts.LoadBalancerMinimumPriority - 1,
+			expectErr:    true,
+		},
 	}
 
-	if priority != expectedPriority {
-		t.Errorf("Expected priority %d. Got priority %d.", expectedPriority, priority)
-	}
-}
-
-func TestSecurityRulePriorityFailsIfExhausted(t *testing.T) {
-	rules := []network.SecurityRule{}
-
-	var i int32
-	for i = consts.LoadBalancerMinimumPriority; i < consts.LoadBalancerMaximumPriority; i++ {
-		rules = append(rules, network.SecurityRule{
-			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-				Priority: pointer.Int32(i),
-			},
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			priority, err := getNextAvailablePriority(tc.rules)
+			if tc.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expectedPriority, priority)
+			}
 		})
-	}
-
-	_, err := getNextAvailablePriority(rules)
-	if err == nil {
-		t.Error("Expect an error. There are no priority levels left.")
 	}
 }
 
@@ -2623,40 +2698,28 @@ func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	svc := getTestService("servicea", v1.ProtocolTCP, nil, false, 80)
-	setServiceLoadBalancerIP(&svc, testIP1)
+	svc := getTestServiceDualStack("servicea", v1.ProtocolTCP, nil, 80)
+	setServiceLoadBalancerIP(&svc, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc, testIPs[0][true])
 	svc.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 	setMockSecurityGroup(az, ctrl, sg)
 
-	isIPv6 := utilnet.IsIPv6String(svc.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc, isIPv6)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, &[]string{getServiceLoadBalancerIP(&svc, false), getServiceLoadBalancerIP(&svc, true)}, nil, true)
 	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svc)
+	validateSecurityGroupDualStack(t, az, sg, svc)
 
-	expectedRuleName := testRuleName
-	_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, expectedRuleName)
-	if !ruleFound {
-		t.Fatalf("Expected security rule %q but it was not present", expectedRuleName)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIP1, securityRule)
-	if err != nil {
-		t.Errorf("Shared rule was not updated with new service IP: %v", err)
-	}
-
-	if securityRule.Priority == nil {
-		t.Errorf("Shared rule %s had no priority", expectedRuleName)
-	}
-
-	if securityRule.Access != network.SecurityRuleAccessAllow {
-		t.Errorf("Shared rule %s did not have Allow access", expectedRuleName)
-	}
-
-	if securityRule.Direction != network.SecurityRuleDirectionInbound {
-		t.Errorf("Shared rule %s did not have Inbound direction", expectedRuleName)
+	for isIPv6, expectedRuleName := range testRuleNames[0] {
+		t.Run(fmt.Sprintf("expectedRuleName=%s isIPv6=%t", expectedRuleName, isIPv6), func(t *testing.T) {
+			_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, expectedRuleName)
+			assert.True(t, ruleFound)
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIPs[0][isIPv6], securityRule))
+			assert.NotNil(t, securityRule.Priority)
+			assert.Equal(t, network.SecurityRuleAccessAllow, securityRule.Access)
+			assert.Equal(t, network.SecurityRuleDirectionInbound, securityRule.Direction)
+		})
 	}
 }
 
@@ -2665,53 +2728,45 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 	defer ctrl.Finish()
 
 	az := GetTestCloud(ctrl)
-	svc := getTestService("servicesr", v1.ProtocolTCP, nil, false, 80)
-	setServiceLoadBalancerIP(&svc, testIP1)
+	svc := getTestServiceDualStack("servicesr", v1.ProtocolTCP, nil, 80)
+	setServiceLoadBalancerIP(&svc, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc, testIPs[0][true])
 	svc.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	expectedRuleName := testRuleName
-
-	sg := getTestSecurityGroup(az)
-	sg.SecurityRules = &[]network.SecurityRule{
-		{
-			Name: &expectedRuleName,
+	sg := getTestSecurityGroupDualStack(az)
+	rules := []network.SecurityRule{}
+	for _, isIPv6 := range []bool{false, true} {
+		ruleName := testRuleNames[0][isIPv6]
+		rule := network.SecurityRule{
+			Name: &ruleName,
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				Protocol:                 network.SecurityRuleProtocolTCP,
 				SourcePortRange:          pointer.String("*"),
 				SourceAddressPrefix:      pointer.String("Internet"),
 				DestinationPortRange:     pointer.String("80"),
-				DestinationAddressPrefix: pointer.String(testIP2),
+				DestinationAddressPrefix: pointer.String(testIPs[1][isIPv6]),
 				Access:                   network.SecurityRuleAccessAllow,
 				Direction:                network.SecurityRuleDirectionInbound,
 			},
-		},
+		}
+		rules = append(rules, rule)
 	}
+	sg.SecurityRules = &rules
 	setMockSecurityGroup(az, ctrl, sg)
 
-	isIPv6 := utilnet.IsIPv6String(svc.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc, isIPv6)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, &[]string{getServiceLoadBalancerIP(&svc, false), getServiceLoadBalancerIP(&svc, true)}, nil, true)
 	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svc)
+	validateSecurityGroupDualStack(t, az, sg, svc)
 
-	_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, expectedRuleName)
-	if !ruleFound {
-		t.Fatalf("Expected security rule %q but it was not present", expectedRuleName)
-	}
-
-	expectedDestinationIPCount := 2
-	if len(*securityRule.DestinationAddressPrefixes) != expectedDestinationIPCount {
-		t.Errorf("Shared rule should have had %d destination IP addresses but had %d", expectedDestinationIPCount, len(*securityRule.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIP2, securityRule)
-	if err != nil {
-		t.Errorf("Shared rule no longer matched other service IP: %v", err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIP1, securityRule)
-	if err != nil {
-		t.Errorf("Shared rule was not updated with new service IP: %v", err)
+	for isIPv6, expectedRuleName := range testRuleNames[0] {
+		t.Run(fmt.Sprintf("expectedRuleName=%s isIPv6=%t", expectedRuleName, isIPv6), func(t *testing.T) {
+			_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, expectedRuleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 2, len(*securityRule.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIPs[1][isIPv6], securityRule))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIPs[0][isIPv6], securityRule))
+		})
 	}
 }
 
@@ -2720,70 +2775,45 @@ func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc1, testIP1)
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
-	setServiceLoadBalancerIP(&svc2, testIP2)
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolTCP, nil, 8888)
+	setServiceLoadBalancerIP(&svc2, testIPs[1][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[1][true])
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
+	setMockSecurityGroup(az, ctrl, sg)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc1: %q", err)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, &[]string{getServiceLoadBalancerIP(&svc2, false), getServiceLoadBalancerIP(&svc2, true)}, nil, true)
+	assert.Nil(t, err)
+
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2)
+
+	for isIPv6, ruleName := range testRuleNames[1] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 1, len(*securityRule.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], securityRule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], securityRule))
+		})
 	}
 
-	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc2.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc2: %q", err)
-	}
-
-	validateSecurityGroup(t, sg, svc1, svc2)
-
-	_, securityRule1, rule1Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName2)
-	if !rule1Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName2)
-	}
-
-	_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
-	}
-
-	expectedDestinationIPCount1 := 1
-	if len(*securityRule1.DestinationAddressPrefixes) != expectedDestinationIPCount1 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName2, expectedDestinationIPCount1, len(*securityRule1.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule1)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName2, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule1)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName2)
-	}
-
-	expectedDestinationIPCount2 := 1
-	if len(*securityRule2.DestinationAddressPrefixes) != expectedDestinationIPCount2 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName3, expectedDestinationIPCount2, len(*securityRule2.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule2)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName3, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
+	for isIPv6, ruleName := range testRuleNames[2] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 1, len(*securityRule.DestinationAddressPrefixes))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], securityRule))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], securityRule))
+		})
 	}
 }
 
@@ -2792,71 +2822,55 @@ func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCre
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
-
-	setServiceLoadBalancerIP(&svc1, testIP1)
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolUDP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc2, testIP1)
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolUDP, nil, 4444)
+	setServiceLoadBalancerIP(&svc2, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[0][true])
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	testRuleName3 := "shared-UDP-4444-Internet"
+	ruleName2 := map[bool]string{
+		false: "shared-UDP-4444-Internet",
+		true:  "shared-UDP-4444-Internet-IPv6",
+	}
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc1: %q", err)
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc2.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2, isIPv6)), nil, true)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, &[]string{getServiceLoadBalancerIP(&svc2, false), getServiceLoadBalancerIP(&svc2, true)}, nil, true)
 	if err != nil {
 		t.Errorf("Unexpected error adding svc2: %q", err)
 	}
 
-	validateSecurityGroup(t, sg, svc1, svc2)
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2)
 
-	_, securityRule1, rule1Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName2)
-	if !rule1Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName2)
+	for isIPv6, ruleName := range testRuleNames[1] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule1, rule1Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule1Found)
+			assert.Equal(t, 1, len(*securityRule1.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], securityRule1))
+			assert.Equal(t, network.SecurityRuleProtocolTCP, securityRule1.Protocol)
+		})
 	}
 
-	_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
-	}
-
-	expectedDestinationIPCount1 := 1
-	if len(*securityRule1.DestinationAddressPrefixes) != expectedDestinationIPCount1 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName2, expectedDestinationIPCount1, len(*securityRule1.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule1)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName2, err)
-	}
-
-	if securityRule1.Protocol != network.SecurityRuleProtocolTCP {
-		t.Errorf("Shared rule %s should have been %s but was %s", testRuleName2, network.SecurityRuleProtocolTCP, securityRule1.Protocol)
-	}
-
-	expectedDestinationIPCount2 := 1
-	if len(*securityRule2.DestinationAddressPrefixes) != expectedDestinationIPCount2 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName3, expectedDestinationIPCount2, len(*securityRule2.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule2)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName3, err)
-	}
-
-	if securityRule2.Protocol != network.SecurityRuleProtocolUDP {
-		t.Errorf("Shared rule %s should have been %s but was %s", testRuleName3, network.SecurityRuleProtocolUDP, securityRule2.Protocol)
+	for isIPv6, ruleName := range ruleName2 {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule2Found)
+			assert.Equal(t, 1, len(*securityRule2.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], securityRule2))
+			assert.Equal(t, network.SecurityRuleProtocolUDP, securityRule2.Protocol)
+		})
 	}
 }
 
@@ -2865,75 +2879,66 @@ func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRules
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 80)
-	setServiceLoadBalancerIP(&svc1, testIP1)
-	svc1.Spec.LoadBalancerSourceRanges = []string{"192.168.12.0/24"}
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 80)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
+	svc1.Spec.LoadBalancerSourceRanges = []string{"192.168.12.0/24", "fd::1:0/112"}
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 80)
-	setServiceLoadBalancerIP(&svc2, testIP2)
-	svc2.Spec.LoadBalancerSourceRanges = []string{"192.168.34.0/24"}
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolTCP, nil, 80)
+	setServiceLoadBalancerIP(&svc2, testIPs[1][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[1][true])
+	svc2.Spec.LoadBalancerSourceRanges = []string{"192.168.34.0/24", "fd::2:0/112"}
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	testRuleName2 := "shared-TCP-80-192.168.12.0_24"
-	testRuleName3 := "shared-TCP-80-192.168.34.0_24"
+	ruleName1 := map[bool]string{
+		false: "shared-TCP-80-192.168.12.0_24",
+		true:  "shared-TCP-80-fd..1.0_112-IPv6",
+	}
+	ruleName2 := map[bool]string{
+		false: "shared-TCP-80-192.168.34.0_24",
+		true:  "shared-TCP-80-fd..2.0_112-IPv6",
+	}
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
+	var err error
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc1: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc2.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc2: %q", err)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, &[]string{getServiceLoadBalancerIP(&svc2, false), getServiceLoadBalancerIP(&svc2, true)}, nil, true)
+	assert.Nil(t, err)
+
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2)
+
+	for isIPv6, ruleName := range ruleName1 {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			loadBalancerSourceRange := svc1.Spec.LoadBalancerSourceRanges[0]
+			if isIPv6 {
+				loadBalancerSourceRange = svc1.Spec.LoadBalancerSourceRanges[1]
+			}
+			_, securityRule1, rule1Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule1Found)
+			assert.Equal(t, 1, len(*securityRule1.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches(loadBalancerSourceRange, v1.ServicePort{Port: 80}, testIPs[0][isIPv6], securityRule1))
+			assert.NotNil(t, securityRuleMatches(loadBalancerSourceRange, v1.ServicePort{Port: 80}, testIPs[1][isIPv6], securityRule1))
+		})
 	}
 
-	validateSecurityGroup(t, sg, svc1, svc2)
-
-	_, securityRule1, rule1Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName2)
-	if !rule1Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName2)
-	}
-
-	_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
-	}
-
-	expectedDestinationIPCount1 := 1
-	if len(*securityRule1.DestinationAddressPrefixes) != expectedDestinationIPCount1 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName2, expectedDestinationIPCount1, len(*securityRule1.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches(svc1.Spec.LoadBalancerSourceRanges[0], v1.ServicePort{Port: 80}, testIP1, securityRule1)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName2, err)
-	}
-
-	err = securityRuleMatches(svc2.Spec.LoadBalancerSourceRanges[0], v1.ServicePort{Port: 80}, testIP2, securityRule1)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName2)
-	}
-
-	expectedDestinationIPCount2 := 1
-	if len(*securityRule2.DestinationAddressPrefixes) != expectedDestinationIPCount2 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName3, expectedDestinationIPCount2, len(*securityRule2.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches(svc2.Spec.LoadBalancerSourceRanges[0], v1.ServicePort{Port: 80}, testIP2, securityRule2)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName3, err)
-	}
-
-	err = securityRuleMatches(svc1.Spec.LoadBalancerSourceRanges[0], v1.ServicePort{Port: 80}, testIP1, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
+	for isIPv6, ruleName := range ruleName2 {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			loadBalancerSourceRange := svc2.Spec.LoadBalancerSourceRanges[0]
+			if isIPv6 {
+				loadBalancerSourceRange = svc2.Spec.LoadBalancerSourceRanges[1]
+			}
+			_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule2Found)
+			assert.Equal(t, 1, len(*securityRule2.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches(loadBalancerSourceRange, v1.ServicePort{Port: 80}, testIPs[1][isIPv6], securityRule2))
+			assert.NotNil(t, securityRuleMatches(loadBalancerSourceRange, v1.ServicePort{Port: 80}, testIPs[0][isIPv6], securityRule2))
+		})
 	}
 }
 
@@ -2942,104 +2947,61 @@ func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSepara
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc1, testIP1)
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
-	setServiceLoadBalancerIP(&svc2, testIP2)
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolTCP, nil, 8888)
+	setServiceLoadBalancerIP(&svc2, testIPs[1][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[1][true])
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc3, testIP3)
+	svc3 := getTestServiceDualStack("servicesr3", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc3, testIPs[2][false])
+	setServiceLoadBalancerIP(&svc3, testIPs[2][true])
 	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	testRuleName23 := testRuleName2
-	sg := getTestSecurityGroup(az)
+	testRuleName23 := testRuleNames[1]
+	sg := getTestSecurityGroupDualStack(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc1: %q", err)
-	}
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc2.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc2: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, &[]string{getServiceLoadBalancerIP(&svc2, false), getServiceLoadBalancerIP(&svc2, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc3.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc3: %q", err)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, &[]string{getServiceLoadBalancerIP(&svc3, false), getServiceLoadBalancerIP(&svc3, true)}, nil, true)
+	assert.Nil(t, err)
+
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2, svc3)
+
+	for isIPv6, ruleName := range testRuleName23 {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, rule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 2, len(*rule.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], rule))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[2][isIPv6], rule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], rule))
+			assert.NotNil(t, rule.Priority)
+			assert.Equal(t, network.SecurityRuleAccessAllow, rule.Access)
+			assert.Equal(t, network.SecurityRuleDirectionInbound, rule.Direction)
+		})
 	}
 
-	validateSecurityGroup(t, sg, svc1, svc2, svc3)
-
-	_, securityRule13, rule13Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName23)
-	if !rule13Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName23)
-	}
-
-	_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
-	}
-
-	expectedDestinationIPCount13 := 2
-	if len(*securityRule13.DestinationAddressPrefixes) != expectedDestinationIPCount13 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName23, expectedDestinationIPCount13, len(*securityRule13.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule13)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName23, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP3, securityRule13)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName23, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule13)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName23)
-	}
-
-	if securityRule13.Priority == nil {
-		t.Errorf("Shared rule %s had no priority", testRuleName23)
-	}
-
-	if securityRule13.Access != network.SecurityRuleAccessAllow {
-		t.Errorf("Shared rule %s did not have Allow access", testRuleName23)
-	}
-
-	if securityRule13.Direction != network.SecurityRuleDirectionInbound {
-		t.Errorf("Shared rule %s did not have Inbound direction", testRuleName23)
-	}
-
-	expectedDestinationIPCount2 := 1
-	if len(*securityRule2.DestinationAddressPrefixes) != expectedDestinationIPCount2 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName3, expectedDestinationIPCount2, len(*securityRule2.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule2)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName3, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP3, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
+	for isIPv6, ruleName := range testRuleNames[2] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, rule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 1, len(*rule.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], rule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], rule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[2][isIPv6], rule))
+		})
 	}
 }
 
@@ -3048,61 +3010,42 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 80)
-	setServiceLoadBalancerIP(&svc1, testIP1)
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 80)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 80)
-	setServiceLoadBalancerIP(&svc2, testIP2)
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolTCP, nil, 80)
+	setServiceLoadBalancerIP(&svc2, testIPs[1][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[1][true])
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	expectedRuleName := testRuleName
-
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc1: %q", err)
-	}
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc2.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc2: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, &[]string{getServiceLoadBalancerIP(&svc2, false), getServiceLoadBalancerIP(&svc2, true)}, nil, true)
+	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svc1, svc2)
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, false)
-	if err != nil {
-		t.Errorf("Unexpected error removing svc1: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, false)
+	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svc2)
+	validateSecurityGroupDualStack(t, az, sg, svc2)
 
-	_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, expectedRuleName)
-	if !ruleFound {
-		t.Fatalf("Expected security rule %q but it was not present", expectedRuleName)
-	}
-
-	expectedDestinationIPCount := 1
-	if len(*securityRule.DestinationAddressPrefixes) != expectedDestinationIPCount {
-		t.Errorf("Shared rule should have had %d destination IP addresses but had %d", expectedDestinationIPCount, len(*securityRule.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIP2, securityRule)
-	if err != nil {
-		t.Errorf("Shared rule no longer matched other service IP: %v", err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIP1, securityRule)
-	if err == nil {
-		t.Error("Shared rule was not updated to remove deleted service IP")
+	for isIPv6, ruleName := range testRuleNames[0] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 1, len(*securityRule.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIPs[1][isIPv6], securityRule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 80}, testIPs[0][isIPv6], securityRule))
+		})
 	}
 }
 
@@ -3111,113 +3054,67 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc1, testIP1)
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
-	setServiceLoadBalancerIP(&svc2, testIP2)
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolTCP, nil, 8888)
+	setServiceLoadBalancerIP(&svc2, testIPs[1][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[1][true])
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc3, testIP3)
+	svc3 := getTestServiceDualStack("servicesr3", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc3, testIPs[2][false])
+	setServiceLoadBalancerIP(&svc3, testIPs[2][true])
 	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	testRuleName23 := testRuleName2
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc1: %q", err)
-	}
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc2.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc2: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, &[]string{getServiceLoadBalancerIP(&svc2, false), getServiceLoadBalancerIP(&svc2, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc3.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc3: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, &[]string{getServiceLoadBalancerIP(&svc3, false), getServiceLoadBalancerIP(&svc3, true)}, nil, true)
+	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svc1, svc2, svc3)
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2, svc3)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, false)
-	if err != nil {
-		t.Errorf("Unexpected error removing svc1: %q", err)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, false)
+	assert.Nil(t, err)
+
+	validateSecurityGroupDualStack(t, az, sg, svc2, svc3)
+
+	for isIPv6, ruleName := range testRuleNames[1] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, rule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 1, len(*rule.DestinationAddressPrefixes))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], rule))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[2][isIPv6], rule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], rule))
+			assert.NotNil(t, rule.Priority)
+			assert.Equal(t, network.SecurityRuleAccessAllow, rule.Access)
+			assert.Equal(t, network.SecurityRuleDirectionInbound, rule.Direction)
+		})
 	}
 
-	validateSecurityGroup(t, sg, svc2, svc3)
+	for isIPv6, ruleName := range testRuleNames[2] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, rule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 1, len(*rule.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], rule))
 
-	_, securityRule13, rule13Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName23)
-	if !rule13Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName23)
-	}
-
-	_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
-	}
-
-	expectedDestinationIPCount13 := 1
-	if len(*securityRule13.DestinationAddressPrefixes) != expectedDestinationIPCount13 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName23, expectedDestinationIPCount13, len(*securityRule13.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule13)
-	if err == nil {
-		t.Errorf("Shared rule %s should have had svc1 removed but did not", testRuleName23)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP3, securityRule13)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName23, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule13)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName23)
-	}
-
-	if securityRule13.Priority == nil {
-		t.Errorf("Shared rule %s had no priority", testRuleName23)
-	}
-
-	if securityRule13.Access != network.SecurityRuleAccessAllow {
-		t.Errorf("Shared rule %s did not have Allow access", testRuleName23)
-	}
-
-	if securityRule13.Direction != network.SecurityRuleDirectionInbound {
-		t.Errorf("Shared rule %s did not have Inbound direction", testRuleName23)
-	}
-
-	expectedDestinationIPCount2 := 1
-	if len(*securityRule2.DestinationAddressPrefixes) != expectedDestinationIPCount2 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName3, expectedDestinationIPCount2, len(*securityRule2.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule2)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName3, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP3, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], rule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[2][isIPv6], rule))
+		})
 	}
 }
 
@@ -3226,88 +3123,63 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 	defer ctrl.Finish()
 	az := GetTestCloud(ctrl)
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc1, testIP1)
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
-	setServiceLoadBalancerIP(&svc2, testIP2)
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolTCP, nil, 8888)
+	setServiceLoadBalancerIP(&svc2, testIPs[1][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[1][true])
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc3, testIP3)
+	svc3 := getTestServiceDualStack("servicesr3", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc3, testIPs[2][false])
+	setServiceLoadBalancerIP(&svc3, testIPs[2][true])
 	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	testRuleName23 := testRuleName2
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc1: %q", err)
-	}
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc2.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, pointer.String(getServiceLoadBalancerIP(&svc2, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc2: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc2, &[]string{getServiceLoadBalancerIP(&svc2, false), getServiceLoadBalancerIP(&svc2, true)}, nil, true)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc3.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error adding svc3: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, &[]string{getServiceLoadBalancerIP(&svc3, false), getServiceLoadBalancerIP(&svc3, true)}, nil, true)
+	assert.Nil(t, err)
 
-	validateSecurityGroup(t, sg, svc1, svc2, svc3)
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2, svc3)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, false)
-	if err != nil {
-		t.Errorf("Unexpected error removing svc1: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, false)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc3.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, pointer.String(getServiceLoadBalancerIP(&svc3, isIPv6)), nil, false)
-	if err != nil {
-		t.Errorf("Unexpected error removing svc3: %q", err)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc3, &[]string{getServiceLoadBalancerIP(&svc3, false), getServiceLoadBalancerIP(&svc3, true)}, nil, false)
+	assert.Nil(t, err)
+
+	validateSecurityGroupDualStack(t, az, sg, svc2)
+
+	for isIPv6, ruleName := range testRuleNames[1] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, _, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.False(t, ruleFound)
+		})
 	}
 
-	validateSecurityGroup(t, sg, svc2)
-
-	_, _, rule13Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName23)
-	if rule13Found {
-		t.Fatalf("Expected security rule %q to have been deleted but it was still present", testRuleName23)
-	}
-
-	_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
-	}
-
-	expectedDestinationIPCount2 := 1
-	if len(*securityRule2.DestinationAddressPrefixes) != expectedDestinationIPCount2 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName3, expectedDestinationIPCount2, len(*securityRule2.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule2)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName3, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP3, securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong service's port and IP", testRuleName3)
+	for isIPv6, ruleName := range testRuleNames[2] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, rule, ruleFound := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, ruleFound)
+			assert.Equal(t, 1, len(*rule.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], rule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], rule))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[2][isIPv6], rule))
+		})
 	}
 }
 
@@ -3317,171 +3189,132 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	az := GetTestCloud(ctrl)
 	var err error
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc1, testIP1)
+	svc1 := getTestServiceDualStack("servicesr1", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc1, testIPs[0][false])
+	setServiceLoadBalancerIP(&svc1, testIPs[0][true])
 	svc1.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, false, 8888)
-	setServiceLoadBalancerIP(&svc2, testIP2)
+	svc2 := getTestServiceDualStack("servicesr2", v1.ProtocolTCP, nil, 8888)
+	setServiceLoadBalancerIP(&svc2, testIPs[1][false])
+	setServiceLoadBalancerIP(&svc2, testIPs[1][true])
 	svc2.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc3, testIP3)
+	svc3 := getTestServiceDualStack("servicesr3", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc3, testIPs[2][false])
+	setServiceLoadBalancerIP(&svc3, testIPs[2][true])
 	svc3.Annotations[consts.ServiceAnnotationSharedSecurityRule] = consts.TrueAnnotationValue
 
-	svc4 := getTestService("servicesr4", v1.ProtocolTCP, nil, false, 4444)
-	setServiceLoadBalancerIP(&svc4, "192.168.22.33")
+	svc4 := getTestServiceDualStack("servicesr4", v1.ProtocolTCP, nil, 4444)
+	setServiceLoadBalancerIP(&svc4, testIPs[3][false])
+	setServiceLoadBalancerIP(&svc4, testIPs[3][true])
 	svc4.Annotations[consts.ServiceAnnotationSharedSecurityRule] = "false"
 
-	svc5 := getTestService("servicesr5", v1.ProtocolTCP, nil, false, 8888)
-	setServiceLoadBalancerIP(&svc5, "192.168.22.33")
+	svc5 := getTestServiceDualStack("servicesr5", v1.ProtocolTCP, nil, 8888)
+	setServiceLoadBalancerIP(&svc5, testIPs[3][false])
+	setServiceLoadBalancerIP(&svc5, testIPs[3][true])
 	svc5.Annotations[consts.ServiceAnnotationSharedSecurityRule] = "false"
 
 	testServices := []v1.Service{svc1, svc2, svc3, svc4, svc5}
 
-	testRuleName23 := testRuleName2
-	isIPv6 := utilnet.IsIPv6String(svc4.Spec.ClusterIP)
-	expectedRuleName4 := az.getSecurityRuleName(&svc4, v1.ServicePort{Port: 4444, Protocol: v1.ProtocolTCP}, "Internet", isIPv6)
-	isIPv6 = utilnet.IsIPv6String(svc5.Spec.ClusterIP)
-	expectedRuleName5 := az.getSecurityRuleName(&svc5, v1.ServicePort{Port: 8888, Protocol: v1.ProtocolTCP}, "Internet", isIPv6)
+	testRuleName23 := testRuleNames[1]
+	expectedRuleName4 := map[bool]string{
+		false: az.getSecurityRuleName(&svc4, v1.ServicePort{Port: 4444, Protocol: v1.ProtocolTCP}, "Internet", false),
+		true:  az.getSecurityRuleName(&svc4, v1.ServicePort{Port: 4444, Protocol: v1.ProtocolTCP}, "Internet", true),
+	}
+	expectedRuleName5 := map[bool]string{
+		false: az.getSecurityRuleName(&svc5, v1.ServicePort{Port: 8888, Protocol: v1.ProtocolTCP}, "Internet", false),
+		true:  az.getSecurityRuleName(&svc5, v1.ServicePort{Port: 8888, Protocol: v1.ProtocolTCP}, "Internet", true),
+	}
 
-	sg := getTestSecurityGroup(az)
+	sg := getTestSecurityGroupDualStack(az)
 
 	for i, svc := range testServices {
 		svc := svc
 		setMockSecurityGroup(az, ctrl, sg)
-		isIPv6 := utilnet.IsIPv6String(svc.Spec.ClusterIP)
-		sg, err = az.reconcileSecurityGroup(testClusterName, &testServices[i], pointer.String(getServiceLoadBalancerIP(&svc, isIPv6)), nil, true)
-		if err != nil {
-			t.Errorf("Unexpected error adding svc%d: %q", i+1, err)
-		}
+		sg, err = az.reconcileSecurityGroup(testClusterName, &testServices[i], &[]string{getServiceLoadBalancerIP(&svc, false), getServiceLoadBalancerIP(&svc, true)}, nil, true)
+		assert.Nil(t, err)
 	}
 
-	validateSecurityGroup(t, sg, svc1, svc2, svc3, svc4, svc5)
+	validateSecurityGroupDualStack(t, az, sg, svc1, svc2, svc3, svc4, svc5)
 
-	expectedRuleCount := 4
-	if len(*sg.SecurityRules) != expectedRuleCount {
-		t.Errorf("Expected security group to have %d rules but it had %d", expectedRuleCount, len(*sg.SecurityRules))
+	assert.Equal(t, 8, len(*sg.SecurityRules))
+
+	for isIPv6, ruleName := range testRuleName23 {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule13, rule13Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule13Found)
+			assert.Equal(t, 2, len(*securityRule13.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[0][isIPv6], securityRule13))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[2][isIPv6], securityRule13))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIPs[3][isIPv6], securityRule13))
+		})
 	}
 
-	_, securityRule13, rule13Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName23)
-	if !rule13Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName23)
+	for isIPv6, ruleName := range testRuleNames[2] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule2Found)
+			assert.Equal(t, 1, len(*securityRule2.DestinationAddressPrefixes))
+			assert.Nil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[1][isIPv6], securityRule2))
+			assert.NotNil(t, securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIPs[3][isIPv6], securityRule2))
+		})
 	}
 
-	_, securityRule2, rule2Found := findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
+	for isIPv6, ruleName := range expectedRuleName4 {
+		t.Run(fmt.Sprintf("expectedRuleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule4, rule4Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule4Found)
+			assert.Nil(t, securityRule4.DestinationAddressPrefixes)
+			assert.NotNil(t, securityRule4.DestinationAddressPrefix)
+			assert.Equal(t, getServiceLoadBalancerIP(&svc4, isIPv6), *securityRule4.DestinationAddressPrefix)
+		})
 	}
 
-	_, securityRule4, rule4Found := findSecurityRuleByName(*sg.SecurityRules, expectedRuleName4)
-	if !rule4Found {
-		t.Fatalf("Expected security rule %q but it was not present", expectedRuleName4)
-	}
-
-	_, securityRule5, rule5Found := findSecurityRuleByName(*sg.SecurityRules, expectedRuleName5)
-	if !rule5Found {
-		t.Fatalf("Expected security rule %q but it was not present", expectedRuleName5)
-	}
-
-	expectedDestinationIPCount13 := 2
-	if len(*securityRule13.DestinationAddressPrefixes) != expectedDestinationIPCount13 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName23, expectedDestinationIPCount13, len(*securityRule13.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP1, securityRule13)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName23, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, testIP3, securityRule13)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName23, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 4444}, "192.168.22.33", securityRule13)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong (unshared) service's port and IP", testRuleName23)
-	}
-
-	expectedDestinationIPCount2 := 1
-	if len(*securityRule2.DestinationAddressPrefixes) != expectedDestinationIPCount2 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName3, expectedDestinationIPCount2, len(*securityRule2.DestinationAddressPrefixes))
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, testIP2, securityRule2)
-	if err != nil {
-		t.Errorf("Shared rule %s did not match service IP: %v", testRuleName3, err)
-	}
-
-	err = securityRuleMatches("Internet", v1.ServicePort{Port: 8888}, "192.168.22.33", securityRule2)
-	if err == nil {
-		t.Errorf("Shared rule %s matched wrong (unshared) service's port and IP", testRuleName3)
-	}
-
-	if securityRule4.DestinationAddressPrefixes != nil {
-		t.Errorf("Expected unshared rule %s to use single destination IP address but used collection", expectedRuleName4)
-	}
-
-	if securityRule4.DestinationAddressPrefix == nil {
-		t.Errorf("Expected unshared rule %s to have a destination IP address", expectedRuleName4)
-	} else {
-		isIPv6 := utilnet.IsIPv6String(svc4.Spec.ClusterIP)
-		if !strings.EqualFold(*securityRule4.DestinationAddressPrefix, getServiceLoadBalancerIP(&svc4, isIPv6)) {
-			t.Errorf("Expected unshared rule %s to have a destination %s but had %s", expectedRuleName4, getServiceLoadBalancerIP(&svc4, isIPv6), *securityRule4.DestinationAddressPrefix)
-		}
-	}
-
-	if securityRule5.DestinationAddressPrefixes != nil {
-		t.Errorf("Expected unshared rule %s to use single destination IP address but used collection", expectedRuleName5)
-	}
-
-	if securityRule5.DestinationAddressPrefix == nil {
-		t.Errorf("Expected unshared rule %s to have a destination IP address", expectedRuleName5)
-	} else {
-		isIPv6 := utilnet.IsIPv6String(svc5.Spec.ClusterIP)
-		if !strings.EqualFold(*securityRule5.DestinationAddressPrefix, getServiceLoadBalancerIP(&svc5, isIPv6)) {
-			t.Errorf("Expected unshared rule %s to have a destination %s but had %s", expectedRuleName5, getServiceLoadBalancerIP(&svc5, isIPv6), *securityRule5.DestinationAddressPrefix)
-		}
+	for isIPv6, ruleName := range expectedRuleName5 {
+		t.Run(fmt.Sprintf("expectedRuleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule5, rule5Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule5Found)
+			assert.Nil(t, securityRule5.DestinationAddressPrefixes)
+			assert.NotNil(t, securityRule5.DestinationAddressPrefix)
+			assert.Equal(t, getServiceLoadBalancerIP(&svc5, isIPv6), *securityRule5.DestinationAddressPrefix)
+		})
 	}
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc1.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, false)
-	if err != nil {
-		t.Errorf("Unexpected error removing svc1: %q", err)
-	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, &[]string{getServiceLoadBalancerIP(&svc1, false), getServiceLoadBalancerIP(&svc1, true)}, nil, false)
+	assert.Nil(t, err)
 
 	setMockSecurityGroup(az, ctrl, sg)
-	isIPv6 = utilnet.IsIPv6String(svc5.Spec.ClusterIP)
-	sg, err = az.reconcileSecurityGroup(testClusterName, &svc5, pointer.String(getServiceLoadBalancerIP(&svc5, isIPv6)), nil, false)
-	if err != nil {
-		t.Errorf("Unexpected error removing svc5: %q", err)
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc5, &[]string{getServiceLoadBalancerIP(&svc5, false), getServiceLoadBalancerIP(&svc5, true)}, nil, false)
+	assert.Nil(t, err)
+
+	for isIPv6, ruleName := range testRuleName23 {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, securityRule13, rule13Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule13Found)
+			assert.Equal(t, 1, len(*securityRule13.DestinationAddressPrefixes))
+		})
 	}
 
-	_, securityRule13, rule13Found = findSecurityRuleByName(*sg.SecurityRules, testRuleName23)
-	if !rule13Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName23)
+	for isIPv6, ruleName := range testRuleNames[2] {
+		t.Run(fmt.Sprintf("ruleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, _, rule2Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule2Found)
+		})
 	}
 
-	_, _, rule2Found = findSecurityRuleByName(*sg.SecurityRules, testRuleName3)
-	if !rule2Found {
-		t.Fatalf("Expected security rule %q but it was not present", testRuleName3)
+	for isIPv6, ruleName := range expectedRuleName4 {
+		t.Run(fmt.Sprintf("expectedRuleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, _, rule4Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.True(t, rule4Found)
+		})
 	}
 
-	_, _, rule4Found = findSecurityRuleByName(*sg.SecurityRules, expectedRuleName4)
-	if !rule4Found {
-		t.Fatalf("Expected security rule %q but it was not present", expectedRuleName4)
-	}
-
-	_, _, rule5Found = findSecurityRuleByName(*sg.SecurityRules, expectedRuleName5)
-	if rule5Found {
-		t.Fatalf("Expected security rule %q to have been removed but it was not present", expectedRuleName5)
-	}
-
-	expectedDestinationIPCount13 = 1
-	if len(*securityRule13.DestinationAddressPrefixes) != expectedDestinationIPCount13 {
-		t.Errorf("Shared rule %s should have had %d destination IP addresses but had %d", testRuleName23, expectedDestinationIPCount13, len(*securityRule13.DestinationAddressPrefixes))
+	for isIPv6, ruleName := range expectedRuleName5 {
+		t.Run(fmt.Sprintf("expectedRuleName=%s isIPv6=%t", ruleName, isIPv6), func(t *testing.T) {
+			_, _, rule5Found := findSecurityRuleByName(*sg.SecurityRules, ruleName)
+			assert.False(t, rule5Found)
+		})
 	}
 }
 
@@ -3849,17 +3682,32 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 }
 
 func TestFindSecurityRule(t *testing.T) {
-	sg := network.SecurityRule{
-		Name: pointer.String(testRuleName4),
-		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-			Protocol:                   network.SecurityRuleProtocolTCP,
-			SourcePortRange:            pointer.String("*"),
-			SourceAddressPrefix:        pointer.String("Internet"),
-			DestinationPortRange:       pointer.String("80"),
-			DestinationAddressPrefix:   pointer.String(testIP1),
-			DestinationAddressPrefixes: &([]string{}),
-			Access:                     network.SecurityRuleAccessAllow,
-			Direction:                  network.SecurityRuleDirectionInbound,
+	srs := []network.SecurityRule{
+		{
+			Name: pointer.String(testRuleNames[3][false]),
+			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+				Protocol:                   network.SecurityRuleProtocolTCP,
+				SourcePortRange:            pointer.String("*"),
+				SourceAddressPrefix:        pointer.String("Internet"),
+				DestinationPortRange:       pointer.String("80"),
+				DestinationAddressPrefix:   pointer.String(testIPs[0][false]),
+				DestinationAddressPrefixes: &([]string{}),
+				Access:                     network.SecurityRuleAccessAllow,
+				Direction:                  network.SecurityRuleDirectionInbound,
+			},
+		},
+		{
+			Name: pointer.String(testRuleNames[3][true]),
+			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+				Protocol:                   network.SecurityRuleProtocolTCP,
+				SourcePortRange:            pointer.String("*"),
+				SourceAddressPrefix:        pointer.String("Internet"),
+				DestinationPortRange:       pointer.String("80"),
+				DestinationAddressPrefix:   pointer.String(testIPs[0][true]),
+				DestinationAddressPrefixes: &([]string{}),
+				Access:                     network.SecurityRuleAccessAllow,
+				Direction:                  network.SecurityRuleDirectionInbound,
+			},
 		},
 	}
 	testCases := []struct {
@@ -3882,7 +3730,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when protocol doesn't match",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol: network.SecurityRuleProtocolUDP,
 				},
@@ -3892,7 +3740,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourcePortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:        network.SecurityRuleProtocolUDP,
 					SourcePortRange: pointer.String("1.2.3.4/32"),
@@ -3903,7 +3751,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when SourceAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:            network.SecurityRuleProtocolUDP,
 					SourcePortRange:     pointer.String("*"),
@@ -3915,7 +3763,7 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationPortRange doesn't match",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:             network.SecurityRuleProtocolUDP,
 					SourcePortRange:      pointer.String("*"),
@@ -3928,13 +3776,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when DestinationAddressPrefix doesn't match",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
 					SourcePortRange:          pointer.String("*"),
 					SourceAddressPrefix:      pointer.String("Internet"),
 					DestinationPortRange:     pointer.String("80"),
-					DestinationAddressPrefix: pointer.String(testIP2),
+					DestinationAddressPrefix: pointer.String(testIPs[1][false]),
 				},
 			},
 			expected: false,
@@ -3942,13 +3790,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Access doesn't match",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
 					SourcePortRange:          pointer.String("*"),
 					SourceAddressPrefix:      pointer.String("Internet"),
 					DestinationPortRange:     pointer.String("80"),
-					DestinationAddressPrefix: pointer.String(testIP1),
+					DestinationAddressPrefix: pointer.String(testIPs[0][false]),
 					Access:                   network.SecurityRuleAccessDeny,
 					// Direction:                network.SecurityRuleDirectionInbound,
 				},
@@ -3958,13 +3806,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "false should be returned when Direction doesn't match",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolUDP,
 					SourcePortRange:          pointer.String("*"),
 					SourceAddressPrefix:      pointer.String("Internet"),
 					DestinationPortRange:     pointer.String("80"),
-					DestinationAddressPrefix: pointer.String(testIP1),
+					DestinationAddressPrefix: pointer.String(testIPs[0][false]),
 					Access:                   network.SecurityRuleAccessAllow,
 					Direction:                network.SecurityRuleDirectionOutbound,
 				},
@@ -3974,13 +3822,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "true should be returned when everything matches but protocol is in different case",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocol("TCP"),
 					SourcePortRange:          pointer.String("*"),
 					SourceAddressPrefix:      pointer.String("Internet"),
 					DestinationPortRange:     pointer.String("80"),
-					DestinationAddressPrefix: pointer.String(testIP1),
+					DestinationAddressPrefix: pointer.String(testIPs[0][false]),
 					Access:                   network.SecurityRuleAccessAllow,
 					Direction:                network.SecurityRuleDirectionInbound,
 				},
@@ -3990,13 +3838,13 @@ func TestFindSecurityRule(t *testing.T) {
 		{
 			desc: "true should be returned when everything matches but DestinationAddressPrefixes is nil",
 			testRule: network.SecurityRule{
-				Name: pointer.String(testRuleName4),
+				Name: pointer.String(testRuleNames[3][false]),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                   network.SecurityRuleProtocolTCP,
 					SourcePortRange:            pointer.String("*"),
 					SourceAddressPrefix:        pointer.String("Internet"),
 					DestinationPortRange:       pointer.String("80"),
-					DestinationAddressPrefix:   pointer.String(testIP1),
+					DestinationAddressPrefix:   pointer.String(testIPs[0][false]),
 					DestinationAddressPrefixes: nil,
 					Access:                     network.SecurityRuleAccessAllow,
 					Direction:                  network.SecurityRuleDirectionInbound,
@@ -4005,15 +3853,22 @@ func TestFindSecurityRule(t *testing.T) {
 			expected: true,
 		},
 		{
-			desc:     "true should be returned when everything matches",
-			testRule: sg,
+			desc:     "true should be returned when everything matches IPv4",
+			testRule: srs[0],
+			expected: true,
+		},
+		{
+			desc:     "true should be returned when everything matches IPv6",
+			testRule: srs[1],
 			expected: true,
 		},
 	}
 
 	for i := range testCases {
-		found := findSecurityRule([]network.SecurityRule{sg}, testCases[i].testRule)
-		assert.Equal(t, testCases[i].expected, found, testCases[i].desc)
+		t.Run(testCases[i].desc, func(t *testing.T) {
+			found := findSecurityRule(srs, testCases[i].testRule)
+			assert.Equal(t, testCases[i].expected, found)
+		})
 	}
 }
 

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -115,9 +115,7 @@ func TestAddPort(t *testing.T) {
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	// ensure we got a frontend ip configuration
 	if len(*lb.FrontendIPConfigurations) != 1 {
@@ -141,6 +139,27 @@ func TestLoadBalancerExternalServiceModeSelection(t *testing.T) {
 	testLoadBalancerServicesSpecifiedSelection(t, false)
 	testLoadBalancerMaxRulesServices(t, false)
 	testLoadBalancerServiceAutoModeDeleteSelection(t, false)
+}
+
+func setMockEnvDualStack(az *Cloud, ctrl *gomock.Controller, expectedInterfaces []network.Interface, expectedVirtualMachines []compute.VirtualMachine, serviceCount int) {
+	mockInterfacesClient := mockinterfaceclient.NewMockInterface(ctrl)
+	az.InterfacesClient = mockInterfacesClient
+	for i := range expectedInterfaces {
+		mockInterfacesClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("vm-%d", i), gomock.Any()).Return(expectedInterfaces[i], nil).AnyTimes()
+		mockInterfacesClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, fmt.Sprintf("vm-%d", i), gomock.Any()).Return(nil).AnyTimes()
+	}
+
+	mockVirtualMachinesClient := mockvmclient.NewMockInterface(ctrl)
+	az.VirtualMachinesClient = mockVirtualMachinesClient
+	mockVirtualMachinesClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(expectedVirtualMachines, nil).AnyTimes()
+	for i := range expectedVirtualMachines {
+		mockVirtualMachinesClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("vm-%d", i), gomock.Any()).Return(expectedVirtualMachines[i], nil).AnyTimes()
+	}
+
+	setMockPublicIPs(az, ctrl, serviceCount, true, true)
+
+	sg := getTestSecurityGroup(az)
+	setMockSecurityGroup(az, ctrl, sg)
 }
 
 func setMockEnv(az *Cloud, ctrl *gomock.Controller, expectedInterfaces []network.Interface, expectedVirtualMachines []compute.VirtualMachine, serviceCount int, services ...v1.Service) {
@@ -173,12 +192,16 @@ func setMockEnv(az *Cloud, ctrl *gomock.Controller, expectedInterfaces []network
 func setMockPublicIPs(az *Cloud, ctrl *gomock.Controller, serviceCount int, v4Enabled, v6Enabled bool) {
 	mockPIPsClient := mockpublicipclient.NewMockInterface(ctrl)
 
+	expectedPIPsTotal := []network.PublicIPAddress{}
 	if v4Enabled {
-		setMockPublicIP(az, mockPIPsClient, serviceCount, false)
+		expectedPIPs := setMockPublicIP(az, mockPIPsClient, serviceCount, false)
+		expectedPIPsTotal = append(expectedPIPsTotal, expectedPIPs...)
 	}
 	if v6Enabled {
-		setMockPublicIP(az, mockPIPsClient, serviceCount, true)
+		expectedPIPs := setMockPublicIP(az, mockPIPsClient, serviceCount, true)
+		expectedPIPsTotal = append(expectedPIPsTotal, expectedPIPs...)
 	}
+	mockPIPsClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(expectedPIPsTotal, nil).AnyTimes()
 
 	az.PublicIPAddressesClient = mockPIPsClient
 	mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -186,14 +209,16 @@ func setMockPublicIPs(az *Cloud, ctrl *gomock.Controller, serviceCount int, v4En
 	mockPIPsClient.EXPECT().Get(gomock.Any(), gomock.Not(az.ResourceGroup), gomock.Any(), gomock.Any()).Return(network.PublicIPAddress{}, &retry.Error{HTTPStatusCode: http.StatusNotFound, RawError: cloudprovider.InstanceNotFound}).AnyTimes()
 }
 
-func setMockPublicIP(az *Cloud, mockPIPsClient *mockpublicipclient.MockInterface, serviceCount int, isIPv6 bool) {
+func setMockPublicIP(az *Cloud, mockPIPsClient *mockpublicipclient.MockInterface, serviceCount int, isIPv6 bool) []network.PublicIPAddress {
 	suffix := ""
 	ipVer := network.IPv4
-	ipAddr := "1.2.3.4"
+	ipAddr1 := "1.2.3.4"
+	ipAddra := "1.2.3.5"
 	if isIPv6 {
 		suffix = "-" + v6Suffix
 		ipVer = network.IPv6
-		ipAddr = "fd00::eef0"
+		ipAddr1 = "fd00::eef0"
+		ipAddra = "fd00::eef1"
 	}
 
 	expectedPIP := network.PublicIPAddress{
@@ -202,7 +227,7 @@ func setMockPublicIP(az *Cloud, mockPIPsClient *mockpublicipclient.MockInterface
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.Static,
 			PublicIPAddressVersion:   ipVer,
-			IPAddress:                pointer.String(ipAddr),
+			IPAddress:                pointer.String(ipAddr1),
 		},
 		Tags: map[string]*string{
 			consts.ServiceTagKey:  pointer.String("default/servicea"),
@@ -218,18 +243,30 @@ func setMockPublicIP(az *Cloud, mockPIPsClient *mockpublicipclient.MockInterface
 	var expectedPIPs []network.PublicIPAddress
 	for i := 1; i <= serviceCount; i++ {
 		expectedPIP.Name = pointer.String(fmt.Sprintf("testCluster-aservice%d%s", i, suffix))
+		expectedPIP.ID = pointer.String(fmt.Sprintf("testCluster-aservice%d%s", i, suffix))
+		expectedPIP.PublicIPAddressPropertiesFormat = &network.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: network.Static,
+			PublicIPAddressVersion:   ipVer,
+			IPAddress:                pointer.String(ipAddr1),
+		}
 		expectedPIP.Tags[consts.ServiceTagKey] = pointer.String(fmt.Sprintf("default/service%d", i))
 		mockPIPsClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%d%s", i, suffix), gomock.Any()).Return(expectedPIP, nil).AnyTimes()
 		mockPIPsClient.EXPECT().Delete(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%d%s", i, suffix)).Return(nil).AnyTimes()
 		expectedPIPs = append(expectedPIPs, expectedPIP)
 		expectedPIP.Name = pointer.String(fmt.Sprintf("testCluster-aservice%c%s", a, suffix))
+		expectedPIP.ID = pointer.String(fmt.Sprintf("testCluster-aservice%c%s", a, suffix))
+		expectedPIP.PublicIPAddressPropertiesFormat = &network.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: network.Static,
+			PublicIPAddressVersion:   ipVer,
+			IPAddress:                pointer.String(ipAddra),
+		}
 		expectedPIP.Tags[consts.ServiceTagKey] = pointer.String(fmt.Sprintf("default/service%c", a))
 		mockPIPsClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%c%s", a, suffix), gomock.Any()).Return(expectedPIP, nil).AnyTimes()
 		mockPIPsClient.EXPECT().Delete(gomock.Any(), az.ResourceGroup, fmt.Sprintf("testCluster-aservice%c%s", a, suffix)).Return(nil).AnyTimes()
 		expectedPIPs = append(expectedPIPs, expectedPIP)
 		a++
 	}
-	mockPIPsClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(expectedPIPs, nil).AnyTimes()
+	return expectedPIPs
 }
 
 func setMockSecurityGroup(az *Cloud, ctrl *gomock.Controller, sgs ...*network.SecurityGroup) {
@@ -239,6 +276,122 @@ func setMockSecurityGroup(az *Cloud, ctrl *gomock.Controller, sgs ...*network.Se
 		mockSGsClient.EXPECT().Get(gomock.Any(), az.SecurityGroupResourceGroup, az.SecurityGroupName, gomock.Any()).Return(*sg, nil).AnyTimes()
 	}
 	mockSGsClient.EXPECT().CreateOrUpdate(gomock.Any(), az.SecurityGroupResourceGroup, az.SecurityGroupName, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+}
+
+func setMockLBsDualStack(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadBalancer, svcName string, lbCount, serviceIndex int, isInternal bool) string {
+	lbIndex := (serviceIndex - 1) % lbCount
+	expectedLBName := ""
+	if lbIndex == 0 {
+		expectedLBName = testClusterName
+	} else {
+		expectedLBName = fmt.Sprintf("as-%d", lbIndex)
+	}
+	if isInternal {
+		expectedLBName += "-internal"
+	}
+
+	fullServiceName := strings.Replace(svcName, "-", "", -1)
+
+	if lbIndex >= len(*expectedLBs) {
+		lb := network.LoadBalancer{
+			Location: &az.Location,
+			LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+				BackendAddressPools: &[]network.BackendAddressPool{
+					{
+						Name: pointer.String("testCluster"),
+					},
+					{
+						Name: pointer.String("testCluster-IPv6"),
+					},
+				},
+			},
+		}
+		lb.Name = &expectedLBName
+		lb.LoadBalancingRules = &[]network.LoadBalancingRule{
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
+			},
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081-IPv6", fullServiceName, serviceIndex)),
+			},
+		}
+		fips := []network.FrontendIPConfiguration{
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
+				ID:   pointer.String("fip"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: "Dynamic",
+					PrivateIPAddressVersion:   network.IPv4,
+					PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+				},
+			},
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d-IPv6", fullServiceName, serviceIndex)),
+				ID:   pointer.String("fip-IPv6"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: "Dynamic",
+					PrivateIPAddressVersion:   network.IPv6,
+					PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d-IPv6", fullServiceName, serviceIndex))},
+				},
+			},
+		}
+		if isInternal {
+			fips[0].Subnet = &network.Subnet{Name: pointer.String("subnet")}
+			fips[1].Subnet = &network.Subnet{Name: pointer.String("subnet")}
+		}
+		lb.FrontendIPConfigurations = &fips
+
+		*expectedLBs = append(*expectedLBs, lb)
+	} else {
+		lbRules := []network.LoadBalancingRule{
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081", fullServiceName, serviceIndex)),
+			},
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d-TCP-8081-IPv6", fullServiceName, serviceIndex)),
+			},
+		}
+		*(*expectedLBs)[lbIndex].LoadBalancingRules = append(*(*expectedLBs)[lbIndex].LoadBalancingRules, lbRules...)
+		fips := []network.FrontendIPConfiguration{
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d", fullServiceName, serviceIndex)),
+				ID:   pointer.String("fip"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: "Dynamic",
+					PrivateIPAddressVersion:   network.IPv4,
+					PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d", fullServiceName, serviceIndex))},
+				},
+			},
+			{
+				Name: pointer.String(fmt.Sprintf("a%s%d-IPv6", fullServiceName, serviceIndex)),
+				ID:   pointer.String("fip-IPv6"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: "Dynamic",
+					PrivateIPAddressVersion:   network.IPv6,
+					PublicIPAddress:           &network.PublicIPAddress{ID: pointer.String(fmt.Sprintf("testCluster-a%s%d-IPv6", fullServiceName, serviceIndex))},
+				},
+			},
+		}
+		if isInternal {
+			for _, fip := range fips {
+				fip.Subnet = &network.Subnet{Name: pointer.String("subnet")}
+			}
+		}
+		*(*expectedLBs)[lbIndex].FrontendIPConfigurations = append(*(*expectedLBs)[lbIndex].FrontendIPConfigurations, fips...)
+	}
+
+	mockLBsClient := mockloadbalancerclient.NewMockInterface(ctrl)
+	az.LoadBalancerClient = mockLBsClient
+	mockLBsClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	for _, lb := range *expectedLBs {
+		mockLBsClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, *lb.Name, gomock.Any()).Return((*expectedLBs)[lbIndex], nil).MaxTimes(2)
+	}
+	mockLBsClient.EXPECT().List(gomock.Any(), az.ResourceGroup).Return(*expectedLBs, nil).MaxTimes(4)
+	mockLBsClient.EXPECT().List(gomock.Any(), gomock.Not(az.ResourceGroup)).Return([]network.LoadBalancer{}, &retry.Error{HTTPStatusCode: http.StatusNotFound, RawError: cloudprovider.InstanceNotFound}).AnyTimes()
+	mockLBsClient.EXPECT().Get(gomock.Any(), gomock.Not(az.ResourceGroup), gomock.Any(), gomock.Any()).Return(network.LoadBalancer{}, &retry.Error{HTTPStatusCode: http.StatusNotFound, RawError: cloudprovider.InstanceNotFound}).AnyTimes()
+	mockLBsClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+
+	return expectedLBName
 }
 
 func setMockLBs(az *Cloud, ctrl *gomock.Controller, expectedLBs *[]network.LoadBalancer, svcName string, lbCount, serviceIndex int, isInternal bool) string {
@@ -712,28 +865,23 @@ func TestReconcileLoadBalancerAddServiceOnInternalSubnet(t *testing.T) {
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
-	svc := getInternalTestService("service1", 80)
+	svc := getInternalTestServiceDualStack("service1", 80)
 	validateTestSubnet(t, az, &svc)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, true)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
-	// ensure we got a frontend ip configuration
-	if len(*lb.FrontendIPConfigurations) != 1 {
-		t.Error("Expected the loadbalancer to have a frontend ip configuration")
-	}
-
+	// ensure we got 2 frontend ip configurations
+	assert.Equal(t, 2, len(*lb.FrontendIPConfigurations))
 	validateLoadBalancer(t, lb, svc)
 }
 
@@ -750,14 +898,10 @@ func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t
 
 	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
 	_, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(""), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	isIPv6 := utilnet.IsIPv6String(svc1.Spec.ClusterIP)
 	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(getServiceLoadBalancerIP(&svc1, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validateSecurityGroup(t, sg, svc1)
 }
 
@@ -774,9 +918,7 @@ func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 
 	dynamicallyAssignedIP := "192.168.0.0"
 	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, pointer.String(dynamicallyAssignedIP), nil, true)
-	if err != nil {
-		t.Errorf("unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validateSecurityGroup(t, sg, svc1)
 }
 
@@ -787,13 +929,13 @@ func TestReconcileLoadBalancerAddServicesOnMultipleSubnets(t *testing.T) {
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
-	svc1 := getTestService("service1", v1.ProtocolTCP, nil, false, 8081)
-	svc2 := getInternalTestService("service2", 8081)
+	svc1 := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 8081)
+	svc2 := getInternalTestServiceDualStack("service2", 8081)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
@@ -806,9 +948,7 @@ func TestReconcileLoadBalancerAddServicesOnMultipleSubnets(t *testing.T) {
 	}
 
 	// ensure we got a frontend ip configuration for each service
-	if len(*lb.FrontendIPConfigurations) != 1 {
-		t.Error("Expected the loadbalancer to have 1 frontend ip configurations")
-	}
+	assert.Equal(t, 2, len(*lb.FrontendIPConfigurations))
 
 	validateLoadBalancer(t, lb, svc1)
 
@@ -816,7 +956,7 @@ func TestReconcileLoadBalancerAddServicesOnMultipleSubnets(t *testing.T) {
 	validateTestSubnet(t, az, &svc2)
 
 	expectedLBs = make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 2, true)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 2, true)
 
 	// svc2 is using LB with "-internal" suffix
 	lb, err = az.reconcileLoadBalancer(testClusterName, &svc2, clusterResources.nodes, true /* wantLb */)
@@ -825,9 +965,7 @@ func TestReconcileLoadBalancerAddServicesOnMultipleSubnets(t *testing.T) {
 	}
 
 	// ensure we got a frontend ip configuration for each service
-	if len(*lb.FrontendIPConfigurations) != 1 {
-		t.Error("Expected the loadbalancer to have 1 frontend ip configurations")
-	}
+	assert.Equal(t, 2, len(*lb.FrontendIPConfigurations))
 
 	validateLoadBalancer(t, lb, svc2)
 }
@@ -839,13 +977,13 @@ func TestReconcileLoadBalancerEditServiceSubnet(t *testing.T) {
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
-	svc := getInternalTestService("service1", 8081)
+	svc := getInternalTestServiceDualStack("service1", 8081)
 	validateTestSubnet(t, az, &svc)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, true)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
@@ -866,7 +1004,7 @@ func TestReconcileLoadBalancerEditServiceSubnet(t *testing.T) {
 	validateTestSubnet(t, az, &svc)
 
 	expectedLBs = make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, true)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, true)
 
 	lb, err = az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
@@ -874,9 +1012,7 @@ func TestReconcileLoadBalancerEditServiceSubnet(t *testing.T) {
 	}
 
 	// ensure we got a frontend ip configuration for the service
-	if len(*lb.FrontendIPConfigurations) != 1 {
-		t.Error("Expected the loadbalancer to have 1 frontend ip configuration")
-	}
+	assert.Equal(t, 2, len(*lb.FrontendIPConfigurations))
 
 	validateLoadBalancer(t, lb, svc)
 }
@@ -887,28 +1023,24 @@ func TestReconcileLoadBalancerNodeHealth(t *testing.T) {
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
-	svc := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
+	svc := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80)
 	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 	svc.Spec.HealthCheckNodePort = int32(32456)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	// ensure we got a frontend ip configuration
-	if len(*lb.FrontendIPConfigurations) != 1 {
-		t.Error("Expected the loadbalancer to have a frontend ip configuration")
-	}
+	assert.Equal(t, 2, len(*lb.FrontendIPConfigurations))
 
 	validateLoadBalancer(t, lb, svc)
 }
@@ -920,21 +1052,19 @@ func TestReconcileLoadBalancerRemoveService(t *testing.T) {
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
-	svc := getTestService("service1", v1.ProtocolTCP, nil, false, 80, 443)
+	svc := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80, 443)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	_, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	expectedLBs[0].FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	mockLBsClient := mockloadbalancerclient.NewMockInterface(ctrl)
@@ -945,14 +1075,10 @@ func TestReconcileLoadBalancerRemoveService(t *testing.T) {
 	mockLBsClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, false /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	// ensure we abandoned the frontend ip configuration
-	if len(*lb.FrontendIPConfigurations) != 0 {
-		t.Error("Expected the loadbalancer to have no frontend ip configuration")
-	}
+	assert.Zero(t, len(*lb.FrontendIPConfigurations))
 
 	validateLoadBalancer(t, lb)
 }
@@ -964,24 +1090,22 @@ func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) 
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
-	svc := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
+	svc := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validateLoadBalancer(t, lb, svc)
 
-	svcUpdated := getTestService("service1", v1.ProtocolTCP, nil, false)
+	svcUpdated := getTestServiceDualStack("service1", v1.ProtocolTCP, nil)
 
 	expectedLBs[0].FrontendIPConfigurations = &[]network.FrontendIPConfiguration{}
 	mockLBsClient := mockloadbalancerclient.NewMockInterface(ctrl)
@@ -992,14 +1116,10 @@ func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) 
 	mockLBsClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	lb, err = az.reconcileLoadBalancer(testClusterName, &svcUpdated, clusterResources.nodes, false /* wantLb*/)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	// ensure we abandoned the frontend ip configuration
-	if len(*lb.FrontendIPConfigurations) != 0 {
-		t.Error("Expected the loadbalancer to have no frontend ip configuration")
-	}
+	assert.Zero(t, len(*lb.FrontendIPConfigurations))
 
 	validateLoadBalancer(t, lb, svcUpdated)
 }
@@ -1011,27 +1131,23 @@ func TestReconcileLoadBalancerRemovesPort(t *testing.T) {
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 1)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
 	mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
-	svc := getTestService("service1", v1.ProtocolTCP, nil, false, 80, 443)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	svc := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80, 443)
 	_, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	expectedLBs = make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
-	svcUpdated := getTestService("service1", v1.ProtocolTCP, nil, false, 80)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	svcUpdated := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80)
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svcUpdated, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateLoadBalancer(t, lb, svcUpdated)
 }
@@ -1043,13 +1159,13 @@ func TestReconcileLoadBalancerMultipleServices(t *testing.T) {
 
 	az := GetTestCloud(ctrl)
 	clusterResources, expectedInterfaces, expectedVirtualMachines := getClusterResources(az, 1, 1)
-	setMockEnv(az, ctrl, expectedInterfaces, expectedVirtualMachines, 2)
+	setMockEnvDualStack(az, ctrl, expectedInterfaces, expectedVirtualMachines, 2)
 
-	svc1 := getTestService("service1", v1.ProtocolTCP, nil, false, 80, 443)
-	svc2 := getTestService("service2", v1.ProtocolTCP, nil, false, 81)
+	svc1 := getTestServiceDualStack("service1", v1.ProtocolTCP, nil, 80, 443)
+	svc2 := getTestServiceDualStack("service2", v1.ProtocolTCP, nil, 81)
 
 	expectedLBs := make([]network.LoadBalancer, 0)
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 1, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 1, false)
 
 	mockLBBackendPool := az.LoadBalancerBackendPool.(*MockBackendPool)
 	mockLBBackendPool.EXPECT().ReconcileBackendPools(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, false, false, nil).AnyTimes()
@@ -1060,16 +1176,12 @@ func TestReconcileLoadBalancerMultipleServices(t *testing.T) {
 	mockPLSClient.EXPECT().List(gomock.Any(), az.Config.ResourceGroup).Return(expectedPLS, nil).MinTimes(1).MaxTimes(1)
 
 	_, err := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
-	setMockLBs(az, ctrl, &expectedLBs, "service", 1, 2, false)
+	setMockLBsDualStack(az, ctrl, &expectedLBs, "service", 1, 2, false)
 
 	updatedLoadBalancer, err := az.reconcileLoadBalancer(testClusterName, &svc2, clusterResources.nodes, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateLoadBalancer(t, updatedLoadBalancer, svc1, svc2)
 }
@@ -1276,9 +1388,7 @@ func TestReconcileSecurityGroupNewServiceAddsPort(t *testing.T) {
 	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
 
 	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateSecurityGroup(t, sg, svc1)
 }
@@ -1304,9 +1414,7 @@ func TestReconcileSecurityGroupNewInternalServiceAddsPort(t *testing.T) {
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
 	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
 	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateSecurityGroup(t, sg, svc1)
 }
@@ -1345,9 +1453,7 @@ func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 	validateSecurityGroup(t, sg, service1, service2)
 
 	sg, err := az.reconcileSecurityGroup(testClusterName, &service1, &lbStatus.Ingress[0].IP, nil, false /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateSecurityGroup(t, sg, service2)
 }
@@ -1381,9 +1487,7 @@ func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc, lb)
 
 	sg, err := az.reconcileSecurityGroup(testClusterName, &svcUpdated, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateSecurityGroup(t, sg, svcUpdated)
 }
@@ -1412,9 +1516,7 @@ func TestReconcileSecurityWithSourceRanges(t *testing.T) {
 	lbStatus, _, _ := az.getServiceLoadBalancerStatus(&svc, lb)
 
 	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, &lbStatus.Ingress[0].IP, nil, true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateSecurityGroup(t, sg, svc)
 }
@@ -1477,15 +1579,11 @@ func TestReconcilePublicIPsWithNewService(t *testing.T) {
 	setMockPublicIPs(az, ctrl, 1, v4Enabled, v6Enabled)
 
 	pips, err := az.reconcilePublicIPs(testClusterName, &svc, "", true /* wantLb*/)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validatePublicIPs(t, pips, &svc, true)
 
 	pips2, err := az.reconcilePublicIPs(testClusterName, &svc, "", true /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validatePublicIPs(t, pips2, &svc, true)
 
 	pipsNames1, pipsNames2 := []string{}, []string{}
@@ -1513,17 +1611,13 @@ func TestReconcilePublicIPsRemoveService(t *testing.T) {
 	setMockPublicIPs(az, ctrl, 1, v4Enabled, v6Enabled)
 
 	pips, err := az.reconcilePublicIPs(testClusterName, &svc, "", true /* wantLb*/)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validatePublicIPs(t, pips, &svc, true)
 
 	// Remove the service
 	pips, err = az.reconcilePublicIPs(testClusterName, &svc, "", false /* wantLb */)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validatePublicIPs(t, pips, &svc, false)
 }
 
@@ -1538,9 +1632,7 @@ func TestReconcilePublicIPsWithInternalService(t *testing.T) {
 	setMockPublicIPs(az, ctrl, 1, v4Enabled, v6Enabled)
 
 	pips, err := az.reconcilePublicIPs(testClusterName, &svc, "", true /* wantLb*/)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validatePublicIPs(t, pips, &svc, true)
 }
@@ -1556,24 +1648,18 @@ func TestReconcilePublicIPsWithExternalAndInternalSwitch(t *testing.T) {
 	setMockPublicIPs(az, ctrl, 1, v4Enabled, v6Enabled)
 
 	pips, err := az.reconcilePublicIPs(testClusterName, &svc, "", true /* wantLb*/)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validatePublicIPs(t, pips, &svc, true)
 
 	// Update to external service
 	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil, false, 80)
 	pips, err = az.reconcilePublicIPs(testClusterName, &svcUpdated, "", true /* wantLb*/)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validatePublicIPs(t, pips, &svcUpdated, true)
 
 	// Update to internal service again
 	pips, err = az.reconcilePublicIPs(testClusterName, &svc, "", true /* wantLb*/)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 	validatePublicIPs(t, pips, &svc, true)
 }
 
@@ -1838,9 +1924,13 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 	expectedFrontendIPCount := 0
 	expectedProbeCount := 0
 	expectedFrontendIPs := []ExpectedFrontendIPInfo{}
+	svcIPFamilyCount := 1
+	if len(services) > 0 {
+		svcIPFamilyCount = len(services[0].Spec.IPFamilies)
+	}
 	for i, svc := range services {
 		if len(svc.Spec.Ports) > 0 {
-			expectedFrontendIPCount++
+			expectedFrontendIPCount += svcIPFamilyCount
 			expectedSubnetName := ""
 			if requiresInternalLoadBalancer(&services[i]) {
 				expectedSubnetName = svc.Annotations[consts.ServiceAnnotationLoadBalancerInternalSubnet]
@@ -1853,22 +1943,33 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 				Subnet: pointer.String(expectedSubnetName),
 			}
 			expectedFrontendIPs = append(expectedFrontendIPs, expectedFrontendIP)
+			if svcIPFamilyCount == 2 {
+				expectedFrontendIP := ExpectedFrontendIPInfo{
+					Name:   az.getDefaultFrontendIPConfigName(&services[i]) + "-" + v6Suffix,
+					Subnet: pointer.String(expectedSubnetName),
+				}
+				expectedFrontendIPs = append(expectedFrontendIPs, expectedFrontendIP)
+			}
 		}
 		for _, wantedRule := range svc.Spec.Ports {
-			expectedRuleCount++
-			isIPv6 := utilnet.IsIPv6String(services[i].Spec.ClusterIP)
-			wantedRuleName := az.getLoadBalancerRuleName(&services[i], wantedRule.Protocol, wantedRule.Port, isIPv6)
-			foundRule := false
-			for _, actualRule := range *loadBalancer.LoadBalancingRules {
-				if strings.EqualFold(*actualRule.Name, wantedRuleName) &&
-					*actualRule.FrontendPort == wantedRule.Port &&
-					*actualRule.BackendPort == wantedRule.Port {
-					foundRule = true
-					break
+			expectedRuleCount += svcIPFamilyCount
+			wantedRuleNameMap := map[bool]string{}
+			for _, ipFamily := range services[i].Spec.IPFamilies {
+				isIPv6 := ipFamily == v1.IPv6Protocol
+				wantedRuleName := az.getLoadBalancerRuleName(&services[i], wantedRule.Protocol, wantedRule.Port, isIPv6)
+				wantedRuleNameMap[isIPv6] = wantedRuleName
+				foundRule := false
+				for _, actualRule := range *loadBalancer.LoadBalancingRules {
+					if strings.EqualFold(*actualRule.Name, wantedRuleName) &&
+						*actualRule.FrontendPort == wantedRule.Port &&
+						*actualRule.BackendPort == wantedRule.Port {
+						foundRule = true
+						break
+					}
 				}
-			}
-			if !foundRule {
-				t.Errorf("Expected load balancer rule but didn't find it: %q", wantedRuleName)
+				if !foundRule {
+					t.Errorf("Expected load balancer rule but didn't find it: %q", wantedRuleName)
+				}
 			}
 
 			// if UDP rule, there is no probe
@@ -1876,35 +1977,37 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 				continue
 			}
 
-			expectedProbeCount++
-			foundProbe := false
-			if servicehelpers.NeedsHealthCheck(&services[i]) {
-				path, port := servicehelpers.GetServiceHealthCheckPathPort(&services[i])
-				isIPv6 := utilnet.IsIPv6String(services[i].Spec.ClusterIP)
-				wantedRuleName := az.getLoadBalancerRuleName(&services[i], v1.ProtocolTCP, port, isIPv6)
-				for _, actualProbe := range *loadBalancer.Probes {
-					if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
-						*actualProbe.Port == port &&
-						*actualProbe.RequestPath == path &&
-						actualProbe.Protocol == network.ProbeProtocolHTTP {
-						foundProbe = true
-						break
+			expectedProbeCount += svcIPFamilyCount
+			for _, ipFamily := range services[i].Spec.IPFamilies {
+				isIPv6 := ipFamily == v1.IPv6Protocol
+				foundProbe := false
+				if servicehelpers.NeedsHealthCheck(&services[i]) {
+					path, port := servicehelpers.GetServiceHealthCheckPathPort(&services[i])
+					wantedRuleName := az.getLoadBalancerRuleName(&services[i], v1.ProtocolTCP, port, isIPv6)
+					for _, actualProbe := range *loadBalancer.Probes {
+						if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
+							*actualProbe.Port == port &&
+							*actualProbe.RequestPath == path &&
+							actualProbe.Protocol == network.ProbeProtocolHTTP {
+							foundProbe = true
+							break
+						}
+					}
+				} else {
+					for _, actualProbe := range *loadBalancer.Probes {
+						if strings.EqualFold(*actualProbe.Name, wantedRuleNameMap[isIPv6]) &&
+							*actualProbe.Port == wantedRule.NodePort {
+							foundProbe = true
+							break
+						}
 					}
 				}
-			} else {
-				for _, actualProbe := range *loadBalancer.Probes {
-					if strings.EqualFold(*actualProbe.Name, wantedRuleName) &&
-						*actualProbe.Port == wantedRule.NodePort {
-						foundProbe = true
-						break
+				if !foundProbe {
+					for _, actualProbe := range *loadBalancer.Probes {
+						t.Logf("Probe: %s %d", *actualProbe.Name, *actualProbe.Port)
 					}
+					t.Errorf("Expected loadbalancer probe but didn't find it: %q", wantedRuleNameMap[isIPv6])
 				}
-			}
-			if !foundProbe {
-				for _, actualProbe := range *loadBalancer.Probes {
-					t.Logf("Probe: %s %d", *actualProbe.Name, *actualProbe.Port)
-				}
-				t.Errorf("Expected loadbalancer probe but didn't find it: %q", wantedRuleName)
 			}
 		}
 	}
@@ -2529,9 +2632,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T
 
 	isIPv6 := utilnet.IsIPv6String(svc.Spec.ClusterIP)
 	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateSecurityGroup(t, sg, svc)
 
@@ -2589,9 +2690,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 
 	isIPv6 := utilnet.IsIPv6String(svc.Spec.ClusterIP)
 	sg, err := az.reconcileSecurityGroup(testClusterName, &svc, pointer.String(getServiceLoadBalancerIP(&svc, isIPv6)), nil, true)
-	if err != nil {
-		t.Errorf("Unexpected error: %q", err)
-	}
+	assert.Nil(t, err)
 
 	validateSecurityGroup(t, sg, svc)
 

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -456,26 +456,29 @@ func getResourceByIPFamily(resource string, isDualStack, isIPv6 bool) string {
 }
 
 // isFIPIPv6 checks if the frontend IP configuration is of IPv6.
-func (az *Cloud) isFIPIPv6(fip *network.FrontendIPConfiguration, pipResourceGroup string, isInternal bool) (isIPv6 bool, err error) {
-	pips, err := az.listPIP(pipResourceGroup, azcache.CacheReadTypeDefault)
-	if err != nil {
-		return false, fmt.Errorf("isFIPIPv6: failed to list pip: %w", err)
-	}
+func (az *Cloud) isFIPIPv6(service *v1.Service, fip *network.FrontendIPConfiguration, isInternal bool) (bool, error) {
 	if isInternal {
 		if fip.FrontendIPConfigurationPropertiesFormat != nil {
 			if fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddressVersion != "" {
 				return fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddressVersion == network.IPv6, nil
 			}
-			return net.ParseIP(pointer.StringDeref(fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress, "")).To4() == nil, nil
+			if fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
+				return net.ParseIP(*fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress).To4() == nil, nil
+			}
 		}
-		klog.Errorf("Checking IP Family of frontend IP configuration %q of internal Service but its"+
-			" FrontendIPConfigurationPropertiesFormat is nil. It's considered to be IPv4",
+		klog.Errorf("Checking IP Family of frontend IP configuration %q of internal Service but "+
+			"it is not clear. It's considered to be IPv4",
 			pointer.StringDeref(fip.Name, ""))
-		return
+		return false, nil
 	}
 	var fipPIPID string
 	if fip.FrontendIPConfigurationPropertiesFormat != nil && fip.FrontendIPConfigurationPropertiesFormat.PublicIPAddress != nil {
 		fipPIPID = pointer.StringDeref(fip.FrontendIPConfigurationPropertiesFormat.PublicIPAddress.ID, "")
+	}
+	pipResourceGroup := az.getPublicIPAddressResourceGroup(service)
+	pips, err := az.listPIP(pipResourceGroup,azcache.CacheReadTypeDefault)
+	if err != nil {
+		return false, err
 	}
 	for _, pip := range pips {
 		id := pointer.StringDeref(pip.ID, "")
@@ -484,15 +487,19 @@ func (az *Cloud) isFIPIPv6(fip *network.FrontendIPConfiguration, pipResourceGrou
 		}
 		if pip.PublicIPAddressPropertiesFormat != nil {
 			// First check PublicIPAddressVersion, then IPAddress
-			if pip.PublicIPAddressPropertiesFormat.PublicIPAddressVersion == network.IPv6 ||
-				net.ParseIP(pointer.StringDeref(pip.PublicIPAddressPropertiesFormat.IPAddress, "")).To4() == nil {
-				isIPv6 = true
-				break
+			if pip.PublicIPAddressPropertiesFormat.PublicIPAddressVersion != "" {
+				return pip.PublicIPAddressPropertiesFormat.PublicIPAddressVersion == network.IPv6, nil
+			}
+			if pip.PublicIPAddressPropertiesFormat.IPAddress != nil {
+				return net.ParseIP(pointer.StringDeref(pip.PublicIPAddressPropertiesFormat.IPAddress, "")).To4() == nil, nil
 			}
 		}
+		klog.Errorf("Checking IP Family of PIP %q of corresponding frontend IP configuration %q of external Service but "+
+			"it is not clear. It's considered to be IPv4",
+			pointer.StringDeref(pip.Name, ""), pointer.StringDeref(fip.Name, ""))
 		break
 	}
-	return isIPv6, nil
+	return false, nil
 }
 
 // getResourceIDPrefix returns a substring from the provided one between beginning and the last "/".
@@ -537,4 +544,22 @@ func countIPsOnBackendPool(backendPool network.BackendAddressPool) int {
 	}
 
 	return ipsCount
+}
+
+// fillSubnet fills subnet value into the variable.
+func (az *Cloud) fillSubnet(subnet *network.Subnet, subnetName string) error {
+	if subnet == nil {
+		return fmt.Errorf("subnet is nil, should not happen")
+	}
+	if subnet.ID == nil {
+		curSubnet, existsSubnet, err := az.getSubnet(az.VnetName, subnetName)
+		if err != nil {
+			return err
+		}
+		if !existsSubnet {
+			return fmt.Errorf("failed to get subnet: %s/%s", az.VnetName, subnetName)
+		}
+		*subnet = curSubnet
+	}
+	return nil
 }

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -405,10 +405,20 @@ func getServiceLoadBalancerIPs(service *v1.Service) []string {
 
 // setServiceLoadBalancerIP sets LB IP to a Service
 func setServiceLoadBalancerIP(service *v1.Service, ip string) {
+	if service == nil {
+		klog.Warning("setServiceLoadBalancerIP: Service is nil")
+		return
+	}
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		klog.Warning("setServiceLoadBalancerIP: IP %q is not valid for Service", ip, service.Name)
+		return
+	}
+
+	isIPv6 := parsedIP.To4() == nil
 	if service.Annotations == nil {
 		service.Annotations = map[string]string{}
 	}
-	isIPv6 := net.ParseIP(ip).To4() == nil
 	service.Annotations[consts.ServiceAnnotationLoadBalancerIPDualStack[isIPv6]] = ip
 }
 

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -456,50 +456,13 @@ func getResourceByIPFamily(resource string, isDualStack, isIPv6 bool) string {
 }
 
 // isFIPIPv6 checks if the frontend IP configuration is of IPv6.
-func (az *Cloud) isFIPIPv6(service *v1.Service, fip *network.FrontendIPConfiguration, isInternal bool) (bool, error) {
-	if isInternal {
-		if fip.FrontendIPConfigurationPropertiesFormat != nil {
-			if fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddressVersion != "" {
-				return fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddressVersion == network.IPv6, nil
-			}
-			if fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
-				return net.ParseIP(*fip.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress).To4() == nil, nil
-			}
-		}
-		klog.Errorf("Checking IP Family of frontend IP configuration %q of internal Service but "+
-			"it is not clear. It's considered to be IPv4",
-			pointer.StringDeref(fip.Name, ""))
-		return false, nil
+// NOTICE: isFIPIPv6 assumes the FIP is owned by the Service and it is the primary Service.
+func (az *Cloud) isFIPIPv6(service *v1.Service, pipRG string, fip *network.FrontendIPConfiguration) (bool, error) {
+	isDualStack := isServiceDualStack(service)
+	if !isDualStack {
+		return service.Spec.IPFamilies[0] == v1.IPv6Protocol, nil
 	}
-	var fipPIPID string
-	if fip.FrontendIPConfigurationPropertiesFormat != nil && fip.FrontendIPConfigurationPropertiesFormat.PublicIPAddress != nil {
-		fipPIPID = pointer.StringDeref(fip.FrontendIPConfigurationPropertiesFormat.PublicIPAddress.ID, "")
-	}
-	pipResourceGroup := az.getPublicIPAddressResourceGroup(service)
-	pips, err := az.listPIP(pipResourceGroup,azcache.CacheReadTypeDefault)
-	if err != nil {
-		return false, err
-	}
-	for _, pip := range pips {
-		id := pointer.StringDeref(pip.ID, "")
-		if !strings.EqualFold(fipPIPID, id) {
-			continue
-		}
-		if pip.PublicIPAddressPropertiesFormat != nil {
-			// First check PublicIPAddressVersion, then IPAddress
-			if pip.PublicIPAddressPropertiesFormat.PublicIPAddressVersion != "" {
-				return pip.PublicIPAddressPropertiesFormat.PublicIPAddressVersion == network.IPv6, nil
-			}
-			if pip.PublicIPAddressPropertiesFormat.IPAddress != nil {
-				return net.ParseIP(pointer.StringDeref(pip.PublicIPAddressPropertiesFormat.IPAddress, "")).To4() == nil, nil
-			}
-		}
-		klog.Errorf("Checking IP Family of PIP %q of corresponding frontend IP configuration %q of external Service but "+
-			"it is not clear. It's considered to be IPv4",
-			pointer.StringDeref(pip.Name, ""), pointer.StringDeref(fip.Name, ""))
-		break
-	}
-	return false, nil
+	return managedResourceHasIPv6Suffix(pointer.StringDeref(fip.Name, "")), nil
 }
 
 // getResourceIDPrefix returns a substring from the provided one between beginning and the last "/".

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -675,16 +675,50 @@ func TestSetServiceLoadBalancerIP(t *testing.T) {
 		expectedSvc *v1.Service
 	}{
 		{
+			"IPv4",
+			"10.0.0.1",
+			&v1.Service{},
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						consts.ServiceAnnotationLoadBalancerIPDualStack[consts.IPVersionIPv4]: "10.0.0.1",
+					},
+				},
+			},
+		},
+		{
 			"IPv6",
 			"2001::1",
 			&v1.Service{},
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						consts.ServiceAnnotationLoadBalancerIPDualStack[true]: "2001::1",
+						consts.ServiceAnnotationLoadBalancerIPDualStack[consts.IPVersionIPv6]: "2001::1",
 					},
 				},
 			},
+		},
+		{
+			"empty IP",
+			"",
+			&v1.Service{},
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		},
+		{
+			"invalid IP",
+			"invalid-ip",
+			&v1.Service{},
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		},
+		{
+			"empty Service",
+			"10.0.0.1",
+			nil,
+			nil,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/provider/azure_wrap.go
+++ b/pkg/provider/azure_wrap.go
@@ -158,9 +158,7 @@ func (az *Cloud) getSubnet(virtualNetworkName string, subnetName string) (networ
 
 	if !exists {
 		klog.V(2).Infof("Subnet %q not found", subnetName)
-		return subnet, false, nil
 	}
-
 	return subnet, exists, nil
 }
 

--- a/tests/e2e/network/node.go
+++ b/tests/e2e/network/node.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
@@ -200,7 +201,7 @@ var _ = Describe("Azure node resources", Label(utils.TestSuiteLabelNode), func()
 
 		utils.Logf("getting all NICs of VMSS VMs")
 		for _, vmssVM := range vmssVMs {
-			utils.Logf("Checking %d VMSS VM %q", vmssVM.Name)
+			utils.Logf("Checking VMSS VM %q", pointer.StringDeref(vmssVM.Name, ""))
 			nodeName, err := utils.GetVMSSVMComputerName(vmssVM)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -45,6 +45,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 	var cs clientset.Interface
 	var ns *v1.Namespace
 	var tc *utils.AzureTestClient
+	var isDeploymentCreated bool
 
 	labels := map[string]string{
 		"app": serviceName,
@@ -77,14 +78,17 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		deployment := createServerDeploymentManifest(serviceName, labels)
 		_, err = cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), deployment, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		isDeploymentCreated = true
 	})
 
 	AfterEach(func() {
 		if ns != nil && cs != nil {
-			err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			if isDeploymentCreated {
+				err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
 
-			err = utils.DeleteNamespace(cs, ns.Name)
+			err := utils.DeleteNamespace(cs, ns.Name)
 			Expect(err).NotTo(HaveOccurred())
 		}
 

--- a/tests/e2e/network/standard_lb.go
+++ b/tests/e2e/network/standard_lb.go
@@ -109,11 +109,18 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 		isVMSS := len(vmsses) != 0
 
 		ipcIDs := []string{}
-		for _, backendAddressPool := range *lb.BackendAddressPools {
-			if os.Getenv(utils.AKSTestCCM) != "" && *backendAddressPool.Name == "aksOutboundBackendPool" {
+		for i := range *lb.BackendAddressPools {
+			backendAddressPool := (*lb.BackendAddressPools)[i]
+			if (os.Getenv(utils.AKSTestCCM) != "" && *backendAddressPool.Name == "aksOutboundBackendPool") ||
+				strings.Contains(*backendAddressPool.Name, "outboundBackendPool") {
 				continue
 			}
-			for _, ipc := range *backendAddressPool.BackendIPConfigurations {
+			if backendAddressPool.BackendIPConfigurations == nil {
+				utils.Logf("BackendIPConfigurations is nil for backendAddressPool %q", *backendAddressPool.Name)
+				continue
+			}
+			for j := range *backendAddressPool.BackendIPConfigurations {
+				ipc := (*backendAddressPool.BackendIPConfigurations)[j]
 				if ipc.ID != nil {
 					if utils.IsAutoscalingAKSCluster() && strings.Contains(*ipc.ID, utils.SystemPool) {
 						continue
@@ -141,7 +148,11 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 				Expect(err).NotTo(HaveOccurred())
 				allVMs = append(allVMs, vms...)
 			}
-			Expect(len(allVMs)).To(Equal(len(ipcIDs)))
+			if tc.IPFamily == utils.DualStack {
+				Expect(len(allVMs) * 2).To(Equal(len(ipcIDs)))
+			} else {
+				Expect(len(allVMs)).To(Equal(len(ipcIDs)))
+			}
 			for _, vm := range allVMs {
 				utils.Logf("Checking VM %q", *vm.ID)
 				found := false

--- a/tests/e2e/network/standard_lb.go
+++ b/tests/e2e/network/standard_lb.go
@@ -103,6 +103,11 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 			Skip("only support cluster with multiple agent pools")
 		}
 
+		// Check if it is a cluster with VMSS
+		vmsses, err := utils.ListUniformVMSSes(tc)
+		Expect(err).NotTo(HaveOccurred())
+		isVMSS := len(vmsses) != 0
+
 		ipcIDs := []string{}
 		for _, backendAddressPool := range *lb.BackendAddressPools {
 			if os.Getenv(utils.AKSTestCCM) != "" && *backendAddressPool.Name == "aksOutboundBackendPool" {
@@ -110,16 +115,23 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 			}
 			for _, ipc := range *backendAddressPool.BackendIPConfigurations {
 				if ipc.ID != nil {
+					if utils.IsAutoscalingAKSCluster() && strings.Contains(*ipc.ID, utils.SystemPool) {
+						continue
+					}
+					if isVMSS && tc.IPFamily == utils.IPv6 && strings.Contains(*ipc.ID, "ipConfigurations/ipConfig0") {
+						// For IPv6 VMSS, there'll be IPv4 IP configurations as well
+						// e.g.
+						// virtualMachines/0/networkInterfaces/<vmss-0>-nic-0/ipConfigurations/ipConfig0
+						// virtualMachines/0/networkInterfaces/<vmss-0>-nic-0/ipConfigurations/ipConfigv6
+						continue
+					}
 					ipcIDs = append(ipcIDs, *ipc.ID)
 				}
 			}
 		}
-		utils.Logf("got BackendIPConfigurations IDs: %v", ipcIDs)
+		utils.Logf("got BackendIPConfigurations IDs: %q", ipcIDs)
 
-		// Check if it is a cluster with VMSS
-		vmsses, err := utils.ListUniformVMSSes(tc)
-		Expect(err).NotTo(HaveOccurred())
-		if len(vmsses) != 0 {
+		if isVMSS {
 			allVMs := []azcompute.VirtualMachineScaleSetVM{}
 			for _, vmss := range vmsses {
 				if strings.Contains(*vmss.ID, "control-plane") || strings.Contains(*vmss.ID, "master") {

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -46,9 +46,6 @@ var (
 		false: "",
 		true:  "-IPv6",
 	}
-
-	// TODO: After dual-stack implementation finished, update here.
-	DualstackSupported = false
 )
 
 // getVirtualNetworkList returns the list of virtual networks in the cluster resource group.
@@ -660,6 +657,7 @@ func retrieveCIDRs(cmd string, reg string) ([]string, error) {
 func GetClusterServiceIPFamily() (IPFamily, error) {
 	// Only test IPv4 in AKS pipeline
 	if os.Getenv(AKSTestCCM) != "" {
+		Logf("Cluster IP family for AKS pipeline: IPv4")
 		return IPv4, nil
 	}
 
@@ -667,13 +665,15 @@ func GetClusterServiceIPFamily() (IPFamily, error) {
 	if err != nil {
 		return "", err
 	}
+	ipFamily := DualStack
 	if svcCIDRs[0] != "" && svcCIDRs[1] == "" {
-		return IPv4, nil
+		ipFamily = IPv4
 	}
 	if svcCIDRs[0] == "" && svcCIDRs[1] != "" {
-		return IPv6, nil
+		ipFamily = IPv6
 	}
-	return DualStack, nil
+	Logf("Cluster IP family: %s", ipFamily)
+	return ipFamily, nil
 }
 
 func IfIPFamiliesEnabled(ipFamily IPFamily) (v4Enabled bool, v6Enabled bool) {
@@ -687,10 +687,6 @@ func IfIPFamiliesEnabled(ipFamily IPFamily) (v4Enabled bool, v6Enabled bool) {
 }
 
 // GetNameWithSuffix returns resource name with IP family suffix.
-// After dual-stack implementation is finished, this function returns name + suffix for all IP families.
 func GetNameWithSuffix(name, suffix string) string {
-	if DualstackSupported {
-		return name + suffix
-	}
-	return name
+	return name + suffix
 }

--- a/tests/e2e/utils/service_utils.go
+++ b/tests/e2e/utils/service_utils.go
@@ -52,14 +52,21 @@ func DeleteService(cs clientset.Interface, ns string, serviceName string) error 
 			Logf("Service %q does not exist, no need to delete", serviceName)
 			return nil
 		}
+		output, _ := RunKubectl(ns, "describe", "service", serviceName)
+		Logf("Service describe info: %s", output)
 		return err
 	}
-	return wait.PollImmediate(poll, deletionTimeout, func() (bool, error) {
+	err := wait.PollImmediate(poll, deletionTimeout, func() (bool, error) {
 		if _, err := cs.CoreV1().Services(ns).Get(context.TODO(), serviceName, metav1.GetOptions{}); err != nil {
 			return apierrs.IsNotFound(err), nil
 		}
 		return false, nil
 	})
+	if err != nil {
+		output, _ := RunKubectl(ns, "describe", "service", serviceName)
+		Logf("Service describe info: %s", output)
+	}
+	return err
 }
 
 // GetServiceDomainName cat prefix and azure suffix


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
    [DualStack] Support NSG and clean LBs
    * Support NSG and clean LBs for dualstack
    * Support related UTs for dualstack
    * Refactor

    [IPv6] Fix reconcileFrontendIPConfigs()
    Current logic handles lb.FrontendIPConfigurations according
    to Service's IP family, which is incorrect. For an IPv6 cluster,
    there're still some IPv4 FIPs due to Azure limitation, which
    will be removed. For an IPv4 cluster, all resources are of IPv4,
    which is not affected.

    [e2e] Adjust for IPv6 VMSS

    [DualStack] Support FrontendIPConfig and reconcileLB()
    * DualStack feature code
    * Refactor related functions and methods
    * Refactor and add new UTs

    [Refactor] Drop RG param in getXXXID()
    Resource group name can be got from az.getLoadBalancerResourceGroup().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[DualStack] Support FrontendIPConfig and reconcileLB() * DualStack feature code * Refactor related functions and methods * Refactor and add new UTs
[IPv6] Fix reconcileFrontendIPConfigs(). Current logic handles lb.FrontendIPConfigurations according to Service's IP family, which is incorrect. For an IPv6 cluster, there're still some IPv4 FIPs due to Azure limitation, which will be removed. For an IPv4 cluster, all resources are of IPv4, which is not affected.
Support NSG and clean LBs for dualstack
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
