### PR TITLE
Revert "fix: support mulltiple subnet when creating private endpoints"

### DIFF
--- a/pkg/provider/azure_subnet_repo.go
+++ b/pkg/provider/azure_subnet_repo.go
@@ -17,8 +17,6 @@ limitations under the License.
 package provider
 
 import (
-	"context"
-
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -68,21 +66,4 @@ func (az *Cloud) getSubnet(vnetResourceGroup, virtualNetworkName, subnetName str
 		klog.V(2).Infof("Subnet %q not found", subnetName)
 	}
 	return subnet, exists, nil
-}
-
-func (az *Cloud) listSubnet(ctx context.Context, vnetResourceGroup, virtualNetworkName string) ([]network.Subnet, error) {
-	if vnetResourceGroup == "" {
-		if len(az.VnetResourceGroup) > 0 {
-			vnetResourceGroup = az.VnetResourceGroup
-		} else {
-			vnetResourceGroup = az.ResourceGroup
-		}
-	}
-
-	subnets, rerr := az.SubnetsClient.List(ctx, vnetResourceGroup, virtualNetworkName)
-	if rerr != nil {
-		return subnets, rerr.Error()
-	}
-
-	return subnets, nil
 }


### PR DESCRIPTION
Reverts kubernetes-sigs/cloud-provider-azure#6783

https://learn.microsoft.com/en-us/azure/private-link/private-link-faq#can-we-link-multiple-private-dns-zones-with-the-same-name--

Do I require a dedicated subnet for Private Endpoints?
No. You don't require a dedicated subnet for Private Endpoints. You can choose a Private Endpoint IP from any subnet from the VNet where your service is deployed.