### PR TITLE
fix: Ensure vnet ID will be attached to backend pool in local service…

### DIFF
--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -388,13 +388,21 @@ func newBackendPoolTypeNodeIP(c *Cloud) BackendPool {
 	return &backendPoolTypeNodeIP{c}
 }
 
+func (az *Cloud) getVnetResourceID() string {
+	rg := az.ResourceGroup
+	if len(az.VnetResourceGroup) > 0 {
+		rg = az.VnetResourceGroup
+	}
+	return fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s",
+		az.SubscriptionID,
+		rg,
+		az.VnetName,
+	)
+}
+
 func (bi *backendPoolTypeNodeIP) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, _, _, clusterName, lbName string, backendPool network.BackendAddressPool) error {
 	isIPv6 := isBackendPoolIPv6(pointer.StringDeref(backendPool.Name, ""))
-	vnetResourceGroup := bi.ResourceGroup
-	if len(bi.VnetResourceGroup) > 0 {
-		vnetResourceGroup = bi.VnetResourceGroup
-	}
-	vnetID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s", bi.SubscriptionID, vnetResourceGroup, bi.VnetName)
 
 	var (
 		changed               bool
@@ -425,10 +433,6 @@ func (bi *backendPoolTypeNodeIP) EnsureHostsInPool(service *v1.Service, nodes []
 	lbBackendPoolName := bi.getBackendPoolNameForService(service, clusterName, isIPv6)
 	if strings.EqualFold(pointer.StringDeref(backendPool.Name, ""), lbBackendPoolName) &&
 		backendPool.BackendAddressPoolPropertiesFormat != nil {
-		backendPool.VirtualNetwork = &network.SubResource{
-			ID: &vnetID,
-		}
-
 		if backendPool.LoadBalancerBackendAddresses == nil {
 			lbBackendPoolAddresses := make([]network.LoadBalancerBackendAddress, 0)
 			backendPool.LoadBalancerBackendAddresses = &lbBackendPoolAddresses
@@ -792,6 +796,22 @@ func newBackendPool(lb *network.LoadBalancer, isBackendPoolPreConfigured bool, p
 }
 
 func (az *Cloud) addNodeIPAddressesToBackendPool(backendPool *network.BackendAddressPool, nodeIPAddresses []string) bool {
+	vnetID := az.getVnetResourceID()
+	if backendPool.BackendAddressPoolPropertiesFormat != nil {
+		if backendPool.VirtualNetwork == nil ||
+			backendPool.VirtualNetwork.ID == nil {
+			backendPool.VirtualNetwork = &network.SubResource{
+				ID: &vnetID,
+			}
+		}
+	} else {
+		backendPool.BackendAddressPoolPropertiesFormat = &network.BackendAddressPoolPropertiesFormat{
+			VirtualNetwork: &network.SubResource{
+				ID: &vnetID,
+			},
+		}
+	}
+
 	if backendPool.LoadBalancerBackendAddresses == nil {
 		lbBackendPoolAddresses := make([]network.LoadBalancerBackendAddress, 0)
 		backendPool.LoadBalancerBackendAddresses = &lbBackendPoolAddresses

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/stretchr/testify/assert"
+
 	"go.uber.org/mock/gomock"
 
 	v1 "k8s.io/api/core/v1"
@@ -397,6 +398,9 @@ func getTestBackendAddressPoolWithIPs(lbName, bpName string, ips []string) netwo
 		ID:   pointer.String(fmt.Sprintf("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/%s/backendAddressPools/%s", lbName, bpName)),
 		Name: pointer.String(bpName),
 		BackendAddressPoolPropertiesFormat: &network.BackendAddressPoolPropertiesFormat{
+			VirtualNetwork: &network.SubResource{
+				ID: pointer.String("/subscriptions/subscriptionID/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet"),
+			},
 			Location:                     pointer.String("eastus"),
 			LoadBalancerBackendAddresses: &[]network.LoadBalancerBackendAddress{},
 		},


### PR DESCRIPTION
… reconciliation loops

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

We need to ensure that the vnet ID is attached to the backend pool in the local service reconciliation loops.
This happens in a rare corner case where the user updates from legacy multi-slb to the current new design of multi-slb. In this case, the backend pool may not have vnet ID attached and the update backend pool request will return an error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6172

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Ensure vnet ID will be attached to backend pool in local service reconciliation loops.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
