### PR TITLE
[release-1.28] Fix: Crash on enforcement failure of clustercidr on existing nodes

### DIFF
--- a/pkg/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/nodeipam/ipam/range_allocator_test.go
@@ -182,9 +182,8 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			expectedAllocatedCIDR: nil,
 			ctrlCreateFail:        false,
 		},
-		// failure cases
 		{
-			description: "fail, single stack incorrect node allocation",
+			description: "success, single stack incorrect node allocation",
 			fakeNodeHandler: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
@@ -209,39 +208,10 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatedCIDRs:        nil,
 			expectedAllocatedCIDR: nil,
-			ctrlCreateFail:        true,
+			ctrlCreateFail:        false,
 		},
 		{
-			description: "fail, dualstack node allocating from non existing cidr",
-
-			fakeNodeHandler: &testutil.FakeNodeHandler{
-				Existing: []*v1.Node{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "node0",
-						},
-						Spec: v1.NodeSpec{
-							PodCIDRs: []string{"10.10.0.1/24", "a00::/86"},
-						},
-					},
-				},
-				Clientset: fake.NewSimpleClientset(),
-			},
-			allocatorParams: CIDRAllocatorParams{
-				ClusterCIDRs: func() []*net.IPNet {
-					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
-					return []*net.IPNet{clusterCIDRv4}
-				}(),
-				ServiceCIDR:          nil,
-				SecondaryServiceCIDR: nil,
-				NodeCIDRMaskSizes:    []int{24},
-			},
-			allocatedCIDRs:        nil,
-			expectedAllocatedCIDR: nil,
-			ctrlCreateFail:        true,
-		},
-		{
-			description: "fail, dualstack node allocating bad v4",
+			description: "success, dualstack node allocating bad v4",
 
 			fakeNodeHandler: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
@@ -268,10 +238,10 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 			},
 			allocatedCIDRs:        nil,
 			expectedAllocatedCIDR: nil,
-			ctrlCreateFail:        true,
+			ctrlCreateFail:        false,
 		},
 		{
-			description: "fail, dualstack node allocating bad v6",
+			description: "success, dualstack node allocating bad v6",
 
 			fakeNodeHandler: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
@@ -280,7 +250,7 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 							Name: "node0",
 						},
 						Spec: v1.NodeSpec{
-							PodCIDRs: []string{"10.10.0.1/24", "cdd::/86"},
+							PodCIDRs: []string{"10.10.0.1/24", "a00::/86"},
 						},
 					},
 				},
@@ -295,6 +265,35 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 				ServiceCIDR:          nil,
 				SecondaryServiceCIDR: nil,
 				NodeCIDRMaskSizes:    []int{24, 24},
+			},
+			allocatedCIDRs:        nil,
+			expectedAllocatedCIDR: nil,
+			ctrlCreateFail:        false,
+		},
+		{
+			description: "fail, dualstack node allocating from non existing cidr",
+
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node0",
+						},
+						Spec: v1.NodeSpec{
+							PodCIDRs: []string{"10.10.0.1/24", "a00::/86"},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(),
+			},
+			allocatorParams: CIDRAllocatorParams{
+				ClusterCIDRs: func() []*net.IPNet {
+					_, clusterCIDRv4, _ := net.ParseCIDR("10.10.0.0/16")
+					return []*net.IPNet{clusterCIDRv4}
+				}(),
+				ServiceCIDR:          nil,
+				SecondaryServiceCIDR: nil,
+				NodeCIDRMaskSizes:    []int{24},
 			},
 			allocatedCIDRs:        nil,
 			expectedAllocatedCIDR: nil,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
This PR fixes a crash that is caused when custercidr is mismatched with nodecidrs.
When the cloud-controller manager detects a mismatch between the clustercidr provided to it via argument and node.spec.podcidrs of existing nodes, it assumes this is a fatal condition and halts its execution and crash. This mismatch is not a fatal condition, controller manager should tolerate this mismatch and keep trying to reconcile instead of crashing. The side-effect of crashing is that when a new node joins the cluster, its not able to get the new podcidr from controller manager because its been crashing. If controller-manager tolerates this mismatch, we can have old nodes running old podcidr and new nodes running new podcidr and that's a perfectly ok condition to be in. In fact when a user wants to live migrate a running cluster from one podcidr to another, it will run thru this exact scenario and get blocked if this issue is not fixed.

 
#### Which issue(s) this PR fixes:
Fixes #6670

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
