### PR TITLE
[release-1.27] fix: Keep auth envs when building e2e azure clients

### DIFF
--- a/tests/e2e/auth/cred.go
+++ b/tests/e2e/auth/cred.go
@@ -70,13 +70,10 @@ var _ = Describe("Azure Credential Provider", Label(utils.TestSuiteLabelCredenti
 			}
 		}()
 
-		err = utils.DockerLogin(*registry.Name)
-		Expect(err).NotTo(HaveOccurred())
-
 		image := "nginx"
-		tag, err := utils.PushImageToACR(*registry.Name, image)
-		Expect(tag).NotTo(Equal(""))
+		tag, err := tc.PushImageToACR(*registry.Name, image)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(tag).NotTo(Equal(""))
 
 		acrImageURL := fmt.Sprintf("%s.azurecr.io/%s:%s", *registry.Name, image, tag)
 		podTemplate := createPodPullingFromACR(image, acrImageURL, "linux")
@@ -85,9 +82,6 @@ var _ = Describe("Azure Credential Provider", Label(utils.TestSuiteLabelCredenti
 
 		result, err := utils.WaitPodTo(v1.PodRunning, cs, podTemplate, ns.Name)
 		Expect(result).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
-
-		err = utils.DockerLogout()
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/tests/e2e/utils/azure_auth.go
+++ b/tests/e2e/utils/azure_auth.go
@@ -146,11 +146,9 @@ func azureAuthConfigFromTestProfile() (*AzureAuthConfig, error) {
 			c.UserAssignedIdentityID = managedIdentityClientIDEnv
 		}
 	} else if federatedTokenFileEnv != "" {
-		c = &AzureAuthConfig{
-			AADFederatedTokenFile:                 federatedTokenFileEnv,
-			UseFederatedWorkloadIdentityExtension: true,
-			AADClientID:                           aadClientIDEnv,
-		}
+		c.AADFederatedTokenFile = federatedTokenFileEnv
+		c.UseFederatedWorkloadIdentityExtension = true
+		c.AADClientID = aadClientIDEnv
 	} else {
 		return c, fmt.Errorf("failed to get Azure auth config from environment")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

/kind failing-test

fix: Keep auth envs when building e2e azure clients

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Partly https://github.com/kubernetes-sigs/cloud-provider-azure/issues/6577

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
