### PR TITLE
[release-1.28] fix: allow space separated load balancer source ranges

### DIFF
--- a/pkg/provider/loadbalancer/accesscontrol.go
+++ b/pkg/provider/loadbalancer/accesscontrol.go
@@ -48,14 +48,18 @@ func AllowedServiceTags(svc *v1.Service) ([]string, error) {
 		return nil, nil
 	}
 
-	return strings.Split(strings.TrimSpace(value), Sep), nil
+	tags := strings.Split(strings.TrimSpace(value), Sep)
+	for i := range tags {
+		tags[i] = strings.TrimSpace(tags[i])
+	}
+	return tags, nil
 }
 
-// AllowedIPRanges returns the allowed IP ranges configured by user through AKS custom annotation.
+// AllowedIPRanges returns the allowed IP ranges configured by user through AKS custom annotations:
+// service.beta.kubernetes.io/azure-allowed-ip-ranges and service.beta.kubernetes.io/load-balancer-source-ranges
 func AllowedIPRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
 	const (
 		Sep = ","
-		Key = consts.ServiceAnnotationAllowedIPRanges
 	)
 	var (
 		errs          []error
@@ -63,28 +67,35 @@ func AllowedIPRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
 		invalidRanges []string
 	)
 
-	value, found := svc.Annotations[Key]
-	if !found {
-		return nil, nil, nil
-	}
+	for _, key := range []string{consts.ServiceAnnotationAllowedIPRanges, v1.AnnotationLoadBalancerSourceRangesKey} {
+		value, found := svc.Annotations[key]
+		if !found {
+			continue
+		}
 
-	for _, p := range strings.Split(strings.TrimSpace(value), Sep) {
-		prefix, err := ParseCIDR(p)
-		if err != nil {
-			errs = append(errs, err)
-			invalidRanges = append(invalidRanges, p)
-		} else {
-			validRanges = append(validRanges, prefix)
+		var errsByKey []error
+		for _, p := range strings.Split(strings.TrimSpace(value), Sep) {
+			p = strings.TrimSpace(p)
+			prefix, err := ParseCIDR(p)
+			if err != nil {
+				errsByKey = append(errsByKey, err)
+				invalidRanges = append(invalidRanges, p)
+			} else {
+				validRanges = append(validRanges, prefix)
+			}
+		}
+		if len(errsByKey) > 0 {
+			errs = append(errs, fmt.Errorf("invalid service annotation %s:%s: %w", key, value, errors.Join(errsByKey...)))
 		}
 	}
+
 	if len(errs) > 0 {
-		return validRanges, invalidRanges, fmt.Errorf("invalid service annotation %s:%s: %w", Key, value, errors.Join(errs...))
+		return validRanges, invalidRanges, errors.Join(errs...)
 	}
 	return validRanges, invalidRanges, nil
 }
 
-// SourceRanges returns the allowed IP ranges configured by user through `spec.LoadBalancerSourceRanges` and standard annotation.
-// If `spec.LoadBalancerSourceRanges` is not set, it will try to parse the annotation.
+// SourceRanges returns the allowed IP ranges configured by user through `spec.LoadBalancerSourceRanges`.
 func SourceRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
 	var (
 		errs          []error
@@ -92,32 +103,8 @@ func SourceRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
 		invalidRanges []string
 	)
 	// Read from spec
-	if len(svc.Spec.LoadBalancerSourceRanges) > 0 {
-		for _, p := range svc.Spec.LoadBalancerSourceRanges {
-			prefix, err := ParseCIDR(p)
-			if err != nil {
-				errs = append(errs, err)
-				invalidRanges = append(invalidRanges, p)
-			} else {
-				validRanges = append(validRanges, prefix)
-			}
-		}
-		if len(errs) > 0 {
-			return validRanges, invalidRanges, fmt.Errorf("invalid service.Spec.LoadBalancerSourceRanges [%v]: %w", svc.Spec.LoadBalancerSourceRanges, errors.Join(errs...))
-		}
-		return validRanges, invalidRanges, nil
-	}
-
-	// Read from annotation
-	const (
-		Sep = ","
-		Key = v1.AnnotationLoadBalancerSourceRangesKey
-	)
-	value, found := svc.Annotations[Key]
-	if !found {
-		return nil, nil, nil
-	}
-	for _, p := range strings.Split(strings.TrimSpace(value), Sep) {
+	for _, p := range svc.Spec.LoadBalancerSourceRanges {
+		p = strings.TrimSpace(p)
 		prefix, err := ParseCIDR(p)
 		if err != nil {
 			errs = append(errs, err)
@@ -127,7 +114,7 @@ func SourceRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
 		}
 	}
 	if len(errs) > 0 {
-		return validRanges, invalidRanges, fmt.Errorf("invalid service annotation %s:%s: %w", Key, value, errors.Join(errs...))
+		return validRanges, invalidRanges, fmt.Errorf("invalid service.Spec.LoadBalancerSourceRanges [%v]: %w", svc.Spec.LoadBalancerSourceRanges, errors.Join(errs...))
 	}
 	return validRanges, invalidRanges, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
cherry-pick #5885 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow space-separated load balancer source ranges in service annotation. Allow `service.beta.kubernetes.io/load-balancer-source-ranges` to be used together with `service.beta.kubernetes.io/azure-allowed-service-tags`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
