### PR TITLE
fix: move lockMap initialization into InitializeCloudFromConfig func to fix panic

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -474,7 +474,9 @@ func NewCloud(ctx context.Context, config *Config, callFromCCM bool) (cloudprovi
 	}
 
 	az.ipv6DualStackEnabled = true
-	az.lockMap = newLockMap()
+	if az.lockMap == nil {
+		az.lockMap = newLockMap()
+	}
 	return az, nil
 }
 
@@ -624,6 +626,7 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *Config, 
 		return err
 	}
 
+	az.lockMap = newLockMap()
 	az.Config = *config
 	az.Environment = *env
 	az.ResourceRequestBackoff = resourceRequestBackoff


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: move lockMap initialization into InitializeCloudFromConfig func to fix panic

`InitializeCloudFromConfig` is more fundamental function and called by azure file driver directly, this PR fixes the panic in azure file driver:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1c0a28b]
goroutine 148 [running]:
sigs.k8s.io/cloud-provider-azure/pkg/provider.(*LockMap).LockEntry(0x0, {0xc00077083f, 0x17})
	/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_utils.go:64 +0x2b
sigs.k8s.io/cloud-provider-azure/pkg/provider.(*Cloud).RemoveStorageAccountTag(0xc000548408, {0x2965f88, 0xc000283860}, {0xc00056c9c0, 0x24}, {0xc000770800, 0x3e}, {0xc00077083f, 0x17}, {0x25edeec, ...})
	/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_storageaccount.go:744 +0x98
sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.(*Driver).RemoveStorageAccountTag(0xc00054e008, {0x2965f88, 0xc000283860}, {0xc00056c9c0, 0x24}, {0xc000770800, 0x3e}, {0xc00077083f, 0x17}, {0x25edeec, ...})
	/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/pkg/azurefile/azurefile.go:1096 +0x514
sigs.k8s.io/azurefile-csi-driver/pkg/azurefile.(*Driver).DeleteVolume(0xc00054e008, {0x2965f88, 0xc000283860}, 0xc0005c9f40)
	/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/pkg/azurefile/controllerserver.go:716 +0xc10
github.com/container-storage-interface/spec/lib/go/csi._Controller_DeleteVolume_Handler.func1({0x2965f88?, 0xc000283860?}, {0x245e260?, 0xc0005c9f40?})
	/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi.pb.go:6438 +0xcb
sigs.k8s.io/azurefile-csi-driver/pkg/csi-common.LogGRPC({0x2965f88, 0xc000283860}, {0x245e260, 0xc0005c9f40}, 0xc0002a73e0, 0xc0006edce0)
	/home/prow/go/src/sigs.k8s.io/azurefile-csi-driver/pkg/csi-common/utils.go:103 +0x392
github.com/container-storage-interface/spec/lib/go/csi._Controller_DeleteVolume_Handler({0x25aa720, 0xc00054e008}, {0x2965f88, 0xc000283860}, 0xc000352b80, 0x2718d10)
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: move lockMap initialization into InitializeCloudFromConfig func to fix panic
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: move lockMap initialization into InitializeCloudFromConfig func to fix panic
```
