### PR TITLE
feat: support local service in multiple standard load balancer mode

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -196,8 +196,11 @@ const (
 
 // IP family variables
 const (
-	IPVersionIPv6 bool = true
-	IPVersionIPv4 bool = false
+	IPVersionIPv6            bool   = true
+	IPVersionIPv4            bool   = false
+	IPVersionIPv4String      string = "IPv4"
+	IPVersionIPv6String      string = "IPv6"
+	IPVersionDualStackString string = "DualStack"
 )
 
 // LB variables for dual-stack
@@ -428,8 +431,8 @@ const (
 	RouteNameFmt       = "%s____%s"
 	RouteNameSeparator = "____"
 
-	// routeUpdateInterval defines the route reconciling interval.
-	RouteUpdateInterval = 30 * time.Second
+	// DefaultRouteUpdateIntervalInSeconds defines the route reconciling interval.
+	DefaultRouteUpdateIntervalInSeconds = 30
 )
 
 // cloud provider config secret
@@ -541,4 +544,8 @@ type LoadBalancerBackendPoolUpdateOperation string
 const (
 	LoadBalancerBackendPoolUpdateOperationAdd    LoadBalancerBackendPoolUpdateOperation = "add"
 	LoadBalancerBackendPoolUpdateOperationRemove LoadBalancerBackendPoolUpdateOperation = "remove"
+
+	DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds = 30
+
+	ServiceNameLabel = "kubernetes.io/service-name"
 )

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -264,6 +264,11 @@ type Config struct {
 
 	// DisableAPICallCache disables the cache for Azure API calls. It is for ARG support and not all resources will be disabled.
 	DisableAPICallCache bool `json:"disableAPICallCache,omitempty" yaml:"disableAPICallCache,omitempty"`
+
+	// RouteUpdateIntervalInSeconds is the interval for updating routes. Default is 30 seconds.
+	RouteUpdateIntervalInSeconds int `json:"routeUpdateIntervalInSeconds,omitempty" yaml:"routeUpdateIntervalInSeconds,omitempty"`
+	// LoadBalancerBackendPoolUpdateIntervalInSeconds is the interval for updating load balancer backend pool of local services. Default is 30 seconds.
+	LoadBalancerBackendPoolUpdateIntervalInSeconds int `json:"loadBalancerBackendPoolUpdateIntervalInSeconds,omitempty" yaml:"loadBalancerBackendPoolUpdateIntervalInSeconds,omitempty"`
 }
 
 // MultipleStandardLoadBalancerConfiguration stores the properties regarding multiple standard load balancers.
@@ -402,10 +407,11 @@ type Cloud struct {
 	regionZonesMap   map[string][]string
 	refreshZonesLock sync.RWMutex
 
-	KubeClient       clientset.Interface
-	eventBroadcaster record.EventBroadcaster
-	eventRecorder    record.EventRecorder
-	routeUpdater     batchProcessor
+	KubeClient         clientset.Interface
+	eventBroadcaster   record.EventBroadcaster
+	eventRecorder      record.EventRecorder
+	routeUpdater       batchProcessor
+	backendPoolUpdater batchProcessor
 
 	vmCache  azcache.Resource
 	lbCache  azcache.Resource
@@ -430,10 +436,11 @@ type Cloud struct {
 	// runs only once every time the cloud provide restarts.
 	multipleStandardLoadBalancerConfigurationsSynced bool
 	// nodesWithCorrectLoadBalancerByPrimaryVMSet marks nodes that are matched with load balancers by primary vmSet.
-	nodesWithCorrectLoadBalancerByPrimaryVMSet sync.Map
-
+	nodesWithCorrectLoadBalancerByPrimaryVMSet      sync.Map
 	multipleStandardLoadBalancersActiveServicesLock sync.Mutex
 	multipleStandardLoadBalancersActiveNodesLock    sync.Mutex
+	localServiceNameToServiceInfoMap                sync.Map
+	endpointSlicesCache                             sync.Map
 }
 
 // NewCloud returns a Cloud with initialized clients
@@ -609,12 +616,6 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *Config, 
 		}
 	}
 
-	if az.useMultipleStandardLoadBalancers() {
-		if err := az.checkEnableMultipleStandardLoadBalancers(); err != nil {
-			return err
-		}
-	}
-
 	env, err := ratelimitconfig.ParseAzureEnvironment(config.Cloud, config.ResourceManagerEndpoint, config.IdentitySystem)
 	if err != nil {
 		return err
@@ -698,6 +699,12 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *Config, 
 		az.LoadBalancerBackendPool = newBackendPoolTypeNodeIP(az)
 	}
 
+	if az.useMultipleStandardLoadBalancers() {
+		if err := az.checkEnableMultipleStandardLoadBalancers(); err != nil {
+			return err
+		}
+	}
+
 	err = az.initCaches()
 	if err != nil {
 		return err
@@ -710,8 +717,17 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *Config, 
 	// updating routes and syncing zones only in CCM
 	if callFromCCM {
 		// start delayed route updater.
-		az.routeUpdater = newDelayedRouteUpdater(az, consts.RouteUpdateInterval)
+		if az.RouteUpdateIntervalInSeconds == 0 {
+			az.RouteUpdateIntervalInSeconds = consts.DefaultRouteUpdateIntervalInSeconds
+		}
+		az.routeUpdater = newDelayedRouteUpdater(az, time.Duration(az.RouteUpdateIntervalInSeconds)*time.Second)
 		go az.routeUpdater.run(ctx)
+
+		// start backend pool updater.
+		if az.useMultipleStandardLoadBalancers() {
+			az.backendPoolUpdater = newLoadBalancerBackendPoolUpdater(az, time.Duration(az.LoadBalancerBackendPoolUpdateIntervalInSeconds)*time.Second)
+			go az.backendPoolUpdater.run(ctx)
+		}
 
 		// Azure Stack does not support zone at the moment
 		// https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-network-differences?view=azs-2102
@@ -759,6 +775,10 @@ func (az *Cloud) checkEnableMultipleStandardLoadBalancers() error {
 			return fmt.Errorf("duplicated primary VMSet %s in multiple standard load balancer configurations %s", multiSLBConfig.PrimaryVMSet, multiSLBConfig.Name)
 		}
 		primaryVMSets.Insert(multiSLBConfig.PrimaryVMSet)
+	}
+
+	if az.LoadBalancerBackendPoolUpdateIntervalInSeconds == 0 {
+		az.LoadBalancerBackendPoolUpdateIntervalInSeconds = consts.DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds
 	}
 
 	return nil
@@ -1180,6 +1200,8 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	az.nodeInformerSynced = nodeInformer.HasSynced
 
 	az.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	az.setUpEndpointSlicesInformer(informerFactory)
 }
 
 // updateNodeCaches updates local cache for node's zones and external resource groups.

--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -248,7 +248,6 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(clusterName string,
 					},
 				})
 				lbBackendPoolIDsSlice = append(lbBackendPoolIDsSlice, lbBackendPoolIDs[isIPv6])
-
 			}
 		} else {
 			klog.V(10).Infof("bc.ReconcileBackendPools for service (%s): lb backendpool - found unmanaged backendpool %s", serviceName, pointer.StringDeref(bp.Name, ""))
@@ -396,15 +395,32 @@ func (bi *backendPoolTypeNodeIP) EnsureHostsInPool(service *v1.Service, nodes []
 		changed               bool
 		numOfAdd, numOfDelete int
 		activeNodes           sets.Set[string]
+		err                   error
 	)
 	if bi.useMultipleStandardLoadBalancers() {
-		activeNodes = bi.getActiveNodesByLoadBalancerName(lbName)
+		if !isLocalService(service) {
+			activeNodes = bi.getActiveNodesByLoadBalancerName(lbName)
+		} else {
+			key := strings.ToLower(getServiceName(service))
+			si, found := bi.getLocalServiceInfo(key)
+			if found && !strings.EqualFold(si.lbName, lbName) {
+				klog.V(4).InfoS("EnsureHostsInPool: the service is not on the load balancer",
+					"service", key,
+					"previous load balancer", lbName,
+					"current load balancer", si.lbName)
+				return nil
+			}
+			activeNodes, err = bi.getLocalServiceEndpointsNodeNames(service)
+			if err != nil {
+				return err
+			}
+		}
 		if activeNodes == nil {
 			activeNodes = sets.New[string]()
 		}
 	}
 
-	lbBackendPoolName := getBackendPoolName(clusterName, isIPv6)
+	lbBackendPoolName := bi.getBackendPoolNameForService(service, clusterName, isIPv6)
 	if strings.EqualFold(pointer.StringDeref(backendPool.Name, ""), lbBackendPoolName) &&
 		backendPool.BackendAddressPoolPropertiesFormat != nil {
 		backendPool.VirtualNetwork = &network.SubResource{
@@ -555,9 +571,9 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 	foundBackendPools := map[bool]bool{}
 	lbName := *lb.Name
 	serviceName := getServiceName(service)
-	lbBackendPoolNames := getBackendPoolNames(clusterName)
+	lbBackendPoolNames := bi.getBackendPoolNamesForService(service, clusterName)
 	vmSetName := bi.mapLoadBalancerNameToVMSet(lbName, clusterName)
-	lbBackendPoolIDs := bi.getBackendPoolIDs(clusterName, pointer.StringDeref(lb.Name, ""))
+	lbBackendPoolIDs := bi.getBackendPoolIDsForService(service, clusterName, pointer.StringDeref(lb.Name, ""))
 	isBackendPoolPreConfigured := bi.isBackendPoolPreConfigured(service)
 
 	mc := metrics.NewMetricContext("services", "migrate_to_ip_based_backend_pool", bi.ResourceGroup, bi.getNetworkResourceSubscriptionID(), serviceName)
@@ -711,7 +727,7 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(clusterName string, servi
 
 func (bi *backendPoolTypeNodeIP) GetBackendPrivateIPs(clusterName string, service *v1.Service, lb *network.LoadBalancer) ([]string, []string) {
 	serviceName := getServiceName(service)
-	lbBackendPoolNames := getBackendPoolNames(clusterName)
+	lbBackendPoolNames := bi.getBackendPoolNamesForService(service, clusterName)
 	if lb.LoadBalancerPropertiesFormat == nil || lb.LoadBalancerPropertiesFormat.BackendAddressPools == nil {
 		return nil, nil
 	}

--- a/pkg/provider/azure_loadbalancer_repo.go
+++ b/pkg/provider/azure_loadbalancer_repo.go
@@ -76,7 +76,7 @@ func (az *Cloud) ListLB(service *v1.Service) ([]network.LoadBalancer, error) {
 
 // ListManagedLBs invokes az.LoadBalancerClient.List and filter out
 // those that are not managed by cloud provider azure or not associated to a managed VMSet.
-func (az *Cloud) ListManagedLBs(service *v1.Service, nodes []*v1.Node, clusterName string) ([]network.LoadBalancer, error) {
+func (az *Cloud) ListManagedLBs(service *v1.Service, nodes []*v1.Node, clusterName string) (*[]network.LoadBalancer, error) {
 	allLBs, err := az.ListLB(service)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (az *Cloud) ListManagedLBs(service *v1.Service, nodes []*v1.Node, clusterNa
 		// return early if wantLb=false
 		if nodes == nil {
 			klog.V(4).Infof("ListManagedLBs: return all LBs in the resource group %s, including unmanaged LBs", az.getLoadBalancerResourceGroup())
-			return allLBs, nil
+			return &allLBs, nil
 		}
 
 		agentPoolVMSetNamesMap := make(map[string]bool)
@@ -127,7 +127,7 @@ func (az *Cloud) ListManagedLBs(service *v1.Service, nodes []*v1.Node, clusterNa
 		}
 	}
 
-	return managedLBs, nil
+	return &managedLBs, nil
 }
 
 // CreateOrUpdateLB invokes az.LoadBalancerClient.CreateOrUpdate with exponential backoff retry

--- a/pkg/provider/azure_loadbalancer_repo_test.go
+++ b/pkg/provider/azure_loadbalancer_repo_test.go
@@ -52,11 +52,12 @@ func TestListManagedLBs(t *testing.T) {
 	defer ctrl.Finish()
 
 	tests := []struct {
-		existingLBs, expectedLBs []network.LoadBalancer
-		callTimes                int
-		multiSLBConfigs          []MultipleStandardLoadBalancerConfiguration
-		clientErr                *retry.Error
-		expectedErr              error
+		existingLBs     []network.LoadBalancer
+		expectedLBs     *[]network.LoadBalancer
+		callTimes       int
+		multiSLBConfigs []MultipleStandardLoadBalancerConfiguration
+		clientErr       *retry.Error
+		expectedErr     error
 	}{
 		{
 			clientErr:   &retry.Error{HTTPStatusCode: http.StatusInternalServerError},
@@ -75,7 +76,7 @@ func TestListManagedLBs(t *testing.T) {
 				{Name: pointer.String("unmanaged")},
 				{Name: pointer.String("unmanaged-internal")},
 			},
-			expectedLBs: []network.LoadBalancer{
+			expectedLBs: &[]network.LoadBalancer{
 				{Name: pointer.String("kubernetes")},
 				{Name: pointer.String("kubernetes-internal")},
 				{Name: pointer.String("vmas-1")},
@@ -94,7 +95,7 @@ func TestListManagedLBs(t *testing.T) {
 				{Name: "kubernetes"},
 				{Name: "lb1"},
 			},
-			expectedLBs: []network.LoadBalancer{
+			expectedLBs: &[]network.LoadBalancer{
 				{Name: pointer.String("kubernetes")},
 				{Name: pointer.String("kubernetes-internal")},
 				{Name: pointer.String("lb1-internal")},

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -23,7 +23,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
+
+	v1 "k8s.io/api/core/v1"
+	discovery_v1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
@@ -38,6 +46,9 @@ type batchProcessor interface {
 
 	// addOperation adds an operation to the batchProcessor.
 	addOperation(operation batchOperation) batchOperation
+
+	// removeOperation removes all operations targeting to the specified service.
+	removeOperation(name string)
 }
 
 // batchOperation is an operation that can be added to a batchProcessor.
@@ -47,15 +58,15 @@ type batchOperation interface {
 
 // loadBalancerBackendPoolUpdateOperation is an operation that updates the backend pool of a load balancer.
 type loadBalancerBackendPoolUpdateOperation struct {
+	serviceName      string
 	loadBalancerName string
 	backendPoolName  string
 	kind             consts.LoadBalancerBackendPoolUpdateOperation
 	nodeIPs          []string
-	result           chan batchOperationResult
 }
 
 func (op *loadBalancerBackendPoolUpdateOperation) wait() batchOperationResult {
-	return <-op.result
+	return batchOperationResult{}
 }
 
 // loadBalancerBackendPoolUpdater is a batchProcessor that updates the backend pool of a load balancer.
@@ -77,36 +88,35 @@ func newLoadBalancerBackendPoolUpdater(az *Cloud, interval time.Duration) *loadB
 
 // run starts the loadBalancerBackendPoolUpdater, and stops if the context exits.
 func (updater *loadBalancerBackendPoolUpdater) run(ctx context.Context) {
+	klog.V(2).Info("loadBalancerBackendPoolUpdater.run: started")
 	err := wait.PollUntilContextCancel(ctx, updater.interval, false, func(ctx context.Context) (bool, error) {
 		updater.process()
 		return false, nil
 	})
-	if err != nil {
-		klog.Infof("loadBalancerBackendPoolUpdater.run: stopped due to %s", err.Error())
-	}
+	klog.Infof("loadBalancerBackendPoolUpdater.run: stopped due to %s", err.Error())
 }
 
 // getAddIPsToBackendPoolOperation creates a new loadBalancerBackendPoolUpdateOperation
 // that adds nodeIPs to the backend pool.
-func getAddIPsToBackendPoolOperation(loadBalancerName, backendPoolName string, nodeIPs []string) *loadBalancerBackendPoolUpdateOperation {
+func getAddIPsToBackendPoolOperation(serviceName, loadBalancerName, backendPoolName string, nodeIPs []string) *loadBalancerBackendPoolUpdateOperation {
 	return &loadBalancerBackendPoolUpdateOperation{
+		serviceName:      serviceName,
 		loadBalancerName: loadBalancerName,
 		backendPoolName:  backendPoolName,
 		kind:             consts.LoadBalancerBackendPoolUpdateOperationAdd,
 		nodeIPs:          nodeIPs,
-		result:           make(chan batchOperationResult),
 	}
 }
 
 // getRemoveIPsFromBackendPoolOperation creates a new loadBalancerBackendPoolUpdateOperation
 // that removes nodeIPs from the backend pool.
-func getRemoveIPsFromBackendPoolOperation(loadBalancerName, backendPoolName string, nodeIPs []string) *loadBalancerBackendPoolUpdateOperation {
+func getRemoveIPsFromBackendPoolOperation(serviceName, loadBalancerName, backendPoolName string, nodeIPs []string) *loadBalancerBackendPoolUpdateOperation {
 	return &loadBalancerBackendPoolUpdateOperation{
+		serviceName:      serviceName,
 		loadBalancerName: loadBalancerName,
 		backendPoolName:  backendPoolName,
 		kind:             consts.LoadBalancerBackendPoolUpdateOperationRemove,
 		nodeIPs:          nodeIPs,
-		result:           make(chan batchOperationResult),
 	}
 }
 
@@ -115,8 +125,34 @@ func (updater *loadBalancerBackendPoolUpdater) addOperation(operation batchOpera
 	updater.lock.Lock()
 	defer updater.lock.Unlock()
 
+	op := operation.(*loadBalancerBackendPoolUpdateOperation)
+	klog.V(4).InfoS("loadBalancerBackendPoolUpdater.addOperation",
+		"kind", op.kind,
+		"service name", op.serviceName,
+		"load balancer name", op.loadBalancerName,
+		"backend pool name", op.backendPoolName,
+		"node IPs", strings.Join(op.nodeIPs, ","))
 	updater.operations = append(updater.operations, operation)
 	return operation
+}
+
+// removeOperation removes all operations targeting to the specified service.
+func (updater *loadBalancerBackendPoolUpdater) removeOperation(serviceName string) {
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+
+	for i := len(updater.operations) - 1; i >= 0; i-- {
+		op := updater.operations[i].(*loadBalancerBackendPoolUpdateOperation)
+		if strings.EqualFold(op.serviceName, serviceName) {
+			klog.V(4).InfoS("loadBalancerBackendPoolUpdater.removeOperation",
+				"kind", op.kind,
+				"service name", op.serviceName,
+				"load balancer name", op.loadBalancerName,
+				"backend pool name", op.backendPoolName,
+				"node IPs", strings.Join(op.nodeIPs, ","))
+			updater.operations = append(updater.operations[:i], updater.operations[i+1:]...)
+		}
+	}
 }
 
 // process processes all operations in the loadBalancerBackendPoolUpdater.
@@ -137,6 +173,19 @@ func (updater *loadBalancerBackendPoolUpdater) process() {
 	groups := make(map[string][]batchOperation)
 	for _, op := range updater.operations {
 		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		si, found := updater.az.getLocalServiceInfo(strings.ToLower(lbOp.serviceName))
+		if !found {
+			klog.V(4).Infof("loadBalancerBackendPoolUpdater.process: service %s is not a local service, skip the operation", lbOp.serviceName)
+			continue
+		}
+		if !strings.EqualFold(si.lbName, lbOp.loadBalancerName) {
+			klog.V(4).InfoS("loadBalancerBackendPoolUpdater.process: service is not associated with the load balancer, skip the operation",
+				"service", lbOp.serviceName,
+				"previous load balancer", lbOp.loadBalancerName,
+				"current load balancer", si.lbName)
+			continue
+		}
+
 		key := fmt.Sprintf("%s:%s", lbOp.loadBalancerName, lbOp.backendPoolName)
 		groups[key] = append(groups[key], op)
 	}
@@ -159,9 +208,11 @@ func (updater *loadBalancerBackendPoolUpdater) process() {
 			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
 			switch lbOp.kind {
 			case consts.LoadBalancerBackendPoolUpdateOperationRemove:
-				changed = removeNodeIPAddressesFromBackendPool(bp, lbOp.nodeIPs, false, true)
+				removed := removeNodeIPAddressesFromBackendPool(bp, lbOp.nodeIPs, false, true)
+				changed = changed || removed
 			case consts.LoadBalancerBackendPoolUpdateOperationAdd:
-				changed = updater.az.addNodeIPAddressesToBackendPool(&bp, lbOp.nodeIPs)
+				added := updater.az.addNodeIPAddressesToBackendPool(&bp, lbOp.nodeIPs)
+				changed = changed || added
 			default:
 				panic("loadBalancerBackendPoolUpdater.process: unknown operation type")
 			}
@@ -169,13 +220,14 @@ func (updater *loadBalancerBackendPoolUpdater) process() {
 		// To keep the code clean, ignore the case when `changed` is true
 		// but the backend pool object is not changed after multiple times of removal and re-adding.
 		if changed {
+			klog.V(2).Infof("loadBalancerBackendPoolUpdater.process: updating backend pool %s/%s", lbName, poolName)
 			rerr = updater.az.LoadBalancerClient.CreateOrUpdateBackendPools(context.Background(), updater.az.ResourceGroup, lbName, poolName, bp, pointer.StringDeref(bp.Etag, ""))
 			if rerr != nil {
 				updater.processError(rerr, operationName, ops...)
 				continue
 			}
 		}
-		notify(newBatchOperationResult(operationName, true, nil), ops...)
+		updater.notify(newBatchOperationResult(operationName, true, nil), ops...)
 	}
 }
 
@@ -186,20 +238,25 @@ func (updater *loadBalancerBackendPoolUpdater) processError(
 	operationName string,
 	operations ...batchOperation,
 ) {
+	if rerr.IsNotFound() {
+		klog.V(4).Infof("backend pool not found for operation %s, skip updating", operationName)
+		return
+	}
+
 	if rerr.Retriable {
 		// Retry if retriable.
 		updater.operations = append(updater.operations, operations...)
 	} else {
 		// Fail all operations if not retriable.
-		notify(newBatchOperationResult(operationName, false, rerr.Error()), operations...)
+		updater.notify(newBatchOperationResult(operationName, false, rerr.Error()), operations...)
 	}
 }
 
 // notify notifies the operations with the result.
-func notify(res batchOperationResult, operations ...batchOperation) {
+func (updater *loadBalancerBackendPoolUpdater) notify(res batchOperationResult, operations ...batchOperation) {
 	for _, op := range operations {
-		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
-		lbOp.result <- res
+		updater.az.processBatchOperationResult(op, res)
+		break
 	}
 }
 
@@ -217,4 +274,272 @@ func newBatchOperationResult(name string, success bool, err error) batchOperatio
 		success: success,
 		err:     err,
 	}
+}
+
+func (az *Cloud) getLocalServiceInfo(serviceName string) (*serviceInfo, bool) {
+	data, ok := az.localServiceNameToServiceInfoMap.Load(serviceName)
+	if !ok {
+		return &serviceInfo{}, false
+	}
+	return data.(*serviceInfo), true
+}
+
+// setUpEndpointSlicesInformer creates an informer for EndpointSlices of local services.
+// It watches the update events and send backend pool update operations to the batch updater.
+// TODO (niqi): the update of endpointslice may be slower than tue update of endpoint pods. Need to fix this.
+func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInformerFactory) {
+	endpointSlicesInformer := informerFactory.Discovery().V1().EndpointSlices().Informer()
+	_, _ = endpointSlicesInformer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				es := obj.(*discovery_v1.EndpointSlice)
+				az.endpointSlicesCache.Store(strings.ToLower(es.Name), es)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				previousES := oldObj.(*discovery_v1.EndpointSlice)
+				newES := newObj.(*discovery_v1.EndpointSlice)
+
+				svcName := getServiceNameOfEndpointSlice(newES)
+				if svcName == "" {
+					klog.V(4).Infof("EndpointSlice %s/%s does not have service name label, skip updating load balancer backend pool", newES.Namespace, newES.Name)
+					return
+				}
+
+				klog.V(4).Infof("Detecting EndpointSlice %s/%s update", newES.Namespace, newES.Name)
+				az.endpointSlicesCache.Store(strings.ToLower(newES.Name), newES)
+
+				key := strings.ToLower(fmt.Sprintf("%s/%s", newES.Namespace, svcName))
+				si, found := az.getLocalServiceInfo(key)
+				if !found {
+					klog.V(4).Infof("EndpointSlice %s/%s belongs to service %s, but the service is not a local service, skip updating load balancer backend pool", key, newES.Namespace, newES.Name)
+					return
+				}
+				lbName, ipFamily := si.lbName, si.ipFamily
+
+				var previousIPs, currentIPs, previousNodeNames, currentNodeNames []string
+				if previousES != nil {
+					for _, ep := range previousES.Endpoints {
+						previousNodeNames = append(previousNodeNames, pointer.StringDeref(ep.NodeName, ""))
+					}
+				}
+				if newES != nil {
+					for _, ep := range newES.Endpoints {
+						currentNodeNames = append(currentNodeNames, pointer.StringDeref(ep.NodeName, ""))
+					}
+				}
+				for _, previousNodeName := range previousNodeNames {
+					nodeIPsSet := az.nodePrivateIPs[previousNodeName]
+					previousIPs = append(previousIPs, setToStrings(nodeIPsSet)...)
+				}
+				for _, currentNodeName := range currentNodeNames {
+					nodeIPsSet := az.nodePrivateIPs[currentNodeName]
+					currentIPs = append(currentIPs, setToStrings(nodeIPsSet)...)
+				}
+				ipsToBeDeleted := compareNodeIPs(previousIPs, currentIPs)
+				if len(ipsToBeDeleted) == 0 && len(previousIPs) == len(currentIPs) {
+					klog.V(4).Infof("No IP change detected for EndpointSlice %s/%s, skip updating load balancer backend pool", newES.Namespace, newES.Name)
+					return
+				}
+
+				if az.backendPoolUpdater != nil {
+					var bpNames []string
+					bpNameIPv4 := getLocalServiceBackendPoolName(key, false)
+					bpNameIPv6 := getLocalServiceBackendPoolName(key, true)
+					switch strings.ToLower(ipFamily) {
+					case strings.ToLower(consts.IPVersionIPv4String):
+						bpNames = append(bpNames, bpNameIPv4)
+					case strings.ToLower(consts.IPVersionIPv6String):
+						bpNames = append(bpNames, bpNameIPv6)
+					default:
+						bpNames = append(bpNames, bpNameIPv4, bpNameIPv6)
+					}
+					for _, bpName := range bpNames {
+						if len(ipsToBeDeleted) > 0 {
+							az.backendPoolUpdater.addOperation(getRemoveIPsFromBackendPoolOperation(key, lbName, bpName, ipsToBeDeleted))
+						}
+						if len(currentIPs) > 0 {
+							az.backendPoolUpdater.addOperation(getAddIPsToBackendPoolOperation(key, lbName, bpName, currentIPs))
+						}
+					}
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				es := obj.(*discovery_v1.EndpointSlice)
+				az.endpointSlicesCache.Delete(strings.ToLower(es.Name))
+			},
+		})
+}
+
+func (az *Cloud) processBatchOperationResult(op batchOperation, res batchOperationResult) {
+	lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+	var svc *v1.Service
+	svc, _, _ = az.getLatestService(lbOp.serviceName, false)
+	if svc == nil {
+		klog.Warningf("Service %s not found, skip sending event", lbOp.serviceName)
+		return
+	}
+	if !res.success {
+		var errStr string
+		if res.err != nil {
+			errStr = res.err.Error()
+		}
+		az.Event(svc, v1.EventTypeWarning, "LoadBalancerBackendPoolUpdateFailed", errStr)
+	} else {
+		az.Event(svc, v1.EventTypeNormal, "LoadBalancerBackendPoolUpdated", "Load balancer backend pool updated successfully")
+	}
+}
+
+// getServiceNameOfEndpointSlice gets the service name of an EndpointSlice.
+func getServiceNameOfEndpointSlice(es *discovery_v1.EndpointSlice) string {
+	if es.Labels != nil {
+		return es.Labels[consts.ServiceNameLabel]
+	}
+	return ""
+}
+
+// compareNodeIPs compares the previous and current node IPs and returns the IPs to be deleted.
+func compareNodeIPs(previousIPs, currentIPs []string) []string {
+	previousIPSet := sets.NewString(previousIPs...)
+	currentIPSet := sets.NewString(currentIPs...)
+	return previousIPSet.Difference(currentIPSet).List()
+}
+
+// getLocalServiceBackendPoolName gets the name of the backend pool of a local service.
+func getLocalServiceBackendPoolName(serviceName string, ipv6 bool) string {
+	serviceName = strings.ToLower(strings.Replace(serviceName, "/", "-", -1))
+	if ipv6 {
+		return fmt.Sprintf("%s-ipv6", serviceName)
+	}
+	return serviceName
+}
+
+// getBackendPoolNameForService determine the expected backend pool name
+// by checking the external traffic policy of the service.
+func (az *Cloud) getBackendPoolNameForService(service *v1.Service, clusterName string, ipv6 bool) string {
+	if !isLocalService(service) || !az.useMultipleStandardLoadBalancers() {
+		return getBackendPoolName(clusterName, ipv6)
+	}
+	return getLocalServiceBackendPoolName(getServiceName(service), ipv6)
+}
+
+// getBackendPoolNamesForService determine the expected backend pool names
+// by checking the external traffic policy of the service.
+func (az *Cloud) getBackendPoolNamesForService(service *v1.Service, clusterName string) map[bool]string {
+	if !isLocalService(service) || !az.useMultipleStandardLoadBalancers() {
+		return getBackendPoolNames(clusterName)
+	}
+	return map[bool]string{
+		consts.IPVersionIPv4: getLocalServiceBackendPoolName(getServiceName(service), false),
+		consts.IPVersionIPv6: getLocalServiceBackendPoolName(getServiceName(service), true),
+	}
+}
+
+// getBackendPoolIDsForService determine the expected backend pool IDs
+// by checking the external traffic policy of the service.
+func (az *Cloud) getBackendPoolIDsForService(service *v1.Service, clusterName, lbName string) map[bool]string {
+	if !isLocalService(service) || !az.useMultipleStandardLoadBalancers() {
+		return az.getBackendPoolIDs(clusterName, lbName)
+	}
+	return map[bool]string{
+		consts.IPVersionIPv4: az.getLocalServiceBackendPoolID(getServiceName(service), lbName, false),
+		consts.IPVersionIPv6: az.getLocalServiceBackendPoolID(getServiceName(service), lbName, true),
+	}
+}
+
+// getLocalServiceBackendPoolID gets the ID of the backend pool of a local service.
+func (az *Cloud) getLocalServiceBackendPoolID(serviceName string, lbName string, ipv6 bool) string {
+	return az.getBackendPoolID(lbName, getLocalServiceBackendPoolName(serviceName, ipv6))
+}
+
+// localServiceOwnsBackendPool checks if a backend pool is owned by a local service.
+func localServiceOwnsBackendPool(serviceName, bpName string) bool {
+	prefix := strings.Replace(serviceName, "/", "-", -1)
+	return strings.HasPrefix(strings.ToLower(bpName), strings.ToLower(prefix))
+}
+
+type serviceInfo struct {
+	ipFamily string
+	lbName   string
+}
+
+func newServiceInfo(ipFamily, lbName string) *serviceInfo {
+	return &serviceInfo{
+		ipFamily: ipFamily,
+		lbName:   lbName,
+	}
+}
+
+// getLocalServiceEndpointsNodeNames gets the node names that host all endpoints of the local service.
+func (az *Cloud) getLocalServiceEndpointsNodeNames(service *v1.Service) (sets.Set[string], error) {
+	var ep *discovery_v1.EndpointSlice
+	az.endpointSlicesCache.Range(func(key, value interface{}) bool {
+		endpointSlice := value.(*discovery_v1.EndpointSlice)
+		if strings.EqualFold(getServiceNameOfEndpointSlice(endpointSlice), service.Name) {
+			ep = endpointSlice
+			return false
+		}
+		return true
+	})
+	if ep == nil {
+		klog.Infof("EndpointSlice for service %s/%s not found, try to list EndpointSlices", service.Namespace, service.Name)
+		eps, err := az.KubeClient.DiscoveryV1().EndpointSlices(service.Namespace).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			klog.Errorf("Failed to list EndpointSlices for service %s/%s: %s", service.Namespace, service.Name, err.Error())
+			return nil, err
+		}
+		for _, endpointSlice := range eps.Items {
+			endpointSlice := endpointSlice
+			if strings.EqualFold(getServiceNameOfEndpointSlice(&endpointSlice), service.Name) {
+				ep = &endpointSlice
+				break
+			}
+		}
+	}
+	if ep == nil {
+		return nil, fmt.Errorf("failed to find EndpointSlice for service %s/%s", service.Namespace, service.Name)
+	}
+
+	var nodeNames []string
+	for _, endpoint := range ep.Endpoints {
+		klog.V(4).Infof("EndpointSlice %s/%s has endpoint %s on node %s", ep.Namespace, ep.Name, endpoint.Addresses, pointer.StringDeref(endpoint.NodeName, ""))
+		nodeNames = append(nodeNames, pointer.StringDeref(endpoint.NodeName, ""))
+	}
+
+	return sets.New[string](nodeNames...), nil
+}
+
+// cleanupLocalServiceBackendPool cleans up the backend pool of
+// a local service among given load balancers.
+func (az *Cloud) cleanupLocalServiceBackendPool(
+	svc *v1.Service,
+	nodes []*v1.Node,
+	lbs *[]network.LoadBalancer,
+	clusterName string,
+) (newLBs *[]network.LoadBalancer, err error) {
+	var changed bool
+	if lbs != nil {
+		for _, lb := range *lbs {
+			lbName := pointer.StringDeref(lb.Name, "")
+			if lb.BackendAddressPools != nil {
+				for _, bp := range *lb.BackendAddressPools {
+					bpName := pointer.StringDeref(bp.Name, "")
+					if localServiceOwnsBackendPool(getServiceName(svc), bpName) {
+						if err := az.DeleteLBBackendPool(lbName, bpName); err != nil {
+							return nil, err
+						}
+						changed = true
+					}
+				}
+			}
+		}
+	}
+	if changed {
+		// Refresh the list of existing LBs after cleanup to update etags for the LBs.
+		klog.V(4).Info("Refreshing the list of existing LBs")
+		lbs, err = az.ListManagedLBs(svc, nodes, clusterName)
+		if err != nil {
+			return nil, fmt.Errorf("reconcileLoadBalancer: failed to list managed LB: %w", err)
+		}
+	}
+	return lbs, nil
 }

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -28,10 +29,16 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	v1 "k8s.io/api/core/v1"
+	discovery_v1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/loadbalancerclient/mockloadbalancerclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 )
 
@@ -39,9 +46,9 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	addOperationPool1 := getAddIPsToBackendPoolOperation("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
-	removeOperationPool1 := getRemoveIPsFromBackendPoolOperation("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
-	addOperationPool2 := getAddIPsToBackendPoolOperation("lb1", "pool2", []string{"10.0.0.1", "10.0.0.2"})
+	addOperationPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
+	removeOperationPool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
+	addOperationPool2 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool2", []string{"10.0.0.1", "10.0.0.2"})
 
 	testCases := []struct {
 		name                               string
@@ -49,9 +56,11 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 		existingBackendPools               []network.BackendAddressPool
 		expectedGetBackendPool             network.BackendAddressPool
 		extraWait                          bool
+		notLocal                           bool
+		changeLB                           bool
+		removeOperationServiceName         string
 		expectedCreateOrUpdateBackendPools []network.BackendAddressPool
 		expectedBackendPools               []network.BackendAddressPool
-		expectedResult                     map[batchOperationResult]bool
 	}{
 		{
 			name:       "Add node IPs to backend pool",
@@ -65,9 +74,6 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			expectedBackendPools: []network.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedResult: map[batchOperationResult]bool{
-				newBatchOperationResult("lb1/pool1", true, nil): true,
-			},
 		},
 		{
 			name:       "Remove node IPs from backend pool",
@@ -80,9 +86,6 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			},
 			expectedBackendPools: []network.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
-			},
-			expectedResult: map[batchOperationResult]bool{
-				newBatchOperationResult("lb1/pool1", true, nil): true,
 			},
 		},
 		{
@@ -100,10 +103,6 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 				getTestBackendAddressPoolWithIPs("lb1", "pool2", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedResult: map[batchOperationResult]bool{
-				newBatchOperationResult("lb1/pool1", true, nil): true,
-				newBatchOperationResult("lb1/pool2", true, nil): true,
-			},
 		},
 		{
 			name:       "Multiple operations in two batches",
@@ -120,24 +119,48 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			expectedBackendPools: []network.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
-			expectedResult: map[batchOperationResult]bool{
-				newBatchOperationResult("lb1/pool1", true, nil): true,
-				newBatchOperationResult("lb1/pool1", true, nil): true,
-			},
+		},
+		{
+			name:                       "remove operations by service name",
+			operations:                 []batchOperation{addOperationPool1, removeOperationPool1},
+			removeOperationServiceName: "ns1/svc1",
+		},
+		{
+			name:       "not local service",
+			operations: []batchOperation{addOperationPool1},
+			notLocal:   true,
+		},
+		{
+			name:       "not on this load balancer",
+			operations: []batchOperation{addOperationPool1},
+			changeLB:   true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cloud := GetTestCloud(ctrl)
+			cloud.localServiceNameToServiceInfoMap = sync.Map{}
+			if !tc.notLocal {
+				cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+			}
+			if tc.changeLB {
+				cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb2"})
+			}
+			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			client := fake.NewSimpleClientset(&svc)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
 			mockLBClient := mockloadbalancerclient.NewMockInterface(ctrl)
-			mockLBClient.EXPECT().GetLBBackendPool(
-				gomock.Any(),
-				gomock.Any(),
-				"lb1",
-				*tc.existingBackendPools[0].Name,
-				gomock.Any(),
-			).Return(tc.existingBackendPools[0], nil)
+			if len(tc.existingBackendPools) > 0 {
+				mockLBClient.EXPECT().GetLBBackendPool(
+					gomock.Any(),
+					gomock.Any(),
+					"lb1",
+					*tc.existingBackendPools[0].Name,
+					gomock.Any(),
+				).Return(tc.existingBackendPools[0], nil)
+			}
 			if len(tc.existingBackendPools) == 2 {
 				mockLBClient.EXPECT().GetLBBackendPool(
 					gomock.Any(),
@@ -156,14 +179,16 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 					gomock.Any(),
 				).Return(tc.expectedGetBackendPool, nil)
 			}
-			mockLBClient.EXPECT().CreateOrUpdateBackendPools(
-				gomock.Any(),
-				gomock.Any(),
-				"lb1",
-				*tc.expectedCreateOrUpdateBackendPools[0].Name,
-				tc.expectedCreateOrUpdateBackendPools[0],
-				gomock.Any(),
-			).Return(nil)
+			if len(tc.expectedCreateOrUpdateBackendPools) > 0 {
+				mockLBClient.EXPECT().CreateOrUpdateBackendPools(
+					gomock.Any(),
+					gomock.Any(),
+					"lb1",
+					*tc.expectedCreateOrUpdateBackendPools[0].Name,
+					tc.expectedCreateOrUpdateBackendPools[0],
+					gomock.Any(),
+				).Return(nil)
+			}
 			if len(tc.existingBackendPools) == 2 || tc.extraWait {
 				mockLBClient.EXPECT().CreateOrUpdateBackendPools(
 					gomock.Any(),
@@ -194,26 +219,30 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 					time.Sleep(time.Second)
 				}
 			}
-			err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-				resultLen := 0
-				results.Range(func(key, value interface{}) bool {
-					resultLen++
-					return true
-				})
-				return resultLen == len(tc.expectedResult), nil
-			})
-			assert.NoError(t, err)
+			if tc.removeOperationServiceName != "" {
+				u.removeOperation(tc.removeOperationServiceName)
+			}
+			time.Sleep(3 * time.Second)
+			//err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+			//	resultLen := 0
+			//	results.Range(func(key, value interface{}) bool {
+			//		resultLen++
+			//		return true
+			//	})
+			//	return resultLen == len(tc.expectedResult), nil
+			//})
+			//assert.NoError(t, err)
 
-			actualResults := make(map[batchOperationResult]bool)
-			results.Range(func(key, value interface{}) bool {
-				actualResults[key.(batchOperationResult)] = true
-				return true
-			})
+			//actualResults := make(map[batchOperationResult]bool)
+			//results.Range(func(key, value interface{}) bool {
+			//	actualResults[key.(batchOperationResult)] = true
+			//	return true
+			//})
 
-			err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-				return assert.Equal(t, tc.expectedResult, actualResults, tc.name), nil
-			})
-			assert.NoError(t, err)
+			//err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+			//	return assert.Equal(t, tc.expectedResult, actualResults, tc.name), nil
+			//})
+			//assert.NoError(t, err)
 		})
 	}
 }
@@ -222,7 +251,7 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	addOperationPool1 := getAddIPsToBackendPoolOperation("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
+	addOperationPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
 
 	testCases := []struct {
 		name                               string
@@ -233,9 +262,9 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 		putBackendPoolErr                  *retry.Error
 		expectedCreateOrUpdateBackendPools []network.BackendAddressPool
 		expectedBackendPools               []network.BackendAddressPool
-		expectedResult                     map[batchOperationResult]bool
-		expectedPoolNameToErrMsg           map[string]string
-		expectedResultCount                int
+		//expectedResult                     map[batchOperationResult]bool
+		//expectedPoolNameToErrMsg           map[string]string
+		//expectedResultCount                int
 	}{
 		{
 			name:       "Retriable error when getting backend pool",
@@ -250,10 +279,10 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			expectedBackendPools: []network.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedResult: map[batchOperationResult]bool{
-				newBatchOperationResult("lb1/pool1", true, nil): true,
-			},
-			expectedResultCount: 1,
+			//expectedResult: map[batchOperationResult]bool{
+			//	newBatchOperationResult("lb1/pool1", true, nil): true,
+			//},
+			//expectedResultCount: 1,
 		},
 		{
 			name:       "Retriable error when updating backend pool",
@@ -270,10 +299,10 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			expectedBackendPools: []network.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedResult: map[batchOperationResult]bool{
-				newBatchOperationResult("lb1/pool1", true, nil): true,
-			},
-			expectedResultCount: 1,
+			//expectedResult: map[batchOperationResult]bool{
+			//	newBatchOperationResult("lb1/pool1", true, nil): true,
+			//},
+			//expectedResultCount: 1,
 		},
 		{
 			name:       "Non-retriable error when getting backend pool",
@@ -285,8 +314,8 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			expectedBackendPools: []network.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
-			expectedPoolNameToErrMsg: map[string]string{"lb1/pool1": "Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: error"},
-			expectedResultCount:      1,
+			//expectedPoolNameToErrMsg: map[string]string{"lb1/pool1": "Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: error"},
+			//expectedResultCount:      1,
 		},
 		{
 			name:       "Non-retriable error when updating backend pool",
@@ -299,14 +328,32 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			expectedCreateOrUpdateBackendPools: []network.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedPoolNameToErrMsg: map[string]string{"lb1/pool1": "Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: error"},
-			expectedResultCount:      1,
+			//expectedPoolNameToErrMsg: map[string]string{"lb1/pool1": "Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: error"},
+			//expectedResultCount:      1,
+		},
+		{
+			name:       "Backend pool not found",
+			operations: []batchOperation{addOperationPool1},
+			existingBackendPools: []network.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
+			},
+			getBackendPoolErr: &retry.Error{
+				HTTPStatusCode: http.StatusNotFound,
+				Retriable:      false,
+				RawError:       errors.New("error"),
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cloud := GetTestCloud(ctrl)
+			cloud.localServiceNameToServiceInfoMap = sync.Map{}
+			cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			client := fake.NewSimpleClientset(&svc)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
 			mockLBClient := mockloadbalancerclient.NewMockInterface(ctrl)
 			mockLBClient.EXPECT().GetLBBackendPool(
 				gomock.Any(),
@@ -369,47 +416,48 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			defer cancel()
 			go u.run(ctx)
 
-			results := sync.Map{}
+			//results := sync.Map{}
 			for _, op := range tc.operations {
 				op := op
-				go func() {
-					u.addOperation(op)
-					result := op.wait()
-					results.Store(result, true)
-				}()
+				//go func() {
+				u.addOperation(op)
+				//result := op.wait()
+				//results.Store(result, true)
+				//}()
 				time.Sleep(100 * time.Millisecond)
 			}
-			err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-				resultLen := 0
-				results.Range(func(key, value interface{}) bool {
-					resultLen++
-					return true
-				})
-				return resultLen == tc.expectedResultCount, nil
-			})
-			assert.NoError(t, err)
+			time.Sleep(3 * time.Second)
+			//err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+			//	resultLen := 0
+			//	results.Range(func(key, value interface{}) bool {
+			//		resultLen++
+			//		return true
+			//	})
+			//	return resultLen == tc.expectedResultCount, nil
+			//})
+			//assert.NoError(t, err)
 
-			actualResults := make(map[batchOperationResult]bool)
-			poolNameToErrMsg := make(map[string]string)
-			results.Range(func(key, value interface{}) bool {
-				actualResults[key.(batchOperationResult)] = true
-				if tc.getBackendPoolErr != nil && !tc.getBackendPoolErr.Retriable ||
-					tc.putBackendPoolErr != nil && !tc.putBackendPoolErr.Retriable {
-					poolNameToErrMsg[key.(batchOperationResult).name] = key.(batchOperationResult).err.Error()
-				}
-				return true
-			})
+			//actualResults := make(map[batchOperationResult]bool)
+			//poolNameToErrMsg := make(map[string]string)
+			//results.Range(func(key, value interface{}) bool {
+			//	actualResults[key.(batchOperationResult)] = true
+			//	if tc.getBackendPoolErr != nil && !tc.getBackendPoolErr.Retriable ||
+			//		tc.putBackendPoolErr != nil && !tc.putBackendPoolErr.Retriable {
+			//		poolNameToErrMsg[key.(batchOperationResult).name] = key.(batchOperationResult).err.Error()
+			//	}
+			//	return true
+			//})
 
-			err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-				if tc.expectedResult != nil {
-					return assert.Equal(t, tc.expectedResult, actualResults, tc.name), nil
-				}
-				if tc.expectedPoolNameToErrMsg != nil {
-					return assert.Equal(t, tc.expectedPoolNameToErrMsg, poolNameToErrMsg, tc.name), nil
-				}
-				return false, errors.New("unexpected result")
-			})
-			assert.NoError(t, err)
+			//err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+			//	if tc.expectedResult != nil {
+			//		return assert.Equal(t, tc.expectedResult, actualResults, tc.name), nil
+			//	}
+			//	if tc.expectedPoolNameToErrMsg != nil {
+			//		return assert.Equal(t, tc.expectedPoolNameToErrMsg, poolNameToErrMsg, tc.name), nil
+			//	}
+			//	return false, errors.New("unexpected result")
+			//})
+			//assert.NoError(t, err)
 		})
 	}
 }
@@ -434,4 +482,125 @@ func getTestBackendAddressPoolWithIPs(lbName, bpName string, ips []string) netwo
 		}
 	}
 	return bp
+}
+
+func getTestEndpointSlice(name, namespace, svcName string, nodeNames ...string) *discovery_v1.EndpointSlice {
+	endpoints := make([]discovery_v1.Endpoint, 0)
+	for _, nodeName := range nodeNames {
+		nodeName := nodeName
+		endpoints = append(endpoints, discovery_v1.Endpoint{
+			NodeName: &nodeName,
+		})
+	}
+	return &discovery_v1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				consts.ServiceNameLabel: svcName,
+			},
+		},
+		Endpoints: endpoints,
+	}
+}
+
+func TestEndpointSlicesInformer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range []struct {
+		name                        string
+		existingEPS                 *discovery_v1.EndpointSlice
+		updatedEPS                  *discovery_v1.EndpointSlice
+		notLocal                    bool
+		expectedGetBackendPoolCount int
+		expectedPutBackendPoolCount int
+	}{
+		{
+			name:                        "remove unwanted ips and add wanted ones",
+			existingEPS:                 getTestEndpointSlice("eps1", "test", "svc1", "node1"),
+			updatedEPS:                  getTestEndpointSlice("eps1", "test", "svc1", "node2"),
+			expectedGetBackendPoolCount: 1,
+			expectedPutBackendPoolCount: 1,
+		},
+		{
+			name:        "skip non-local services",
+			existingEPS: getTestEndpointSlice("eps1", "test", "svc2", "node1"),
+			updatedEPS:  getTestEndpointSlice("eps1", "test", "svc2", "node2"),
+		},
+		{
+			name:        "skip an endpoint slice that don't belong to a service",
+			existingEPS: getTestEndpointSlice("eps1", "test", "", "node1"),
+			updatedEPS:  getTestEndpointSlice("eps1", "test", "", "node2"),
+		},
+		{
+			name:        "not a local service",
+			existingEPS: getTestEndpointSlice("eps1", "test", "", "node1"),
+			updatedEPS:  getTestEndpointSlice("eps1", "test", "", "node2"),
+			notLocal:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := GetTestCloud(ctrl)
+			cloud.localServiceNameToServiceInfoMap = sync.Map{}
+			if !tc.notLocal {
+				cloud.localServiceNameToServiceInfoMap.Store("test/svc1", &serviceInfo{lbName: "lb1"})
+			}
+			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
+			cloud.LoadBalancerSku = consts.LoadBalancerSkuStandard
+			cloud.MultipleStandardLoadBalancerConfigurations = []MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+				},
+			}
+			cloud.localServiceNameToServiceInfoMap.Store("test/svc1", newServiceInfo(consts.IPVersionIPv4String, "lb1"))
+			cloud.nodePrivateIPs = map[string]sets.Set[string]{
+				"node1": sets.New[string]("10.0.0.1"),
+				"node2": sets.New[string]("10.0.0.2"),
+			}
+
+			existingBackendPool := getTestBackendAddressPoolWithIPs("lb1", "test-svc1", []string{"10.0.0.1"})
+			expectedBackendPool := getTestBackendAddressPoolWithIPs("lb1", "test-svc1", []string{"10.0.0.2"})
+			mockLBClient := mockloadbalancerclient.NewMockInterface(ctrl)
+			mockLBClient.EXPECT().GetLBBackendPool(gomock.Any(), gomock.Any(), "lb1", "test-svc1", "").Return(existingBackendPool, nil).Times(tc.expectedGetBackendPoolCount)
+			mockLBClient.EXPECT().CreateOrUpdateBackendPools(gomock.Any(), gomock.Any(), "lb1", "test-svc1", expectedBackendPool, "").Return(nil).Times(tc.expectedPutBackendPoolCount)
+			cloud.LoadBalancerClient = mockLBClient
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			cloud.backendPoolUpdater = u
+			go cloud.backendPoolUpdater.run(ctx)
+
+			cloud.setUpEndpointSlicesInformer(informerFactory)
+			stopChan := make(chan struct{})
+			defer func() {
+				stopChan <- struct{}{}
+			}()
+			informerFactory.Start(stopChan)
+			time.Sleep(100 * time.Millisecond)
+
+			_, err := client.DiscoveryV1().EndpointSlices("test").Update(context.Background(), tc.updatedEPS, metav1.UpdateOptions{})
+			assert.NoError(t, err)
+			time.Sleep(2 * time.Second)
+		})
+	}
+}
+
+func TestGetBackendPoolNamesAndIDsForService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.MultipleStandardLoadBalancerConfigurations = []MultipleStandardLoadBalancerConfiguration{
+		{},
+	}
+	svc := getTestService("test", v1.ProtocolTCP, nil, false)
+	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+	_ = cloud.getBackendPoolNamesForService(&svc, "test")
+	_ = cloud.getBackendPoolIDsForService(&svc, "test", "lb")
 }

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -272,6 +272,8 @@ func (d *delayedRouteUpdater) addOperation(operation batchOperation) batchOperat
 	return operation
 }
 
+func (d *delayedRouteUpdater) removeOperation(name string) {}
+
 // ListRoutes lists all managed routes that belong to the specified clusterName
 func (az *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
 	klog.V(10).Infof("ListRoutes: START clusterName=%q", clusterName)

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -580,3 +580,27 @@ func safeRemoveKeyFromStringsSet(set sets.Set[string], key string) (sets.Set[str
 
 	return set, has
 }
+
+func setToStrings(set sets.Set[string]) []string {
+	var res []string
+	for key := range set {
+		res = append(res, key)
+	}
+	return res
+}
+
+func isLocalService(service *v1.Service) bool {
+	return service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyLocal
+}
+
+func getServiceIPFamily(service *v1.Service) string {
+	if len(service.Spec.IPFamilies) > 1 {
+		return consts.IPVersionDualStackString
+	}
+	for _, ipFamily := range service.Spec.IPFamilies {
+		if ipFamily == v1.IPv6Protocol {
+			return consts.IPVersionIPv6String
+		}
+	}
+	return consts.IPVersionIPv4String
+}

--- a/tests/e2e/network/node.go
+++ b/tests/e2e/network/node.go
@@ -254,7 +254,7 @@ var _ = Describe("Azure node resources", Label(utils.TestSuiteLabelNode), func()
 		utils.Logf("nodeSet: %v", nodeSet)
 
 		// Considering the route reconciling interval, the timeout is set to interval + 10s.
-		err = wait.PollImmediate(5*time.Second, consts.RouteUpdateInterval+10*time.Second, func() (bool, error) {
+		err = wait.PollImmediate(5*time.Second, consts.DefaultRouteUpdateIntervalInSeconds*time.Second+10*time.Second, func() (bool, error) {
 			for _, routeTable := range *routeTables {
 				routeSet, err := utils.GetNodesInRouteTable(routeTable)
 				if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

In multiple slb mode, each local service owns a backend pool named after the service name. The backend pool will be created in the service reconciliation loop when the service is created or updated from external traffic policy cluster. It will be deleted in the service reconciliation loop when: 1, the service is deleted; 2, the service is changed to etp cluster; 3, the cluster is migrated from multi-slb to single-slb; and 4, the service is moved to another load balancer.
Besides the service reconciliation loop, an endpointslice informer is added in this pr. It watches all endpointslices of local services, monitors any updating events, and updates the corresponding backend pool. Considering local services may churn quickly, the informer will send backend pool updating operations to a buffer queue. The queue merges operations targeting to the same backend pool, and updates them every 30s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Related: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/4013

#### Special notes for your reviewer:

Doc: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/4451

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat: support local service in multiple standard load balancer mode
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
