### PR TITLE
[CI] Cut cache TTL to half for VM

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -156,8 +156,6 @@ const (
 
 	// NonVmssUniformNodesCacheTTLDefaultInSeconds is the TTL of the non vmss uniform node cache
 	NonVmssUniformNodesCacheTTLDefaultInSeconds = 900
-	// AvailabilitySetNodesCacheTTLDefaultInSeconds is the TTL of the availabilitySet node cache
-	AvailabilitySetNodesCacheTTLDefaultInSeconds = 900
 	// VMSSCacheTTLDefaultInSeconds is the TTL of the vmss cache
 	VMSSCacheTTLDefaultInSeconds = 600
 	// VMSSVirtualMachinesCacheTTLDefaultInSeconds is the TTL of the vmss vm cache

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -218,9 +218,6 @@ type Config struct {
 	// NonVmssUniformNodesCacheTTLInSeconds sets the Cache TTL for NonVmssUniformNodesCacheTTLInSeconds
 	// if not set, will use default value
 	NonVmssUniformNodesCacheTTLInSeconds int `json:"nonVmssUniformNodesCacheTTLInSeconds,omitempty" yaml:"nonVmssUniformNodesCacheTTLInSeconds,omitempty"`
-	// AvailabilitySetNodesCacheTTLInSeconds sets the Cache TTL for availabilitySetNodesCache
-	// if not set, will use default value
-	AvailabilitySetNodesCacheTTLInSeconds int `json:"availabilitySetNodesCacheTTLInSeconds,omitempty" yaml:"availabilitySetNodesCacheTTLInSeconds,omitempty"`
 	// VmssCacheTTLInSeconds sets the cache TTL for VMSS
 	VmssCacheTTLInSeconds int `json:"vmssCacheTTLInSeconds,omitempty" yaml:"vmssCacheTTLInSeconds,omitempty"`
 	// VmssVirtualMachinesCacheTTLInSeconds sets the cache TTL for vmssVirtualMachines

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2382,7 +2382,7 @@ func TestNewCloudFromJSON(t *testing.T) {
 		"cloudProviderRatelimit": true,
 		"cloudProviderRateLimitQPS": 0.5,
 		"cloudProviderRateLimitBucket": 5,
-		"availabilitySetNodesCacheTTLInSeconds": 100,
+		"availabilitySetsCacheTTLInSeconds": 100,
 		"nonVmssUniformNodesCacheTTLInSeconds": 100,
 		"vmssCacheTTLInSeconds": 100,
 		"vmssVirtualMachinesCacheTTLInSeconds": 100,
@@ -2449,7 +2449,7 @@ cloudProviderBackoffJitter: 1.0
 cloudProviderRatelimit: true
 cloudProviderRateLimitQPS: 0.5
 cloudProviderRateLimitBucket: 5
-availabilitySetNodesCacheTTLInSeconds: 100
+availabilitySetsCacheTTLInSeconds: 100
 nonVmssUniformNodesCacheTTLInSeconds: 100
 vmssCacheTTLInSeconds: 100
 vmssVirtualMachinesCacheTTLInSeconds: 100
@@ -2544,8 +2544,8 @@ func validateConfig(t *testing.T, config string) { //nolint
 	if azureCloud.CloudProviderRateLimitBucket != 5 {
 		t.Errorf("got incorrect value for CloudProviderRateLimitBucket")
 	}
-	if azureCloud.AvailabilitySetNodesCacheTTLInSeconds != 100 {
-		t.Errorf("got incorrect value for availabilitySetNodesCacheTTLInSeconds")
+	if azureCloud.AvailabilitySetsCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for AvailabilitySetsCacheTTLInSeconds")
 	}
 	if azureCloud.NonVmssUniformNodesCacheTTLInSeconds != 100 {
 		t.Errorf("got incorrect value for nonVmssUniformNodesCacheTTLInSeconds")

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -404,7 +404,7 @@ func setServiceLoadBalancerIP(service *v1.Service, ip string) {
 	}
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
-		klog.Warning("setServiceLoadBalancerIP: IP %q is not valid for Service", ip, service.Name)
+		klog.Warningf("setServiceLoadBalancerIP: IP %q is not valid for Service %q", ip, service.Name)
 		return
 	}
 

--- a/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json
+++ b/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json
@@ -19,6 +19,12 @@
   "useInstanceMetadata": true,
   "primaryScaleSetName": "${CLUSTER_NAME}-vmss-0",
   "loadBalancerBackendPoolConfigurationType": "${LB_BACKEND_POOL_CONFIG_TYPE}",
+  "nonVmssUniformNodesCacheTTLInSeconds": 450,
+  "vmssCacheTTLInSeconds": 300,
+  "vmssVirtualMachinesCacheTTLInSeconds": 300,
+  "availabilitySetsCacheTTLInSeconds": 300,
+  "vmssFlexCacheTTLInSeconds": 300,
+  "vmssFlexVMCacheTTLInSeconds": 300,
   "putVMSSVMBatchSize": ${PUT_VMSS_VM_BATCH_SIZE},
   "enableVmssFlexNodes": ${ENABLE_VMSS_FLEX}
 }

--- a/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-short-cache-ttl.json
+++ b/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-short-cache-ttl.json
@@ -17,27 +17,7 @@
   "maximumLoadBalancerRuleCount": 250,
   "useManagedIdentityExtension": false,
   "useInstanceMetadata": true,
-  "primaryScaleSetName": "${CLUSTER_NAME}-vmss-0",
-  "loadBalancerBackendPoolConfigurationType": "nodeIP",
-  "multipleStandardLoadBalancerConfigurations": [
-    {
-      "name": "${CLUSTER_NAME}",
-      "primaryVMSet": "${CLUSTER_NAME}-mp-0"
-    },
-    {
-      "name": "lb-1",
-      "primaryVMSet": "${CLUSTER_NAME}-mp-1"
-    },
-    {
-      "name": "lb-2",
-      "primaryVMSet": "${CLUSTER_NAME}-mp-2",
-      "serviceLabelSelector": {
-        "matchLabels": {
-          "a": "b"
-        }
-      }
-    }
-  ],
+  "enableVmssFlexNodes": true,
   "nonVmssUniformNodesCacheTTLInSeconds": 450,
   "vmssCacheTTLInSeconds": 300,
   "vmssVirtualMachinesCacheTTLInSeconds": 300,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[CI] Cut cache TTL to half for VM
* cloud-config-vmss-default.json
* cloud-config-vmss-multi-slb.json
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Related: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/4594

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
