### PR TITLE
test: improve autoscaling E2E to prevent unexpected scale operations

### DIFF
--- a/.pipelines/run-autoscaling-e2e.yml
+++ b/.pipelines/run-autoscaling-e2e.yml
@@ -29,7 +29,7 @@ stages:
         - template: ./cnm-image.yml
     - job: create_aks_cluster_and_run_tests_job
       dependsOn: [build_push_ccm_image_job, build_push_cnm_image_job]
-      timeoutInMinutes: 300
+      timeoutInMinutes: 340
       steps:
         - task: GoTool@0
           inputs:

--- a/.pipelines/run-autoscaling-multipool-e2e.yml
+++ b/.pipelines/run-autoscaling-multipool-e2e.yml
@@ -29,7 +29,7 @@ stages:
         - template: ./cnm-image.yml
     - job: create_aks_cluster_and_run_tests_job
       dependsOn: [build_push_ccm_image_job, build_push_cnm_image_job]
-      timeoutInMinutes: 300
+      timeoutInMinutes: 340
       steps:
         - task: GoTool@0
           inputs:

--- a/tests/e2e/autoscaling/autoscaler.go
+++ b/tests/e2e/autoscaling/autoscaler.go
@@ -140,7 +140,11 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		Expect(err).NotTo(HaveOccurred())
 
 		waitForScaleUpToComplete(cs, ns, initNodeCount+1)
+		err = utils.HoldAutoScaleNodes(cs, initNodeCount+1)
+		Expect(err).NotTo(HaveOccurred())
 		waitForScaleDownToComplete(cs, ns, initNodeCount, deployment)
+		err = utils.HoldAutoScaleNodes(cs, initNodeCount)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should scale up, deploy a statefulset with disks attached, scale down, and certain pods + disks should be evicted to a new node", func() {
@@ -154,6 +158,8 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		}()
 		Expect(err).NotTo(HaveOccurred())
 		waitForScaleUpToComplete(cs, ns, initNodeCount+1)
+		err = utils.HoldAutoScaleNodes(cs, initNodeCount+1)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Deploying a StatefulSet")
 		statefulSetManifest := createStatefulSetWithPVCManifest(basename+"-statefulset", int32(2), map[string]string{"app": basename + "-statefulset"})
@@ -183,6 +189,8 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		}
 
 		waitForScaleDownToComplete(cs, ns, initNodeCount, deployment)
+		err = utils.HoldAutoScaleNodes(cs, initNodeCount)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for certain StatefulSet's pods + disks to be evicted to new nodes")
 		err = waitForStatefulSetComplete(cs, ns, statefulSet)
@@ -247,6 +255,8 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		}()
 		Expect(err).NotTo(HaveOccurred())
 		waitForScaleUpToComplete(cs, ns, len(nodes)+10)
+		err = utils.HoldAutoScaleNodes(cs, len(nodes)+10)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking the balancing state of the node groups")
 		nodes, err = utils.GetAgentNodes(cs)
@@ -256,6 +266,8 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		Expect(isBalance).To(BeTrue())
 
 		waitForScaleDownToComplete(cs, ns, initNodeCount, scaleUpDeployment)
+		err = utils.HoldAutoScaleNodes(cs, initNodeCount)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should support one node pool with slow scaling", Label(utils.TestSuiteLabelSingleNodePool), func() {
@@ -413,7 +425,11 @@ var _ = Describe("Cluster size autoscaler", Label(utils.TestSuiteLabelFeatureAut
 		Expect(err).NotTo(HaveOccurred())
 
 		waitForScaleUpToComplete(cs, ns, initNodeCount+1)
+		err = utils.HoldAutoScaleNodes(cs, initNodeCount+1)
+		Expect(err).NotTo(HaveOccurred())
 		waitForScaleDownToComplete(cs, ns, initNodeCount, deployment)
+		err = utils.HoldAutoScaleNodes(cs, initNodeCount)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 

--- a/tests/e2e/utils/node_utils.go
+++ b/tests/e2e/utils/node_utils.go
@@ -221,6 +221,7 @@ func WaitAutoScaleNodes(cs clientset.Interface, targetNodeCount int, isScaleDown
 	poll := 60 * time.Second
 	autoScaleTimeOut := 90 * time.Minute
 	nodeConditions := map[string][]v1.NodeCondition{}
+	previousNodeCount := -1
 	if err = wait.PollImmediate(poll, autoScaleTimeOut, func() (bool, error) {
 		nodes, err = GetAgentNodes(cs)
 		if err != nil {
@@ -237,16 +238,73 @@ func WaitAutoScaleNodes(cs clientset.Interface, targetNodeCount int, isScaleDown
 		for _, node := range nodes {
 			nodeConditions[node.Name] = node.Status.Conditions
 		}
+
 		Logf("Detect %v nodes, target %v", len(nodes), targetNodeCount)
-		if len(nodes) > targetNodeCount && !isScaleDown {
+
+		// Overscaling validation
+		if isScaleDown && len(nodes) < targetNodeCount {
+			Logf("error: less nodes than expected, Node conditions: %v", nodeConditions)
+			return false, fmt.Errorf("there are less nodes than expected")
+		} else if !isScaleDown && len(nodes) > targetNodeCount {
 			Logf("error: more nodes than expected, Node conditions: %v", nodeConditions)
-			err = fmt.Errorf("there are more nodes than expected")
-			return false, err
+			return false, fmt.Errorf("there are more nodes than expected")
 		}
-		return (targetNodeCount > len(nodes) && isScaleDown) || targetNodeCount == len(nodes), nil
+
+		// Monotonous autoscaling progress validation
+		if previousNodeCount != -1 {
+			if isScaleDown && previousNodeCount < len(nodes) {
+				Logf("error: unexpected scale up while expecting scale down, Node conditions: %v", nodeConditions)
+				return false, fmt.Errorf("unexpected scale up while expecting scale down")
+			} else if !isScaleDown && previousNodeCount > len(nodes) {
+				Logf("error: unexpected scale down while expecting scale up, Node conditions: %v", nodeConditions)
+				return false, fmt.Errorf("unexpected scale down while expecting scale up")
+			}
+		}
+		previousNodeCount = len(nodes)
+
+		return len(nodes) == targetNodeCount, nil
 	}); errors.Is(err, wait.ErrWaitTimeout) {
 		Logf("Node conditions: %v", nodeConditions)
 		return fmt.Errorf("Fail to get target node count in limited time")
+	}
+	Logf("Node conditions: %v", nodeConditions)
+	return err
+}
+
+// HoldAutoScaleNodes validate node count to not change for few minutes
+func HoldAutoScaleNodes(cs clientset.Interface, targetNodeCount int) error {
+	Logf(fmt.Sprintf("checking node count stability... Target node count: %v", targetNodeCount))
+	var nodes []v1.Node
+	var err error
+	poll := 60 * time.Second
+	checkDuration := 5 * time.Minute
+	nodeConditions := map[string][]v1.NodeCondition{}
+	if err = wait.PollImmediate(poll, checkDuration, func() (bool, error) {
+		nodes, err = GetAgentNodes(cs)
+		if err != nil {
+			if IsRetryableAPIError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if nodes == nil {
+			err = fmt.Errorf("Unexpected nil node list")
+			return false, err
+		}
+		nodeConditions = map[string][]v1.NodeCondition{}
+		for _, node := range nodes {
+			nodeConditions[node.Name] = node.Status.Conditions
+		}
+
+		if len(nodes) != targetNodeCount {
+			Logf("error: unexpected node count changes, Node conditions: %v", nodeConditions)
+			return false, fmt.Errorf("unexpected node count changes")
+		}
+
+		return false, nil
+	}); errors.Is(err, wait.ErrWaitTimeout) {
+		// Survived
+		err = nil
 	}
 	Logf("Node conditions: %v", nodeConditions)
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind flake

#### What this PR does / why we need it:

Current autoscaling E2Es can be unreliable when trying to catch over-scaling, as it only checks once at the end. 
This has resulted in a Cluster Autoscaler image that contains over-scaling issue to get through the check unnoticed.

This PR aims to increase test coverage to cover the case where there are unexpected scale operations during and after standard scaling check.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
