### PR TITLE
Updates Makefile to allow override of $(PKG_CONFIG)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,11 @@ clean: ## Cleanup local builds.
 	rm -rf $(BIN_DIR) $(PKG_CONFIG) $(TEST_RESULTS_DIR)
 
 $(PKG_CONFIG):
+ifeq ($(OVERRIDE_PKG_CONFIG), true)
+	@echo "Overriding pkg-config script. Use an alternate method to generate .pkg_config"
+else
 	ENABLE_GIT_COMMAND=$(ENABLE_GIT_COMMAND) hack/pkg-config.sh > $@
+endif
 
 ## --------------------------------------
 ##@ Release


### PR DESCRIPTION
This change updates the makefile to allow an override of the $(PKG_CONFIG) target.

This allows for overriding of the generated ldflags from `hack/pkg-config.sh`.

### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

#### Why?

We are trying to ship the acr-credential-provider with openshift. To do this we are building an RPM. The build system expects the version(s) to be settable from env vars so they are consistent across openshift (e.g 4.15). We don't want to use the git commit / version, or just pin to 'latest'. 

#### What?

This allows setting ldflags without using the `hack/pkg-config.sh` script.

Currently, the options for setting version `ldflags` are:

-  Set everything to `latest` 
-  Rely on `git` being present in the build environment, and use the pkg-config script.

This change allows you to override the invocation of the pkg-config script, and pass your own flags in the `.pkg_config` file. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

