### PR TITLE
fix: azure_loadbalancer.go: don't use service.Name, when service is nil

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -269,7 +269,7 @@ func (az *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, ser
 	}
 	if !serviceExists {
 		isOperationSucceeded = true
-		klog.V(2).Infof("UpdateLoadBalancer: skipping service %s because service is going to be deleted", service.Name)
+		klog.V(2).Infof("UpdateLoadBalancer: skipping service %s because service is going to be deleted", serviceName)
 		return nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Summary:
The `service` object is always `nil` when code execution reaches [this line](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/b65c47cc857e4b915d75f718a35b629d23e872e8/pkg/provider/azure_loadbalancer.go#L272) and as such, logging `service.Name` will result in a nil pointer dereference panic (see [this panic log](https://gist.github.com/damdo/f11638dfa61edeb55a0bfd7a080bd216) (note that this comes from an older fork, so panic code lines might not exactly match)).

Analysis:
If `if !serviceExists` [is satisfied](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/b65c47cc857e4b915d75f718a35b629d23e872e8/pkg/provider/azure_loadbalancer.go#L270), we log a line with `service.Name`
But for the execution to branch into `if !serviceExists`, `serviceExists` must be false.
Looking at `getLatestService` where `service` and `serviceExists` come from, you’ll see that the only case when `serviceExists` is `false`, service is `nil`, resulting in a nil pointer dereference panic.
Changing to `serviceName` (a pre populated string) instead of `service.Name` should fix this issue.


#### Does this PR introduce a user-facing change?
```release-note
fix: azure_loadbalancer.go: don't use service.Name, when service is nil
```