### PR TITLE
chore: integrate binary build in windows dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ build-node-image-linux: buildx-setup ## Build node-manager image.
 		--sbom=false
 
 .PHONY: build-node-image-windows
-build-node-image-windows: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ## Build node-manager image for Windows.
+build-node-image-windows: buildx-setup ## Build node-manager image for Windows.
 	$(DOCKER_BUILDX) build --pull \
 		--output=type=$(OUTPUT_TYPE) \
 		--platform windows/$(ARCH) \
@@ -180,7 +180,7 @@ build-node-image-windows: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe #
 		--sbom=false
 
 .PHONY: build-node-image-windows-hpc
-build-node-image-windows-hpc: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ## Build node-manager image for Windows.
+build-node-image-windows-hpc: buildx-setup ## Build node-manager image for Windows.
 	$(DOCKER_BUILDX) build --pull \
 		--output=type=$(OUTPUT_TYPE) \
 		--platform windows/$(ARCH) \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ ARCH ?= amd64
 WINDOWS_OSVERSION ?= 1809
 # The output type for `docker buildx build` could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
+# LOCAL_WINDOWS_BUILD, when set to true, allows picking a local windows binary built locally.
+# This is beneficial when the windows binary requires additional security protection like binary signing.
+LOCAL_WINDOWS_BUILD ?=false
 
 BASE.windows := mcr.microsoft.com/windows/nanoserver
 
@@ -175,6 +178,7 @@ build-node-image-windows: buildx-setup ## Build node-manager image for Windows.
 		-t $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH) \
 		--build-arg OSVERSION=$(WINDOWS_OSVERSION) \
 		--build-arg ARCH=$(ARCH) \
+		--build-arg LOCAL_BUILD=$(LOCAL_WINDOWS_BUILD) \
 		-f cloud-node-manager-windows.Dockerfile . \
 		--provenance=false \
 		--sbom=false
@@ -186,6 +190,7 @@ build-node-image-windows-hpc: buildx-setup ## Build node-manager image for Windo
 		--platform windows/$(ARCH) \
 		-t $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH) \
 		--build-arg ARCH=$(ARCH) \
+		--build-arg LOCAL_BUILD=$(LOCAL_WINDOWS_BUILD) \
 		-f cloud-node-manager-windows-hpc.Dockerfile . \
 		--provenance=false \
 		--sbom=false

--- a/cloud-node-manager-windows-hpc.Dockerfile
+++ b/cloud-node-manager-windows-hpc.Dockerfile
@@ -13,17 +13,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# check cloud-node-manager-windows.Dockerfile for the context of conditional builder image
 ARG ARCH=amd64
-
-# build windows cloud noder manager binary
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS builder
+ARG LOCAL_BUILD=false
+# build windows cloud node manager binary
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS local-build-false
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH
 WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
 COPY . .
 RUN make bin/azure-cloud-node-manager.exe ENABLE_GIT_COMMAND=${ENABLE_GIT_COMMAND} ARCH=${ARCH}
 
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS local-build-true
+WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
+COPY . .
+COPY bin/azure-cloud-node-manager-*.exe bin/
+
+FROM local-build-${LOCAL_BUILD} AS builder
+
 FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
 ARG ARCH
+ARG LOCAL_BUILD
 COPY --from=builder /go/src/sigs.k8s.io/cloud-provider-azure/bin/azure-cloud-node-manager-${ARCH}.exe /cloud-node-manager.exe
 ENTRYPOINT ["/cloud-node-manager.exe"]

--- a/cloud-node-manager-windows-hpc.Dockerfile
+++ b/cloud-node-manager-windows-hpc.Dockerfile
@@ -14,7 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH=amd64
+
+# build windows cloud noder manager binary
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS builder
+ARG ENABLE_GIT_COMMAND=true
+ARG ARCH
+WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
+COPY . .
+RUN make bin/azure-cloud-node-manager.exe ENABLE_GIT_COMMAND=${ENABLE_GIT_COMMAND} ARCH=${ARCH}
+
 FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
 ARG ARCH
-COPY bin/azure-cloud-node-manager-${ARCH}.exe /cloud-node-manager.exe
+COPY --from=builder /go/src/sigs.k8s.io/cloud-provider-azure/bin/azure-cloud-node-manager-${ARCH}.exe /cloud-node-manager.exe
 ENTRYPOINT ["/cloud-node-manager.exe"]

--- a/cloud-node-manager-windows.Dockerfile
+++ b/cloud-node-manager-windows.Dockerfile
@@ -17,7 +17,7 @@ ARG OSVERSION=1809
 ARG ARCH=amd64
 ARG LOCAL_BUILD=false
 
-# NOTE(mainred): BuildKit-based builder will skip the used stage depending on the value LOCAL_BUILD.
+# NOTE(mainred): BuildKit-based builder will skip the unused stage determined by  the value LOCAL_BUILD.
 
 # Build windows cloud node manager binary from golang build stage
 FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS local-build-false

--- a/cloud-node-manager-windows.Dockerfile
+++ b/cloud-node-manager-windows.Dockerfile
@@ -13,9 +13,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 ARG OSVERSION=1809
 ARG ARCH=amd64
+
+# build windows cloud noder manager binary
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS builder
+ARG ENABLE_GIT_COMMAND=true
+ARG ARCH
+WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
+COPY . .
+# Build the Go app
+RUN make bin/azure-cloud-node-manager.exe ENABLE_GIT_COMMAND=${ENABLE_GIT_COMMAND} ARCH=${ARCH}
 
 # NOTE(claudiub): Instead of pulling the servercore image, which is ~2GB in side, we
 # can instead pull the windows-servercore-cache image, which is only a few MBs in size.
@@ -28,6 +36,6 @@ ARG OSVERSION
 ARG ARCH
 
 COPY --from=servercore-helper /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
-COPY bin/azure-cloud-node-manager-${ARCH}.exe /cloud-node-manager.exe
+COPY --from=builder /go/src/sigs.k8s.io/cloud-provider-azure/bin/azure-cloud-node-manager-${ARCH}.exe /cloud-node-manager.exe
 USER ContainerUser
 ENTRYPOINT ["/cloud-node-manager.exe"]

--- a/cloud-node-manager-windows.Dockerfile
+++ b/cloud-node-manager-windows.Dockerfile
@@ -15,9 +15,12 @@
 # limitations under the License.
 ARG OSVERSION=1809
 ARG ARCH=amd64
+ARG LOCAL_BUILD=false
 
-# build windows cloud noder manager binary
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS builder
+# NOTE(mainred): BuildKit-based builder will skip the used stage depending on the value LOCAL_BUILD.
+
+# Build windows cloud node manager binary from golang build stage
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS local-build-false
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH
 WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
@@ -25,14 +28,27 @@ COPY . .
 # Build the Go app
 RUN make bin/azure-cloud-node-manager.exe ENABLE_GIT_COMMAND=${ENABLE_GIT_COMMAND} ARCH=${ARCH}
 
+# COPY the binary built locally to the builder container to normalize the following COPY behavior
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e AS local-build-true
+WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
+COPY . .
+COPY bin/azure-cloud-node-manager-*.exe bin/
+
+# mutli-stage dependency are determined before the build starts, so it's invalid to use command like
+# `COPY --from=local-build-{LOCAL_BUILD}` to copy the binary from a dynamic source, so we create a
+# normalized builder base as a workaround.
+# Example of the error:
+# ERROR: failed to solve: failed to parse stage name "local-build-{LOCAL_BUILD}": invalid reference format: repository name (library/local-build-{LOCAL_BUILD}) must be lowercase
+FROM local-build-${LOCAL_BUILD} AS builder
+
+
 # NOTE(claudiub): Instead of pulling the servercore image, which is ~2GB in side, we
 # can instead pull the windows-servercore-cache image, which is only a few MBs in size.
 # The image contains the netapi32.dll we need.
-FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-${ARCH}-$OSVERSION as servercore-helper
+FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-${ARCH}-$OSVERSION AS servercore-helper
 
 FROM mcr.microsoft.com/windows/nanoserver:$OSVERSION
 
-ARG OSVERSION
 ARG ARCH
 
 COPY --from=servercore-helper /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll

--- a/cloud-node-manager.Dockerfile
+++ b/cloud-node-manager.Dockerfile
@@ -27,8 +27,6 @@ RUN if [ "$ARCH" = "arm64" ] ; then \
 
 WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure
 COPY . .
-
-# Build the Go app
 RUN make bin/azure-cloud-node-manager ENABLE_GIT_COMMAND=${ENABLE_GIT_COMMAND} ARCH=${ARCH}
 
 # Use distroless base image for a lean production container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This change is originated from the [image build failure](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-provider-azure-push-images/1867492268739399680), which fails to recognize the godebug directive in go.mod because the lower version of local golang version. While linux docker images are built successfully because we build the binary the in linux dockerfile, the build environment is the same one defined in go.mod. We want to apply the method in windows docker image build as well.  Since windows binary can be treated differently for security reason, we support building windows binary locally optionally, and by default, we use non-local windows binary by building the binary in a build stage in the dockerfile.


- test build windows amd64 image with local build

```
LOCAL_WINDOWS_BUILD=true make build-node-image-windows
docker buildx inspect img-builder > /dev/null 2>&1 || docker buildx create --name img-builder --use
# enable qemu for arm64 build
# https://github.com/docker/buildx/issues/464#issuecomment-741507760
docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
uninstalling: qemu-aarch64 OK
{
  "supported": [
    "linux/amd64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker run --rm --privileged tonistiigi/binfmt --install all
installing: arm64 OK
{
  "supported": [
    "linux/amd64",
    "linux/arm64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-aarch64",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker buildx build --pull \
        --output=type=docker \
        --platform windows/amd64 \
        -t local/azure-cloud-node-manager:fda2cd4-windows-1809-amd64 \
        --build-arg OSVERSION=1809 \
        --build-arg ARCH=amd64 \
        --build-arg LOCAL_BUILD=true \
        -f cloud-node-manager-windows.Dockerfile . \
        --provenance=false \
        --sbom=false
[+] Building 21.6s (20/20) FINISHED                                                                                                      docker-container:img-builder
 => [internal] load build definition from cloud-node-manager-windows.Dockerfile                                                                                  0.1s
 => => transferring dockerfile: 2.85kB                                                                                                                           0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                        0.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                  0.0s
 => => resolve docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                             0.0s
 => [internal] load build definition from cloud-node-manager-windows.Dockerfile                                                                                  0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 23)                                            0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 32)                                            0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 48)                                            0.0s
 => [internal] load metadata for mcr.microsoft.com/windows/nanoserver:1809                                                                                       0.1s
 => [internal] load metadata for mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e          0.1s
 => [internal] load metadata for gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809                                                0.5s
 => [internal] load .dockerignore                                                                                                                                0.1s
 => => transferring context: 150B                                                                                                                                0.0s
 => [local-build-false 1/4] FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e          0.1s
 => => resolve mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                            0.1s
 => [internal] load build context                                                                                                                               15.5s
 => => transferring context: 400.45MB                                                                                                                           15.3s
 => [stage-4 1/3] FROM mcr.microsoft.com/windows/nanoserver:1809@sha256:579994616649b876dd2e4009dae4af92f6e53561045230b8cdd53b3baf2f99d0                         0.1s
 => => resolve mcr.microsoft.com/windows/nanoserver:1809@sha256:579994616649b876dd2e4009dae4af92f6e53561045230b8cdd53b3baf2f99d0                                 0.1s
 => [servercore-helper 1/1] FROM gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809@sha256:8630b0020e3c6b57879818b8cccf3e47e66f3c  0.1s
 => => resolve gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809@sha256:8630b0020e3c6b57879818b8cccf3e47e66f3c4feac0a7a73469c9ba  0.1s
 => CACHED [local-build-false 2/4] WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure                                                                              0.0s
 => CACHED [local-build-false 3/4] COPY . .                                                                                                                      0.0s
 => CACHED [stage-4 2/3] COPY --from=servercore-helper /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll                                             0.0s
 => CACHED [local-build-true 3/4] COPY . .                                                                                                                       0.0s
 => CACHED [local-build-true 4/4] COPY bin/azure-cloud-node-manager-*.exe bin/                                                                                   0.0s
 => CACHED [stage-4 3/3] COPY --from=builder /go/src/sigs.k8s.io/cloud-provider-azure/bin/azure-cloud-node-manager-amd64.exe /cloud-node-manager.exe             0.0s
 => exporting to docker image format                                                                                                                             4.1s
 => => exporting layers                                                                                                                                          0.0s
 => => exporting manifest sha256:47ef884e3a35e6d3270d361c73ab6e7b33e78cbd2a066bdad493590035ea53c9                                                                0.1s
 => => exporting config sha256:47e5fe3b214b379eb2c04b208e6c8b6c6828d940f7d801fa7a19d22cc2df18ed                                                                  0.0s
 => => sending tarball                                                                                                                                           4.0s
 => importing to docker                                                                                                                                          0.0s

 3 warnings found (use --debug to expand):
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 23)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 32)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 48)
 ```

- test build windows amd64 image without local build

```
make build-node-image-windows
docker buildx inspect img-builder > /dev/null 2>&1 || docker buildx create --name img-builder --use
# enable qemu for arm64 build
# https://github.com/docker/buildx/issues/464#issuecomment-741507760
docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
uninstalling: qemu-aarch64 OK
{
  "supported": [
    "linux/amd64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker run --rm --privileged tonistiigi/binfmt --install all
installing: arm64 OK
{
  "supported": [
    "linux/amd64",
    "linux/arm64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-aarch64",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker buildx build --pull \
        --output=type=docker \
        --platform windows/amd64 \
        -t local/azure-cloud-node-manager:fda2cd4-windows-1809-amd64 \
        --build-arg OSVERSION=1809 \
        --build-arg ARCH=amd64 \
        --build-arg LOCAL_BUILD=false \
        -f cloud-node-manager-windows.Dockerfile . \
        --provenance=false \
        --sbom=false
[+] Building 60.1s (22/22) FINISHED                                                                                                              docker-container:img-builder
 => [internal] load build definition from cloud-node-manager-windows.Dockerfile                                                                                          0.1s
 => => transferring dockerfile: 2.85kB                                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                0.7s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                                         0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                          0.0s
 => => resolve docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                                     0.0s
 => [internal] load build definition from cloud-node-manager-windows.Dockerfile                                                                                          0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 23)                                                    0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 32)                                                    0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 48)                                                    0.0s
 => [internal] load metadata for mcr.microsoft.com/windows/nanoserver:1809                                                                                               0.2s
 => [internal] load metadata for mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                  0.2s
 => [internal] load metadata for gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809                                                        0.6s
 => [internal] load .dockerignore                                                                                                                                        0.2s
 => => transferring context: 150B                                                                                                                                        0.0s
 => [local-build-false 1/4] FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                  0.1s
 => => resolve mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                                    0.1s
 => [stage-4 1/3] FROM mcr.microsoft.com/windows/nanoserver:1809@sha256:579994616649b876dd2e4009dae4af92f6e53561045230b8cdd53b3baf2f99d0                                 0.1s
 => => resolve mcr.microsoft.com/windows/nanoserver:1809@sha256:579994616649b876dd2e4009dae4af92f6e53561045230b8cdd53b3baf2f99d0                                         0.1s
 => [servercore-helper 1/1] FROM gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809@sha256:8630b0020e3c6b57879818b8cccf3e47e66f3c4feac0a7  0.1s
 => => resolve gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809@sha256:8630b0020e3c6b57879818b8cccf3e47e66f3c4feac0a7a73469c9baf6b2f73a  0.1s
 => [internal] load build context                                                                                                                                       11.0s
 => => transferring context: 400.45MB                                                                                                                                   10.8s
 => CACHED [local-build-false 2/4] WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure                                                                                      0.0s
 => CACHED [local-build-false 3/4] COPY . .                                                                                                                              0.0s
 => [local-build-false 4/4] RUN make bin/azure-cloud-node-manager.exe ENABLE_GIT_COMMAND=true ARCH=amd64                                                               135.7s
 => CACHED [stage-4 2/3] COPY --from=servercore-helper /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll                                                     0.0s
 => CACHED [local-build-false 3/4] COPY . .                                                                                                                              0.0s
 => CACHED [local-build-false 4/4] RUN make bin/azure-cloud-node-manager.exe ENABLE_GIT_COMMAND=true ARCH=amd64                                                          0.0s
 => [stage-4 3/3] COPY --from=builder /go/src/sigs.k8s.io/cloud-provider-azure/bin/azure-cloud-node-manager-amd64.exe /cloud-node-manager.exe                            1.4s
 => exporting to docker image format                                                                                                                                     6.3s
 => => exporting layers                                                                                                                                                  4.6s
 => => exporting manifest sha256:174c8642f20cef3052c8d272b6cccef39dfcfa39e707197da99b80ac55a7e931                                                                        0.0s
 => => exporting config sha256:44e6d6eee16883fb0ba08557197c81cee104ecac7f119f13bc3405ea5a3bbbdb                                                                          0.0s
 => => sending tarball                                                                                                                                                   1.7s
 => importing to docker                                                                                                                                                  0.0s

 3 warnings found (use --debug to expand):
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 23)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 32)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 48)
```

- test build windows hostprocess image with local build

```
LOCAL_WINDOWS_BUILD=true make build-node-image-windows-hpc
docker buildx inspect img-builder > /dev/null 2>&1 || docker buildx create --name img-builder --use
# enable qemu for arm64 build
# https://github.com/docker/buildx/issues/464#issuecomment-741507760
docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
uninstalling: qemu-aarch64 OK
{
  "supported": [
    "linux/amd64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker run --rm --privileged tonistiigi/binfmt --install all
installing: arm64 OK
{
  "supported": [
    "linux/amd64",
    "linux/arm64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-aarch64",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker buildx build --pull \
        --output=type=docker \
        --platform windows/amd64 \
        -t local/azure-cloud-node-manager:fda2cd4-windows-hpc-amd64 \
        --build-arg ARCH=amd64 \
        --build-arg LOCAL_BUILD=true \
        -f cloud-node-manager-windows-hpc.Dockerfile . \
        --provenance=false \
        --sbom=false
[+] Building 7.8s (16/16) FINISHED                                                                                                               docker-container:img-builder
 => [internal] load build definition from cloud-node-manager-windows-hpc.Dockerfile                                                                                      0.0s
 => => transferring dockerfile: 1.81kB                                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                0.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                          0.0s
 => => resolve docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                                     0.0s
 => [internal] load build definition from cloud-node-manager-windows-hpc.Dockerfile                                                                                      0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 20)                                                    0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 27)                                                    0.0s
 => [internal] load metadata for mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0                                                      0.1s
 => [internal] load metadata for mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                  0.1s
 => [internal] load .dockerignore                                                                                                                                        0.0s
 => => transferring context: 150B                                                                                                                                        0.0s
 => [local-build-true 1/4] FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                   0.1s
 => => resolve mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                                    0.1s
 => [stage-3 1/2] FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a5105  0.1s
 => => resolve mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf3403  0.1s
 => [internal] load build context                                                                                                                                        0.7s
 => => transferring context: 2.28MB                                                                                                                                      0.6s
 => CACHED [local-build-true 2/4] WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure                                                                                       0.0s
 => [local-build-true 3/4] COPY . .                                                                                                                                      5.1s
 => [local-build-true 4/4] COPY bin/azure-cloud-node-manager-*.exe bin/                                                                                                  0.7s
 => CACHED [stage-3 2/2] COPY --from=builder /go/src/sigs.k8s.io/cloud-provider-azure/bin/azure-cloud-node-manager-amd64.exe /cloud-node-manager.exe                     0.0s
 => exporting to docker image format                                                                                                                                     0.2s
 => => exporting layers                                                                                                                                                  0.0s
 => => exporting manifest sha256:c53d38e93b265fb601711e04f95232947c74c31598c9f3f6b6585a67a890ae54                                                                        0.0s
 => => exporting config sha256:7f937234c61a4ae8a9bac39766f02423b7f631d728e8c6df01972b28141a6473                                                                          0.0s
 => => sending tarball                                                                                                                                                   0.2s
 => importing to docker                                                                                                                                                  0.0s

 2 warnings found (use --debug to expand):
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 20)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 27)
 ```
- test build windows hostprocess image without local build

```
make build-node-image-windows-hpc
docker buildx inspect img-builder > /dev/null 2>&1 || docker buildx create --name img-builder --use
# enable qemu for arm64 build
# https://github.com/docker/buildx/issues/464#issuecomment-741507760
docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
uninstalling: qemu-aarch64 OK
{
  "supported": [
    "linux/amd64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker run --rm --privileged tonistiigi/binfmt --install all
installing: arm64 OK
{
  "supported": [
    "linux/amd64",
    "linux/arm64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "llvm-14-runtime.binfmt",
    "llvm-17-runtime.binfmt",
    "qemu-aarch64",
    "qemu-arm",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x"
  ]
}
docker buildx build --pull \
        --output=type=docker \
        --platform windows/amd64 \
        -t local/azure-cloud-node-manager:fda2cd4-windows-hpc-amd64 \
        --build-arg ARCH=amd64 \
        --build-arg LOCAL_BUILD=false \
        -f cloud-node-manager-windows-hpc.Dockerfile . \
        --provenance=false \
        --sbom=false
[+] Building 144.0s (16/16) FINISHED                                                                                                             docker-container:img-builder
 => [internal] load build definition from cloud-node-manager-windows-hpc.Dockerfile                                                                                      0.0s
 => => transferring dockerfile: 1.81kB                                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                0.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                          0.0s
 => => resolve docker.io/docker/dockerfile:1@sha256:db1ff77fb637a5955317c7a3a62540196396d565f3dd5742e76dddbb6d75c4c5                                                     0.0s
 => [internal] load build definition from cloud-node-manager-windows-hpc.Dockerfile                                                                                      0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 20)                                                    0.0s
 => WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 27)                                                    0.0s
 => [internal] load metadata for mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0                                                      0.1s
 => [internal] load metadata for mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                  0.0s
 => [internal] load .dockerignore                                                                                                                                        0.0s
 => => transferring context: 150B                                                                                                                                        0.0s
 => CACHED [stage-3 1/2] FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f  0.1s
 => => resolve mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0@sha256:b4c9637e032f667c52d1eccfa31ad8c63f1b035e8639f3f48a510536bf3403  0.1s
 => [local-build-false 1/4] FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                  0.1s
 => => resolve mcr.microsoft.com/oss/go/microsoft/golang:1.23@sha256:f4fc81062796c14e704559cad3748c5db70bf961ef24d5fac798afa18dff300e                                    0.1s
 => [internal] load build context                                                                                                                                        0.7s
 => => transferring context: 961.44kB                                                                                                                                    0.6s
 => CACHED [local-build-false 2/4] WORKDIR /go/src/sigs.k8s.io/cloud-provider-azure                                                                                      0.0s
 => CACHED [local-build-false 3/4] COPY . .                                                                                                                              0.0s
 => [local-build-false 4/4] RUN make bin/azure-cloud-node-manager.exe ENABLE_GIT_COMMAND=true ARCH=amd64                                                               135.7s
 => [stage-3 2/2] COPY --from=builder /go/src/sigs.k8s.io/cloud-provider-azure/bin/azure-cloud-node-manager-amd64.exe /cloud-node-manager.exe                            1.4s
 => exporting to docker image format                                                                                                                                     4.9s
 => => exporting layers                                                                                                                                                  4.5s
 => => exporting manifest sha256:d64ba6cb6c56fb3cff2bc94758bf51203bf341dcf36ac8bbdb9308ec1a82a55a                                                                        0.0s
 => => exporting config sha256:9d6fb0c86fb834c5d30b0281acc2f75cbd10cb0e32a74f5634b2416a8563744d                                                                          0.1s
 => => sending tarball                                                                                                                                                   0.3s
 => importing to docker                                                                                                                                                  0.0s

 2 warnings found (use --debug to expand):
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 20)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 27)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
