### PR TITLE
Add support for JSON-formatted logging

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -83,6 +83,8 @@ func NewCloudControllerManagerCommand() *cobra.Command {
 		Use:  "cloud-controller-manager",
 		Long: `The Cloud controller manager is a daemon that embeds the cloud specific control loops shipped with Kubernetes.`,
 		Run: func(cmd *cobra.Command, _ []string) {
+			log.Setup(log.OptionsFromCLIFlags(cmd.Flags()))
+			defer log.Flush()
 			verflag.PrintAndExitIfRequested("Cloud Provider Azure")
 			cliflag.PrintFlags(cmd.Flags())
 
@@ -202,6 +204,8 @@ func NewCloudControllerManagerCommand() *cobra.Command {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
 		cliflag.PrintSections(cmd.OutOrStdout(), namedFlagSets, cols)
 	})
+
+	log.BindCLIFlags(fs)
 
 	return cmd
 }

--- a/cmd/cloud-controller-manager/controller-manager.go
+++ b/cmd/cloud-controller-manager/controller-manager.go
@@ -24,24 +24,18 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugins
 
 	"sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app"
+	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	_ "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(time.Now().UnixNano()) // FIXME: should use crypto/rand for better randomness
+	defer log.Flush()
 
 	command := app.NewCloudControllerManagerCommand()
-
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	// utilflag.InitFlags()
-	logs.InitLogs()
-	defer logs.FlushLogs()
 
 	if err := command.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/log/flag.go
+++ b/pkg/log/flag.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+type Format string
+
+const (
+	JSON Format = "json"
+	Text Format = "text"
+)
+
+const (
+	flagLogFormat         = "log-format"
+	flagLogFlushFrequency = "log-flush-frequency"
+
+	DefaultFormat         = Text
+	DefaultFlushFrequency = 5 * time.Second
+)
+
+func BindCLIFlags(fs *pflag.FlagSet) {
+	fs.String(flagLogFormat, "text", "The log format to use. One of: text, json.")
+	// log-flush-frequency is registered in kubernetes component-base.
+}
+
+type Options struct {
+	Format         Format
+	FlushFrequency time.Duration
+}
+
+func OptionsFromCLIFlags(fs *pflag.FlagSet) *Options {
+	var o Options
+
+	o.Format = Format(fs.Lookup(flagLogFormat).Value.String())
+	if o.Format != JSON && o.Format != Text {
+		SetupError("Invalid log format", flagLogFormat, o.Format)
+		o.Format = DefaultFormat
+	}
+
+	freq, err := fs.GetDuration(flagLogFlushFrequency)
+	if err != nil {
+		SetupError("Invalid log flush frequency", flagLogFlushFrequency, err)
+		o.FlushFrequency = DefaultFlushFrequency
+	}
+	o.FlushFrequency = freq
+
+	return &o
+}

--- a/pkg/log/slog.go
+++ b/pkg/log/slog.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"context"
+	"io"
+	"log/slog"
+)
+
+const (
+	TimeKey      = slog.TimeKey
+	LevelKey     = slog.LevelKey
+	VerbosityKey = "v"
+)
+
+type SLogJSONHandler struct {
+	handler *slog.JSONHandler
+}
+
+func NewJSONHandler(w io.Writer, opts *slog.HandlerOptions) *SLogJSONHandler {
+	return &SLogJSONHandler{
+		handler: slog.NewJSONHandler(w, opts),
+	}
+}
+
+func (h *SLogJSONHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+func (h *SLogJSONHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Extract verbosity from negative log levels and set it as an attribute.
+	// This is necessary because slog will convert negative levels to DEBUG+N.
+	if record.Level < 0 {
+		verbosity := int(-record.Level)
+		record.Level = slog.LevelInfo
+		record.AddAttrs(slog.Int(VerbosityKey, verbosity))
+	} else {
+		record.AddAttrs(slog.Int(VerbosityKey, 0))
+	}
+
+	return h.handler.Handle(ctx, record)
+}
+
+func (h *SLogJSONHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h.handler.WithAttrs(attrs)
+}
+
+func (h *SLogJSONHandler) WithGroup(name string) slog.Handler {
+	return h.handler.WithGroup(name)
+}

--- a/pkg/log/std.go
+++ b/pkg/log/std.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"log/slog"
+)
+
+func SetupError(msg string, args ...any) {
+	slog.Error(msg, args...)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

It adds a CLI flag `--log-format` to cloud-controller-manager, which supports a new logging format JSON. When --log-format=json is set, the loggers of both klog and slog will print log messages as JSON. Structured logging is easier to query and filter.

**NOTE**
1. The verbosity of `klog.V(N)` will be attached to the log key-value with the name `v`, as in `{"level":"info", "msg":"foo", "v":"5"}`. But logs with `level=error` always have a verbosity of 0.
2. slog will be used as the klog backend iff JSON is enabled.
3. Plain text remains the default log format if not set.

**Sample Output**

```
{"level":"INFO","source":{"function":"sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app.startControllers","file":"/go/src/sigs.k8s.io/cloud-provider-azure/cmd/cloud-controller-manager/app/controllermanager.go","line":447},"msg":"startControllers: starting shared informers","v":2}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).Run","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":305},"msg":"Starting reflector *v1.EndpointSlice (21h2m54.929090295s) from k8s.io/client-go/informers/factory.go:160","v":3}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":341},"msg":"Listing and watching *v1.EndpointSlice from k8s.io/client-go/informers/factory.go:160","v":3}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).Run","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":305},"msg":"Starting reflector *v1.Service (30s) from k8s.io/client-go/informers/factory.go:160","v":3}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":341},"msg":"Listing and watching *v1.Service from k8s.io/client-go/informers/factory.go:160","v":3}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).Run","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":305},"msg":"Starting reflector *v1.Node (1m40s) from k8s.io/client-go/informers/factory.go:160","v":3}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":341},"msg":"Listing and watching *v1.Node from k8s.io/client-go/informers/factory.go:160","v":3}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":368},"msg":"Caches populated for *v1.EndpointSlice from k8s.io/client-go/informers/factory.go:160","v":2}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":368},"msg":"Caches populated for *v1.Service from k8s.io/client-go/informers/factory.go:160","v":2}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/reflector.go","line":368},"msg":"Caches populated for *v1.Node from k8s.io/client-go/informers/factory.go:160","v":2}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.WaitForNamedCacheSync","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/shared_informer.go","line":320},"msg":"Caches are synced for service","v":0}
{"level":"INFO","source":{"function":"k8s.io/cloud-provider/controllers/service.(*Controller).syncNodes","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/cloud-provider/controllers/service/controller.go","line":737},"msg":"Syncing backends for all LB services.","v":2}
{"level":"INFO","source":{"function":"k8s.io/cloud-provider/controllers/service.(*Controller).updateLoadBalancerHosts","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/cloud-provider/controllers/service/controller.go","line":816},"msg":"Running updateLoadBalancerHosts(len(services)==0, workers==1)","v":4}
{"level":"INFO","source":{"function":"k8s.io/cloud-provider/controllers/service.(*Controller).updateLoadBalancerHosts","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/cloud-provider/controllers/service/controller.go","line":832},"msg":"Finished updateLoadBalancerHosts","v":4}
{"level":"INFO","source":{"function":"k8s.io/cloud-provider/controllers/service.(*Controller).syncNodes","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/cloud-provider/controllers/service/controller.go","line":741},"msg":"Successfully updated 0 out of 0 load balancers to direct traffic to the updated set of nodes","v":2}
{"level":"INFO","source":{"function":"k8s.io/cloud-provider/controllers/service.(*Controller).syncNodes.func1","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/cloud-provider/controllers/service/controller.go","line":733},"msg":"It took 0.000240699 seconds to finish syncNodes","v":4}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.WaitForNamedCacheSync","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/shared_informer.go","line":320},"msg":"Caches are synced for route","v":0}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.WaitForNamedCacheSync","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/shared_informer.go","line":320},"msg":"Caches are synced for node","v":0}
{"level":"INFO","source":{"function":"sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/ipam.(*rangeAllocator).Run","file":"/go/src/sigs.k8s.io/cloud-provider-azure/pkg/nodeipam/ipam/range_allocator.go","line":177},"msg":"Starting range CIDR allocator","v":0}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.WaitForNamedCacheSync","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/shared_informer.go","line":313},"msg":"Waiting for caches to sync for cidrallocator","v":0}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/cache.WaitForNamedCacheSync","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/cache/shared_informer.go","line":320},"msg":"Caches are synced for cidrallocator","v":0}
{"level":"INFO","source":{"function":"k8s.io/cloud-provider/controllers/route.(*RouteController).reconcile","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/cloud-provider/controllers/route/route_controller.go","line":214},"msg":"action for Node \"aks-nodes-26761298-vmss000000\" with CIDR \"10.244.0.0/24\": \"keep\"","v":0}
{"level":"INFO","source":{"function":"k8s.io/cloud-provider/controllers/route.(*RouteController).updateNetworkingCondition","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/cloud-provider/controllers/route/route_controller.go","line":376},"msg":"set node aks-nodes-26761298-vmss000000 with NodeNetworkUnavailable=false was canceled because it is already set","v":2}
{"level":"INFO","source":{"function":"k8s.io/client-go/tools/leaderelection.(*LeaderElector).renew.func1","file":"/go/src/sigs.k8s.io/cloud-provider-azure/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go","line":293},"msg":"successfully renewed lease kube-system/cloud-controller-manager","v":5}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of #1575 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
