### PR TITLE
[release-1.29] fix: Ensure NSG rules cleanup excludes DestinationApplicationSecurityGroups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # syntax=docker/dockerfile:1
 
-FROM --platform=linux/amd64 golang:1.22-bullseye@sha256:78b171fe51f25b8c3197710f281dacae94759a254e9a486576005f9dadba9e7d AS builder
+FROM --platform=linux/amd64 golang:1.22-bullseye@sha256:0742798b94c656e75ba5409583c2485f18b52de5c9b7cf12859c945bb7414718 AS builder
 
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH=amd64

--- a/cloud-node-manager.Dockerfile
+++ b/cloud-node-manager.Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.22-bullseye@sha256:78b171fe51f25b8c3197710f281dacae94759a254e9a486576005f9dadba9e7d AS builder
+FROM --platform=linux/amd64 golang:1.22-bullseye@sha256:0742798b94c656e75ba5409583c2485f18b52de5c9b7cf12859c945bb7414718 AS builder
 
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH=amd64

--- a/pkg/provider/loadbalancer/securitygroup/securitygroup.go
+++ b/pkg/provider/loadbalancer/securitygroup/securitygroup.go
@@ -386,9 +386,12 @@ func (helper *RuleHelper) SecurityGroup() (*network.SecurityGroup, bool, error) 
 		rules = make([]network.SecurityRule, 0, len(helper.rules))
 	)
 	for _, r := range helper.rules {
-		noDstPrefixes := ptr.Deref(r.DestinationAddressPrefix, "") == "" &&
-			len(ptr.Deref(r.DestinationAddressPrefixes, []string{})) == 0
-		if noDstPrefixes {
+		var (
+			dstAddresses = ListDestinationPrefixes(r)
+			dstASGs      = ptr.Deref(r.DestinationApplicationSecurityGroups, []network.ApplicationSecurityGroup{})
+		)
+
+		if len(dstAddresses) == 0 && len(dstASGs) == 0 {
 			// Skip the rule without destination prefixes.
 			continue
 		}

--- a/pkg/provider/loadbalancer/testutil/fixture/azure_securitygroup.go
+++ b/pkg/provider/loadbalancer/testutil/fixture/azure_securitygroup.go
@@ -62,16 +62,29 @@ func (f *AzureFixture) NoiseSecurityRules(nRules int) []network.SecurityRule {
 					fmt.Sprintf("130.0.50.%d", i),
 				}),
 				SourcePortRange: ptr.To("*"),
-				DestinationAddressPrefixes: ptr.To([]string{
-					fmt.Sprintf("222.111.0.%d", i), // NOTE: keep the source IP / destination IP unique to LB ips.
-					fmt.Sprintf("200.0.50.%d", i),
-				}),
 				DestinationPortRanges: ptr.To([]string{
 					fmt.Sprintf("4000%d", i),
 					fmt.Sprintf("5000%d", i),
 				}),
 			},
 		}
+
+		switch i % 3 {
+		case 0:
+			rule.DestinationAddressPrefixes = ptr.To([]string{
+				fmt.Sprintf("222.111.0.%d", i),
+				fmt.Sprintf("200.0.50.%d", i),
+			})
+		case 1:
+			rule.DestinationAddressPrefix = ptr.To(fmt.Sprintf("222.111.0.%d", i))
+		case 2:
+			rule.DestinationApplicationSecurityGroups = &[]network.ApplicationSecurityGroup{
+				{
+					ID: ptr.To(fmt.Sprintf("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/the-rg/providers/Microsoft.Network/applicationSecurityGroups/the-asg-%d", i)),
+				},
+			}
+		}
+
 		rv = append(rv, rule)
 
 		initPriority++


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
cherry-pick #6331 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure NSG rules cleanup excludes DestinationApplicationSecurityGroups
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
