### PR TITLE
feat: add node-role.kubernetes.io/controlplane support

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -87,6 +87,8 @@ const (
 	MasterNodeRoleLabel = "node-role.kubernetes.io/master"
 	// ControlPlaneNodeRoleLabel specifies is the control-plane node label for a node
 	ControlPlaneNodeRoleLabel = "node-role.kubernetes.io/control-plane"
+	// ControlPlaneAltNodeRoleLabel specifies is the controlplane node label for a node
+	ControlPlaneNodeRoleLabel = "node-role.kubernetes.io/controlplane"
 
 	// NicFailedState is the failed state of a nic
 	NicFailedState = "Failed"

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -138,9 +138,12 @@ func (az *Cloud) mapVMSetNameToLoadBalancerName(vmSetName, clusterName string) s
 
 // isControlPlaneNode returns true if the node has a control-plane role label.
 // The control-plane role is determined by looking for:
-// * a node-role.kubernetes.io/control-plane or node-role.kubernetes.io/master="" label
+// * a node-role.kubernetes.io/control-plane or node-role.kubernetes.io/controlplane or node-role.kubernetes.io/master="" label
 func isControlPlaneNode(node *v1.Node) bool {
 	if _, ok := node.Labels[consts.ControlPlaneNodeRoleLabel]; ok {
+		return true
+	}
+	if _, ok := node.Labels[consts.ControlPlaneAltNodeRoleLabel]; ok {
 		return true
 	}
 	// include master role labels for k8s < 1.19


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds support for the [RKE1 control-plane label](https://rke.docs.rancher.com/config-options/nodes#controlplane) `node-role.kubernetes.io/controlplane`


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Add support for RKE1 controlplane label

- [Reference]: https://rke.docs.rancher.com/config-options/nodes#controlplane
```
