### PR TITLE
[release-1.27] Reorder security rules to ensure 'DenyAll' rule appears after 'Allow' rule

### DIFF
--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -4693,12 +4693,12 @@ func TestReconcileSecurityGroupCommon(t *testing.T) {
 							},
 						},
 						{
-							Name: pointer.String("asvc-TCP-80-foo"),
+							Name: pointer.String("asvc-TCP-80-bar"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
 								SourcePortRange:            pointer.String("*"),
 								DestinationPortRange:       pointer.String(strconv.Itoa(80)),
-								SourceAddressPrefix:        pointer.String("foo"),
+								SourceAddressPrefix:        pointer.String("bar"),
 								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
 								Access:                     network.SecurityRuleAccessAllow,
 								Priority:                   pointer.Int32(502),
@@ -4706,12 +4706,12 @@ func TestReconcileSecurityGroupCommon(t *testing.T) {
 							},
 						},
 						{
-							Name: pointer.String("asvc-TCP-80-bar"),
+							Name: pointer.String("asvc-TCP-80-foo"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
 								SourcePortRange:            pointer.String("*"),
 								DestinationPortRange:       pointer.String(strconv.Itoa(80)),
-								SourceAddressPrefix:        pointer.String("bar"),
+								SourceAddressPrefix:        pointer.String("foo"),
 								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
 								Access:                     network.SecurityRuleAccessAllow,
 								Priority:                   pointer.Int32(503),
@@ -4770,19 +4770,6 @@ func TestReconcileSecurityGroupCommon(t *testing.T) {
 				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 					SecurityRules: &[]network.SecurityRule{
 						{
-							Name: pointer.String("asvc-TCP-80-192.168.0.1_32"),
-							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-								Protocol:                   network.SecurityRuleProtocol("Tcp"),
-								SourcePortRange:            pointer.String("*"),
-								DestinationPortRange:       pointer.String(strconv.Itoa(80)),
-								SourceAddressPrefix:        pointer.String("192.168.0.1/32"),
-								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
-								Access:                     network.SecurityRuleAccessAllow,
-								Priority:                   pointer.Int32(500),
-								Direction:                  network.SecurityRuleDirection("Inbound"),
-							},
-						},
-						{
 							Name: pointer.String("asvc-TCP-80-10.10.10.0_24"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
@@ -4791,20 +4778,20 @@ func TestReconcileSecurityGroupCommon(t *testing.T) {
 								SourceAddressPrefix:        pointer.String("10.10.10.0/24"),
 								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
 								Access:                     network.SecurityRuleAccessAllow,
-								Priority:                   pointer.Int32(501),
+								Priority:                   pointer.Int32(500),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
 						{
-							Name: pointer.String("asvc-TCP-80-foo"),
+							Name: pointer.String("asvc-TCP-80-192.168.0.1_32"),
 							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 								Protocol:                   network.SecurityRuleProtocol("Tcp"),
 								SourcePortRange:            pointer.String("*"),
 								DestinationPortRange:       pointer.String(strconv.Itoa(80)),
-								SourceAddressPrefix:        pointer.String("foo"),
+								SourceAddressPrefix:        pointer.String("192.168.0.1/32"),
 								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
 								Access:                     network.SecurityRuleAccessAllow,
-								Priority:                   pointer.Int32(502),
+								Priority:                   pointer.Int32(501),
 								Direction:                  network.SecurityRuleDirection("Inbound"),
 							},
 						},
@@ -4815,6 +4802,19 @@ func TestReconcileSecurityGroupCommon(t *testing.T) {
 								SourcePortRange:            pointer.String("*"),
 								DestinationPortRange:       pointer.String(strconv.Itoa(80)),
 								SourceAddressPrefix:        pointer.String("bar"),
+								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
+								Access:                     network.SecurityRuleAccessAllow,
+								Priority:                   pointer.Int32(502),
+								Direction:                  network.SecurityRuleDirection("Inbound"),
+							},
+						},
+						{
+							Name: pointer.String("asvc-TCP-80-foo"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								Protocol:                   network.SecurityRuleProtocol("Tcp"),
+								SourcePortRange:            pointer.String("*"),
+								DestinationPortRange:       pointer.String(strconv.Itoa(80)),
+								SourceAddressPrefix:        pointer.String("foo"),
 								DestinationAddressPrefixes: &([]string{"10.0.0.1", "10.0.0.2"}),
 								Access:                     network.SecurityRuleAccessAllow,
 								Priority:                   pointer.Int32(503),
@@ -4855,58 +4855,398 @@ func TestReconcileSecurityGroupCommon(t *testing.T) {
 }
 
 func TestReconcileSecurityGroupLoadBalancerSourceRanges(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
-	az := GetTestCloud(ctrl)
-	service := getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true"}, false, 80)
-	service.Spec.LoadBalancerSourceRanges = []string{"1.2.3.4/32"}
-	existingSg := network.SecurityGroup{
-		Name: pointer.String("nsg"),
-		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-			SecurityRules: &[]network.SecurityRule{},
-		},
-	}
-	lbIPs := &[]string{"1.1.1.1"}
-	expectedSg := network.SecurityGroup{
-		Name: pointer.String("nsg"),
-		SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
-			SecurityRules: &[]network.SecurityRule{
+	tests := []struct {
+		name          string
+		sourceRanges  []string
+		originalRules []network.SecurityRule
+		expectedRules []network.SecurityRule
+	}{
+		{
+			name:          "should add deny-all rule if not exists #1",
+			sourceRanges:  []string{"1.2.3.4/32"},
+			originalRules: nil,
+			expectedRules: []network.SecurityRule{
 				{
 					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                 network.SecurityRuleProtocol("Tcp"),
+						Protocol:                 network.SecurityRuleProtocolTCP,
 						SourcePortRange:          pointer.String("*"),
 						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
 						DestinationPortRange:     pointer.String("80"),
 						DestinationAddressPrefix: pointer.String("1.1.1.1"),
-						Access:                   network.SecurityRuleAccess("Allow"),
+						Access:                   network.SecurityRuleAccessAllow,
 						Priority:                 pointer.Int32(500),
-						Direction:                network.SecurityRuleDirection("Inbound"),
+						Direction:                network.SecurityRuleDirectionInbound,
 					},
 				},
 				{
 					Name: pointer.String("atest1-TCP-80-deny_all"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                 network.SecurityRuleProtocol("Tcp"),
+						Protocol:                 network.SecurityRuleProtocolTCP,
 						SourcePortRange:          pointer.String("*"),
 						SourceAddressPrefix:      pointer.String("*"),
 						DestinationPortRange:     pointer.String("80"),
 						DestinationAddressPrefix: pointer.String("1.1.1.1"),
-						Access:                   network.SecurityRuleAccess("Deny"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(4096),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+		},
+
+		{
+			name:         "should add deny-all rule if not exists #2",
+			sourceRanges: []string{"1.2.3.4/32"},
+			originalRules: []network.SecurityRule{
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(505),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+			expectedRules: []network.SecurityRule{
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(500), // would be reset
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-deny_all"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(4096),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+		},
+		{
+			name:         "should move deny-all rule after allow rule: reorder priority",
+			sourceRanges: []string{"1.2.3.4/32"},
+			originalRules: []network.SecurityRule{
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(505),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-deny_all"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(503),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+			expectedRules: []network.SecurityRule{
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(500), // would be reset
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-deny_all"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(4096),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+		},
+		{
+			name:         "should move deny-all rule after allow rule: add new source range",
+			sourceRanges: []string{"1.2.3.4/32", "10.0.0.0/16"},
+			originalRules: []network.SecurityRule{
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(505),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-deny_all"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(503),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+			expectedRules: []network.SecurityRule{
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(500), // would be reset
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-10.0.0.0_16"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("10.0.0.0/16"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
 						Priority:                 pointer.Int32(501),
-						Direction:                network.SecurityRuleDirection("Inbound"),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-deny_all"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(4096),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+		},
+		{
+			name:         "should move deny-all rule after allow rule: keep unmanaged rules unchanged",
+			sourceRanges: []string{"1.2.3.4/32"},
+			originalRules: []network.SecurityRule{
+				{
+					Name: pointer.String("unmanaged_rule_1"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(499),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("unmanaged_rule_2"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/16"),
+						DestinationPortRange:     pointer.String("443"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(5000),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("unmanaged_rule_3"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/16"),
+						DestinationPortRange:     pointer.String("443"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(400),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(505),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-deny_all"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(503),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+			},
+			expectedRules: []network.SecurityRule{
+				{
+					Name: pointer.String("unmanaged_rule_3"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/16"),
+						DestinationPortRange:     pointer.String("443"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(400),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("unmanaged_rule_1"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(499),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-1.2.3.4_32"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/32"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(500), // would be reset
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("atest1-TCP-80-deny_all"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("*"),
+						DestinationPortRange:     pointer.String("80"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessDeny,
+						Priority:                 pointer.Int32(4096),
+						Direction:                network.SecurityRuleDirectionInbound,
+					},
+				},
+				{
+					Name: pointer.String("unmanaged_rule_2"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolTCP,
+						SourcePortRange:          pointer.String("*"),
+						SourceAddressPrefix:      pointer.String("1.2.3.4/16"),
+						DestinationPortRange:     pointer.String("443"),
+						DestinationAddressPrefix: pointer.String("1.1.1.1"),
+						Access:                   network.SecurityRuleAccessAllow,
+						Priority:                 pointer.Int32(5000),
+						Direction:                network.SecurityRuleDirectionInbound,
 					},
 				},
 			},
 		},
 	}
-	mockSGClient := az.SecurityGroupsClient.(*mocksecuritygroupclient.MockInterface)
-	mockSGClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any()).Return(existingSg, nil)
-	mockSGClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	sg, err := az.reconcileSecurityGroup("testCluster", &service, lbIPs, nil, true)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedSg, *sg)
+
+	for _, tt := range tests {
+		originalSg := network.SecurityGroup{
+			Name: pointer.String("nsg"),
+			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
+				SecurityRules: &tt.originalRules,
+			},
+		}
+		expectedSg := network.SecurityGroup{
+			Name: pointer.String("nsg"),
+			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
+				SecurityRules: &tt.expectedRules,
+			},
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			az := GetTestCloud(ctrl)
+			service := getTestService("test1", v1.ProtocolTCP, map[string]string{consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true"}, false, 80)
+			service.Spec.LoadBalancerSourceRanges = tt.sourceRanges
+			lbIPs := &[]string{"1.1.1.1"}
+
+			mockSGClient := az.SecurityGroupsClient.(*mocksecuritygroupclient.MockInterface)
+			mockSGClient.EXPECT().Get(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any()).Return(originalSg, nil)
+			mockSGClient.EXPECT().CreateOrUpdate(gomock.Any(), az.ResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			sg, err := az.reconcileSecurityGroup("testCluster", &service, lbIPs, nil, true)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedSg, *sg)
+		})
+	}
 }
 
 func TestReconcileSecurityGroup(t *testing.T) {
@@ -7836,6 +8176,265 @@ func TestEqualSubResource(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			equal := equalSubResource(tc.subResource1, tc.subResource2)
 			assert.Equal(t, tc.expected, equal)
+		})
+	}
+}
+
+func newAllowRule(name string, priority int32) network.SecurityRule {
+	return network.SecurityRule{
+		Name: &name,
+		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+			Priority: &priority,
+			Access:   network.SecurityRuleAccessAllow,
+		},
+	}
+}
+func newDenyRule(name string, priority int32) network.SecurityRule {
+	return network.SecurityRule{
+		Name: &name,
+		SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+			Priority: &priority,
+			Access:   network.SecurityRuleAccessDeny,
+		},
+	}
+}
+
+func Test_shouldTidySecurityRules(t *testing.T) {
+	type args struct {
+		rules []network.SecurityRule
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should return false if there are no rules #1",
+			args: args{
+				rules: nil,
+			},
+			want: false,
+		},
+		{
+			name: "should return false if there are no rules #2",
+			args: args{
+				rules: []network.SecurityRule{},
+			},
+			want: false,
+		},
+		{
+			name: "should return false if there is 1 rule",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("rule1", 500),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false if no allow rule after deny rule",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("rule1", 500),
+					newDenyRule("rule2", 505),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false if no allow rule after deny rule: ignore unmanaged rules",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("unmanaged_rule1", 300),
+					newAllowRule("unmanaged_rule2", 400),
+					newDenyRule("unmanaged_rule3", 450),
+
+					newAllowRule("rule1", 500),
+					newDenyRule("rule2", 505),
+
+					newDenyRule("unmanaged_rule4", 5000),
+					newAllowRule("unmanaged_rule5", 6000),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return true if allow rule after deny rule",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("rule1", 500),
+					newDenyRule("rule4", 501),
+					newAllowRule("rule2", 502),
+					newDenyRule("rule5", 503),
+					newAllowRule("rule3", 504),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "should return true if allow rule after deny rule: with unmanaged rules",
+			args: args{
+				rules: []network.SecurityRule{
+
+					newAllowRule("unmanaged_rule1", 300),
+					newAllowRule("unmanaged_rule2", 400),
+					newDenyRule("unmanaged_rule3", 450),
+
+					newAllowRule("rule1", 500),
+					newDenyRule("rule4", 501),
+					newAllowRule("rule2", 502),
+					newDenyRule("rule5", 503),
+					newAllowRule("rule3", 504),
+
+					newDenyRule("unmanaged_rule4", 5000),
+					newAllowRule("unmanaged_rule5", 6000),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, shouldTidySecurityRules(tt.args.rules), "shouldTidySecurityRules(%v)", tt.args.rules)
+		})
+	}
+}
+
+func Test_tidySecurityRules(t *testing.T) {
+
+	type args struct {
+		rules []network.SecurityRule
+	}
+	tests := []struct {
+		name string
+		args args
+		want []network.SecurityRule
+	}{
+		{
+			name: "should return the same rules if there are no rules #1",
+			args: args{
+				rules: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "should return the same rules if there are no rules #2",
+			args: args{
+				rules: []network.SecurityRule{},
+			},
+			want: []network.SecurityRule{},
+		},
+		{
+			name: "should return the same rules if there is 1 rule",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("rule1", 500),
+				},
+			},
+			want: []network.SecurityRule{
+				newAllowRule("rule1", 500),
+			},
+		},
+		{
+			name: "should return the same rules if there are only unmanaged rules",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("unmanaged_rule1", 300),
+					newAllowRule("unmanaged_rule2", 400),
+					newDenyRule("unmanaged_rule3", 450),
+
+					newAllowRule("rule1", 500),
+
+					newDenyRule("unmanaged_rule4", 5000),
+					newAllowRule("unmanaged_rule5", 6000),
+				},
+			},
+			want: []network.SecurityRule{
+				newAllowRule("unmanaged_rule1", 300),
+				newAllowRule("unmanaged_rule2", 400),
+				newDenyRule("unmanaged_rule3", 450),
+
+				newAllowRule("rule1", 500),
+
+				newDenyRule("unmanaged_rule4", 5000),
+				newAllowRule("unmanaged_rule5", 6000),
+			},
+		},
+		{
+			name: "should reorder managed rules #1",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("rule1", 500),
+					newAllowRule("rule2", 541),
+					newAllowRule("rule3", 652),
+					newDenyRule("rule4", 700),
+					newDenyRule("rule5", 1000),
+				},
+			},
+			want: []network.SecurityRule{
+				newAllowRule("rule1", 500),
+				newAllowRule("rule2", 501),
+				newAllowRule("rule3", 502),
+				newDenyRule("rule5", 4095),
+				newDenyRule("rule4", 4096),
+			},
+		},
+		{
+			name: "should reorder managed rules #2",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("rule1", 500),
+					newDenyRule("rule4", 501),
+					newAllowRule("rule2", 502),
+					newDenyRule("rule5", 503),
+					newAllowRule("rule3", 504),
+				},
+			},
+			want: []network.SecurityRule{
+				newAllowRule("rule1", 500),
+				newAllowRule("rule2", 501),
+				newAllowRule("rule3", 502),
+				newDenyRule("rule5", 4095),
+				newDenyRule("rule4", 4096),
+			},
+		},
+		{
+			name: "should reorder managed rules #3: ignore unmanaged rules",
+			args: args{
+				rules: []network.SecurityRule{
+					newAllowRule("unmanaged_rule1", 300),
+					newAllowRule("unmanaged_rule2", 400),
+					newDenyRule("unmanaged_rule3", 450),
+
+					newAllowRule("rule1", 500),
+					newDenyRule("rule4", 501),
+					newAllowRule("rule2", 502),
+					newDenyRule("rule5", 503),
+					newAllowRule("rule3", 504),
+
+					newDenyRule("unmanaged_rule4", 5000),
+					newAllowRule("unmanaged_rule5", 6000),
+				},
+			},
+			want: []network.SecurityRule{
+				newAllowRule("unmanaged_rule1", 300),
+				newAllowRule("unmanaged_rule2", 400),
+				newDenyRule("unmanaged_rule3", 450),
+
+				newAllowRule("rule1", 500),
+				newAllowRule("rule2", 501),
+				newAllowRule("rule3", 502),
+				newDenyRule("rule5", 4095),
+				newDenyRule("rule4", 4096),
+
+				newDenyRule("unmanaged_rule4", 5000),
+				newAllowRule("unmanaged_rule5", 6000),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tidySecurityRules(tt.args.rules), "tidySecurityRules(%v)", tt.args.rules)
 		})
 	}
 }

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -1969,6 +1969,7 @@ func getTestSecurityGroupCommon(az *Cloud, v4Enabled, v6Enabled bool, services .
 				return network.SecurityRule{
 					Name: pointer.String(ruleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Priority:             pointer.Int32(0),
 						SourceAddressPrefix:  pointer.String(src),
 						DestinationPortRange: pointer.String(fmt.Sprintf("%d", port.Port)),
 					},
@@ -2263,6 +2264,7 @@ func securityRuleMatches(serviceSourceRange string, servicePort v1.ServicePort, 
 }
 
 func validateSecurityGroupCommon(t *testing.T, az *Cloud, securityGroup *network.SecurityGroup, v4Enabled, v6Enabled bool, services ...v1.Service) {
+	t.Helper()
 	expectedRules := make(map[string]bool)
 	for _, svc := range services {
 		svc := svc
@@ -2788,6 +2790,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 		rule := network.SecurityRule{
 			Name: &ruleName,
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+				Priority:                 pointer.Int32(500),
 				Protocol:                 network.SecurityRuleProtocolTCP,
 				SourcePortRange:          pointer.String("*"),
 				SourceAddressPrefix:      pointer.String("Internet"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5762

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix NSG DenyAll rule priority
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
