### PR TITLE
[release-1.27 | release-1.28] fix: enable the `cloud-node-controller`

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -67,6 +67,7 @@ type CloudControllerManagerOptions struct {
 	KubeCloudShared    *cpoptions.KubeCloudSharedOptions
 	ServiceController  *cpoptions.ServiceControllerOptions
 	NodeIPAMController *NodeIPAMControllerOptions
+	NodeController     *cpoptions.NodeControllerOptions
 
 	SecureServing  *apiserveroptions.SecureServingOptionsWithLoopback
 	Authentication *apiserveroptions.DelegatingAuthenticationOptions
@@ -94,7 +95,10 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 		ServiceController: &cpoptions.ServiceControllerOptions{
 			ServiceControllerConfiguration: &componentConfig.ServiceController,
 		},
-		NodeIPAMController:        defaultNodeIPAMControllerOptions(),
+		NodeIPAMController: defaultNodeIPAMControllerOptions(),
+		NodeController: &cpoptions.NodeControllerOptions{
+			NodeControllerConfiguration: &componentConfig.NodeController,
+		},
 		SecureServing:             apiserveroptions.NewSecureServingOptions().WithLoopback(),
 		Authentication:            apiserveroptions.NewDelegatingAuthenticationOptions(),
 		Authorization:             apiserveroptions.NewDelegatingAuthorizationOptions(),
@@ -137,6 +141,7 @@ func (o *CloudControllerManagerOptions) Flags(allControllers, disabledByDefaultC
 	o.Generic.AddFlags(&fss, allControllers, disabledByDefaultControllers, names.CCMControllerAliases())
 	o.KubeCloudShared.AddFlags(fss.FlagSet("generic"))
 	o.ServiceController.AddFlags(fss.FlagSet("service controller"))
+	o.NodeController.AddFlags(fss.FlagSet("node controller"))
 	o.NodeIPAMController.AddFlags(fss.FlagSet("node ipam controller"))
 
 	o.SecureServing.AddFlags(fss.FlagSet("secure serving"))
@@ -172,6 +177,9 @@ func (o *CloudControllerManagerOptions) ApplyTo(
 		return err
 	}
 	if err = o.NodeIPAMController.ApplyTo(&c.NodeIPAMControllerConfig); err != nil {
+		return err
+	}
+	if err = o.NodeController.ApplyTo(&c.ComponentConfig.NodeController); err != nil {
 		return err
 	}
 	if err = o.SecureServing.ApplyTo(&c.SecureServing, &c.LoopbackClientConfig); err != nil {
@@ -239,6 +247,7 @@ func (o *CloudControllerManagerOptions) Validate(allControllers, disabledByDefau
 	errors = append(errors, o.KubeCloudShared.Validate()...)
 	errors = append(errors, o.ServiceController.Validate()...)
 	errors = append(errors, o.NodeIPAMController.Validate()...)
+	errors = append(errors, o.NodeController.Validate()...)
 	errors = append(errors, o.SecureServing.Validate()...)
 	errors = append(errors, o.Authentication.Validate()...)
 	errors = append(errors, o.Authorization.Validate()...)

--- a/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/cmd/cloud-controller-manager/app/options/options_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	cpconfig "k8s.io/cloud-provider/config"
+	nodeconfig "k8s.io/cloud-provider/controllers/node/config"
 	serviceconfig "k8s.io/cloud-provider/controllers/service/config"
 	"k8s.io/cloud-provider/names"
 	cpoptions "k8s.io/cloud-provider/options"
@@ -99,6 +100,11 @@ func TestDefaultFlags(t *testing.T) {
 		NodeIPAMController: &NodeIPAMControllerOptions{
 			NodeIPAMControllerConfiguration: &config.NodeIPAMControllerConfiguration{
 				NodeCIDRMaskSize: consts.DefaultNodeCIDRMaskSize,
+			},
+		},
+		NodeController: &cpoptions.NodeControllerOptions{
+			NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{
+				ConcurrentNodeSyncs: int32(1),
 			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{
@@ -244,6 +250,11 @@ func TestAddFlags(t *testing.T) {
 		NodeIPAMController: &NodeIPAMControllerOptions{
 			NodeIPAMControllerConfiguration: &config.NodeIPAMControllerConfiguration{
 				NodeCIDRMaskSize: consts.DefaultNodeCIDRMaskSize,
+			},
+		},
+		NodeController: &cpoptions.NodeControllerOptions{
+			NodeControllerConfiguration: &nodeconfig.NodeControllerConfiguration{
+				ConcurrentNodeSyncs: int32(1),
 			},
 		},
 		SecureServing: (&apiserveroptions.SecureServingOptions{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

##### Overview
In `v1.26`, the `cloud-node-controller` was running its reconciliation logic in the `cloud-controller-manager`, but in `v1.27` and `v1.28` the it wasn't. When running `v1.26` of the `cloud-controller-manager` in our cluster, we observed that the `spec.ProviderID` field of nodes was populated, but not when running `v1.27` OR `v1.28`. In addition, we observed NO `Update` calls by the `cloud-controller-manager` in `v1.27` and `v1.28`. 

We realized that in `v1.26`, the `node-controller` was configured to run by default on `release-1.26`: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/47d04bebceda815d88821badf318ba6bd061e9f5/vendor/k8s.io/cloud-provider/controllers/node/node_controller.go#L181

but in `v1.27`:
https://github.com/kubernetes-sigs/cloud-provider-azure/blob/95a67a1597c85b1565855320c3a8603ece2677ce/vendor/k8s.io/cloud-provider/controllers/node/node_controller.go#L184-L188

and `v1.28`:
https://github.com/kubernetes-sigs/cloud-provider-azure/blob/492d2fb0c241cd0877d9f70c4ef97462f274e252/vendor/k8s.io/cloud-provider/controllers/node/node_controller.go#L188-L192

The `node-controller` would only run if the `workerCount` variable was configured.

The `workerCount` variable gets configured in the `NewCloudNodeController` function in `release-1.27`:

https://github.com/kubernetes-sigs/cloud-provider-azure/blob/95a67a1597c85b1565855320c3a8603ece2677ce/vendor/k8s.io/cloud-provider/controllers/node/node_controller.go#L113C6-L118

which is supposed to get configured via the command line argument `--concurrent-node-syncs` CLI flag:
https://github.com/kubernetes-sigs/cloud-provider-azure/blob/be9e1821ee4fec885264eb256192a2bc419efbe4/cmd/cloud-controller-manager/app/core.go#L54

In `release-1.27` and `release-1.28`, this CLI flag is not provided:
https://github.com/kubernetes-sigs/cloud-provider-azure/blob/release-1.27/cmd/cloud-controller-manager/app/options/options.go#L134-L155


##### Justification
The `cloud-node-controller` configuration was removed from `v1.27` and `v1.28` of the `cloud-controller-manager`, thereby preventing the controller from being run. It seems like `node-controller` should be run as part of the `cloud-node-manager` instead of `cloud-controller-manager`. Based on this [issue](https://github.com/kubernetes-sigs/cloud-provider-azure/issues/1700), we understand that the reason behind this change is due to throttling by the cloud-provider, but in `v1.26` and prior to the `cloud-controller-manager`, we did not encounter issues with cloud provider limits on `Azure` when the `node-controller` ran in the `kube-controller-manager`. In addition, if a user does not want to run the `node-controller` as part of the `cloud-controller-manager` they can simply exclude it from the list of controllers by doing `-cloud-node-controller` and can deploy the `cloud-node-manager`.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/cloud-provider-azure/issues/1700

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Runs the cloud-node-controller if it is included as part of the list of controllers in the cloud-controller-manager.
```