### PR TITLE
[release-1.26] Fix leftover IPv6 support in e2e

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -65,7 +65,10 @@ func TestAzureTest(t *testing.T) {
 	suiteConfig, reporterConfig := GinkgoConfiguration()
 	suiteConfig.Timeout = 0
 
-	labelFilters := []string{suiteConfig.LabelFilter}
+	labelFilters := []string{}
+	if suiteConfig.LabelFilter != "" {
+		labelFilters = append(labelFilters, suiteConfig.LabelFilter)
+	}
 	if strings.EqualFold(os.Getenv(clusterProvisioningToolKey), clusterProvisioningToolCAPZ) {
 		labelFilters = append(labelFilters, "!SLBOutbound")
 	}

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -839,7 +839,11 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 		}
 
 		service := utils.CreateLoadBalancerServiceManifest(testServiceName, annotation, labels, ns.Name, ports)
-		service.Spec.LoadBalancerSourceRanges = []string{"0.0.0.0/0"}
+		if tc.IPFamily == utils.IPv6 {
+			service.Spec.LoadBalancerSourceRanges = []string{"::/0"}
+		} else {
+			service.Spec.LoadBalancerSourceRanges = []string{"0.0.0.0/0"}
+		}
 		service.Spec.SessionAffinity = "ClientIP"
 		_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/network/standard_lb.go
+++ b/tests/e2e/network/standard_lb.go
@@ -103,6 +103,11 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 			Skip("only support cluster with multiple agent pools")
 		}
 
+		// Check if it is a cluster with VMSS
+		vmsses, err := utils.ListUniformVMSSes(tc)
+		Expect(err).NotTo(HaveOccurred())
+		isVMSS := len(vmsses) != 0
+
 		ipcIDs := []string{}
 		for _, backendAddressPool := range *lb.BackendAddressPools {
 			if os.Getenv(utils.AKSTestCCM) != "" && *backendAddressPool.Name == "aksOutboundBackendPool" {
@@ -110,6 +115,13 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 			}
 			for _, ipc := range *backendAddressPool.BackendIPConfigurations {
 				if ipc.ID != nil {
+					if isVMSS && tc.IPFamily == utils.IPv6 && strings.Contains(*ipc.ID, "ipConfigurations/ipConfig0") {
+						// For IPv6 VMSS, there'll be IPv4 IP configurations as well
+						// e.g.
+						// virtualMachines/0/networkInterfaces/<vmss-0>-nic-0/ipConfigurations/ipConfig0
+						// virtualMachines/0/networkInterfaces/<vmss-0>-nic-0/ipConfigurations/ipConfigv6
+						continue
+					}
 					ipcIDs = append(ipcIDs, *ipc.ID)
 				}
 			}
@@ -117,8 +129,6 @@ var _ = Describe("[StandardLoadBalancer] Standard load balancer", func() {
 		utils.Logf("got BackendIPConfigurations IDs: %v", ipcIDs)
 
 		// Check if it is a cluster with VMSS
-		vmsses, err := utils.ListUniformVMSSes(tc)
-		Expect(err).NotTo(HaveOccurred())
 		if len(vmsses) != 0 {
 			allVMs := []azcompute.VirtualMachineScaleSetVM{}
 			for _, vmss := range vmsses {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix leftover IPv6 support in e2e
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
