### PR TITLE
Handle endpoint not being rerturned in AzureCloudConfigFromURL

### DIFF
--- a/pkg/azclient/cloud.go
+++ b/pkg/azclient/cloud.go
@@ -77,6 +77,14 @@ func AzureCloudConfigFromURL(endpoint string) (*cloud.Configuration, error) {
 	}
 
 	if len(metadata) > 0 {
+		// We use the endpoint to build our config, but on ASH the config returned
+		// does not contain the endpoint, and this is not accounted for. This
+		// ultimately unsets it for the returned config, causing the bootstrap of
+		// the provider to fail. Instead, check if the endpoint is returned, and if
+		// it is not then set it.
+		if len(metadata[0].ResourceManager) == 0 {
+			metadata[0].ResourceManager = endpoint
+		}
 		return &cloud.Configuration{
 			ActiveDirectoryAuthorityHost: metadata[0].Authentication.LoginEndpoint,
 			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{

--- a/pkg/azclient/cloud_test.go
+++ b/pkg/azclient/cloud_test.go
@@ -84,6 +84,61 @@ var _ = Describe("Cloud", func() {
 				Expect(cloudConfig.Services[cloud.ResourceManager].Audience).To(Equal("https://management.core.windows.net/"))
 			})
 		})
+
+		When("the resourceManager is not returned from a valid url", func() {
+			It("should substitute the url into the response", func() {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write([]byte(`
+[
+    {
+        "portal":"https://portal.azure.com",
+        "authentication":{
+            "loginEndpoint":"https://login.microsoftonline.com/",
+            "audiences":[
+                "https://management.core.windows.net/",
+                "https://management.azure.com/"
+            ],
+            "tenant":"common",
+            "identityProvider":"AAD"
+        }
+,
+        "media":"https://rest.media.azure.net",
+        "graphAudience":"https://graph.windows.net/",
+        "graph":"https://graph.windows.net/",
+        "name":"AzureCloud",
+        "suffixes":{
+            "azureDataLakeStoreFileSystem":"azuredatalakestore.net",
+            "acrLoginServer":"azurecr.io",
+            "sqlServerHostname":"database.windows.net",
+            "azureDataLakeAnalyticsCatalogAndJob":"azuredatalakeanalytics.net",
+            "keyVaultDns":"vault.azure.net",
+            "storage":"core.windows.net",
+            "azureFrontDoorEndpointSuffix":"azurefd.net"
+        }
+,
+        "batch":"https://batch.core.windows.net/",
+        "vmImageAliasDoc":"https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+        "activeDirectoryDataLake":"https://datalake.azure.net/",
+        "sqlManagement":"https://management.core.windows.net:8443/",
+        "gallery":"https://gallery.azure.com/"
+    }
+
+]
+					`))
+					Expect(err).ToNot(HaveOccurred())
+				}))
+				defer server.Close()
+
+				cloudConfig, err := azclient.AzureCloudConfigFromURL(server.URL)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cloudConfig).ToNot(BeNil())
+				Expect(cloudConfig.ActiveDirectoryAuthorityHost).To(Equal("https://login.microsoftonline.com/"))
+				Expect(cloudConfig.Services).NotTo(BeEmpty())
+				Expect(cloudConfig.Services[cloud.ResourceManager].Audience).To(Equal("https://management.core.windows.net/"))
+				Expect(cloudConfig.Services[cloud.ResourceManager].Endpoint).To(Equal(server.URL))
+			})
+		})
 	})
 	Context("AzureCloudFromName", func() {
 		When("cloud name is empty", func() {


### PR DESCRIPTION

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This change updates AzureCloudConfigFromURL to check that the URL (ResourceManagerEndpoint) that is used to build the config has been returned. If it has not, it sets it using the URL provided.

This avoids the case where the endpoint is used to build config, but does not return it's self - causing the created configuration to fail .

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


Fixes  https://github.com/kubernetes-sigs/cloud-provider-azure/issues/5558

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
