### PR TITLE
[e2e] Print string instead of string pointer

### DIFF
--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -262,7 +262,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		Expect(utils.CompareStrings(ips1, targetIPs)).To(BeFalse())
 
 		By("Updating service to bound to specific public IP")
-		utils.Logf("will update IPs to %s", targetIPs)
+		utils.Logf("will update IPs to %v", utils.StrPtrSliceToStrSlice(targetIPs))
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		service = updateServiceLBIPs(service, false, targetIPs)
 
@@ -290,7 +290,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		By(fmt.Sprintf("Waiting for exposure of internal service with specific IPs %+v", ips1))
+		By(fmt.Sprintf("Waiting for exposure of internal service with specific IPs %v", utils.StrPtrSliceToStrSlice(ips1)))
 		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, ips1)
 		Expect(err).NotTo(HaveOccurred())
 		list, errList := cs.CoreV1().Events(ns.Name).List(context.TODO(), metav1.ListOptions{})
@@ -304,7 +304,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Updating internal service private IP")
-		utils.Logf("will update IPs to %q", ips2)
+		utils.Logf("will update IPs to %v", utils.StrPtrSliceToStrSlice(ips2))
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		service = updateServiceLBIPs(service, true, ips2)
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
@@ -358,7 +358,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		}
 
 		By("Updating service to bound to specific public IP")
-		utils.Logf("will update IPs to %q", targetIPs)
+		utils.Logf("will update IPs to %v", utils.StrPtrSliceToStrSlice(targetIPs))
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		service = updateServiceLBIPs(service, false, targetIPs)
 
@@ -391,7 +391,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		service = updateServiceLBIPs(service, false, targetIPs)
 		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created LoadBalancer service %s in namespace %s", testServiceName, ns.Name)
+		utils.PrintCreateSVCSuccessfully(testServiceName, ns.Name)
 
 		defer func() {
 			By("Cleaning up")
@@ -513,7 +513,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		for _, serviceName := range serviceNames {
 			_, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, targetIPs)
 			Expect(err).NotTo(HaveOccurred())
-			utils.Logf("Successfully created LoadBalancer Service %q in namespace %s with IPs: %v", serviceName, ns.Name, targetIPs)
+			utils.Logf("Successfully created LoadBalancer Service %q in namespace %s with IPs: %v", serviceName, ns.Name, utils.StrPtrSliceToStrSlice(targetIPs))
 		}
 	})
 
@@ -575,7 +575,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		for _, serviceName := range serviceNames {
 			_, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, sharedIPs)
 			Expect(err).NotTo(HaveOccurred())
-			utils.Logf("Successfully created LoadBalancer Service %q in namespace %q with IPs %q", serviceName, ns.Name, sharedIPs)
+			utils.Logf("Successfully created LoadBalancer Service %q in namespace %q with IPs %v", serviceName, ns.Name, utils.StrPtrSliceToStrSlice(sharedIPs))
 		}
 
 		By("Deleting one Service and check if the other service works well")
@@ -670,7 +670,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		for _, serviceName := range serviceNames {
 			_, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, sharedIPs)
 			Expect(err).NotTo(HaveOccurred())
-			utils.Logf("Successfully created LoadBalancer Service %q in namespace %q with IPs %q", serviceName, ns.Name, sharedIPs)
+			utils.Logf("Successfully created LoadBalancer Service %q in namespace %q with IPs %v", serviceName, ns.Name, utils.StrPtrSliceToStrSlice(sharedIPs))
 		}
 	})
 

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -118,7 +118,7 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		Expect(result).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 
-		By(fmt.Sprintf("Validating External domain name %+v", ips))
+		By(fmt.Sprintf("Validating External domain name %v", utils.StrPtrSliceToStrSlice(ips)))
 		Expect(len(ports)).NotTo(BeZero())
 		for _, ip := range ips {
 			err = utils.ValidateServiceConnectivity(ns.Name, agnhostPod, *ip, int(ports[0].Port), v1.ProtocolTCP)
@@ -299,7 +299,7 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		Expect(err).NotTo(HaveOccurred())
 		for _, port := range service.Spec.Ports {
 			for _, internalIP := range internalIPs {
-				utils.Logf("checking the connectivity of addr %s:%d with protocol %v", internalIP, int(port.Port), port.Protocol)
+				utils.Logf("checking the connectivity of addr %s:%d with protocol %v", *internalIP, int(port.Port), port.Protocol)
 				err := utils.ValidateServiceConnectivity(ns.Name, agnhostPod, *internalIP, int(port.Port), port.Protocol)
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -468,7 +468,7 @@ func validateUnsharedSecurityRuleExists(nsgs []*aznetwork.SecurityGroup, ips []*
 		utils.Logf("Checking nsg %q", pointer.StringDeref(nsg.Name, ""))
 		count := 0
 		for _, ip := range ips {
-			utils.Logf("Checking IP %q", ip)
+			utils.Logf("Checking IP %q", *ip)
 			for _, securityRule := range nsg.Properties.SecurityRules {
 				utils.Logf("Checking security rule %q", pointer.StringDeref(securityRule.Name, ""))
 				if strings.EqualFold(pointer.StringDeref(securityRule.Properties.DestinationAddressPrefix, ""), *ip) &&
@@ -512,7 +512,7 @@ func validateSharedSecurityRuleExistsSingleStack(nsgs []*aznetwork.SecurityGroup
 		utils.Logf("Checking nsg %q", pointer.StringDeref(nsg.Name, ""))
 		for _, securityRule := range nsg.Properties.SecurityRules {
 			utils.Logf("Checking security rule %q DestinationPortRange %q DestinationAddressPrefixes %q",
-				pointer.StringDeref(securityRule.Name, ""), pointer.StringDeref(securityRule.Properties.DestinationPortRange, ""), securityRule.Properties.DestinationAddressPrefixes)
+				pointer.StringDeref(securityRule.Name, ""), pointer.StringDeref(securityRule.Properties.DestinationPortRange, ""), utils.StrPtrSliceToStrSlice(securityRule.Properties.DestinationAddressPrefixes))
 			if strings.EqualFold(pointer.StringDeref(securityRule.Properties.DestinationPortRange, ""), port) {
 				found := true
 				for _, ip := range ips {
@@ -566,7 +566,7 @@ func validateLoadBalancerSourceRangesRuleExistsSingleStack(nsgs []*aznetwork.Sec
 		utils.Logf("Checking nsg %q", pointer.StringDeref(nsg.Name, ""))
 		count := 0
 		for _, ip := range ips {
-			utils.Logf("Checking IP %q", ip)
+			utils.Logf("Checking IP %q", *ip)
 			for _, securityRule := range nsg.Properties.SecurityRules {
 				utils.Logf("Checking security rule %q access %q DestinationAddressPrefix %q SourceAddressPrefix %q",
 					pointer.StringDeref(securityRule.Name, ""), *securityRule.Properties.Access,
@@ -630,7 +630,7 @@ func validateDenyAllSecurityRuleExistsSingleStack(nsgs []*aznetwork.SecurityGrou
 		utils.Logf("Checking nsg %q", pointer.StringDeref(nsg.Name, ""))
 		count := 0
 		for _, ip := range ips {
-			utils.Logf("Checking IP %q", ip)
+			utils.Logf("Checking IP %q", *ip)
 			for _, securityRule := range nsg.Properties.SecurityRules {
 				utils.Logf("Checking security rule %q DestinationAddressPrefix %q SourceAddressPrefix %q",
 					pointer.StringDeref(securityRule.Name, ""), pointer.StringDeref(securityRule.Properties.DestinationAddressPrefix, ""), pointer.StringDeref(securityRule.Properties.SourceAddressPrefix, ""))

--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -112,7 +112,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}()
 		Expect(len(ips)).NotTo(BeZero())
 		ip := ips[0]
-		utils.Logf("Get Internal IP: %s", ip)
+		utils.Logf("Get Internal IP: %s", *ip)
 
 		// get pls from azure client
 		pls := getPrivateLinkServiceFromIP(tc, ip, "", "", "")
@@ -142,7 +142,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}()
 		Expect(len(ips)).NotTo(BeZero())
 		ip := ips[0]
-		utils.Logf("Get Internal IP: %s", ip)
+		utils.Logf("Get Internal IP: %s", *ip)
 
 		// get pls from azure client
 		pls := getPrivateLinkServiceFromIP(tc, ip, "", "", plsName)
@@ -264,7 +264,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		Expect(len(selectedIPs)).NotTo(BeZero())
 		selectedIP := selectedIPs[0]
 		annotation[consts.ServiceAnnotationPLSIpConfigurationIPAddress] = *selectedIP
-		utils.Logf("Now update private link service's static ip to %s", selectedIP)
+		utils.Logf("Now update private link service's static ip to %s", *selectedIP)
 
 		service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -430,7 +430,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		}()
 		Expect(len(ips)).NotTo(BeZero())
 		ip := ips[0]
-		utils.Logf("Successfully created %s in namespace %s with IP %s", svc1, ns.Name, ip)
+		utils.Logf("Successfully created %s in namespace %s with IP %s", svc1, ns.Name, *ip)
 
 		deployName0 := "pls-deploy0"
 		utils.Logf("Creating deployment %s", deployName0)
@@ -462,7 +462,7 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		Expect(err).NotTo(HaveOccurred())
 		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, svc2, ips)
 		Expect(err).NotTo(HaveOccurred())
-		utils.Logf("Successfully created %s in namespace %s with IPs %q", svc2, ns.Name, ips)
+		utils.Logf("Successfully created %s in namespace %s with IPs %v", svc2, ns.Name, utils.StrPtrSliceToStrSlice(ips))
 
 		// get pls from azure client
 		pls := getPrivateLinkServiceFromIP(tc, ip, "", "", "")

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -333,7 +333,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			err := utils.DeleteService(cs, ns.Name, serviceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		utils.Logf("Get External IPs: %q", ips)
+		utils.Logf("Get External IPs: %v", utils.StrPtrSliceToStrSlice(ips))
 
 		By("Validating external ip in target subnet")
 		Expect(len(ips)).NotTo(BeZero())
@@ -526,7 +526,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			if err != nil {
 				return false, err
 			}
-			utils.Logf("ipList %q", ipList)
+			utils.Logf("ipList %v", utils.StrPtrSliceToStrSlice(ipList))
 			ipListV4, ipListV6 := []*string{}, []*string{}
 			for _, ip := range ipList {
 				ip := ip

--- a/tests/e2e/utils/log.go
+++ b/tests/e2e/utils/log.go
@@ -41,5 +41,5 @@ func Logf(format string, args ...interface{}) {
 }
 
 func PrintCreateSVCSuccessfully(svc string, ns string) {
-	Logf("Successfully created LoadBalancer service " + svc + " in namespace " + ns)
+	Logf("Successfully created LoadBalancer service %q in namespace %q", svc, ns)
 }

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -88,7 +88,7 @@ func (azureTestClient *AzureTestClient) GetClusterVirtualNetwork() (virtualNetwo
 
 // CreateSubnet creates a new subnet in the specified virtual network.
 func (azureTestClient *AzureTestClient) CreateSubnet(vnet *aznetwork.VirtualNetwork, subnetName *string, prefixes []*string, waitUntilComplete bool) (*aznetwork.Subnet, error) {
-	Logf("creating a new subnet %s, %v", *subnetName, prefixes)
+	Logf("creating a new subnet %s, %v", *subnetName, StrPtrSliceToStrSlice(prefixes))
 	subnetParameter := *vnet.Properties.Subnets[0]
 	subnetParameter.Name = subnetName
 	if len(prefixes) == 1 {
@@ -142,12 +142,12 @@ func (azureTestClient *AzureTestClient) DeleteSubnet(vnetName string, subnetName
 
 			Logf("subnet %s still exists with IP config IDs %q, will retry", subnetName, ipConfigIDs)
 			return false, nil
-		} else if strings.Contains(err.Error(), "StatusCode=404") {
+		} else if strings.Contains(err.Error(), "StatusCode=404") || strings.Contains(err.Error(), "NotFound") {
 			Logf("subnet %s has been deleted", subnetName)
 			return true, nil
 		}
-		Logf("encountered unexpected error %w while getting subnet %s", err, subnetName)
-		return true, nil
+		Logf("encountered unexpected error %v while getting subnet %q", err, subnetName)
+		return false, nil
 	})
 }
 

--- a/tests/e2e/utils/service_utils.go
+++ b/tests/e2e/utils/service_utils.go
@@ -151,7 +151,7 @@ func WaitServiceExposureAndValidateConnectivity(cs clientset.Interface, ipFamily
 	// should test connectivity as well.
 	for _, port := range service.Spec.Ports {
 		for _, ip := range ips {
-			Logf("checking the connectivity of address %s %d with protocol %v", ip, int(port.Port), port.Protocol)
+			Logf("checking the connectivity of address %q %d with protocol %v", *ip, int(port.Port), port.Protocol)
 			if err := ValidateServiceConnectivity(namespace, ExecAgnhostPod, *ip, int(port.Port), port.Protocol); err != nil {
 				return ips, err
 			}
@@ -198,7 +198,7 @@ func WaitServiceExposure(cs clientset.Interface, namespace string, name string, 
 		}
 		if len(targetIPs) != 0 {
 			if !CompareStrings(externalIPs, targetIPs) {
-				Logf("expected IPs are %v, current IPs are %v, retry in 10 seconds", targetIPs, externalIPs)
+				Logf("expected IPs are %v, current IPs are %v, retry in 10 seconds", StrPtrSliceToStrSlice(targetIPs), StrPtrSliceToStrSlice(externalIPs))
 				return false, nil
 			}
 		}
@@ -210,7 +210,7 @@ func WaitServiceExposure(cs clientset.Interface, namespace string, name string, 
 		return nil, err
 	}
 
-	Logf("Exposure successfully, get external ip: %s", externalIPs)
+	Logf("Exposure successfully, get external IPs: %v", StrPtrSliceToStrSlice(externalIPs))
 	return service, nil
 }
 

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -202,6 +202,14 @@ func CompareStrings(s0, s1 []*string) bool {
 	return ss0.Equal(ss1)
 }
 
+func StrPtrSliceToStrSlice(s []*string) []string {
+	res := []string{}
+	for _, str := range s {
+		res = append(res, *str)
+	}
+	return res
+}
+
 func DeepCopyMap(m map[string]string) map[string]string {
 	newMap := make(map[string]string)
 	for k, v := range m {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[e2e] Print string instead of string pointer
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
