### PR TITLE
[release-1.27] Support workload identity in e2e test

### DIFF
--- a/tests/e2e/utils/container_registry_utils.go
+++ b/tests/e2e/utils/container_registry_utils.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 
 	acr "github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry"
@@ -146,11 +148,30 @@ func AZACRLogin(acrName string) (err error) {
 	}
 
 	Logf("Attempting az login with azure cred.")
-	//nolint:gosec // G204 ignore this!
-	cmd := exec.Command("az", "login", "--service-principal",
+	authFlags := []string{
 		"--username", authConfig.AADClientID,
 		"--password", authConfig.AADClientSecret,
-		"--tenant", authConfig.TenantID)
+	}
+	if authConfig.UseFederatedWorkloadIdentityExtension {
+		tokenFile, err := os.Open(authConfig.AADFederatedTokenFile)
+		if err != nil {
+			return err
+		}
+		token, err := io.ReadAll(tokenFile)
+		if err != nil {
+			return err
+		}
+		authFlags = []string{
+			"--username", authConfig.AADClientID,
+			"--federated-token", string(token),
+		}
+	}
+	args := []string{
+		"login", "--service-principal",
+		"--tenant", authConfig.TenantID,
+	}
+	//nolint:gosec // G204 ignore this!
+	cmd := exec.Command("az", append(args, authFlags...)...)
 	if err = cmd.Run(); err != nil {
 		return fmt.Errorf("az failed to login with error: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR 
1. modifies an `az login` command invoked from the e2e tests to use a federated token when available instead of always trying to use a service principal password.
2. support workload identity in e2e test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
