### PR TITLE
cleanup: remove unused async attach functionality

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -41,7 +41,6 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/flowcontrol"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
@@ -722,7 +721,6 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *Config, 
 	common := &controllerCommon{
 		cloud:                        az,
 		lockMap:                      newLockMap(),
-		diskOpRateLimiter:            flowcontrol.NewTokenBucketRateLimiter(qps, bucket),
 		AttachDetachInitialDelayInMs: defaultAttachDetachInitialDelayInMs,
 	}
 
@@ -1171,7 +1169,6 @@ func InitDiskControllers(az *Cloud) error {
 	common := &controllerCommon{
 		cloud:                        az,
 		lockMap:                      newLockMap(),
-		diskOpRateLimiter:            flowcontrol.NewTokenBucketRateLimiter(qps, bucket),
 		AttachDetachInitialDelayInMs: defaultAttachDetachInitialDelayInMs,
 	}
 

--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -36,7 +36,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/flowcontrol"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/utils/pointer"
 
@@ -294,7 +293,7 @@ func TestCommonAttachDisk(t *testing.T) {
 				}()
 			}
 
-			lun, err := testCloud.AttachDisk(ctx, true, test.diskName, diskURI, tt.nodeName, compute.CachingTypesReadOnly, tt.existedDisk, nil)
+			lun, err := testCloud.AttachDisk(ctx, test.diskName, diskURI, tt.nodeName, compute.CachingTypesReadOnly, tt.existedDisk, nil)
 
 			assert.Equal(t, tt.expectedLun, lun, "TestCase[%d]: %s", i, tt.desc)
 			assert.Equal(t, tt.expectErr, err != nil, "TestCase[%d]: %s, return error: %v", i, tt.desc, err)
@@ -497,9 +496,8 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 		}
 
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
 			testCloud.SubscriptionID, testCloud.ResourceGroup, test.diskName)
@@ -515,7 +513,7 @@ func TestCommonAttachDiskWithVMSS(t *testing.T) {
 			mockVMsClient.EXPECT().Update(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		}
 
-		lun, err := common.AttachDisk(ctx, true, "test", diskURI, test.nodeName, compute.CachingTypesReadOnly, test.existedDisk, nil)
+		lun, err := common.AttachDisk(ctx, "test", diskURI, test.nodeName, compute.CachingTypesReadOnly, test.existedDisk, nil)
 		assert.Equal(t, test.expectedLun, lun, "TestCase[%d]: %s", i, test.desc)
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s, return error: %v", i, test.desc, err)
 	}
@@ -559,9 +557,8 @@ func TestCommonDetachDisk(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/disk-name",
 			testCloud.SubscriptionID, testCloud.ResourceGroup)
@@ -626,9 +623,8 @@ func TestCommonUpdateVM(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, test.vmList, false)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -686,9 +682,8 @@ func TestGetDiskLun(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -756,9 +751,8 @@ func TestSetDiskLun(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, map[string]string{test.nodeName: "PowerState/Running"}, test.isDataDisksFull)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -802,9 +796,8 @@ func TestDisksAreAttached(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		expectedVMs := setTestVirtualMachines(testCloud, map[string]string{"vm1": "PowerState/Running"}, false)
 		mockVMsClient := testCloud.VirtualMachinesClient.(*mockvmclient.MockInterface)
@@ -1114,9 +1107,8 @@ func TestAttachDiskRequestFuncs(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		for i := 1; i <= test.diskNum; i++ {
 			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)
@@ -1191,9 +1183,8 @@ func TestDetachDiskRequestFuncs(t *testing.T) {
 	for i, test := range testCases {
 		testCloud := GetTestCloud(ctrl)
 		common := &controllerCommon{
-			cloud:             testCloud,
-			lockMap:           newLockMap(),
-			diskOpRateLimiter: flowcontrol.NewTokenBucketRateLimiter(10, 20),
+			cloud:   testCloud,
+			lockMap: newLockMap(),
 		}
 		for i := 1; i <= test.diskNum; i++ {
 			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
cleanup: remove unused async attach functionality
async attach is never used in azure disk csi driver since it would lead to stale vm state issue, this PR removes the functionality, to make code logic more clear

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
