### PR TITLE
Improvements to reduce rate limiting with flex scalesets

### DIFF
--- a/pkg/cache/azure_cache.go
+++ b/pkg/cache/azure_cache.go
@@ -41,6 +41,10 @@ const (
 	// CacheReadTypeForceRefresh force refreshes the cache even if the cache entry
 	// is not expired
 	CacheReadTypeForceRefresh
+	// CacheReadTypeNoRefresh returns data from cache even if the cache entry is
+	// active/expired. If entry doesn't exist in cache, then nil is returned.
+	// Data must be nil checked before inference.
+	CacheReadTypeNoRefresh
 )
 
 // GetFunc defines a getter function for timedCache.
@@ -178,6 +182,10 @@ func (t *TimedCache) get(key string, crt AzureCacheReadType) (interface{}, error
 
 	entry.Lock.Lock()
 	defer entry.Lock.Unlock()
+
+	if crt == CacheReadTypeNoRefresh {
+		return entry.Data, nil
+	}
 
 	// entry exists and if cache is not force refreshed
 	if entry.Data != nil && crt != CacheReadTypeForceRefresh {

--- a/pkg/cache/azure_cache_test.go
+++ b/pkg/cache/azure_cache_test.go
@@ -230,6 +230,31 @@ func TestCacheAllowUnsafeRead(t *testing.T) {
 	assert.Equal(t, val, v, "cache should return expired as allow unsafe read is allowed")
 }
 
+func TestCacheAllowNoRefreshRead(t *testing.T) {
+	val := &fakeDataObj{}
+	data := map[string]*fakeDataObj{
+		testKey: val,
+	}
+	dataSource, cache := newFakeCache(t)
+	dataSource.set(data)
+
+	v, err := cache.GetWithDeepCopy(testKey, CacheReadTypeDefault)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, dataSource.called)
+	assert.Equal(t, val, v, "cache should get correct data")
+
+	time.Sleep(fakeCacheTTL)
+	v, err = cache.GetWithDeepCopy(testKey, CacheReadTypeNoRefresh)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, dataSource.called)
+	assert.Equal(t, val, v, "cache should return expired as allow unsafe read is allowed")
+
+	v, err = cache.GetWithDeepCopy("doesNotExist", CacheReadTypeNoRefresh)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, dataSource.called)
+	assert.Equal(t, nil, v, "cache should return nil as entry does not exist")
+}
+
 func TestCacheNoConcurrentGet(t *testing.T) {
 	val := &fakeDataObj{}
 	data := map[string]*fakeDataObj{

--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -50,7 +50,8 @@ type FlexScaleSet struct {
 
 	vmssFlexCache azcache.Resource
 
-	vmssFlexVMNameToVmssID   *sync.Map
+	vmssFlexNodeNameToVmssID *sync.Map
+	vmssFlexNodeNameToVMName *sync.Map
 	vmssFlexVMNameToNodeName *sync.Map
 	vmssFlexVMCache          azcache.Resource
 
@@ -61,7 +62,8 @@ type FlexScaleSet struct {
 func newFlexScaleSet(ctx context.Context, az *Cloud) (VMSet, error) {
 	fs := &FlexScaleSet{
 		Cloud:                    az,
-		vmssFlexVMNameToVmssID:   &sync.Map{},
+		vmssFlexNodeNameToVmssID: &sync.Map{},
+		vmssFlexNodeNameToVMName: &sync.Map{},
 		vmssFlexVMNameToNodeName: &sync.Map{},
 		lockMap:                  newLockMap(),
 	}

--- a/pkg/provider/azure_vmssflex_cache.go
+++ b/pkg/provider/azure_vmssflex_cache.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 
+	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -90,9 +91,8 @@ func (fs *FlexScaleSet) newVmssFlexVMCache(ctx context.Context) (azcache.Resourc
 			vm := vms[i]
 			if vm.OsProfile != nil && vm.OsProfile.ComputerName != nil {
 				localCache.Store(strings.ToLower(*vm.OsProfile.ComputerName), &vm)
-				fs.vmssFlexVMNameToVmssID.Store(strings.ToLower(*vm.OsProfile.ComputerName), key)
-				fs.vmssFlexVMNameToNodeName.Store(*vm.Name, strings.ToLower(*vm.OsProfile.ComputerName))
 			}
+			fs.cacheVirtualMachine(vm)
 		}
 
 		vms, rerr = fs.VirtualMachinesClient.ListVmssFlexVMsWithOnlyInstanceView(ctx, key)
@@ -135,25 +135,15 @@ func (fs *FlexScaleSet) getNodeNameByVMName(vmName string) (string, error) {
 	}
 
 	getter := func(vmName string, crt azcache.AzureCacheReadType) (string, error) {
-		cached, err := fs.vmssFlexCache.Get(consts.VmssFlexKey, crt)
+		vm, err := fs.getVmssFlexVMByVMName(vmName, crt)
 		if err != nil {
 			return "", err
 		}
-		vmssFlexes := cached.(*sync.Map)
 
-		vmssFlexes.Range(func(key, value interface{}) bool {
-			vmssFlexID := key.(string)
-			_, err := fs.vmssFlexVMCache.Get(vmssFlexID, azcache.CacheReadTypeForceRefresh)
-			if err != nil {
-				klog.Errorf("failed to refresh vmss flex VM cache for vmssFlexID %s", vmssFlexID)
-			}
-			return true
-		})
-
-		cachedNodeName, isCached = fs.vmssFlexVMNameToNodeName.Load(vmName)
-		if isCached {
-			return fmt.Sprintf("%v", cachedNodeName), nil
+		if vm.OsProfile != nil && vm.OsProfile.ComputerName != nil {
+			return strings.ToLower(*vm.OsProfile.ComputerName), nil
 		}
+
 		return "", cloudprovider.InstanceNotFound
 	}
 
@@ -169,7 +159,7 @@ func (fs *FlexScaleSet) getNodeNameByVMName(vmName string) (string, error) {
 func (fs *FlexScaleSet) getNodeVmssFlexID(nodeName string) (string, error) {
 	fs.lockMap.LockEntry(consts.GetNodeVmssFlexIDLockKey)
 	defer fs.lockMap.UnlockEntry(consts.GetNodeVmssFlexIDLockKey)
-	cachedVmssFlexID, isCached := fs.vmssFlexVMNameToVmssID.Load(nodeName)
+	cachedVmssFlexID, isCached := fs.vmssFlexNodeNameToVmssID.Load(nodeName)
 
 	if isCached {
 		return fmt.Sprintf("%v", cachedVmssFlexID), nil
@@ -205,9 +195,10 @@ func (fs *FlexScaleSet) getNodeVmssFlexID(nodeName string) (string, error) {
 		for _, vmssID := range vmssFlexIDs {
 			if _, err := fs.vmssFlexVMCache.Get(vmssID, azcache.CacheReadTypeForceRefresh); err != nil {
 				klog.Errorf("failed to refresh vmss flex VM cache for vmssFlexID %s", vmssID)
+				return "", err
 			}
 			// if the vm is cached stop refreshing
-			cachedVmssFlexID, isCached = fs.vmssFlexVMNameToVmssID.Load(nodeName)
+			cachedVmssFlexID, isCached = fs.vmssFlexNodeNameToVmssID.Load(nodeName)
 			if isCached {
 				return fmt.Sprintf("%v", cachedVmssFlexID), nil
 			}
@@ -225,6 +216,11 @@ func (fs *FlexScaleSet) getNodeVmssFlexID(nodeName string) (string, error) {
 }
 
 func (fs *FlexScaleSet) getVmssFlexVM(nodeName string, crt azcache.AzureCacheReadType) (vm compute.VirtualMachine, err error) {
+	cachedVMName, isCached := fs.vmssFlexNodeNameToVMName.Load(nodeName)
+	if isCached {
+		return fs.getVmssFlexVMByVMName(cachedVMName.(string), crt)
+	}
+
 	vmssFlexID, err := fs.getNodeVmssFlexID(nodeName)
 	if err != nil {
 		return vm, err
@@ -332,6 +328,25 @@ func (fs *FlexScaleSet) getVmssFlexByName(vmssFlexName string) (*compute.Virtual
 	return nil, cloudprovider.InstanceNotFound
 }
 
+func (fs *FlexScaleSet) getVmssFlexVMByVMName(vmName string, crt azcache.AzureCacheReadType) (compute.VirtualMachine, error) {
+	vm, err := fs.getVirtualMachine(types.NodeName(vmName), crt)
+	if err != nil {
+		return compute.VirtualMachine{}, err
+	}
+	fs.cacheVirtualMachine(vm)
+	return vm, nil
+}
+
+func (fs *FlexScaleSet) cacheVirtualMachine(vm compute.VirtualMachine) {
+	if vm.OsProfile != nil && vm.OsProfile.ComputerName != nil {
+		fs.vmssFlexVMNameToNodeName.Store(*vm.Name, strings.ToLower(*vm.OsProfile.ComputerName))
+		fs.vmssFlexNodeNameToVMName.Store(strings.ToLower(*vm.OsProfile.ComputerName), *vm.Name)
+		if vm.VirtualMachineScaleSet != nil && vm.VirtualMachineScaleSet.ID != nil {
+			fs.vmssFlexNodeNameToVmssID.Store(strings.ToLower(*vm.OsProfile.ComputerName), *vm.VirtualMachineScaleSet.ID)
+		}
+	}
+}
+
 func (fs *FlexScaleSet) DeleteCacheForNode(nodeName string) error {
 	if fs.Config.DisableAPICallCache {
 		return nil
@@ -344,21 +359,25 @@ func (fs *FlexScaleSet) DeleteCacheForNode(nodeName string) error {
 
 	fs.lockMap.LockEntry(vmssFlexID)
 	defer fs.lockMap.UnlockEntry(vmssFlexID)
-	cached, err := fs.vmssFlexVMCache.Get(vmssFlexID, azcache.CacheReadTypeDefault)
+	cached, err := fs.vmssFlexVMCache.Get(vmssFlexID, azcache.CacheReadTypeNoRefresh)
 	if err != nil {
 		klog.Errorf("vmssFlexVMCache.Get(%s, %s) failed with %v", vmssFlexID, nodeName, err)
 		return err
 	}
-	if cached == nil {
-		err := fmt.Errorf("nil cache returned from %s", vmssFlexID)
-		klog.Errorf("DeleteCacheForNode(%s, %s) failed with %v", vmssFlexID, nodeName, err)
-		return err
+	if cached != nil {
+		vmMap := cached.(*sync.Map)
+		vmMap.Delete(nodeName)
+		fs.vmssFlexVMCache.Update(vmssFlexID, vmMap)
 	}
-	vmMap := cached.(*sync.Map)
-	vmMap.Delete(nodeName)
 
-	fs.vmssFlexVMCache.Update(vmssFlexID, vmMap)
-	fs.vmssFlexVMNameToVmssID.Delete(nodeName)
+	cachedVMName, isCached := fs.vmssFlexNodeNameToVMName.Load(nodeName)
+	if isCached {
+		vmName := cachedVMName.(string)
+		fs.vmssFlexVMNameToNodeName.Delete(vmName)
+	}
+
+	fs.vmssFlexNodeNameToVmssID.Delete(nodeName)
+	fs.vmssFlexNodeNameToVMName.Delete(nodeName)
 
 	klog.V(2).Infof("DeleteCacheForNode(%s, %s) successfully", vmssFlexID, nodeName)
 	return nil

--- a/pkg/provider/azure_vmssflex_cache_test.go
+++ b/pkg/provider/azure_vmssflex_cache_test.go
@@ -231,15 +231,17 @@ func TestGetNodeNameByVMName(t *testing.T) {
 	testCases := []struct {
 		description                    string
 		vmName                         string
+		testVM                         compute.VirtualMachine
 		testVMListWithoutInstanceView  []compute.VirtualMachine
 		testVMListWithOnlyInstanceView []compute.VirtualMachine
-		vmListErr                      error
+		vmListErr                      *retry.Error
 		expectedNodeName               string
 		expectedErr                    error
 	}{
 		{
 			description:                    "getNodeNameByVMName should return the nodeName of the corresponding vm by the vm name",
 			vmName:                         "testvm1",
+			testVM:                         testVM1,
 			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
 			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
 			vmListErr:                      nil,
@@ -249,11 +251,15 @@ func TestGetNodeNameByVMName(t *testing.T) {
 		{
 			description:                    "getNodeVmssFlexID should throw InstanceNotFound error if the VM cannot be found",
 			vmName:                         nonExistingNodeName,
+			testVM:                         compute.VirtualMachine{},
 			testVMListWithoutInstanceView:  []compute.VirtualMachine{},
 			testVMListWithOnlyInstanceView: []compute.VirtualMachine{},
-			vmListErr:                      nil,
-			expectedNodeName:               "",
-			expectedErr:                    cloudprovider.InstanceNotFound,
+			vmListErr: &retry.Error{
+				HTTPStatusCode: http.StatusNotFound,
+				RawError:       cloudprovider.InstanceNotFound,
+			},
+			expectedNodeName: "",
+			expectedErr:      cloudprovider.InstanceNotFound,
 		},
 	}
 
@@ -265,6 +271,7 @@ func TestGetNodeNameByVMName(t *testing.T) {
 		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(testVmssFlexList, nil).AnyTimes()
 
 		mockVMClient := fs.VirtualMachinesClient.(*mockvmclient.MockInterface)
+		mockVMClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.testVM, tc.vmListErr).AnyTimes()
 		mockVMClient.EXPECT().ListVmssFlexVMsWithoutInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
 		mockVMClient.EXPECT().ListVmssFlexVMsWithOnlyInstanceView(gomock.Any(), gomock.Any()).Return(tc.testVMListWithOnlyInstanceView, tc.vmListErr).AnyTimes()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

The implementation of Azure flexible scalesets in cloud controller manager is causing a high rate of API rate limiting when used at scale due to the volume of calls made to retrieve instances, this has the knock on affect of causing instances to be deleted from kubernetes because the error is passed down and the instance is handled as not found:
https://github.com/kubernetes-sigs/cloud-provider-azure/blob/371c1509418bdad8cbe23ff2d093f762e9abcf60/pkg/provider/azure_vmssflex_cache.go#L146-L157

This PR implements a new `NodeExistsByProviderID` method on the scaleset and for uniform and standard implementations this should behave the same as currently, for flex we extract the VM name from the provider ID and get the VM from the vm cache (which will call `GetVirtualMachine` if uncached) this saves us pulling the scaleset cache and listing every VM when `InstanceExists` is invoked by the node lifecycle controller. Also changes the power status and provisioning status checks to use a provider ID instead of node names for the same reasons so we can easily retrieve the desired VM just by taking the VM name from the provider ID in flex

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/cloud-provider-azure/issues/2880


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
