### PR TITLE
fix: fix duplicate podCIDR allocation when node patch request fails

### DIFF
--- a/pkg/util/controller/testutil/test_utils.go
+++ b/pkg/util/controller/testutil/test_utils.go
@@ -53,8 +53,9 @@ type FakeNodeHandler struct {
 	*fake.Clientset
 
 	// Input: Hooks determine if request is valid or not
-	CreateHook func(*FakeNodeHandler, *v1.Node) bool
-	Existing   []*v1.Node
+	CreateHook      func(*FakeNodeHandler, *v1.Node) bool
+	Existing        []*v1.Node
+	PatchErrorCount int
 
 	// Output
 	CreatedNodes        []*v1.Node
@@ -274,6 +275,11 @@ func (m *FakeNodeHandler) Patch(_ context.Context, name string, pt types.PatchTy
 		}
 		m.lock.Unlock()
 	}()
+
+	if m.RequestCount < m.PatchErrorCount {
+		return nil, fmt.Errorf("patch failed count is %d, which is smaller than %d", m.RequestCount, m.PatchErrorCount)
+	}
+
 	var nodeCopy v1.Node
 	for i := range m.Existing {
 		if m.Existing[i].Name == name {

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -78,7 +78,7 @@ func PatchNodeCIDRs(c clientset.Interface, node types.NodeName, cidrs []string) 
 	if err != nil {
 		return fmt.Errorf("failed to json.Marshal CIDR: %w", err)
 	}
-	klog.V(4).Infof("cidrs patch bytes are:%s", string(patchBytes))
+	klog.V(4).Infof("cidrs patch bytes for node %s are:%s", string(node), string(patchBytes))
 	if _, err := c.CoreV1().Nodes().Patch(context.TODO(), string(node), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
 		return fmt.Errorf("failed to patch node CIDR: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When node podCIDR patch request fails, we release the allocated CIDR but retry without claiming new ones. This PR fixes the issue by re-allocating new CIDR when updateNodeCIDR is retried.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4556 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix possible duplicate podCIDR allocation when node podCIDR patch request fails.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
