### PR TITLE
[release-1.28] fix: Keep auth envs when building e2e azure clients

### DIFF
--- a/tests/e2e/auth/cred.go
+++ b/tests/e2e/auth/cred.go
@@ -70,13 +70,10 @@ var _ = Describe("Azure Credential Provider", Label(utils.TestSuiteLabelCredenti
 			}
 		}()
 
-		err = utils.DockerLogin(*registry.Name)
-		Expect(err).NotTo(HaveOccurred())
-
 		image := "nginx"
-		tag, err := utils.PushImageToACR(*registry.Name, image)
-		Expect(tag).NotTo(Equal(""))
+		tag, err := tc.PushImageToACR(*registry.Name, image)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(tag).NotTo(Equal(""))
 
 		acrImageURL := fmt.Sprintf("%s.azurecr.io/%s:%s", *registry.Name, image, tag)
 		podTemplate := createPodPullingFromACR(image, acrImageURL, "linux")
@@ -85,9 +82,6 @@ var _ = Describe("Azure Credential Provider", Label(utils.TestSuiteLabelCredenti
 
 		result, err := utils.WaitPodTo(v1.PodRunning, cs, podTemplate, ns.Name)
 		Expect(result).To(BeTrue())
-		Expect(err).NotTo(HaveOccurred())
-
-		err = utils.DockerLogout()
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/tests/e2e/utils/azure_auth.go
+++ b/tests/e2e/utils/azure_auth.go
@@ -146,11 +146,9 @@ func azureAuthConfigFromTestProfile() (*AzureAuthConfig, error) {
 			c.UserAssignedIdentityID = managedIdentityClientIDEnv
 		}
 	} else if federatedTokenFileEnv != "" {
-		c = &AzureAuthConfig{
-			AADFederatedTokenFile:                 federatedTokenFileEnv,
-			UseFederatedWorkloadIdentityExtension: true,
-			AADClientID:                           aadClientIDEnv,
-		}
+		c.AADFederatedTokenFile = federatedTokenFileEnv
+		c.UseFederatedWorkloadIdentityExtension = true
+		c.AADClientID = aadClientIDEnv
 	} else {
 		return c, fmt.Errorf("failed to get Azure auth config from environment")
 	}

--- a/tests/e2e/utils/container_registry_utils.go
+++ b/tests/e2e/utils/container_registry_utils.go
@@ -72,70 +72,30 @@ func (tc *AzureTestClient) DeleteContainerRegistry(registryName string) (err err
 	return nil
 }
 
-// DockerLogin execute the `docker login` if docker is available
-func DockerLogin(registryName string) (err error) {
-	authConfig, err := azureAuthConfigFromTestProfile()
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command("docker", "-v")
-	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("failed to execute docker command with error: %w", err)
-	}
-
-	Logf("Attempting Docker login with azure cred.")
-	arg0 := "--username=" + authConfig.AADClientID
-	arg1 := "--password=" + authConfig.AADClientSecret
-	cmd = exec.Command("docker",
-		"login",
-		arg0,
-		arg1,
-		registryName+".azurecr.io")
-	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("docker failed to login with error: %w", err)
-	}
-	Logf("Docker login success.")
-	return nil
-}
-
-// DockerLogout execute the `docker logout` if docker is available
-func DockerLogout() (err error) {
-	Logf("Docker logout.")
-	cmd := exec.Command("docker", "logout")
-	return cmd.Run()
-}
-
 // PushImageToACR pull an image from MCR and push
 // it to the given azure container registry
-func PushImageToACR(registryName, image string) (tag string, err error) {
-	Logf("Pulling %s from MCR.", image)
-	imageNameMapToMCR := map[string]string{
-		"nginx": "mcr.microsoft.com/mirror/docker/library/nginx:1.25",
-	}
-	mcrImage := imageNameMapToMCR[image]
+func (tc *AzureTestClient) PushImageToACR(registryName, image string) (tag string, err error) {
+	acrClient := tc.createACRClient()
+	rgName := tc.GetResourceGroup()
 
-	cmd := exec.Command("docker", "pull", mcrImage)
-	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed pulling %s with error: %w", image, err)
+	tag = "1.25"
+	future, err := acrClient.ImportImage(context.Background(), rgName, registryName, acr.ImportImageParameters{
+		Source: &acr.ImportSource{
+			RegistryURI: pointer.String("mcr.microsoft.com"),
+			SourceImage: pointer.String("mirror/docker/library/" + image + ":" + tag),
+		},
+		TargetTags: &[]string{
+			image + ":" + tag,
+		},
+		Mode: acr.NoForce,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to import image %s from mcr to acr %s with error: %w", image, registryName, err)
 	}
-
-	Logf("Tagging image.")
-	tagSuffix := string(uuid.NewUUID())[0:4]
-	registry := fmt.Sprintf("%s.azurecr.io/%s:e2e-%s", registryName, image, tagSuffix)
-	cmd = exec.Command("docker", "tag", mcrImage, registry)
-	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed tagging nginx image with error: %w", err)
+	err = future.WaitForCompletionRef(context.Background(), acrClient.Client)
+	if err != nil {
+		return "", fmt.Errorf("failed to import image %s from mcr to acr %s with error: %w", image, registryName, err)
 	}
-
-	Logf("Pushing image to ACR.")
-	cmd = exec.Command("docker", "push", registry)
-	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed pushing %s image to registry %s with error: %w", image, registryName, err)
-	}
-
-	Logf("Pushing image success.")
-	tag = fmt.Sprintf("e2e-%s", tagSuffix)
 	return tag, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

/kind failing-test

fix: Keep auth envs when building e2e azure clients

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Partly https://github.com/kubernetes-sigs/cloud-provider-azure/issues/6577

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
