### PR TITLE
[release-1.28] feat: skip invalid LoadBalancerSourceRanges network CIDRs when provisioning nsg rules

### DIFF
--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -4688,6 +4688,38 @@ func TestReconcileSecurityGroupCommon(t *testing.T) {
 			},
 		},
 		{
+			desc: "reconcileSecurityGroup shall create sgs with deny_all rule and not allow internet access when provided allowedIPRanges is invalid",
+			service: getTestService("svc", v1.ProtocolTCP, map[string]string{
+				consts.ServiceAnnotationAllowedIPRanges: "10.10.10.1/24",
+			}, false, 80),
+			existingSgs: map[string]network.SecurityGroup{"nsg": {
+				Name:                          pointer.String("nsg"),
+				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{},
+			}},
+			lbIPs:  &[]string{"10.0.0.1", "10.0.0.2"},
+			wantLb: true,
+			expectedSg: &network.SecurityGroup{
+				Name: pointer.String("nsg"),
+				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
+					SecurityRules: &[]network.SecurityRule{
+						{
+							Name: pointer.String("asvc-TCP-80-deny_all"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								Protocol:                   network.SecurityRuleProtocol("Tcp"),
+								SourcePortRange:            pointer.String("*"),
+								SourceAddressPrefix:        pointer.String("*"),
+								DestinationPortRange:       pointer.String("80"),
+								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
+								Access:                     network.SecurityRuleAccess("Deny"),
+								Priority:                   pointer.Int32(500),
+								Direction:                  network.SecurityRuleDirection("Inbound"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "reconcileSecurityGroup shall create sgs while allowedIPRanges and serviceTags annotation is set",
 			service: getTestService("svc", v1.ProtocolTCP, map[string]string{
 				consts.ServiceAnnotationAllowedIPRanges:    "10.10.10.0/24,192.168.0.1/32",

--- a/pkg/provider/loadbalancer/netip.go
+++ b/pkg/provider/loadbalancer/netip.go
@@ -37,14 +37,14 @@ func IsCIDRsAllowAll(cidrs []netip.Prefix) bool {
 	return false
 }
 
-func ParseCIDRs(parts []string) ([]netip.Prefix, error) {
-	var rv []netip.Prefix
-	for _, part := range parts {
-		prefix, err := netip.ParsePrefix(part)
-		if err != nil {
-			return nil, fmt.Errorf("invalid IP range %s: %w", part, err)
-		}
-		rv = append(rv, prefix)
+func ParseCIDR(v string) (netip.Prefix, error) {
+	prefix, err := netip.ParsePrefix(v)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("invalid CIDR `%s`: %w", v, err)
 	}
-	return rv, nil
+	masked := prefix.Masked()
+	if prefix.Addr().Compare(masked.Addr()) != 0 {
+		return netip.Prefix{}, fmt.Errorf("invalid CIDR `%s`: not a valid network prefix, should be properly masked like %s", v, masked)
+	}
+	return prefix, nil
 }

--- a/pkg/provider/loadbalancer/netip_test.go
+++ b/pkg/provider/loadbalancer/netip_test.go
@@ -44,52 +44,33 @@ func TestIsAllowAll(t *testing.T) {
 	}))
 }
 
-func TestParseCIDRs(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		actual, err := ParseCIDRs([]string{})
-		assert.NoError(t, err)
-		assert.Empty(t, actual)
-	})
+func TestParseCIDR(t *testing.T) {
 	t.Run("1 ipv4 cidr", func(t *testing.T) {
-		actual, err := ParseCIDRs([]string{
-			"10.10.10.0/24",
-		})
+		actual, err := ParseCIDR("10.10.10.0/24")
 		assert.NoError(t, err)
-		assert.Equal(t, []netip.Prefix{
-			netip.MustParsePrefix("10.10.10.0/24"),
-		}, actual)
+		assert.Equal(t, netip.MustParsePrefix("10.10.10.0/24"), actual)
 	})
 	t.Run("1 ipv6 cidr", func(t *testing.T) {
-		actual, err := ParseCIDRs([]string{
-			"2001:db8::/32",
-		})
+		actual, err := ParseCIDR("2001:db8::/32")
 		assert.NoError(t, err)
-		assert.Equal(t, []netip.Prefix{
-			netip.MustParsePrefix("2001:db8::/32"),
-		}, actual)
-	})
-	t.Run("multiple cidrs", func(t *testing.T) {
-		actual, err := ParseCIDRs([]string{
-			"10.10.10.0/24",
-			"2001:db8::/32",
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, []netip.Prefix{
-			netip.MustParsePrefix("10.10.10.0/24"),
-			netip.MustParsePrefix("2001:db8::/32"),
-		}, actual)
+		assert.Equal(t, netip.MustParsePrefix("2001:db8::/32"), actual)
 	})
 	t.Run("invalid cidr", func(t *testing.T) {
 		{
-			_, err := ParseCIDRs([]string{""})
+			_, err := ParseCIDR("")
 			assert.Error(t, err)
 		}
 		{
-			_, err := ParseCIDRs([]string{"foo"})
+			_, err := ParseCIDR("foo")
+			assert.Error(t, err)
+		}
+		// below two tests check for valid cidr but not valid network prefix
+		{
+			_, err := ParseCIDR("10.10.10.1/24")
 			assert.Error(t, err)
 		}
 		{
-			_, err := ParseCIDRs([]string{"10.10.10.0/24", "foo"})
+			_, err := ParseCIDR("2001:db8::5/32")
 			assert.Error(t, err)
 		}
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
cherry-pick #5650 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When user-provided `LoadBalancerSourceRanges` or `azure-allowed-ip-ranges` are not valid network prefixes, cloud-controller-manager skips these invalid ranges, emits a warning event, and adds a deny-All rule in nsg.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
