### PR TITLE
fix: The case of load balancer name should be ignored when determing …

### DIFF
--- a/kubetest2-aks/go.mod
+++ b/kubetest2-aks/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/cloud-provider-azure/kubetest2-aks
 
-go 1.18
+go 1.21
+
+toolchain go1.21.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -246,10 +246,6 @@ func getIPConfigByIPFamily(nic network.Interface, IPv6 bool) (*network.Interface
 	return nil, fmt.Errorf("failed to determine the ipconfig(IPv6=%v). nicname=%q", IPv6, pointer.StringDeref(nic.Name, ""))
 }
 
-func isInternalLoadBalancer(lb *network.LoadBalancer) bool {
-	return strings.HasSuffix(*lb.Name, consts.InternalLoadBalancerNameSuffix)
-}
-
 // getBackendPoolName the LB BackendPool name for a service.
 // to ensure backward and forward compat:
 // SingleStack -v4 (pre v1.16) => BackendPool name == clusterName

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -562,3 +562,7 @@ func getResourceGroupAndNameFromNICID(ipConfigurationID string) (string, string,
 	}
 	return nicResourceGroup, nicName, nil
 }
+
+func isInternalLoadBalancer(lb *network.LoadBalancer) bool {
+	return strings.HasSuffix(strings.ToLower(*lb.Name), consts.InternalLoadBalancerNameSuffix)
+}

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -895,3 +895,41 @@ func TestGetResourceIDPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestIsInternalLoadBalancer(t *testing.T) {
+	tests := []struct {
+		name     string
+		lb       network.LoadBalancer
+		expected bool
+	}{
+		{
+			name: "internal load balancer",
+			lb: network.LoadBalancer{
+				Name: pointer.String("test-internal"),
+			},
+			expected: true,
+		},
+		{
+			name: "internal load balancer",
+			lb: network.LoadBalancer{
+				Name: pointer.String("TEST-INTERNAL"),
+			},
+			expected: true,
+		},
+		{
+			name: "not internal load balancer",
+			lb: network.LoadBalancer{
+				Name: pointer.String("test"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lb := test.lb
+			result := isInternalLoadBalancer(&lb)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
…if it is an internal load balancer.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

fix: The case of load balancer name should be ignored when determing if it is an internal load balancer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5192

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: The case of load balancer name should be ignored when determing if it is an internal load balancer.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
