### PR TITLE
[release-1.28] fix: ignore Windows 2019 in ensureVMSSInPool for IPv6 backend pools only

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -125,6 +125,7 @@ const (
 	// Microsoft.Compute/galleries/AKSWindows gallery
 	VmssWindows2019ImageGalleryName = "windows-2019-containerd"
 	// Windows2019OSBuildVersion is the official build version of Windows Server 2019
+	// https://learn.microsoft.com/en-us/windows-server/get-started/windows-server-release-info
 	Windows2019OSBuildVersion = "17763"
 
 	// TagsDelimiter is the delimiter of tags

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -121,6 +121,11 @@ const (
 	VMSetCIDRIPV4TagKey = "kubernetesNodeCIDRMaskIPV4"
 	// VMSetCIDRIPV6TagKey specifies the node ipv6 CIDR mask of the instances on the VMSS or VMAS
 	VMSetCIDRIPV6TagKey = "kubernetesNodeCIDRMaskIPV6"
+	// VmssWindows2019ImageGalleryName is the name of Windows 2019 images from the
+	// Microsoft.Compute/galleries/AKSWindows gallery
+	VmssWindows2019ImageGalleryName = "windows-2019-containerd"
+	// Windows2019OSBuildVersion is the official build version of Windows Server 2019
+	Windows2019OSBuildVersion = "17763"
 
 	// TagsDelimiter is the delimiter of tags
 	TagsDelimiter = ","

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1374,7 +1374,7 @@ func isWindows2019(vmss *compute.VirtualMachineScaleSet) bool {
 	if storageProfile.ImageReference == nil || storageProfile.ImageReference.ID == nil {
 		return false
 	}
-	// example: /subscriptions/109a5e88-712a-48ae-9078-9ca8b3c81345/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516
+	// example: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516
 	imageRef := *storageProfile.ImageReference.ID
 	parts := strings.Split(imageRef, "/")
 	if len(parts) < 4 {

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1272,6 +1272,14 @@ func (ss *ScaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 			klog.V(4).Infof("EnsureHostInPool: cannot obtain the primary network interface configuration of vmss %s", vmssName)
 			continue
 		}
+
+		// It is possible to run Windows 2019 nodes in IPv4-only mode in a dual-stack cluster. IPv6 is not supported on
+		// Windows 2019 nodes and therefore does not need to be added to the IPv6 backend pool.
+		if isWindows2019(vmss) && isBackendPoolIPv6(backendPoolID) {
+			klog.V(3).Infof("ensureVMSSInPool: vmss %s is Windows 2019, skipping adding to IPv6 backend pool", vmssName)
+			continue
+		}
+
 		vmssNIC := *vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
 		primaryNIC, err := getPrimaryNetworkInterfaceConfiguration(vmssNIC, vmssName)
 		if err != nil {
@@ -1345,6 +1353,46 @@ func (ss *ScaleSet) ensureVMSSInPool(service *v1.Service, nodes []*v1.Node, back
 		}
 	}
 	return nil
+}
+
+// isWindows2019 checks if the ImageReference on the VMSS matches a Windows Server 2019 image.
+func isWindows2019(vmss *compute.VirtualMachineScaleSet) bool {
+	if vmss == nil {
+		return false
+	}
+
+	if vmss.VirtualMachineProfile == nil || vmss.VirtualMachineProfile.StorageProfile == nil {
+		return false
+	}
+
+	storageProfile := vmss.VirtualMachineProfile.StorageProfile
+
+	if storageProfile.OsDisk == nil || storageProfile.OsDisk.OsType != compute.OperatingSystemTypesWindows {
+		return false
+	}
+
+	if storageProfile.ImageReference == nil || storageProfile.ImageReference.ID == nil {
+		return false
+	}
+	// example: /subscriptions/109a5e88-712a-48ae-9078-9ca8b3c81345/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516
+	imageRef := *storageProfile.ImageReference.ID
+	parts := strings.Split(imageRef, "/")
+	if len(parts) < 4 {
+		return false
+	}
+
+	imageName := parts[len(parts)-3]
+	if !strings.EqualFold(imageName, consts.VmssWindows2019ImageGalleryName) {
+		return false
+	}
+
+	osVersion := strings.Split(parts[len(parts)-1], ".")
+	if len(osVersion) != 3 {
+		return false
+	}
+	// Windows Server 2019 is build number 17763
+	// https://learn.microsoft.com/en-us/windows-server/get-started/windows-server-release-info
+	return osVersion[0] == consts.Windows2019OSBuildVersion
 }
 
 func (ss *ScaleSet) ensureHostsInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetNameOfLB string) error {

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -2335,6 +2335,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 		vmSetName             string
 		clusterIP             string
 		nodes                 []*v1.Node
+		mutate                func(compute.VirtualMachineScaleSet)
 		isBasicLB             bool
 		isVMSSDeallocating    bool
 		isVMSSNilNICConfig    bool
@@ -2438,6 +2439,110 @@ func TestEnsureVMSSInPool(t *testing.T) {
 			expectedErr:     fmt.Errorf("failed to find a primary IP configuration (IPv6=true) for the VMSS VM or VMSS \"vmss\""),
 		},
 		{
+			description: "ensureVMSSInPool should skip Windows 2019 VM for IPv6 backend pool",
+			nodes: []*v1.Node{
+				{
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			isBasicLB:       false,
+			backendPoolID:   testLBBackendpoolID1 + "-" + consts.IPVersionIPv6String,
+			clusterIP:       "fd00::e68b",
+			expectedPutVMSS: false,
+			setIPv6Config:   false,
+			expectedErr:     nil,
+			mutate: func(vmss compute.VirtualMachineScaleSet) {
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
+					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
+						OsType: compute.OperatingSystemTypesWindows,
+					},
+					ImageReference: &compute.ImageReference{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516"),
+					},
+				}
+			},
+		},
+		{
+			description: "ensureVMSSInPool should add Windows2019 VM to IPv4 backend pool even if service is IPv6",
+			nodes: []*v1.Node{
+				{
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			isBasicLB:       false,
+			backendPoolID:   testLBBackendpoolID1,
+			clusterIP:       "fd00::e68b",
+			expectedPutVMSS: true,
+			setIPv6Config:   false,
+			expectedErr:     nil,
+			mutate: func(vmss compute.VirtualMachineScaleSet) {
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
+					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
+						OsType: compute.OperatingSystemTypesWindows,
+					},
+					ImageReference: &compute.ImageReference{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516"),
+					},
+				}
+			},
+		},
+		{
+			description: "ensureVMSSInPool should add Windows 2022 VM to IPv6 backend pool",
+			nodes: []*v1.Node{
+				{
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			isBasicLB:       false,
+			backendPoolID:   testLBBackendpoolID1 + "-" + consts.IPVersionIPv6String,
+			clusterIP:       "fd00::e68b",
+			expectedPutVMSS: true,
+			setIPv6Config:   true,
+			expectedErr:     nil,
+			mutate: func(vmss compute.VirtualMachineScaleSet) {
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
+					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
+						OsType: compute.OperatingSystemTypesWindows,
+					},
+					ImageReference: &compute.ImageReference{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2022-containerd/versions/20348.5820.240516"),
+					},
+				}
+			},
+		},
+		{
+			description: "ensureVMSSInPool should fail if no IPv6 network config - Windows 2022",
+			nodes: []*v1.Node{
+				{
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			isBasicLB:       false,
+			backendPoolID:   testLBBackendpoolID1 + "-" + consts.IPVersionIPv6String,
+			clusterIP:       "fd00::e68b",
+			expectedPutVMSS: false,
+			setIPv6Config:   false,
+			expectedErr:     fmt.Errorf("failed to find a primary IP configuration (IPv6=true) for the VMSS VM or VMSS \"vmss\""),
+			mutate: func(vmss compute.VirtualMachineScaleSet) {
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
+					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
+						OsType: compute.OperatingSystemTypesWindows,
+					},
+					ImageReference: &compute.ImageReference{
+						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2022-containerd/versions/20348.5820.240516"),
+					},
+				}
+			},
+		},
+		{
 			description: "ensureVMSSInPool should update the VMSS correctly for IPv6",
 			nodes: []*v1.Node{
 				{
@@ -2522,6 +2627,9 @@ func TestEnsureVMSSInPool(t *testing.T) {
 			}
 
 			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, test.setIPv6Config)
+			if test.mutate != nil {
+				test.mutate(expectedVMSS)
+			}
 			if test.isVMSSDeallocating {
 				expectedVMSS.ProvisioningState = pointer.String(consts.ProvisionStateDeleting)
 			}

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -58,6 +58,42 @@ const (
 	testLBBackendpoolID2   = "/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-2"
 )
 
+// helper enum for setting the OS variant
+// of the VMSS image ref.
+type osVersion int
+
+const (
+	unspecified osVersion = iota
+	windows2019
+	windows2022
+	ubuntu
+)
+
+func buildTestOSSpecificVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, os osVersion, ipv6 bool) compute.VirtualMachineScaleSet {
+	vmss := buildTestVMSSWithLB(name, namePrefix, lbBackendpoolIDs, ipv6)
+	switch os {
+	case windows2019:
+		vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
+			OsDisk: &compute.VirtualMachineScaleSetOSDisk{
+				OsType: compute.OperatingSystemTypesWindows,
+			},
+			ImageReference: &compute.ImageReference{
+				ID: pointer.String("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516"),
+			},
+		}
+	case windows2022:
+		vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
+			OsDisk: &compute.VirtualMachineScaleSetOSDisk{
+				OsType: compute.OperatingSystemTypesWindows,
+			},
+			ImageReference: &compute.ImageReference{
+				ID: pointer.String("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2022-containerd/versions/20348.5820.240516"),
+			},
+		}
+	}
+	return vmss
+}
+
 func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv6 bool) compute.VirtualMachineScaleSet {
 	lbBackendpoolsV4, lbBackendpoolsV6 := make([]compute.SubResource, 0), make([]compute.SubResource, 0)
 	for _, id := range lbBackendpoolIDs {
@@ -2335,7 +2371,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 		vmSetName             string
 		clusterIP             string
 		nodes                 []*v1.Node
-		mutate                func(compute.VirtualMachineScaleSet)
+		os                    osVersion
 		isBasicLB             bool
 		isVMSSDeallocating    bool
 		isVMSSNilNICConfig    bool
@@ -2448,21 +2484,12 @@ func TestEnsureVMSSInPool(t *testing.T) {
 				},
 			},
 			isBasicLB:       false,
-			backendPoolID:   testLBBackendpoolID1 + "-" + consts.IPVersionIPv6String,
+			backendPoolID:   testLBBackendpoolID1 + "-" + "IPv6",
 			clusterIP:       "fd00::e68b",
 			expectedPutVMSS: false,
 			setIPv6Config:   false,
 			expectedErr:     nil,
-			mutate: func(vmss compute.VirtualMachineScaleSet) {
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
-					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
-						OsType: compute.OperatingSystemTypesWindows,
-					},
-					ImageReference: &compute.ImageReference{
-						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516"),
-					},
-				}
-			},
+			os:              windows2019,
 		},
 		{
 			description: "ensureVMSSInPool should add Windows2019 VM to IPv4 backend pool even if service is IPv6",
@@ -2479,16 +2506,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 			expectedPutVMSS: true,
 			setIPv6Config:   false,
 			expectedErr:     nil,
-			mutate: func(vmss compute.VirtualMachineScaleSet) {
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
-					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
-						OsType: compute.OperatingSystemTypesWindows,
-					},
-					ImageReference: &compute.ImageReference{
-						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2019-containerd/versions/17763.5820.240516"),
-					},
-				}
-			},
+			os:              windows2019,
 		},
 		{
 			description: "ensureVMSSInPool should add Windows 2022 VM to IPv6 backend pool",
@@ -2500,21 +2518,12 @@ func TestEnsureVMSSInPool(t *testing.T) {
 				},
 			},
 			isBasicLB:       false,
-			backendPoolID:   testLBBackendpoolID1 + "-" + consts.IPVersionIPv6String,
+			backendPoolID:   testLBBackendpoolID1 + "-" + "IPv6",
 			clusterIP:       "fd00::e68b",
 			expectedPutVMSS: true,
 			setIPv6Config:   true,
 			expectedErr:     nil,
-			mutate: func(vmss compute.VirtualMachineScaleSet) {
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
-					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
-						OsType: compute.OperatingSystemTypesWindows,
-					},
-					ImageReference: &compute.ImageReference{
-						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2022-containerd/versions/20348.5820.240516"),
-					},
-				}
-			},
+			os:              windows2022,
 		},
 		{
 			description: "ensureVMSSInPool should fail if no IPv6 network config - Windows 2022",
@@ -2526,21 +2535,12 @@ func TestEnsureVMSSInPool(t *testing.T) {
 				},
 			},
 			isBasicLB:       false,
-			backendPoolID:   testLBBackendpoolID1 + "-" + consts.IPVersionIPv6String,
+			backendPoolID:   testLBBackendpoolID1 + "-" + "IPv6",
 			clusterIP:       "fd00::e68b",
 			expectedPutVMSS: false,
 			setIPv6Config:   false,
 			expectedErr:     fmt.Errorf("failed to find a primary IP configuration (IPv6=true) for the VMSS VM or VMSS \"vmss\""),
-			mutate: func(vmss compute.VirtualMachineScaleSet) {
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile = &compute.VirtualMachineScaleSetStorageProfile{
-					OsDisk: &compute.VirtualMachineScaleSetOSDisk{
-						OsType: compute.OperatingSystemTypesWindows,
-					},
-					ImageReference: &compute.ImageReference{
-						ID: ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/AKS-Windows/providers/Microsoft.Compute/galleries/AKSWindows/images/windows-2022-containerd/versions/20348.5820.240516"),
-					},
-				}
-			},
+			os:              windows2022,
 		},
 		{
 			description: "ensureVMSSInPool should update the VMSS correctly for IPv6",
@@ -2626,10 +2626,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 				ss.LoadBalancerSku = consts.LoadBalancerSkuStandard
 			}
 
-			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, test.setIPv6Config)
-			if test.mutate != nil {
-				test.mutate(expectedVMSS)
-			}
+			expectedVMSS := buildTestOSSpecificVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, test.os, test.setIPv6Config)
 			if test.isVMSSDeallocating {
 				expectedVMSS.ProvisioningState = pointer.String(consts.ProvisionStateDeleting)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

doesn't try to add Windows  2019 VMSS to IPv6 backend pools because 2019 will never support IPv6 so it shouldn't be added.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6315 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This only affects 1P, internal-to-Microsoft, customers. Windows 2019 with dual-stack is not possible otherwise.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
