### PR TITLE
Refactor: remove function wrapper in nodemanager

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
@@ -29,7 +28,7 @@ import (
 
 // IMDSNodeProvider implements nodemanager.NodeProvider.
 type IMDSNodeProvider struct {
-	azure *azureprovider.Cloud
+	*azureprovider.Cloud
 }
 
 // NewIMDSNodeProvider creates a new IMDSNodeProvider.
@@ -43,42 +42,24 @@ func NewIMDSNodeProvider(ctx context.Context) *IMDSNodeProvider {
 	}
 
 	return &IMDSNodeProvider{
-		azure: az.(*azureprovider.Cloud),
+		az.(*azureprovider.Cloud),
 	}
-}
-
-// NodeAddresses returns the addresses of the specified instance.
-func (np *IMDSNodeProvider) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
-	return np.azure.NodeAddresses(ctx, name)
 }
 
 // InstanceID returns the cloud provider ID of the specified instance.
 // Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 func (np *IMDSNodeProvider) InstanceID(ctx context.Context, name types.NodeName) (string, error) {
-	instanceID, err := np.azure.InstanceID(ctx, name)
+	instanceID, err := np.Cloud.InstanceID(ctx, name)
 	if err != nil {
 		return "", err
 	}
 
-	return np.azure.ProviderName() + "://" + instanceID, nil
-}
-
-// InstanceType returns the type of the specified instance.
-// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
-// (Implementer Note): This is used by kubelet. Kubelet will label the node. Real log from kubelet:
-// Adding node label from cloud provider: beta.kubernetes.io/instance-type=[value]
-func (np *IMDSNodeProvider) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
-	return np.azure.InstanceType(ctx, name)
+	return np.Cloud.ProviderName() + "://" + instanceID, nil
 }
 
 // GetZone returns the Zone containing the current failure zone and locality region that the program is running in
 // In most cases, this method is called from the kubelet querying a local metadata service to acquire its zone.
 // If the node is not running with availability zones, then it will fall back to fault domain.
 func (np *IMDSNodeProvider) GetZone(ctx context.Context, name types.NodeName) (cloudprovider.Zone, error) {
-	return np.azure.GetZone(ctx)
-}
-
-// GetPlatformSubFaultDomain returns the PlatformSubFaultDomain from IMDS if set.
-func (np *IMDSNodeProvider) GetPlatformSubFaultDomain() (string, error) {
-	return np.azure.GetPlatformSubFaultDomain()
+	return np.Cloud.GetZone(ctx)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Refactor: remove function wrapper in cloud node manager

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
remove wrapper to make sure nodemanager is compatible with cloud node controller in k8s.io/cloud-provider.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
