### PR TITLE
fix: fileshare snapshot does not require setting RequestGiB

### DIFF
--- a/pkg/azureclients/fileclient/azure_fileclient.go
+++ b/pkg/azureclients/fileclient/azure_fileclient.go
@@ -93,9 +93,10 @@ func (c *Client) CreateFileShare(ctx context.Context, resourceGroupName, account
 	if shareOptions == nil {
 		return storage.FileShare{}, fmt.Errorf("share options is nil")
 	}
-	quota := int32(shareOptions.RequestGiB)
-	fileShareProperties := &storage.FileShareProperties{
-		ShareQuota: &quota,
+	fileShareProperties := &storage.FileShareProperties{}
+	if shareOptions.RequestGiB > 0 {
+		quota := int32(shareOptions.RequestGiB)
+		fileShareProperties.ShareQuota = &quota
 	}
 	if shareOptions.Protocol == storage.EnabledProtocolsNFS {
 		fileShareProperties.EnabledProtocols = shareOptions.Protocol


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: fileshare snapshot does not require setting RequestGiB

RequestGiB is only required in file share creation, fileshare snapshot does not require setting RequestGiB

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: fileshare snapshot does not require setting RequestGiB
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: fileshare snapshot does not require setting RequestGiB
```
