### PR TITLE
Refactor: expose fields of AttachDiskOptions

### DIFF
--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -111,11 +111,11 @@ type controllerCommon struct {
 
 // AttachDiskOptions attach disk options
 type AttachDiskOptions struct {
-	cachingMode             compute.CachingTypes
-	diskName                string
-	diskEncryptionSetID     string
-	writeAcceleratorEnabled bool
-	lun                     int32
+	CachingMode             compute.CachingTypes
+	DiskName                string
+	DiskEncryptionSetID     string
+	WriteAcceleratorEnabled bool
+	Lun                     int32
 }
 
 // ExtendedLocation contains additional info about the location of resources.
@@ -227,11 +227,11 @@ func (c *controllerCommon) AttachDisk(ctx context.Context, diskName, diskURI str
 	}
 
 	options := AttachDiskOptions{
-		lun:                     -1,
-		diskName:                diskName,
-		cachingMode:             cachingMode,
-		diskEncryptionSetID:     diskEncryptionSetID,
-		writeAcceleratorEnabled: writeAcceleratorEnabled,
+		Lun:                     -1,
+		DiskName:                diskName,
+		CachingMode:             cachingMode,
+		DiskEncryptionSetID:     diskEncryptionSetID,
+		WriteAcceleratorEnabled: writeAcceleratorEnabled,
 	}
 	node := strings.ToLower(string(nodeName))
 	diskuri := strings.ToLower(diskURI)
@@ -611,7 +611,7 @@ func (c *controllerCommon) SetDiskLun(nodeName types.NodeName, diskURI string, d
 		if strings.EqualFold(uri, diskURI) {
 			lun = diskLuns[count]
 		}
-		opt.lun = diskLuns[count]
+		opt.Lun = diskLuns[count]
 		count++
 	}
 	if lun < 0 {

--- a/pkg/provider/azure_controller_common_test.go
+++ b/pkg/provider/azure_controller_common_test.go
@@ -1113,7 +1113,7 @@ func TestAttachDiskRequestFuncs(t *testing.T) {
 		for i := 1; i <= test.diskNum; i++ {
 			diskURI := fmt.Sprintf("%s%d", test.diskURI, i)
 			diskName := fmt.Sprintf("%s%d", test.diskName, i)
-			attachDiskOptions := &AttachDiskOptions{diskName: diskName}
+			attachDiskOptions := &AttachDiskOptions{DiskName: diskName}
 			_, err := common.insertAttachDiskRequest(diskURI, test.nodeName, attachDiskOptions)
 			assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 			if test.duplicateDiskRequest {
@@ -1127,7 +1127,7 @@ func TestAttachDiskRequestFuncs(t *testing.T) {
 		assert.Equal(t, test.diskNum, len(diskMap), "TestCase[%d]: %s", i, test.desc)
 		for diskURI, opt := range diskMap {
 			assert.Equal(t, strings.Contains(diskURI, test.diskURI), true, "TestCase[%d]: %s", i, test.desc)
-			assert.Equal(t, strings.Contains(opt.diskName, test.diskName), true, "TestCase[%d]: %s", i, test.desc)
+			assert.Equal(t, strings.Contains(opt.DiskName, test.diskName), true, "TestCase[%d]: %s", i, test.desc)
 		}
 	}
 }

--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -56,39 +56,39 @@ func (as *availabilitySet) AttachDisk(ctx context.Context, nodeName types.NodeNa
 		attached := false
 		for _, disk := range *vm.StorageProfile.DataDisks {
 			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diskURI) && disk.Lun != nil {
-				if *disk.Lun == opt.lun {
+				if *disk.Lun == opt.Lun {
 					attached = true
 					break
 				}
-				return nil, fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.lun)
+				return nil, fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.Lun)
 			}
 		}
 		if attached {
-			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.lun)
+			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.Lun)
 			continue
 		}
 
 		managedDisk := &compute.ManagedDiskParameters{ID: &diskURI}
-		if opt.diskEncryptionSetID == "" {
+		if opt.DiskEncryptionSetID == "" {
 			if vm.StorageProfile.OsDisk != nil &&
 				vm.StorageProfile.OsDisk.ManagedDisk != nil &&
 				vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet != nil &&
 				vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID != nil {
 				// set diskEncryptionSet as value of os disk by default
-				opt.diskEncryptionSetID = *vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID
+				opt.DiskEncryptionSetID = *vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID
 			}
 		}
-		if opt.diskEncryptionSetID != "" {
-			managedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: &opt.diskEncryptionSetID}
+		if opt.DiskEncryptionSetID != "" {
+			managedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: &opt.DiskEncryptionSetID}
 		}
 		disks = append(disks,
 			compute.DataDisk{
-				Name:                    &opt.diskName,
-				Lun:                     &opt.lun,
-				Caching:                 opt.cachingMode,
+				Name:                    &opt.DiskName,
+				Lun:                     &opt.Lun,
+				Caching:                 opt.CachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.WriteAcceleratorEnabled),
 			})
 	}
 

--- a/pkg/provider/azure_controller_standard_test.go
+++ b/pkg/provider/azure_controller_standard_test.go
@@ -118,14 +118,14 @@ func TestStandardAttachDisk(t *testing.T) {
 		}
 
 		options := AttachDiskOptions{
-			lun:                     0,
-			diskName:                "disk-name2",
-			cachingMode:             compute.CachingTypesReadOnly,
-			diskEncryptionSetID:     "",
-			writeAcceleratorEnabled: false,
+			Lun:                     0,
+			DiskName:                "disk-name2",
+			CachingMode:             compute.CachingTypesReadOnly,
+			DiskEncryptionSetID:     "",
+			WriteAcceleratorEnabled: false,
 		}
 		if test.inconsistentLUN {
-			options.lun = 63
+			options.Lun = 63
 		}
 		diskMap := map[string]*AttachDiskOptions{
 			"uri": &options,

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -62,40 +62,40 @@ func (ss *ScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName, dis
 		attached := false
 		for _, disk := range *storageProfile.DataDisks {
 			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diskURI) && disk.Lun != nil {
-				if *disk.Lun == opt.lun {
+				if *disk.Lun == opt.Lun {
 					attached = true
 					break
 				}
-				return nil, fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.lun)
+				return nil, fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.Lun)
 
 			}
 		}
 		if attached {
-			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.lun)
+			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.Lun)
 			continue
 		}
 
 		managedDisk := &compute.ManagedDiskParameters{ID: &diskURI}
-		if opt.diskEncryptionSetID == "" {
+		if opt.DiskEncryptionSetID == "" {
 			if storageProfile.OsDisk != nil &&
 				storageProfile.OsDisk.ManagedDisk != nil &&
 				storageProfile.OsDisk.ManagedDisk.DiskEncryptionSet != nil &&
 				storageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID != nil {
 				// set diskEncryptionSet as value of os disk by default
-				opt.diskEncryptionSetID = *storageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID
+				opt.DiskEncryptionSetID = *storageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID
 			}
 		}
-		if opt.diskEncryptionSetID != "" {
-			managedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: &opt.diskEncryptionSetID}
+		if opt.DiskEncryptionSetID != "" {
+			managedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: &opt.DiskEncryptionSetID}
 		}
 		disks = append(disks,
 			compute.DataDisk{
-				Name:                    &opt.diskName,
-				Lun:                     &opt.lun,
-				Caching:                 opt.cachingMode,
+				Name:                    &opt.DiskName,
+				Lun:                     &opt.Lun,
+				Caching:                 opt.CachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.WriteAcceleratorEnabled),
 			})
 	}
 

--- a/pkg/provider/azure_controller_vmss_test.go
+++ b/pkg/provider/azure_controller_vmss_test.go
@@ -138,14 +138,14 @@ func TestAttachDiskWithVMSS(t *testing.T) {
 		diskMap := map[string]*AttachDiskOptions{}
 		for i, diskName := range test.disks {
 			options := AttachDiskOptions{
-				lun:                     int32(i),
-				diskName:                diskName,
-				cachingMode:             compute.CachingTypesReadWrite,
-				diskEncryptionSetID:     "",
-				writeAcceleratorEnabled: true,
+				Lun:                     int32(i),
+				DiskName:                diskName,
+				CachingMode:             compute.CachingTypesReadWrite,
+				DiskEncryptionSetID:     "",
+				WriteAcceleratorEnabled: true,
 			}
 			if test.inconsistentLUN {
-				options.lun = 63
+				options.Lun = 63
 			}
 
 			diskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",

--- a/pkg/provider/azure_controller_vmssflex.go
+++ b/pkg/provider/azure_controller_vmssflex.go
@@ -56,39 +56,39 @@ func (fs *FlexScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName,
 		attached := false
 		for _, disk := range *vm.StorageProfile.DataDisks {
 			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diskURI) && disk.Lun != nil {
-				if *disk.Lun == opt.lun {
+				if *disk.Lun == opt.Lun {
 					attached = true
 					break
 				}
-				return nil, fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.lun)
+				return nil, fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.Lun)
 			}
 		}
 		if attached {
-			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.lun)
+			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.Lun)
 			continue
 		}
 
 		managedDisk := &compute.ManagedDiskParameters{ID: &diskURI}
-		if opt.diskEncryptionSetID == "" {
+		if opt.DiskEncryptionSetID == "" {
 			if vm.StorageProfile.OsDisk != nil &&
 				vm.StorageProfile.OsDisk.ManagedDisk != nil &&
 				vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet != nil &&
 				vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID != nil {
 				// set diskEncryptionSet as value of os disk by default
-				opt.diskEncryptionSetID = *vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID
+				opt.DiskEncryptionSetID = *vm.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID
 			}
 		}
-		if opt.diskEncryptionSetID != "" {
-			managedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: &opt.diskEncryptionSetID}
+		if opt.DiskEncryptionSetID != "" {
+			managedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: &opt.DiskEncryptionSetID}
 		}
 		disks = append(disks,
 			compute.DataDisk{
-				Name:                    &opt.diskName,
-				Lun:                     &opt.lun,
-				Caching:                 opt.cachingMode,
+				Name:                    &opt.DiskName,
+				Lun:                     &opt.Lun,
+				Caching:                 opt.CachingMode,
 				CreateOption:            "attach",
 				ManagedDisk:             managedDisk,
-				WriteAcceleratorEnabled: pointer.Bool(opt.writeAcceleratorEnabled),
+				WriteAcceleratorEnabled: pointer.Bool(opt.WriteAcceleratorEnabled),
 			})
 	}
 

--- a/pkg/provider/azure_controller_vmssflex_test.go
+++ b/pkg/provider/azure_controller_vmssflex_test.go
@@ -109,14 +109,14 @@ func TestAttachDiskWithVmssFlex(t *testing.T) {
 		mockVMClient.EXPECT().UpdateAsync(gomock.Any(), gomock.Any(), tc.vmName, gomock.Any(), gomock.Any()).Return(nil, tc.vmssFlexVMUpdateError).AnyTimes()
 
 		options := AttachDiskOptions{
-			lun:                     1,
-			diskName:                "diskname",
-			cachingMode:             compute.CachingTypesReadOnly,
-			diskEncryptionSetID:     "",
-			writeAcceleratorEnabled: false,
+			Lun:                     1,
+			DiskName:                "diskname",
+			CachingMode:             compute.CachingTypesReadOnly,
+			DiskEncryptionSetID:     "",
+			WriteAcceleratorEnabled: false,
 		}
 		if tc.inconsistentLUN {
-			options.lun = 63
+			options.Lun = 63
 		}
 		diskMap := map[string]*AttachDiskOptions{
 			"uri": &options,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Refactor: expose fields of AttachDiskOptions
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
With this change, managed disk controller can be moved to azuredisk csi driver. 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
