### PR TITLE
fix empty string NSG's DestinationAddressPrefix

### DIFF
--- a/pkg/provider/securitygroup/securityrule.go
+++ b/pkg/provider/securitygroup/securityrule.go
@@ -100,7 +100,7 @@ func ListSourcePrefixes(r *armnetwork.SecurityRule) []string {
 
 func ListDestinationPrefixes(r *armnetwork.SecurityRule) []string {
 	var rv []string
-	if r.Properties.DestinationAddressPrefix != nil {
+	if r.Properties.DestinationAddressPrefix != nil && *r.Properties.DestinationAddressPrefix != "" {
 		rv = append(rv, *r.Properties.DestinationAddressPrefix)
 	}
 	if r.Properties.DestinationAddressPrefixes != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

On special (aka undetermined) cases, the Azure API may return an empty string for security group's `DestinationAddressPrefixes`. For example:

```
 ...
       "destinationAddressPrefix": "",
        "destinationAddressPrefixes": [
          "20.23.46.159"
        ],
...
        "destinationAddressPrefix": "",
        "destinationAddressPrefixes": [
          "20.31.182.144",
          "20.103.204.84",
          "20.93.254.98",
...
```

As a result, the request to update the NSG may contain incorrect DAP prefixes resulting to an error like the following:

```
{
     "name": "k8s-azure-lb_allow_IPv4_a4dbc5c93f3bdd7a058a3939da862f9c",
     "properties": {
      "access": "Allow",
      "destinationAddressPrefixes": [
       "", <--------------- not supported -------------
       "20.101.205.120",
       "20.101.205.84",
       "20.103.202.213",
      ],
      "destinationPortRange": "",
      "destinationPortRanges": [
       "15021",
       "443",
       "80"
      ],
      "direction": "Inbound",
      "priority": 545,
      "protocol": "Tcp",
      "sourceAddressPrefix": "Internet",
      "sourceAddressPrefixes": [],
      "sourcePortRange": "*",
      "sourcePortRanges": []
     },
     "type": "Microsoft.Network/networkSecurityGroups/securityRules"
    }
}
```

With this PR, we will skip including the empty string with the NSG patch requests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug that prevented patches to NSGs when the Azure API responded with empty strings for `DestinationAddressPrefix`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
