### PR TITLE
feat: add node label scalesetpriority for spot nodes

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -45,6 +45,9 @@ const (
 	// LabelPlatformSubFaultDomain is the label key of platformSubFaultDomain
 	LabelPlatformSubFaultDomain = "topology.kubernetes.azure.com/sub-fault-domain"
 
+	// LabelScaleSetPriority is the label key of priority
+	LabelScaleSetPriority = "kubernetes.azure.com/scalesetpriority"
+
 	// ADFSIdentitySystem is the override value for tenantID on Azure Stack clouds.
 	ADFSIdentitySystem = "adfs"
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -83,3 +83,8 @@ func (np *IMDSNodeProvider) GetZone(ctx context.Context, name types.NodeName) (c
 func (np *IMDSNodeProvider) GetPlatformSubFaultDomain() (string, error) {
 	return np.azure.GetPlatformSubFaultDomain()
 }
+
+// GetPriority returns scale set priority from IMDS if set.
+func (np *IMDSNodeProvider) GetPriority() (string, error) {
+	return np.azure.GetPriority()
+}

--- a/pkg/node/nodearm.go
+++ b/pkg/node/nodearm.go
@@ -102,3 +102,8 @@ func (np *ARMNodeProvider) GetZone(ctx context.Context, name types.NodeName) (cl
 func (np *ARMNodeProvider) GetPlatformSubFaultDomain() (string, error) {
 	return "", nil
 }
+
+// GetPriority returns scale set priority
+func (np *ARMNodeProvider) GetPriority() (string, error) {
+	return "", nil
+}

--- a/pkg/nodemanager/mock/mock_node_provider.go
+++ b/pkg/nodemanager/mock/mock_node_provider.go
@@ -57,11 +57,24 @@ func (m *NodeProvider) GetPlatformSubFaultDomain() (string, error) {
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
+func (m *NodeProvider) GetPriority() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPriority")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
 
 // GetPlatformSubFaultDomain indicates an expected call of GetPlatformSubFaultDomain.
 func (mr *NodeProviderMockRecorder) GetPlatformSubFaultDomain() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlatformSubFaultDomain", reflect.TypeOf((*NodeProvider)(nil).GetPlatformSubFaultDomain))
+}
+
+// GetPriority indicates an expected call of GetPriority.
+func (mr *NodeProviderMockRecorder) GetPriority() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPriority", reflect.TypeOf((*NodeProvider)(nil).GetPriority))
 }
 
 // GetZone mocks base method.

--- a/pkg/nodemanager/nodemanager_test.go
+++ b/pkg/nodemanager/nodemanager_test.go
@@ -183,6 +183,7 @@ func TestNodeInitialized(t *testing.T) {
 		},
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("1", nil)
+	mockNP.EXPECT().GetPriority().Return("Spot", nil).AnyTimes()
 
 	cloudNodeController := NewCloudNodeController(
 		"node0",
@@ -199,6 +200,7 @@ func TestNodeInitialized(t *testing.T) {
 	assert.Equal(t, "node0", fnh.UpdatedNodes[0].Name, "Node was not updated")
 	assert.Equal(t, 0, len(fnh.UpdatedNodes[0].Spec.Taints), "Node Taint was not removed after cloud init")
 	assert.Equal(t, "1", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformSubFaultDomain])
+	assert.Equal(t, "spot", fnh.UpdatedNodes[0].Labels[consts.LabelScaleSetPriority])
 }
 
 func TestUpdateCloudNode(t *testing.T) {
@@ -261,6 +263,7 @@ func TestUpdateCloudNode(t *testing.T) {
 		},
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("1", nil)
+	mockNP.EXPECT().GetPriority().Return("", nil).AnyTimes()
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := NewCloudNodeController(
@@ -281,6 +284,7 @@ func TestUpdateCloudNode(t *testing.T) {
 	assert.Equal(t, 2, len(fnh.UpdatedNodes[0].Status.Conditions), "Node Contions was not updated")
 	assert.Equal(t, "NetworkUnavailable", string(fnh.UpdatedNodes[0].Status.Conditions[0].Type), "Node Condition NetworkUnavailable was not updated")
 	assert.Equal(t, "1", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformSubFaultDomain])
+	assert.NotContains(t, fnh.UpdatedNodes[0].Labels, consts.LabelScaleSetPriority)
 }
 
 // This test checks that a node without the external cloud provider taint are NOT cloudprovider initialized
@@ -394,6 +398,7 @@ func TestZoneInitialized(t *testing.T) {
 			},
 		}, nil).AnyTimes()
 		mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
+		mockNP.EXPECT().GetPriority().Return("", nil).AnyTimes()
 
 		eventBroadcaster := record.NewBroadcaster()
 		cloudNodeController := &CloudNodeController{
@@ -475,6 +480,7 @@ func TestZoneInitialized(t *testing.T) {
 			},
 		}, nil).AnyTimes()
 		mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
+		mockNP.EXPECT().GetPriority().Return("", nil).AnyTimes()
 
 		eventBroadcaster := record.NewBroadcaster()
 		cloudNodeController := &CloudNodeController{
@@ -572,6 +578,7 @@ func TestAddCloudNode(t *testing.T) {
 		},
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
+	mockNP.EXPECT().GetPriority().Return("", nil).AnyTimes()
 
 	factory := informers.NewSharedInformerFactory(fnh, 0)
 	nodeInformer := factory.Core().V1().Nodes()
@@ -736,6 +743,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 		},
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil)
+	mockNP.EXPECT().GetPriority().Return("", nil).AnyTimes()
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := NewCloudNodeController(
@@ -1158,6 +1166,7 @@ func TestNodeProviderID(t *testing.T) {
 		},
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil).AnyTimes()
+	mockNP.EXPECT().GetPriority().Return("", nil).AnyTimes()
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := &CloudNodeController{
@@ -1244,6 +1253,7 @@ func TestNodeProviderIDAlreadySet(t *testing.T) {
 		},
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain().Return("", nil).AnyTimes()
+	mockNP.EXPECT().GetPriority().Return("", nil).AnyTimes()
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := &CloudNodeController{

--- a/pkg/provider/azure_instance_metadata.go
+++ b/pkg/provider/azure_instance_metadata.go
@@ -75,6 +75,7 @@ type ComputeMetadata struct {
 	VMScaleSetName         string `json:"vmScaleSetName,omitempty"`
 	SubscriptionID         string `json:"subscriptionId,omitempty"`
 	ResourceID             string `json:"resourceId,omitempty"`
+	Priority               string `json:"priority,omitempty"`
 }
 
 // InstanceMetadata represents instance information.

--- a/pkg/provider/azure_zones.go
+++ b/pkg/provider/azure_zones.go
@@ -233,3 +233,20 @@ func (az *Cloud) GetPlatformSubFaultDomain() (string, error) {
 	}
 	return "", nil
 }
+
+// GetPriority returns scale set priority from IMDS if set.
+func (az *Cloud) GetPriority() (string, error) {
+	if az.UseInstanceMetadata {
+		metadata, err := az.Metadata.GetMetadata(azcache.CacheReadTypeUnsafe)
+		if err != nil {
+			klog.Errorf("GetPriority: failed to GetMetadata: %s", err.Error())
+			return "", err
+		}
+		if metadata.Compute == nil {
+			_ = az.Metadata.imsCache.Delete(consts.MetadataCacheKey)
+			return "", errors.New("failure of getting compute information from instance metadata")
+		}
+		return metadata.Compute.Priority, nil
+	}
+	return "", nil
+}


### PR DESCRIPTION

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds label k/v `kubernetes.azure.com/scalesetpriority=spot` if node is a spot node. This label is used e.g. in [opencost](https://github.com/opencost/opencost) to distinguish spot and non-spot nodes.

#### Which issue(s) this PR fixes:
No issue created beforehand

#### Special notes for your reviewer:
I personally haven't tested this in a real cluster yet. 

#### Does this PR introduce a user-facing change?

```release-note
add node label `kubernetes.azure.com/scalesetpriority` if VM priority is set in metadata (for example for spot VMs)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
