### PR TITLE
Track2 sdk:add DisableAzureStackCloud to override arm endpoint when cluster is n…

### DIFF
--- a/pkg/azclient/arm_conf.go
+++ b/pkg/azclient/arm_conf.go
@@ -45,6 +45,10 @@ type ARMClientConfig struct {
 	CloudProviderBackoffRetries int32 `json:"cloudProviderBackoffRetries,omitempty" yaml:"cloudProviderBackoffRetries,omitempty"`
 	// Backoff duration
 	CloudProviderBackoffDuration int `json:"cloudProviderBackoffDuration,omitempty" yaml:"cloudProviderBackoffDuration,omitempty"`
+	// DisableAzureStackCloud disables AzureStackCloud support. It should be used
+	// when setting AzureAuthConfig.Cloud with "AZURESTACKCLOUD" to customize ARM endpoints
+	// while the cluster is not running on AzureStack.
+	DisableAzureStackCloud bool `json:"disableAzureStackCloud,omitempty" yaml:"disableAzureStackCloud,omitempty"`
 }
 
 func (config *ARMClientConfig) GetTenantID() string {

--- a/pkg/azclient/client-gen/generator/clientfactory.go
+++ b/pkg/azclient/client-gen/generator/clientfactory.go
@@ -247,7 +247,7 @@ func (factory *ClientFactoryImpl) create{{$resource}}Client(subscription string)
 	}
 	options.Cloud = factory.cloudConfig
 	{{if $client.AzureStackCloudAPIVersion}}
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud{
 		options.ClientOptions.APIVersion = {{.PkgAlias}}.AzureStackCloudAPIVersion
 	}
 	{{- end }}

--- a/pkg/azclient/factory_gen.go
+++ b/pkg/azclient/factory_gen.go
@@ -354,7 +354,7 @@ func (factory *ClientFactoryImpl) createAccountClient(subscription string) (acco
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = accountclient.AzureStackCloudAPIVersion
 	}
 
@@ -401,7 +401,7 @@ func (factory *ClientFactoryImpl) createAvailabilitySetClient(subscription strin
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = availabilitysetclient.AzureStackCloudAPIVersion
 	}
 
@@ -457,7 +457,7 @@ func (factory *ClientFactoryImpl) createBlobContainerClient(subscription string)
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = blobcontainerclient.AzureStackCloudAPIVersion
 	}
 
@@ -498,7 +498,7 @@ func (factory *ClientFactoryImpl) createBlobServicePropertiesClient(subscription
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = blobservicepropertiesclient.AzureStackCloudAPIVersion
 	}
 
@@ -565,7 +565,7 @@ func (factory *ClientFactoryImpl) createDiskClient(subscription string) (diskcli
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = diskclient.AzureStackCloudAPIVersion
 	}
 
@@ -706,7 +706,7 @@ func (factory *ClientFactoryImpl) createInterfaceClient(subscription string) (in
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = interfaceclient.AzureStackCloudAPIVersion
 	}
 
@@ -762,7 +762,7 @@ func (factory *ClientFactoryImpl) createLoadBalancerClient(subscription string) 
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = loadbalancerclient.AzureStackCloudAPIVersion
 	}
 
@@ -864,7 +864,7 @@ func (factory *ClientFactoryImpl) createPrivateLinkServiceClient(subscription st
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = privatelinkserviceclient.AzureStackCloudAPIVersion
 	}
 
@@ -894,7 +894,7 @@ func (factory *ClientFactoryImpl) createPrivateZoneClient(subscription string) (
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = privatezoneclient.AzureStackCloudAPIVersion
 	}
 
@@ -944,7 +944,7 @@ func (factory *ClientFactoryImpl) createPublicIPAddressClient(subscription strin
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = publicipaddressclient.AzureStackCloudAPIVersion
 	}
 
@@ -1054,7 +1054,7 @@ func (factory *ClientFactoryImpl) createRouteTableClient(subscription string) (r
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = routetableclient.AzureStackCloudAPIVersion
 	}
 
@@ -1104,7 +1104,7 @@ func (factory *ClientFactoryImpl) createSecurityGroupClient(subscription string)
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = securitygroupclient.AzureStackCloudAPIVersion
 	}
 
@@ -1134,7 +1134,7 @@ func (factory *ClientFactoryImpl) createSnapshotClient(subscription string) (sna
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = snapshotclient.AzureStackCloudAPIVersion
 	}
 
@@ -1201,7 +1201,7 @@ func (factory *ClientFactoryImpl) createSubnetClient(subscription string) (subne
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = subnetclient.AzureStackCloudAPIVersion
 	}
 
@@ -1251,7 +1251,7 @@ func (factory *ClientFactoryImpl) createVirtualMachineClient(subscription string
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = virtualmachineclient.AzureStackCloudAPIVersion
 	}
 
@@ -1281,7 +1281,7 @@ func (factory *ClientFactoryImpl) createVirtualMachineScaleSetClient(subscriptio
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = virtualmachinescalesetclient.AzureStackCloudAPIVersion
 	}
 
@@ -1311,7 +1311,7 @@ func (factory *ClientFactoryImpl) createVirtualMachineScaleSetVMClient(subscript
 	}
 	options.Cloud = factory.cloudConfig
 
-	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) {
+	if factory.armConfig != nil && strings.EqualFold(factory.armConfig.Cloud, utils.AzureStackCloudName) && !factory.armConfig.DisableAzureStackCloud {
 		options.ClientOptions.APIVersion = virtualmachinescalesetvmclient.AzureStackCloudAPIVersion
 	}
 


### PR DESCRIPTION
…ot running on azurestack

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Track2 sdk:add DisableAzureStackCloud to override arm endpoint when cluster is n…
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
