### PR TITLE
test: update CAPZ test templates to include calico HelmChartProxy

### DIFF
--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
@@ -6,6 +6,7 @@ metadata:
     containerd-logger: enabled
     csi-proxy: enabled
     metrics-server: enabled
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -1214,3 +1215,28 @@ metadata:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
@@ -247,3 +247,37 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico-dual-stack
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico-dual-stack
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: HostLocal
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        - blockSize: 26
+          cidr: {{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 0 }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all()
+        - blockSize: 122
+          cidr: {{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 1 }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all()

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
@@ -319,3 +319,37 @@ spec:
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
   - systemctl restart systemd-resolved
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico-dual-stack
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico-dual-stack
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: HostLocal
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        - blockSize: 26
+          cidr: {{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 0 }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all()
+        - blockSize: 122
+          cidr: {{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 1 }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all()

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
@@ -4,6 +4,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico-ipv6
 spec:
   clusterNetwork:
     pods:
@@ -263,3 +265,32 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico-ipv6
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico-ipv6
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: HostLocal
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - blockSize: 122
+          cidr: {{ $cidr }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all(){{end}}

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
@@ -4,6 +4,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico-ipv6
 spec:
   clusterNetwork:
     pods:
@@ -345,3 +347,32 @@ spec:
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
   - systemctl restart systemd-resolved
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico-ipv6
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico-ipv6
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: HostLocal
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - blockSize: 122
+          cidr: {{ $cidr }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all(){{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-dualstack.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-dualstack.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico-dual-stack
 spec:
   clusterNetwork:
     pods:
@@ -259,3 +261,37 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico-dual-stack
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico-dual-stack
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: HostLocal
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        - blockSize: 26
+          cidr: {{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 0 }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all()
+        - blockSize: 122
+          cidr: {{ index .Cluster.spec.clusterNetwork.pods.cidrBlocks 1 }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all()

--- a/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico-ipv6
 spec:
   clusterNetwork:
     pods:
@@ -280,3 +282,32 @@ spec:
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
       - systemctl restart systemd-resolved
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico-ipv6
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico-ipv6
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: HostLocal
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - blockSize: 122
+          cidr: {{ $cidr }}
+          encapsulation: None
+          natOutgoing: Enabled
+          nodeSelector: all(){{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss-multiple-zones.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss-multiple-zones.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico
 spec:
   clusterNetwork:
     pods:
@@ -304,3 +306,28 @@ spec:
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
   type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico
 spec:
   clusterNetwork:
     pods:
@@ -298,3 +300,28 @@ spec:
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
   type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-local.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-local.yaml
@@ -5,6 +5,7 @@ metadata:
     containerd-logger: enabled
     csi-proxy: enabled
     metrics-server: enabled
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -114,12 +115,12 @@ spec:
         permissions: "0644"
       - content: |
           #!/bin/bash
-          
+
           set -o nounset
           set -o pipefail
           set -o errexit
           [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-          
+
           # This test installs release packages or binaries that are a result of the CI and release builds.
           # It runs '... --version' commands to verify that the binaries are correctly installed
           # and finally uninstalls the packages.
@@ -772,3 +773,28 @@ metadata:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
@@ -5,6 +5,7 @@ metadata:
     containerd-logger: enabled
     csi-proxy: enabled
     metrics-server: enabled
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -114,7 +115,7 @@ spec:
         permissions: "0644"
       - content: |
           #!/bin/bash
-          
+
           set -o nounset
           set -o pipefail
           set -o errexit
@@ -833,3 +834,28 @@ metadata:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
@@ -5,6 +5,7 @@ metadata:
     containerd-logger: enabled
     csi-proxy: enabled
     metrics-server: enabled
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -114,12 +115,12 @@ spec:
         permissions: "0644"
       - content: |
           #!/bin/bash
-          
+
           set -o nounset
           set -o pipefail
           set -o errexit
           [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-          
+
           # This test installs release packages or binaries that are a result of the CI and release builds.
           # It runs '... --version' commands to verify that the binaries are correctly installed
           # and finally uninstalls the packages.
@@ -772,3 +773,28 @@ metadata:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
@@ -2,6 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
+    cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
     csi-proxy: enabled
@@ -936,3 +937,28 @@ metadata:
     type: generated
   name: containerd-logger-${CLUSTER_NAME}
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
@@ -2,6 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
+    cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
     csi-proxy: enabled
@@ -1087,3 +1088,28 @@ metadata:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
@@ -2,6 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
+    cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
     csi-proxy: enabled
@@ -1144,3 +1145,28 @@ metadata:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico
 spec:
   clusterNetwork:
     pods:
@@ -235,3 +237,28 @@ spec:
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
   type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico
 spec:
   clusterNetwork:
     pods:
@@ -232,3 +234,28 @@ spec:
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
   type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/vmss-multi-nodepool-in-tree.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/vmss-multi-nodepool-in-tree.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
   namespace: default
+  labels:
+    cni: calico
 spec:
   clusterNetwork:
     pods:
@@ -287,3 +289,28 @@ spec:
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
   type: ServicePrincipal
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}

--- a/tests/k8s-azure/manifest/cluster-api/vmss-multi-nodepool.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/vmss-multi-nodepool.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     ccm: external
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -646,3 +647,28 @@ metadata:
     type: generated
   name: cloud-node-manager-addon
   namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR adds an appropriate calico `HelmChartProxy` resource spec for each custom CAPZ cluster template used by cloud-provider-azure test scenarios. This addition is to fulfill a new CAPZ `ci-entrypoint.sh` requirement to include the calico helm spec as a declarative `HelmChartProxy` resource. `ci-entrypoint.sh` no longer automatically installs calico manually by shelling out to the helm CLI as of CAPZ v1.12.0.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
