### PR TITLE
cleanup: fileshareclient parameter naming

### DIFF
--- a/pkg/azclient/fileshareclient/custom.go
+++ b/pkg/azclient/fileshareclient/custom.go
@@ -22,16 +22,16 @@ import (
 	armstorage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 )
 
-func (client *Client) Create(ctx context.Context, resourceGroupName string, resourceName string, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
-	resp, err := client.FileSharesClient.Create(ctx, resourceGroupName, resourceName, parentResourceName, resource, nil)
+func (client *Client) Create(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
+	resp, err := client.FileSharesClient.Create(ctx, resourceGroupName, accountName, shareName, resource, nil)
 	if err != nil {
 		return nil, err
 	}
 	return &resp.FileShare, nil
 }
 
-func (client *Client) Update(ctx context.Context, resourceGroupName string, resourceName string, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
-	resp, err := client.FileSharesClient.Update(ctx, resourceGroupName, resourceName, parentResourceName, resource, nil)
+func (client *Client) Update(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
+	resp, err := client.FileSharesClient.Update(ctx, resourceGroupName, accountName, shareName, resource, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (client *Client) Update(ctx context.Context, resourceGroupName string, reso
 }
 
 // Delete deletes a FileShare by name.
-func (client *Client) Delete(ctx context.Context, resourceGroupName string, parentResourceName string, resourceName string) error {
-	_, err := client.FileSharesClient.Delete(ctx, resourceGroupName, parentResourceName, resourceName, nil)
+func (client *Client) Delete(ctx context.Context, resourceGroupName, accountName, shareName string) error {
+	_, err := client.FileSharesClient.Delete(ctx, resourceGroupName, accountName, shareName, nil)
 	return err
 }

--- a/pkg/azclient/fileshareclient/interface.go
+++ b/pkg/azclient/fileshareclient/interface.go
@@ -28,7 +28,7 @@ import (
 // +azure:client:verbs=get,resource=Account,subResource=FileShare,packageName=github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage,packageAlias=armstorage,clientName=FileSharesClient,expand=false,crossSubFactory=true
 type Interface interface {
 	utils.SubResourceGetFunc[armstorage.FileShare]
-	Create(ctx context.Context, resourceGroupName string, resourceName string, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error)
-	Update(ctx context.Context, resourceGroupName string, resourceName string, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error)
-	Delete(ctx context.Context, resourceGroupName string, parentResourceName string, resourceName string) error
+	Create(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error)
+	Update(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error)
+	Delete(ctx context.Context, resourceGroupName, accountName, shareName string) error
 }

--- a/pkg/azclient/fileshareclient/mock_fileshareclient/interface.go
+++ b/pkg/azclient/fileshareclient/mock_fileshareclient/interface.go
@@ -61,18 +61,18 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockInterface) Create(ctx context.Context, resourceGroupName, resourceName, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
+func (m *MockInterface) Create(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, resourceGroupName, resourceName, parentResourceName, resource)
+	ret := m.ctrl.Call(m, "Create", ctx, resourceGroupName, accountName, shareName, resource)
 	ret0, _ := ret[0].(*armstorage.FileShare)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockInterfaceMockRecorder) Create(ctx, resourceGroupName, resourceName, parentResourceName, resource any) *MockInterfaceCreateCall {
+func (mr *MockInterfaceMockRecorder) Create(ctx, resourceGroupName, accountName, shareName, resource any) *MockInterfaceCreateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInterface)(nil).Create), ctx, resourceGroupName, resourceName, parentResourceName, resource)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInterface)(nil).Create), ctx, resourceGroupName, accountName, shareName, resource)
 	return &MockInterfaceCreateCall{Call: call}
 }
 
@@ -177,18 +177,18 @@ func (c *MockInterfaceGetCall) DoAndReturn(f func(context.Context, string, strin
 }
 
 // Update mocks base method.
-func (m *MockInterface) Update(ctx context.Context, resourceGroupName, resourceName, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
+func (m *MockInterface) Update(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, resourceGroupName, resourceName, parentResourceName, resource)
+	ret := m.ctrl.Call(m, "Update", ctx, resourceGroupName, accountName, shareName, resource)
 	ret0, _ := ret[0].(*armstorage.FileShare)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, resourceName, parentResourceName, resource any) *MockInterfaceUpdateCall {
+func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, accountName, shareName, resource any) *MockInterfaceUpdateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, resourceName, parentResourceName, resource)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, accountName, shareName, resource)
 	return &MockInterfaceUpdateCall{Call: call}
 }
 

--- a/pkg/azclient/fileshareclient/mock_fileshareclient/interface.go
+++ b/pkg/azclient/fileshareclient/mock_fileshareclient/interface.go
@@ -61,18 +61,18 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockInterface) Create(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
+func (m *MockInterface) Create(ctx context.Context, resourceGroupName, resourceName, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, resourceGroupName, accountName, shareName, resource)
+	ret := m.ctrl.Call(m, "Create", ctx, resourceGroupName, resourceName, parentResourceName, resource)
 	ret0, _ := ret[0].(*armstorage.FileShare)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockInterfaceMockRecorder) Create(ctx, resourceGroupName, accountName, shareName, resource any) *MockInterfaceCreateCall {
+func (mr *MockInterfaceMockRecorder) Create(ctx, resourceGroupName, resourceName, parentResourceName, resource any) *MockInterfaceCreateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInterface)(nil).Create), ctx, resourceGroupName, accountName, shareName, resource)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockInterface)(nil).Create), ctx, resourceGroupName, resourceName, parentResourceName, resource)
 	return &MockInterfaceCreateCall{Call: call}
 }
 
@@ -177,18 +177,18 @@ func (c *MockInterfaceGetCall) DoAndReturn(f func(context.Context, string, strin
 }
 
 // Update mocks base method.
-func (m *MockInterface) Update(ctx context.Context, resourceGroupName, accountName, shareName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
+func (m *MockInterface) Update(ctx context.Context, resourceGroupName, resourceName, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, resourceGroupName, accountName, shareName, resource)
+	ret := m.ctrl.Call(m, "Update", ctx, resourceGroupName, resourceName, parentResourceName, resource)
 	ret0, _ := ret[0].(*armstorage.FileShare)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, accountName, shareName, resource any) *MockInterfaceUpdateCall {
+func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, resourceName, parentResourceName, resource any) *MockInterfaceUpdateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, accountName, shareName, resource)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, resourceName, parentResourceName, resource)
 	return &MockInterfaceUpdateCall{Call: call}
 }
 

--- a/pkg/azclient/fileshareclient/zz_generated_client.go
+++ b/pkg/azclient/fileshareclient/zz_generated_client.go
@@ -56,13 +56,12 @@ func New(subscriptionID string, credential azcore.TokenCredential, options *arm.
 const GetOperationName = "FileSharesClient.Get"
 
 // Get gets the FileShare
-func (client *Client) Get(ctx context.Context, resourceGroupName string, parentResourceName string, resourceName string) (result *armstorage.FileShare, err error) {
-
+func (client *Client) Get(ctx context.Context, resourceGroupName, accountName, shareName string) (result *armstorage.FileShare, err error) {
 	metricsCtx := metrics.BeginARMRequest(client.subscriptionID, resourceGroupName, "FileShare", "get")
 	defer func() { metricsCtx.Observe(ctx, err) }()
 	ctx, endSpan := runtime.StartSpan(ctx, GetOperationName, client.tracer, nil)
 	defer endSpan(err)
-	resp, err := client.FileSharesClient.Get(ctx, resourceGroupName, parentResourceName, resourceName, nil)
+	resp, err := client.FileSharesClient.Get(ctx, resourceGroupName, accountName, shareName, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
cleanup: fileshareclient parameter naming, the right naming is `resourceGroupName, accountName, shareName string`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
