### PR TITLE
Revert "Use CAAPH for credential-provider-capz template"

### DIFF
--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
     csi-proxy: enabled
@@ -633,31 +632,6 @@ spec:
   - kind: ConfigMap
     name: containerd-logger-${CLUSTER_NAME}
   strategy: ApplyOnce
----
-apiVersion: addons.cluster.x-k8s.io/v1alpha1
-kind: HelmChartProxy
-metadata:
-  name: calico
-  namespace: default
-spec:
-  chartName: tigera-operator
-  clusterSelector:
-    matchLabels:
-      cni: calico
-  namespace: tigera-operator
-  releaseName: projectcalico
-  repoURL: https://docs.tigera.io/calico/charts
-  valuesTemplate: |-
-    installation:
-      cni:
-        type: Calico
-      calicoNetwork:
-        bgp: Disabled
-        mtu: 1350
-        ipPools:
-        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
-        - cidr: {{ $cidr }}
-          encapsulation: VXLAN{{end}}
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
Reverts kubernetes-sigs/cloud-provider-azure#4812