### PR TITLE
fix: subnet update issue when vnetResourceGroup is specified

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2324,7 +2324,7 @@ func (az *Cloud) reconcileFrontendIPConfigs(clusterName string,
 			if subnetName == nil {
 				subnetName = &az.SubnetName
 			}
-			subnet, existsSubnet, err = az.getSubnet(az.VnetName, *subnetName)
+			subnet, existsSubnet, err = az.getSubnet("", az.VnetName, *subnetName)
 			if err != nil {
 				return nil, toDeleteConfigs, false, err
 			}

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -199,7 +199,7 @@ func (az *Cloud) disablePLSNetworkPolicy(service *v1.Service) error {
 		subnetName = &az.SubnetName
 	}
 
-	subnet, existsSubnet, err := az.getSubnet(az.VnetName, *subnetName)
+	subnet, existsSubnet, err := az.getSubnet("", az.VnetName, *subnetName)
 	if err != nil {
 		return err
 	}
@@ -352,7 +352,7 @@ func (az *Cloud) reconcilePLSIpConfigs(
 	if subnetName == nil {
 		subnetName = &az.SubnetName
 	}
-	subnet, existsSubnet, err := az.getSubnet(az.VnetName, *subnetName)
+	subnet, existsSubnet, err := az.getSubnet("", az.VnetName, *subnetName)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -604,7 +604,7 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 func (az *Cloud) createPrivateEndpoint(ctx context.Context, accountName string, accountID *string, privateEndpointName, vnetResourceGroup, vnetName, subnetName, location string, storageType StorageType) error {
 	klog.V(2).Infof("Creating private endpoint(%s) for account (%s)", privateEndpointName, accountName)
 
-	subnet, _, err := az.getSubnet(vnetName, subnetName)
+	subnet, _, err := az.getSubnet(vnetResourceGroup, vnetName, subnetName)
 	if err != nil {
 		return err
 	}
@@ -614,6 +614,7 @@ func (az *Cloud) createPrivateEndpoint(ctx context.Context, accountName string, 
 		// Disable the private endpoint network policies before creating private endpoint
 		subnet.SubnetPropertiesFormat.PrivateEndpointNetworkPolicies = network.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled
 	}
+
 	if rerr := az.SubnetsClient.CreateOrUpdate(ctx, vnetResourceGroup, vnetName, subnetName, subnet); rerr != nil {
 		return rerr.Error()
 	}

--- a/pkg/provider/azure_subnet_repo.go
+++ b/pkg/provider/azure_subnet_repo.go
@@ -45,17 +45,18 @@ func (az *Cloud) CreateOrUpdateSubnet(service *v1.Service, subnet network.Subnet
 	return nil
 }
 
-func (az *Cloud) getSubnet(virtualNetworkName string, subnetName string) (network.Subnet, bool, error) {
-	var rg string
-	if len(az.VnetResourceGroup) > 0 {
-		rg = az.VnetResourceGroup
-	} else {
-		rg = az.ResourceGroup
+func (az *Cloud) getSubnet(vnetResourceGroup, virtualNetworkName, subnetName string) (network.Subnet, bool, error) {
+	if vnetResourceGroup == "" {
+		if len(az.VnetResourceGroup) > 0 {
+			vnetResourceGroup = az.VnetResourceGroup
+		} else {
+			vnetResourceGroup = az.ResourceGroup
+		}
 	}
 
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
-	subnet, err := az.SubnetsClient.Get(ctx, rg, virtualNetworkName, subnetName, "")
+	subnet, err := az.SubnetsClient.Get(ctx, vnetResourceGroup, virtualNetworkName, subnetName, "")
 	exists, rerr := checkResourceExistsFromError(err)
 	if rerr != nil {
 		return subnet, false, rerr.Error()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fix: subnet update issue when vnetResourceGroup is specified in azure file storage class

this PR adds a new parameter `vnetResourceGroup` into `getSubnet` func, if `vnetResourceGroup` is provided, then use it, otherwise use `vnetResourceGroup` from cloud provider config which keeps the same logic

<summary> related config and error msg </summary>
<details>

```
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    name: my-azurefile
  mountOptions:
  - dir_mode=0777
  - file_mode=0777
  - uid=0
  - gid=0
  - mfsymlinks
  - cache=strict
  - actimeo=30
  - nobrl
  parameters:
    networkEndpointType: privateEndpoint
    skuName: Premium_LRS
    subnetName: default
    vnetName: my-vnet  # this is the name of the private vnet created on step 3
    vnetResourceGroup: aks-ds-rg
  provisioner: file.csi.azure.com
  reclaimPolicy: Delete
  volumeBindingMode: Immediate
```

```
I0726 13:12:03.775852       1 utils.go:77] GRPC call: /csi.v1.Controller/CreateVolume
 
I0726 13:12:03.775883       1 utils.go:78] GRPC request: {"capacity_range":{"required_bytes":10737418240},"name":"pvc-9ac5081e-1483-4a9c-9915-e21ea222e53d","parameters":{"csi.storage.k8s.io/pv/name":"pvc-9ac5081e-1483-4a9c-9915-e21ea222e53d","csi.storage.k8s.io/pvc/name":"my-azurefile","csi.storage.k8s.io/pvc/namespace":"default","networkEndpointType":"privateEndpoint","skuName":"Premium_LRS","subnetName":"default","vnetName":"my-vnet","vnetResourceGroup":"aks-ds-rg"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["dir_mode=0777","file_mode=0777","uid=0","gid=0","mfsymlinks","cache=strict","actimeo=30","nobrl"]}},"access_mode":{"mode":5}}]}
 
I0726 13:12:04.313940       1 azure_storageaccount.go:413] azure - no matching account found, begin to create a new account yyy in resource group MC_aks-ds-rg_aks-test_australiacentral, location: australiacentral, accountType: Premium_LRS, accountKind: FileStorage, tags: map[k8s-azure-created-by:azure]
 
I0726 13:12:04.313999       1 azure_storageaccount.go:438] set AllowBlobPublicAccess(false) for storage account(yyy)
 
I0726 13:12:04.313940       1 azure_storageaccount.go:413] azure - no matching account found, begin to create a new account yyy in resource group MC_aks-ds-rg_aks-test_australiacentral, location: australiacentral, accountType: Premium_LRS, accountKind: FileStorage, tags: map[k8s-azure-created-by:azure]
 
I0726 13:12:04.313999       1 azure_storageaccount.go:438] set AllowBlobPublicAccess(false) for storage account(yyy)
 
I0726 13:12:30.176409       1 azure_storageaccount.go:583] Creating private endpoint(yyy-pvtendpoint) for account (yyy)
 
I0726 13:12:30.248922       1 azure_subnetclient.go:135] Received error in subnet.get.request: resourceID: /subscriptions/xxx/resourceGroups/MC_aks-ds-rg_aks-test_australiacentral/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/default, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: {"error":{"code":"ResourceNotFound","message":"The Resource 'Microsoft.Network/virtualNetworks/my-vnet' under resource group 'MC_aks-ds-rg_aks-test_australiacentral' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}}
 
I0726 13:12:30.249020       1 azure_subnet_repo.go:65] Subnet "default" not found
 
E0726 13:12:30.249040       1 azure_storageaccount.go:590] SubnetPropertiesFormat of (my-vnet, default) is nil
 
I0726 13:12:30.450263       1 azure_armclient.go:302] Received error in sendAsync.send: resourceID: http://localhost:7788/subscriptions/xxx/resourceGroups/aks-ds-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/default?api-version=2022-07-01, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
 
  "error": {
 
    "code": "AddressPrefixStringCannotBeNullOrEmpty",
 
    "message": "Address prefix string for resource /subscriptions/xxx/resourceGroups/aks-ds-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/default cannot be null or empty.",
 
    "details": []
 
  }
```

</details>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: subnet update issue when vnetResourceGroup is specified in azure file storage class
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: subnet update issue when vnetResourceGroup is specified in azure file storage class
```


/kind bug