### PR TITLE
fix: VM name should be obtained from NIC.VirtualMachine.ID instead of…

### DIFF
--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -339,3 +339,18 @@ func getServicePIPName(service *v1.Service) string {
 	}
 	return service.Annotations[consts.ServiceAnnotationPIPNameDualStack[false]]
 }
+
+// getResourceGroupAndNameFromNICID parses the ip configuration ID to get the resource group and nic name.
+func getResourceGroupAndNameFromNICID(ipConfigurationID string) (string, string, error) {
+	matches := nicIDRE.FindStringSubmatch(ipConfigurationID)
+	if len(matches) != 3 {
+		klog.V(4).Infof("Can not extract nic name from ipConfigurationID (%s)", ipConfigurationID)
+		return "", "", fmt.Errorf("invalid ip config ID %s", ipConfigurationID)
+	}
+
+	nicResourceGroup, nicName := matches[1], matches[2]
+	if nicResourceGroup == "" || nicName == "" {
+		return "", "", fmt.Errorf("invalid ip config ID %s", ipConfigurationID)
+	}
+	return nicResourceGroup, nicName, nil
+}

--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -391,6 +391,12 @@ func (ss *ScaleSet) isNodeManagedByAvailabilitySet(nodeName string, crt azcache.
 	return cachedVMs.Has(nodeName), nil
 }
 
+// getVMManagementTypeByIPConfigurationID determines the VM type by the following steps:
+//  1. If the ipConfigurationID is in the format of vmssIPConfigurationRE, returns vmss uniform.
+//  2. If the name of the VM can be obtained by trimming the `-nic` suffix from the nic name, and the VM name is in the
+//     VMAS cache, returns availability set.
+//  3. If the VM name obtained from step 2 is not in the VMAS cache, try to get the VM name from NIC.VirtualMachine.ID.
+//  4. If the VM name obtained from step 3 is in the VMAS cache, returns availability set. Or, returns vmss flex.
 func (ss *ScaleSet) getVMManagementTypeByIPConfigurationID(ipConfigurationID string, crt azcache.AzureCacheReadType) (VMManagementType, error) {
 	if ss.DisableAvailabilitySetNodes {
 		return ManagedByVmssUniform, nil
@@ -408,14 +414,9 @@ func (ss *ScaleSet) getVMManagementTypeByIPConfigurationID(ipConfigurationID str
 		return ManagedByUnknownVMSet, err
 	}
 
-	matches := nicIDRE.FindStringSubmatch(ipConfigurationID)
-	if len(matches) != 3 {
+	nicResourceGroup, nicName, err := getResourceGroupAndNameFromNICID(ipConfigurationID)
+	if err != nil {
 		return ManagedByUnknownVMSet, fmt.Errorf("can not extract nic name from ipConfigurationID (%s)", ipConfigurationID)
-	}
-
-	nicResourceGroup, nicName := matches[1], matches[2]
-	if nicResourceGroup == "" || nicName == "" {
-		return ManagedByUnknownVMSet, fmt.Errorf("invalid ip config ID %s", ipConfigurationID)
 	}
 
 	vmName := strings.Replace(nicName, "-nic", "", 1)
@@ -425,6 +426,36 @@ func (ss *ScaleSet) getVMManagementTypeByIPConfigurationID(ipConfigurationID str
 	if cachedAvSetVMs.Has(vmName) {
 		return ManagedByAvSet, nil
 	}
+
+	// Get the vmName by nic.VirtualMachine.ID if the vmName is not in the format
+	// of `vmName-nic`. This introduces an extra ARM call.
+	vmName, err = ss.GetVMNameByIPConfigurationName(nicResourceGroup, nicName)
+	if err != nil {
+		return ManagedByUnknownVMSet, fmt.Errorf("failed to get vm name by ip config ID %s: %w", ipConfigurationID, err)
+	}
+	if cachedAvSetVMs.Has(vmName) {
+		return ManagedByAvSet, nil
+	}
+
 	klog.Warningf("Cannot determine the management type by IP configuration ID %s", ipConfigurationID)
 	return ManagedByUnknownVMSet, nil
+}
+
+func (az *Cloud) GetVMNameByIPConfigurationName(nicResourceGroup, nicName string) (string, error) {
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+	nic, rerr := az.InterfacesClient.Get(ctx, nicResourceGroup, nicName, "")
+	if rerr != nil {
+		return "", fmt.Errorf("failed to get interface of name %s: %w", nicName, rerr.Error())
+	}
+	if nic.InterfacePropertiesFormat == nil || nic.InterfacePropertiesFormat.VirtualMachine == nil || nic.InterfacePropertiesFormat.VirtualMachine.ID == nil {
+		return "", fmt.Errorf("failed to get vm ID of nic %s", pointer.StringDeref(nic.Name, ""))
+	}
+	vmID := pointer.StringDeref(nic.InterfacePropertiesFormat.VirtualMachine.ID, "")
+	matches := vmIDRE.FindStringSubmatch(vmID)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("invalid virtual machine ID %s", vmID)
+	}
+	vmName := matches[1]
+	return vmName, nil
 }

--- a/pkg/provider/azure_vmss_cache_test.go
+++ b/pkg/provider/azure_vmss_cache_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package provider
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -24,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -31,6 +34,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/utils/pointer"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/interfaceclient/mockinterfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmclient/mockvmclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssclient/mockvmssclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/vmssvmclient/mockvmssvmclient"
@@ -248,4 +252,124 @@ func TestVMSSVMCacheClearedWhenRGDeleted(t *testing.T) {
 	// verify cache is cleared.
 	_, ok = ss.vmssVMCache.Load(cacheKey)
 	assert.Equal(t, false, ok)
+}
+
+func buildTestNICWithVMName(vmName string) network.Interface {
+	return network.Interface{
+		Name: &vmName,
+		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+			VirtualMachine: &network.SubResource{
+				ID: pointer.String(fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/%s", vmName)),
+			},
+		},
+	}
+}
+
+func TestGetVMManagementTypeByIPConfigurationID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	testVM1 := generateVmssFlexTestVMWithoutInstanceView(testVM1Spec)
+	testVM2 := generateVmssFlexTestVMWithoutInstanceView(testVM2Spec)
+	testVM2.VirtualMachineScaleSet = nil
+	testVM2.VirtualMachineProperties.OsProfile.ComputerName = pointer.String("testvm2")
+	testVMList := []compute.VirtualMachine{
+		testVM1,
+		testVM2,
+	}
+
+	testVM1NIC := buildTestNICWithVMName("testvm1")
+	testVM2NIC := buildTestNICWithVMName("testvm2")
+	testVM3NIC := buildTestNICWithVMName("testvm3")
+	testVM3NIC.VirtualMachine = nil
+
+	testCases := []struct {
+		description                 string
+		ipConfigurationID           string
+		DisableAvailabilitySetNodes bool
+		EnableVmssFlexNodes         bool
+		vmListErr                   *retry.Error
+		nicGetErr                   *retry.Error
+		expectedNIC                 string
+		expectedVMManagementType    VMManagementType
+		expectedErr                 error
+	}{
+		{
+			description:              "getVMManagementTypeByIPConfigurationID should return ManagedByAvSet for availabilityset node",
+			ipConfigurationID:        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm2-nic/ipConfigurations/pipConfig",
+			expectedVMManagementType: ManagedByAvSet,
+		},
+		{
+			description:              "getVMManagementTypeByIPConfigurationID should return ManagedByAvSet for availabilityset node from nic.VirtualMachine.ID",
+			ipConfigurationID:        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm2-interface/ipConfigurations/pipConfig",
+			expectedNIC:              "testvm2",
+			expectedVMManagementType: ManagedByAvSet,
+		},
+		{
+			description:              "getVMManagementTypeByIPConfigurationID should return an error if nic.VirtualMachine.ID is empty",
+			ipConfigurationID:        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm3-interface/ipConfigurations/pipConfig",
+			expectedNIC:              "testvm3",
+			expectedVMManagementType: ManagedByUnknownVMSet,
+			expectedErr:              fmt.Errorf("failed to get vm name by ip config ID /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm3-interface/ipConfigurations/pipConfig: %w", errors.New("failed to get vm ID of nic testvm3")),
+		},
+		{
+			description:              "getVMManagementTypeByIPConfigurationID should return an error if failed to get nic",
+			ipConfigurationID:        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm3-nic/ipConfigurations/pipConfig",
+			expectedNIC:              "testvm1",
+			nicGetErr:                &retry.Error{RawError: fmt.Errorf("failed to get nic")},
+			expectedVMManagementType: ManagedByUnknownVMSet,
+			expectedErr:              fmt.Errorf("failed to get vm name by ip config ID /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm3-nic/ipConfigurations/pipConfig: %w", errors.New("failed to get interface of name testvm3-nic: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: failed to get nic")),
+		},
+		{
+			description:              "getVMManagementTypeByIPConfigurationID should return ManagedByVmssUniform for vmss uniform node",
+			ipConfigurationID:        "/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/1/networkInterfaces/nic1",
+			vmListErr:                nil,
+			expectedVMManagementType: ManagedByVmssUniform,
+			expectedErr:              nil,
+		},
+		{
+			description:                 "getVMManagementTypeByIPConfigurationID should return ManagedByVmssUniform if DisableAvailabilitySetNodes is set to true and EnableVmssFlexNodes is set to false",
+			ipConfigurationID:           "anyID",
+			DisableAvailabilitySetNodes: true,
+			EnableVmssFlexNodes:         false,
+			vmListErr:                   nil,
+			expectedVMManagementType:    ManagedByVmssUniform,
+			expectedErr:                 nil,
+		},
+		{
+			description:              "getVMManagementTypeByIPConfigurationID should return ManagedByUnknownVMSet if error happens",
+			ipConfigurationID:        "fakeID",
+			vmListErr:                &retry.Error{RawError: fmt.Errorf("failed to list VMs")},
+			expectedVMManagementType: ManagedByUnknownVMSet,
+			expectedErr:              fmt.Errorf("newAvailabilitySetNodesCache: failed to list vms in the resource group rg: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 0, RawError: failed to list VMs"),
+		},
+	}
+	for _, tc := range testCases {
+		ss, err := NewTestScaleSet(ctrl)
+		assert.NoError(t, err, tc.description)
+		ss.DisableAvailabilitySetNodes = tc.DisableAvailabilitySetNodes
+		mockVMClient := ss.cloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
+		mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(testVMList, tc.vmListErr).AnyTimes()
+
+		if tc.expectedNIC != "" {
+			mockNICClient := ss.InterfacesClient.(*mockinterfaceclient.MockInterface)
+			mockNICClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, resourceGroupName string, nicName string, expand string) (network.Interface, *retry.Error) {
+				switch tc.expectedNIC {
+				case "testvm1":
+					return testVM1NIC, tc.nicGetErr
+				case "testvm2":
+					return testVM2NIC, tc.nicGetErr
+				case "testvm3":
+					return testVM3NIC, tc.nicGetErr
+				default:
+					return network.Interface{}, retry.NewError(false, errors.New("failed to get nic"))
+				}
+			})
+		}
+
+		vmManagementType, err := ss.getVMManagementTypeByIPConfigurationID(tc.ipConfigurationID, azcache.CacheReadTypeDefault)
+		assert.Equal(t, tc.expectedVMManagementType, vmManagementType, tc.description)
+		if tc.expectedErr != nil {
+			assert.EqualError(t, err, tc.expectedErr.Error(), tc.description)
+		}
+	}
 }


### PR DESCRIPTION
… NIC name.

(cherry picked from commit 1bde33e33970d6fc78023648658fbe9322170662)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The VM name cannot be derived from NIC name when using standalone VMs. We need to obtain it from NIC.VirtualMachine.ID.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: VM name should be obtained from NIC.VirtualMachine.ID instead of NIC name.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
