### PR TITLE
[release-1.30] Fix setting single dst prefix for NSG rule

### DIFF
--- a/hack/test-ccm-e2e.sh
+++ b/hack/test-ccm-e2e.sh
@@ -20,7 +20,8 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 DEFAULT_LABEL_FILTER="!Serial && !Slow"
 LABEL_FILTER="${LABEL_FILTER:-${DEFAULT_LABEL_FILTER}}"
+FLAKE_ATTEMPTS=${FLAKE_ATTEMPTS:-2}
 
 source "${REPO_ROOT}/hack/ensure-ginkgo-v2.sh"
 
-ginkgo -flake-attempts 2 -skip "${SKIP_ARGS}" -label-filter "${LABEL_FILTER}" "${REPO_ROOT}"/tests/e2e/ --timeout "${CCM_E2E_TIMEOUT:-210m}"
+ginkgo -flake-attempts ${FLAKE_ATTEMPTS} -skip "${SKIP_ARGS}" -label-filter "${LABEL_FILTER}" "${REPO_ROOT}"/tests/e2e/ --timeout "${CCM_E2E_TIMEOUT:-210m}"

--- a/pkg/azclient/client-gen/go.mod
+++ b/pkg/azclient/client-gen/go.mod
@@ -1,7 +1,8 @@
 module sigs.k8s.io/cloud-provider-azure/pkg/azclient/client-gen
 
-go 1.21
-toolchain go1.22.2
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/pkg/azclient/configloader/go.mod
+++ b/pkg/azclient/configloader/go.mod
@@ -1,7 +1,8 @@
 module sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader
 
-go 1.21
-toolchain go1.22.2
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/pkg/nodemanager/nodemanager.go
+++ b/pkg/nodemanager/nodemanager.go
@@ -161,7 +161,7 @@ func NewCloudNodeController(
 		enableBetaTopologyLabels:  enableBetaTopologyLabels,
 	}
 
-	// Only reconcile the beta toplogy labels when the feature flag is enabled.
+	// Only reconcile the beta topology labels when the feature flag is enabled.
 	if cnc.enableBetaTopologyLabels {
 		cnc.labelReconcileInfo = append(cnc.labelReconcileInfo, betaToplogyLabels...)
 	}

--- a/pkg/nodemanager/nodemanager_test.go
+++ b/pkg/nodemanager/nodemanager_test.go
@@ -846,7 +846,7 @@ func Test_reconcileNodeLabels(t *testing.T) {
 			cnc := &CloudNodeController{
 				kubeClient:   clientset,
 				nodeInformer: factory.Core().V1().Nodes(),
-				// Test using the beta toplogy labels.
+				// Test using the beta topology labels.
 				labelReconcileInfo: betaToplogyLabels,
 			}
 

--- a/pkg/provider/azure_loadbalancer_accesscontrol_test.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol_test.go
@@ -1522,14 +1522,14 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					network.SecurityRule{
 						Name: ptr.To("bar"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Protocol:                   network.SecurityRuleProtocolUDP,
-							Access:                     network.SecurityRuleAccessAllow,
-							Direction:                  network.SecurityRuleDirectionInbound,
-							SourcePortRange:            ptr.To("*"),
-							SourceAddressPrefixes:      ptr.To([]string{"bar"}),
-							DestinationPortRanges:      ptr.To([]string{"5000", "6000"}),
-							DestinationAddressPrefixes: ptr.To([]string{"bar"}), // Should keep bar but clean the rest
-							Priority:                   ptr.To(int32(4004)),
+							Protocol:                 network.SecurityRuleProtocolUDP,
+							Access:                   network.SecurityRuleAccessAllow,
+							Direction:                network.SecurityRuleDirectionInbound,
+							SourcePortRange:          ptr.To("*"),
+							SourceAddressPrefixes:    ptr.To([]string{"bar"}),
+							DestinationPortRanges:    ptr.To([]string{"5000", "6000"}),
+							DestinationAddressPrefix: ptr.To("bar"), // Should keep bar but clean the rest
+							Priority:                 ptr.To(int32(4004)),
 						},
 					},
 				)
@@ -1837,14 +1837,14 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					network.SecurityRule{
 						Name: ptr.To("bar"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Protocol:                   network.SecurityRuleProtocolUDP,
-							Access:                     network.SecurityRuleAccessAllow,
-							Direction:                  network.SecurityRuleDirectionInbound,
-							SourcePortRange:            ptr.To("*"),
-							SourceAddressPrefixes:      ptr.To([]string{"bar"}),
-							DestinationPortRanges:      ptr.To([]string{"5000", "6000"}),
-							DestinationAddressPrefixes: ptr.To([]string{"bar"}), // Should keep bar but clean the rest
-							Priority:                   ptr.To(int32(4004)),
+							Protocol:                 network.SecurityRuleProtocolUDP,
+							Access:                   network.SecurityRuleAccessAllow,
+							Direction:                network.SecurityRuleDirectionInbound,
+							SourcePortRange:          ptr.To("*"),
+							SourceAddressPrefixes:    ptr.To([]string{"bar"}),
+							DestinationPortRanges:    ptr.To([]string{"5000", "6000"}),
+							DestinationAddressPrefix: ptr.To("bar"), // Should keep bar but clean the rest
+							Priority:                 ptr.To(int32(4004)),
 						},
 					},
 					azureFx.
@@ -2114,14 +2114,14 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					network.SecurityRule{
 						Name: ptr.To("bar"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Protocol:                   network.SecurityRuleProtocolUDP,
-							Access:                     network.SecurityRuleAccessAllow,
-							Direction:                  network.SecurityRuleDirectionInbound,
-							SourcePortRange:            ptr.To("*"),
-							SourceAddressPrefixes:      ptr.To([]string{"bar"}),
-							DestinationPortRanges:      ptr.To([]string{"5000", "6000"}),
-							DestinationAddressPrefixes: ptr.To([]string{"bar"}), // Should keep bar but clean the rest
-							Priority:                   ptr.To(int32(4004)),
+							Protocol:                 network.SecurityRuleProtocolUDP,
+							Access:                   network.SecurityRuleAccessAllow,
+							Direction:                network.SecurityRuleDirectionInbound,
+							SourcePortRange:          ptr.To("*"),
+							SourceAddressPrefixes:    ptr.To([]string{"bar"}),
+							DestinationPortRanges:    ptr.To([]string{"5000", "6000"}),
+							DestinationAddressPrefix: ptr.To("bar"), // Should keep bar but clean the rest
+							Priority:                 ptr.To(int32(4004)),
 						},
 					},
 
@@ -2142,14 +2142,14 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					network.SecurityRule{
 						Name: ptr.To("quo"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Protocol:                   network.SecurityRuleProtocolTCP,
-							Access:                     network.SecurityRuleAccessAllow,
-							Direction:                  network.SecurityRuleDirectionInbound,
-							SourcePortRange:            ptr.To("*"),
-							SourceAddressPrefixes:      ptr.To([]string{"quo"}),
-							DestinationPortRanges:      ptr.To([]string{"18000", "19000", "20000"}),
-							DestinationAddressPrefixes: ptr.To([]string{"quo"}), // Should split the rules
-							Priority:                   ptr.To(int32(4006)),
+							Protocol:                 network.SecurityRuleProtocolTCP,
+							Access:                   network.SecurityRuleAccessAllow,
+							Direction:                network.SecurityRuleDirectionInbound,
+							SourcePortRange:          ptr.To("*"),
+							SourceAddressPrefixes:    ptr.To([]string{"quo"}),
+							DestinationPortRanges:    ptr.To([]string{"18000", "19000", "20000"}),
+							DestinationAddressPrefix: ptr.To("quo"), // Should split the rules
+							Priority:                 ptr.To(int32(4006)),
 						},
 					},
 
@@ -2329,14 +2329,14 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					network.SecurityRule{
 						Name: ptr.To("bar"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Protocol:                   network.SecurityRuleProtocolUDP,
-							Access:                     network.SecurityRuleAccessAllow,
-							Direction:                  network.SecurityRuleDirectionInbound,
-							SourcePortRange:            ptr.To("*"),
-							SourceAddressPrefixes:      ptr.To([]string{"bar"}),
-							DestinationPortRanges:      ptr.To([]string{"5000", "6000"}),
-							DestinationAddressPrefixes: ptr.To([]string{"bar"}), // Should keep bar but clean the rest
-							Priority:                   ptr.To(int32(4004)),
+							Protocol:                 network.SecurityRuleProtocolUDP,
+							Access:                   network.SecurityRuleAccessAllow,
+							Direction:                network.SecurityRuleDirectionInbound,
+							SourcePortRange:          ptr.To("*"),
+							SourceAddressPrefixes:    ptr.To([]string{"bar"}),
+							DestinationPortRanges:    ptr.To([]string{"5000", "6000"}),
+							DestinationAddressPrefix: ptr.To("bar"), // Should keep bar but clean the rest
+							Priority:                 ptr.To(int32(4004)),
 						},
 					},
 
@@ -2518,14 +2518,14 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					network.SecurityRule{
 						Name: ptr.To("bar"),
 						SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-							Protocol:                   network.SecurityRuleProtocolUDP,
-							Access:                     network.SecurityRuleAccessAllow,
-							Direction:                  network.SecurityRuleDirectionInbound,
-							SourcePortRange:            ptr.To("*"),
-							SourceAddressPrefixes:      ptr.To([]string{"bar"}),
-							DestinationPortRanges:      ptr.To([]string{"5000", "6000"}),
-							DestinationAddressPrefixes: ptr.To([]string{"bar"}), // Should keep bar but clean the rest
-							Priority:                   ptr.To(int32(4004)),
+							Protocol:                 network.SecurityRuleProtocolUDP,
+							Access:                   network.SecurityRuleAccessAllow,
+							Direction:                network.SecurityRuleDirectionInbound,
+							SourcePortRange:          ptr.To("*"),
+							SourceAddressPrefixes:    ptr.To([]string{"bar"}),
+							DestinationPortRanges:    ptr.To([]string{"5000", "6000"}),
+							DestinationAddressPrefix: ptr.To("bar"), // Should keep bar but clean the rest
+							Priority:                 ptr.To(int32(4004)),
 						},
 					},
 

--- a/pkg/provider/loadbalancer/securitygroup/securitygroup_test.go
+++ b/pkg/provider/loadbalancer/securitygroup/securitygroup_test.go
@@ -952,6 +952,95 @@ func TestSecurityGroupHelper_AddRuleForDenyAll(t *testing.T) {
 		}
 	})
 
+	t.Run("when rule exists and outdated, it should update the one - dst prefix corner case", func(t *testing.T) {
+		cases := []struct {
+			TestName     string
+			IPFamily     iputil.Family
+			DstAddresses []netip.Addr
+		}{
+			{
+				TestName:     "TCP / IPv4",
+				IPFamily:     iputil.IPv4,
+				DstAddresses: fx.RandomIPv4Addresses(2),
+			},
+			{
+				TestName:     "TCP / IPv6",
+				IPFamily:     iputil.IPv6,
+				DstAddresses: fx.RandomIPv6Addresses(2),
+			},
+			{
+				TestName:     "UDP / IPv4",
+				IPFamily:     iputil.IPv4,
+				DstAddresses: fx.RandomIPv4Addresses(2),
+			},
+			{
+				TestName:     "UDP / IPv6",
+				IPFamily:     iputil.IPv6,
+				DstAddresses: fx.RandomIPv6Addresses(2),
+			},
+			{
+				TestName:     "ANY / IPv4",
+				IPFamily:     iputil.IPv4,
+				DstAddresses: fx.RandomIPv4Addresses(2),
+			},
+			{
+				TestName:     "ANY / IPv6",
+				IPFamily:     iputil.IPv6,
+				DstAddresses: fx.RandomIPv6Addresses(2),
+			},
+		}
+
+		for _, c := range cases {
+			var (
+				ipFamily     = c.IPFamily
+				dstAddresses = c.DstAddresses
+
+				targetRule = network.SecurityRule{
+					Name: ptr.To(GenerateDenyAllSecurityRuleName(ipFamily)),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                 network.SecurityRuleProtocolAsterisk,
+						Access:                   network.SecurityRuleAccessDeny,
+						Direction:                network.SecurityRuleDirectionInbound,
+						SourceAddressPrefix:      ptr.To("*"),
+						SourcePortRange:          ptr.To("*"),
+						DestinationAddressPrefix: ptr.To("foo"), // Should append the dstAddresses.
+						DestinationPortRange:     ptr.To("*"),
+						Priority:                 ptr.To(int32(950)), // A random priority, should remain unchanged.
+					},
+				}
+				irrelevantRules = fx.Azure().NoiseSecurityRules(10)
+				sg              = fx.Azure().SecurityGroup().WithRules(append(irrelevantRules, targetRule)).Build()
+				helper          = ExpectNewSecurityGroupHelper(t, &sg)
+			)
+
+			err := helper.AddRuleForDenyAll(dstAddresses)
+			assert.NoError(t, err)
+
+			outputSG, updated, err := helper.SecurityGroup()
+
+			assert.NoError(t, err)
+			assert.True(t, updated, "[`%s`] should update 1 rule", c.TestName)
+			assert.Equal(t, len(*outputSG.SecurityRules), len(irrelevantRules)+1, "[`%s`] should only update 1 rule", c.TestName)
+			testutil.ExpectHasSecurityRules(t, outputSG, irrelevantRules, "[`%s`] the original irrelevant rules should remain unchanged", c.TestName)
+
+			expectedTargetRule := testutil.CloneInJSON(targetRule)
+			{
+				// It should append the new destination addresses.
+				ps := append(
+					fnutil.Map(func(v netip.Addr) string { return v.String() }, dstAddresses),
+					*expectedTargetRule.DestinationAddressPrefix,
+				)
+				expectedTargetRule.DestinationAddressPrefixes = &ps
+				sort.Strings(*expectedTargetRule.DestinationAddressPrefixes)
+
+				expectedTargetRule.DestinationAddressPrefix = nil
+			}
+			testutil.ExpectHasSecurityRules(t, outputSG, []network.SecurityRule{
+				expectedTargetRule,
+			}, "[`%s`] 1 allow rule should be updated", c.TestName)
+		}
+	})
+
 	t.Run("when rules exists and rules up-to-update, it should remain the same", func(t *testing.T) {
 		cases := []struct {
 			TestName     string
@@ -1263,7 +1352,21 @@ func TestRuleHelper_RemoveDestinationFromRules(t *testing.T) {
 						DestinationAddressPrefixes: ptr.To([]string{}),
 						DestinationAddressPrefix:   ptr.To("192.168.0.1"),
 						DestinationPortRanges:      ptr.To([]string{"8000"}),
-						Priority:                   ptr.To(int32(2000)),
+						Priority:                   ptr.To(int32(2001)),
+					},
+				},
+				{
+					Name: ptr.To("test-rule-5"),
+					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+						Protocol:                   network.SecurityRuleProtocolAsterisk,
+						Access:                     network.SecurityRuleAccessDeny,
+						Direction:                  network.SecurityRuleDirectionInbound,
+						SourceAddressPrefix:        ptr.To("*"),
+						SourcePortRange:            ptr.To("*"),
+						DestinationAddressPrefixes: ptr.To([]string{}),
+						DestinationAddressPrefix:   ptr.To("*"), // Should not overwrite the DestinationAddressPrefixes.
+						DestinationPortRanges:      ptr.To([]string{"8000"}),
+						Priority:                   ptr.To(int32(2002)),
 					},
 				},
 			}
@@ -1306,6 +1409,20 @@ func TestRuleHelper_RemoveDestinationFromRules(t *testing.T) {
 					DestinationAddressPrefixes: ptr.To([]string{"8.8.8.8"}),
 					DestinationPortRanges:      ptr.To([]string{"5000"}),
 					Priority:                   ptr.To(int32(502)),
+				},
+			},
+			{
+				Name: ptr.To("test-rule-5"),
+				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+					Protocol:                   network.SecurityRuleProtocolAsterisk,
+					Access:                     network.SecurityRuleAccessDeny,
+					Direction:                  network.SecurityRuleDirectionInbound,
+					SourceAddressPrefix:        ptr.To("*"),
+					SourcePortRange:            ptr.To("*"),
+					DestinationAddressPrefixes: ptr.To([]string{}),
+					DestinationAddressPrefix:   ptr.To("*"),
+					DestinationPortRanges:      ptr.To([]string{"8000"}),
+					Priority:                   ptr.To(int32(2002)),
 				},
 			},
 		}, outputSG.SecurityRules)
@@ -1392,14 +1509,14 @@ func TestRuleHelper_RemoveDestinationFromRules(t *testing.T) {
 			{
 				Name: ptr.To("test-rule-0"),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-					Protocol:                   network.SecurityRuleProtocolTCP,
-					Access:                     network.SecurityRuleAccessAllow,
-					Direction:                  network.SecurityRuleDirectionInbound,
-					SourceAddressPrefixes:      ptr.To([]string{"bar", "foo"}),
-					SourcePortRange:            ptr.To("*"),
-					DestinationAddressPrefixes: ptr.To([]string{"192.168.0.1"}),
-					DestinationPortRanges:      ptr.To([]string{"443", "80"}),
-					Priority:                   ptr.To(int32(500)),
+					Protocol:                 network.SecurityRuleProtocolTCP,
+					Access:                   network.SecurityRuleAccessAllow,
+					Direction:                network.SecurityRuleDirectionInbound,
+					SourceAddressPrefixes:    ptr.To([]string{"bar", "foo"}),
+					SourcePortRange:          ptr.To("*"),
+					DestinationAddressPrefix: ptr.To("192.168.0.1"),
+					DestinationPortRanges:    ptr.To([]string{"443", "80"}),
+					Priority:                 ptr.To(int32(500)),
 				},
 			},
 			{
@@ -1425,279 +1542,6 @@ func TestRuleHelper_RemoveDestinationFromRules(t *testing.T) {
 					SourcePortRange:            ptr.To("*"),
 					DestinationAddressPrefixes: ptr.To([]string{"10.0.0.1", "10.0.0.2"}),
 					DestinationPortRanges:      ptr.To([]string{"443"}),
-					Priority:                   ptr.To(int32(502)),
-				},
-			},
-		}, outputSG.SecurityRules)
-	})
-
-}
-
-func TestSecurityGroupHelper_RemoveDstAddressesFromRules(t *testing.T) {
-	fx := fixture.NewFixture()
-
-	t.Run("it should not patch rules if no rules exist", func(t *testing.T) {
-		var (
-			sg           = fx.Azure().SecurityGroup().Build()
-			helper       = ExpectNewSecurityGroupHelper(t, &sg)
-			dstAddresses = fnutil.Map(func(p netip.Addr) string {
-				return p.String()
-			}, fx.RandomIPv4Addresses(2))
-		)
-		helper.RemoveDestinationPrefixesFromRules(dstAddresses)
-		_, updated, err := helper.SecurityGroup()
-		assert.NoError(t, err)
-		assert.False(t, updated)
-	})
-
-	t.Run("it should not patch rules if no rules match", func(t *testing.T) {
-		var (
-			rules = []network.SecurityRule{
-				{
-					Name: ptr.To("test-rule-0"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolTCP,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefixes:      ptr.To([]string{"src_foo", "src_bar"}),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"10.0.0.1", "10.0.0.2"}),
-						DestinationPortRanges:      ptr.To([]string{"443", "80"}),
-						Priority:                   ptr.To(int32(500)),
-					},
-				},
-				{
-					Name: ptr.To("test-rule-1"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolUDP,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefixes:      ptr.To([]string{"src_baz", "src_quo"}),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"20.0.0.1", "20.0.0.2"}),
-						DestinationPortRanges:      ptr.To([]string{"53"}),
-						Priority:                   ptr.To(int32(501)),
-					},
-				},
-			}
-
-			sg           = fx.Azure().SecurityGroup().WithRules(rules).Build()
-			helper       = ExpectNewSecurityGroupHelper(t, &sg)
-			dstAddresses = []string{
-				"192.168.0.1",
-				"192.168.0.2",
-			}
-		)
-		helper.RemoveDestinationPrefixesFromRules(dstAddresses)
-		_, updated, err := helper.SecurityGroup()
-		assert.NoError(t, err)
-		assert.False(t, updated)
-	})
-
-	t.Run("it should patch the matched rules", func(t *testing.T) {
-		var (
-			rules = []network.SecurityRule{
-				{
-					Name: ptr.To("test-rule-0"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolTCP,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefixes:      ptr.To([]string{"src_foo", "src_bar"}),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"10.0.0.1", "10.0.0.2", "192.168.0.1"}),
-						DestinationPortRanges:      ptr.To([]string{"443", "80"}),
-						Priority:                   ptr.To(int32(500)),
-					},
-				},
-				{
-					Name: ptr.To("test-rule-1"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolUDP,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefixes:      ptr.To([]string{"src_baz", "src_quo"}),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"20.0.0.1", "192.168.0.1", "192.168.0.2", "20.0.0.2"}),
-						DestinationPortRanges:      ptr.To([]string{"53"}),
-						Priority:                   ptr.To(int32(501)),
-					},
-				},
-				{
-					Name: ptr.To("test-rule-2"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolAsterisk,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefix:        ptr.To("*"),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"8.8.8.8"}),
-						DestinationPortRanges:      ptr.To([]string{"5000"}),
-						Priority:                   ptr.To(int32(502)),
-					},
-				},
-			}
-
-			sg           = fx.Azure().SecurityGroup().WithRules(rules).Build()
-			helper       = ExpectNewSecurityGroupHelper(t, &sg)
-			dstAddresses = []string{
-				"192.168.0.1",
-				"192.168.0.2",
-			}
-		)
-		helper.RemoveDestinationPrefixesFromRules(dstAddresses)
-		outputSG, updated, err := helper.SecurityGroup()
-		assert.NoError(t, err)
-		assert.True(t, updated)
-		testutil.ExpectEqualInJSON(t, []network.SecurityRule{
-			{
-				Name: ptr.To("test-rule-0"),
-				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-					Protocol:                   network.SecurityRuleProtocolTCP,
-					Access:                     network.SecurityRuleAccessAllow,
-					Direction:                  network.SecurityRuleDirectionInbound,
-					SourceAddressPrefixes:      ptr.To([]string{"src_foo", "src_bar"}),
-					SourcePortRange:            ptr.To("*"),
-					DestinationAddressPrefixes: ptr.To([]string{"10.0.0.1", "10.0.0.2"}),
-					DestinationPortRanges:      ptr.To([]string{"443", "80"}),
-					Priority:                   ptr.To(int32(500)),
-				},
-			},
-			{
-				Name: ptr.To("test-rule-1"),
-				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-					Protocol:                   network.SecurityRuleProtocolUDP,
-					Access:                     network.SecurityRuleAccessAllow,
-					Direction:                  network.SecurityRuleDirectionInbound,
-					SourceAddressPrefixes:      ptr.To([]string{"src_baz", "src_quo"}),
-					SourcePortRange:            ptr.To("*"),
-					DestinationAddressPrefixes: ptr.To([]string{"20.0.0.1", "20.0.0.2"}),
-					DestinationPortRanges:      ptr.To([]string{"53"}),
-					Priority:                   ptr.To(int32(501)),
-				},
-			},
-			{
-				Name: ptr.To("test-rule-2"),
-				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-					Protocol:                   network.SecurityRuleProtocolAsterisk,
-					Access:                     network.SecurityRuleAccessAllow,
-					Direction:                  network.SecurityRuleDirectionInbound,
-					SourceAddressPrefix:        ptr.To("*"),
-					SourcePortRange:            ptr.To("*"),
-					DestinationAddressPrefixes: ptr.To([]string{"8.8.8.8"}),
-					DestinationPortRanges:      ptr.To([]string{"5000"}),
-					Priority:                   ptr.To(int32(502)),
-				},
-			},
-		}, outputSG.SecurityRules)
-	})
-
-	t.Run("it should remove the matched rules if no destination addresses left", func(t *testing.T) {
-		var (
-			rules = []network.SecurityRule{
-				{
-					Name: ptr.To("test-rule-0"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolTCP,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefixes:      ptr.To([]string{"src_foo", "src_bar"}),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"10.0.0.1", "10.0.0.2", "192.168.0.1"}),
-						DestinationPortRanges:      ptr.To([]string{"443", "80"}),
-						Priority:                   ptr.To(int32(500)),
-					},
-				},
-				{
-					Name: ptr.To("test-rule-1"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolUDP,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefixes:      ptr.To([]string{"src_baz", "src_quo"}),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"192.168.0.1", "192.168.0.2"}),
-						DestinationPortRanges:      ptr.To([]string{"53"}),
-						Priority:                   ptr.To(int32(501)),
-					},
-				},
-				{
-					Name: ptr.To("test-rule-2"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolAsterisk,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefix:        ptr.To("*"),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{"8.8.8.8"}),
-						DestinationPortRanges:      ptr.To([]string{"5000"}),
-						Priority:                   ptr.To(int32(502)),
-					},
-				},
-				{
-					Name: ptr.To("test-rule-3"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                 network.SecurityRuleProtocolAsterisk,
-						Access:                   network.SecurityRuleAccessAllow,
-						Direction:                network.SecurityRuleDirectionInbound,
-						SourceAddressPrefix:      ptr.To("*"),
-						SourcePortRange:          ptr.To("*"),
-						DestinationAddressPrefix: ptr.To("192.168.0.1"),
-						DestinationPortRanges:    ptr.To([]string{"8000"}),
-						Priority:                 ptr.To(int32(2000)),
-					},
-				},
-				{
-					Name: ptr.To("test-rule-4"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Protocol:                   network.SecurityRuleProtocolAsterisk,
-						Access:                     network.SecurityRuleAccessAllow,
-						Direction:                  network.SecurityRuleDirectionInbound,
-						SourceAddressPrefix:        ptr.To("*"),
-						SourcePortRange:            ptr.To("*"),
-						DestinationAddressPrefixes: ptr.To([]string{}),
-						DestinationAddressPrefix:   ptr.To("192.168.0.1"),
-						DestinationPortRanges:      ptr.To([]string{"8000"}),
-						Priority:                   ptr.To(int32(2000)),
-					},
-				},
-			}
-
-			sg           = fx.Azure().SecurityGroup().WithRules(rules).Build()
-			helper       = ExpectNewSecurityGroupHelper(t, &sg)
-			dstAddresses = []string{
-				"192.168.0.1",
-				"192.168.0.2",
-			}
-		)
-		helper.RemoveDestinationPrefixesFromRules(dstAddresses)
-		outputSG, updated, err := helper.SecurityGroup()
-		assert.NoError(t, err)
-		assert.True(t, updated)
-		testutil.ExpectEqualInJSON(t, []network.SecurityRule{
-			{
-				Name: ptr.To("test-rule-0"),
-				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-					Protocol:                   network.SecurityRuleProtocolTCP,
-					Access:                     network.SecurityRuleAccessAllow,
-					Direction:                  network.SecurityRuleDirectionInbound,
-					SourceAddressPrefixes:      ptr.To([]string{"src_foo", "src_bar"}),
-					SourcePortRange:            ptr.To("*"),
-					DestinationAddressPrefixes: ptr.To([]string{"10.0.0.1", "10.0.0.2"}),
-					DestinationPortRanges:      ptr.To([]string{"443", "80"}),
-					Priority:                   ptr.To(int32(500)),
-				},
-			},
-			{
-				Name: ptr.To("test-rule-2"),
-				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-					Protocol:                   network.SecurityRuleProtocolAsterisk,
-					Access:                     network.SecurityRuleAccessAllow,
-					Direction:                  network.SecurityRuleDirectionInbound,
-					SourceAddressPrefix:        ptr.To("*"),
-					SourcePortRange:            ptr.To("*"),
-					DestinationAddressPrefixes: ptr.To([]string{"8.8.8.8"}),
-					DestinationPortRanges:      ptr.To([]string{"5000"}),
 					Priority:                   ptr.To(int32(502)),
 				},
 			},

--- a/pkg/provider/loadbalancer/securitygroup/securityrule.go
+++ b/pkg/provider/loadbalancer/securitygroup/securityrule.go
@@ -107,6 +107,17 @@ func ListDestinationPrefixes(r *network.SecurityRule) []string {
 	return rv
 }
 
+func SetDestinationPrefixes(r *network.SecurityRule, prefixes []string) {
+	ps := NormalizeSecurityRuleAddressPrefixes(prefixes)
+	if len(ps) == 1 {
+		r.DestinationAddressPrefix = &ps[0]
+		r.DestinationAddressPrefixes = nil
+	} else {
+		r.DestinationAddressPrefix = nil
+		r.DestinationAddressPrefixes = &ps
+	}
+}
+
 func ListDestinationPortRanges(r *network.SecurityRule) ([]int32, error) {
 	var values []string
 	if r.DestinationPortRange != nil {

--- a/pkg/provider/loadbalancer/testutil/fixture/azure_securitygroup.go
+++ b/pkg/provider/loadbalancer/testutil/fixture/azure_securitygroup.go
@@ -172,7 +172,14 @@ func (f *AzureAllowSecurityRuleFixture) WithPriority(p int32) *AzureAllowSecurit
 }
 
 func (f *AzureAllowSecurityRuleFixture) WithDestination(prefixes ...string) *AzureAllowSecurityRuleFixture {
-	f.rule.DestinationAddressPrefixes = ptr.To(securitygroup.NormalizeSecurityRuleAddressPrefixes(prefixes))
+	if len(prefixes) == 1 {
+		f.rule.DestinationAddressPrefix = ptr.To(prefixes[0])
+		f.rule.DestinationAddressPrefixes = nil
+	} else {
+		f.rule.DestinationAddressPrefix = nil
+		f.rule.DestinationAddressPrefixes = ptr.To(securitygroup.NormalizeSecurityRuleAddressPrefixes(prefixes))
+	}
+
 	return f
 }
 
@@ -191,7 +198,13 @@ func (f *AzureDenyAllSecurityRuleFixture) WithPriority(p int32) *AzureDenyAllSec
 }
 
 func (f *AzureDenyAllSecurityRuleFixture) WithDestination(prefixes ...string) *AzureDenyAllSecurityRuleFixture {
-	f.rule.DestinationAddressPrefixes = ptr.To(securitygroup.NormalizeSecurityRuleAddressPrefixes(prefixes))
+	if len(prefixes) == 1 {
+		f.rule.DestinationAddressPrefix = ptr.To(prefixes[0])
+		f.rule.DestinationAddressPrefixes = nil
+	} else {
+		f.rule.DestinationAddressPrefix = nil
+		f.rule.DestinationAddressPrefixes = ptr.To(securitygroup.NormalizeSecurityRuleAddressPrefixes(prefixes))
+	}
 	return f
 }
 

--- a/tests/kubemark/configs/experimental/storage/pod-startup/config.yaml
+++ b/tests/kubemark/configs/experimental/storage/pod-startup/config.yaml
@@ -6,7 +6,7 @@
   {{$NODE_MODE := DefaultParam .NODE_MODE "allnodes"}}
   {{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
 
-# Test Variales
+# Test Variables
   {{$PODS_PER_NODE := .PODS_PER_NODE}}
   {{$DEPLOYMENT_TEMPLATE_PATH := .DEPLOYMENT_TEMPLATE_PATH }}
   {{$VOLUMES_PER_POD := .VOLUMES_PER_POD}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

cherry-pick #6258 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix setting single dst prefix for NSG rule
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
