### PR TITLE
[relase-1.30] Fix: Preserve Whitespace for Tag Values Resembling "null" to Prevent ARM Assignment Errors

### DIFF
--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -131,6 +131,102 @@ func TestReconcileTags(t *testing.T) {
 	}
 }
 
+func TestParseTags(t *testing.T) {
+	for _, testCase := range []struct {
+		description, tags string
+		tagsMap           map[string]string
+		expectedTags      map[string]*string
+	}{
+		{
+			description: "parseTags should return a map of tags",
+			tags:        "a=b, c=d",
+			tagsMap: map[string]string{
+				"e": "f",
+				"g": "h",
+			},
+			expectedTags: map[string]*string{
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
+				"e": pointer.String("f"),
+				"g": pointer.String("h"),
+			},
+		},
+		{
+			description:  "parseTags should work when `tags` and `tagsMap` are all empty",
+			tags:         "",
+			tagsMap:      map[string]string{},
+			expectedTags: map[string]*string{},
+		},
+		{
+			description: "parseTags should let the tagsMap override the tags",
+			tags:        "a=e, c=f",
+			tagsMap: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+			expectedTags: map[string]*string{
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
+			},
+		},
+		{
+			description: "parseTags override should ignore the case of keys and values",
+			tags:        "A=e, C=f",
+			tagsMap: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+			expectedTags: map[string]*string{
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
+			},
+		},
+		{
+			description: "parseTags should keep the blank character after or before string 'Null', eg. 'Null '",
+			tags:        "a=b, c=Null , d= null",
+			expectedTags: map[string]*string{
+				"a": pointer.String("b"),
+				"c": pointer.String("Null "),
+				"d": pointer.String(" null"),
+			},
+		},
+		{
+			description: "parseTags should also keep blank character of values from tagsMap, case insensitive as well",
+			tags:        "",
+			tagsMap: map[string]string{
+				"a": "b",
+				"c": "Null ",
+				"d": " nuLl",
+			},
+			expectedTags: map[string]*string{
+				"a": pointer.String("b"),
+				"c": pointer.String("Null "),
+				"d": pointer.String(" nuLl"),
+			},
+		},
+		{
+			description: "parseTags should trim the blank character of values from tags other than 'Null'",
+			tags:        "a=b, c= d , d= e",
+			tagsMap: map[string]string{
+				"x": " y ",
+				"z": " z",
+			},
+			expectedTags: map[string]*string{
+				"a": pointer.String("b"),
+				"c": pointer.String("d"),
+				"d": pointer.String("e"),
+				"x": pointer.String("y"),
+				"z": pointer.String("z"),
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			tags := parseTags(testCase.tags, testCase.tagsMap)
+			assert.Equal(t, testCase.expectedTags, tags)
+		})
+	}
+}
+
 func TestGetNodePrivateIPAddress(t *testing.T) {
 	testcases := []struct {
 		desc       string

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -446,7 +446,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		Expect(err).NotTo(HaveOccurred())
 		utils.PrintCreateSVCSuccessfully(serviceName, ns.Name)
 
-		//wait and get service's public IP Address
+		// wait and get service's public IP Address
 		By("Waiting service to expose...")
 		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, pips)
 		Expect(err).NotTo(HaveOccurred())
@@ -466,6 +466,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 			"c": pointer.String("d"),
 			"e": pointer.String(""),
 			"x": pointer.String("y"),
+			"z": pointer.String("Null "),
 		}
 
 		testPIPTagAnnotationWithTags(cs, tc, ns, serviceName, labels, ports, expectedTags)
@@ -479,6 +480,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		expectedTags := map[string]*string{
 			"a": pointer.String("c"),
 			"x": pointer.String("y"),
+			"z": pointer.String("Null "),
 		}
 
 		testPIPTagAnnotationWithTags(cs, tc, ns, serviceName, labels, ports, expectedTags)
@@ -719,7 +721,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		if tc.IPFamily == utils.DualStack {
 			expectedTargetProbesCount = 2
 		}
-		//wait for backend update
+		// wait for backend update
 		err := wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
 			lb = getAzureLoadBalancerFromPIP(tc, publicIPs[0], tc.GetResourceGroup(), "")
 			targetProbes = []*network.Probe{}
@@ -793,7 +795,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		if tc.IPFamily == utils.DualStack {
 			expectedTargetProbesCount = 2
 		}
-		//wait for backend update
+		// wait for backend update
 		err := wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
 			lb = getAzureLoadBalancerFromPIP(tc, publicIPs[0], tc.GetResourceGroup(), "")
 			targetProbes = []*network.Probe{}
@@ -946,7 +948,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		if tc.IPFamily == utils.DualStack {
 			expectedTargetProbesCount = 2
 		}
-		//wait for backend update
+		// wait for backend update
 		err := wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
 			lb = getAzureLoadBalancerFromPIP(tc, publicIPs[0], tc.GetResourceGroup(), "")
 			targetProbes = []*network.Probe{}
@@ -1133,7 +1135,7 @@ var _ = Describe("Multiple VMSS", Label(utils.TestSuiteLabelMultiNodePools, util
 			Skip("service.beta.kubernetes.io/azure-load-balancer-mode only works for basic load balancer")
 		}
 
-		//get nodelist and providerID specific to an agentnodes
+		// get nodelist and providerID specific to an agentnodes
 		By("Getting agent nodes list")
 		nodes, err := utils.GetAgentNodes(cs)
 		Expect(err).NotTo(HaveOccurred())
@@ -1157,7 +1159,7 @@ var _ = Describe("Multiple VMSS", Label(utils.TestSuiteLabelMultiNodePools, util
 		Expect(resourceGroupName).NotTo(Equal(""))
 		utils.Logf("Got vmss names %v", vmssNames.List())
 
-		//Skip if there're less than two vmss
+		// Skip if there're less than two vmss
 		if len(vmssNames) < 2 {
 			Skip("azure-load-balancer-mode tests only works for cluster with multiple vmss agent pools")
 		}
@@ -1183,17 +1185,18 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 	labels := map[string]string{
 		"app": serviceName,
 	}
-	ports := []v1.ServicePort{{
-		AppProtocol: pointer.String("Tcp"),
-		Port:        serverPort,
-		Name:        "port1",
-		TargetPort:  intstr.FromInt(serverPort),
-	}, {
-		Port:        serverPort + 1,
-		Name:        "port2",
-		TargetPort:  intstr.FromInt(serverPort),
-		AppProtocol: pointer.String("Tcp"),
-	},
+	ports := []v1.ServicePort{
+		{
+			AppProtocol: pointer.String("Tcp"),
+			Port:        serverPort,
+			Name:        "port1",
+			TargetPort:  intstr.FromInt(serverPort),
+		}, {
+			Port:        serverPort + 1,
+			Name:        "port2",
+			TargetPort:  intstr.FromInt(serverPort),
+			AppProtocol: pointer.String("Tcp"),
+		},
 	}
 
 	BeforeEach(func() {
@@ -1261,7 +1264,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 			Expect(err).NotTo(HaveOccurred())
 			utils.PrintCreateSVCSuccessfully(serviceName, ns.Name)
 
-			//wait and get service's public IP Address
+			// wait and get service's public IP Address
 			utils.Logf("Waiting service to expose...")
 			publicIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []*string{})
 			Expect(err).NotTo(HaveOccurred())
@@ -1325,7 +1328,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 			if tc.IPFamily == utils.DualStack {
 				expectedTargetProbesCount = 2
 			}
-			//wait for backend update
+			// wait for backend update
 			checkPort := func(port int32, targetProbes []*network.Probe) bool {
 				utils.Logf("Checking port %d", port)
 				match := true
@@ -1357,7 +1360,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			var nodeHealthCheckPort = service.Spec.HealthCheckNodePort
+			nodeHealthCheckPort := service.Spec.HealthCheckNodePort
 			By("Changing ExternalTrafficPolicy of the service to Cluster")
 			utils.Logf("Updating service "+serviceName, ns.Name)
 			retryErr = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -1372,7 +1375,7 @@ var _ = Describe("Multi-ports service", Label(utils.TestSuiteLabelMultiPorts), f
 			Expect(retryErr).NotTo(HaveOccurred())
 			utils.Logf("Successfully updated LoadBalancer service "+serviceName, ns.Name)
 
-			//wait for backend update
+			// wait for backend update
 			expectedTargetProbesCount = 2
 			if tc.IPFamily == utils.DualStack {
 				expectedTargetProbesCount = 4
@@ -1523,7 +1526,7 @@ func createAndExposeDefaultServiceWithAnnotation(cs clientset.Interface, ipFamil
 	Expect(err).NotTo(HaveOccurred())
 	utils.PrintCreateSVCSuccessfully(serviceName, nsName)
 
-	//wait and get service's IP Address
+	// wait and get service's IP Address
 	utils.Logf("Waiting service to expose...")
 	publicIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, ipFamily, nsName, serviceName, []*string{})
 	Expect(err).NotTo(HaveOccurred())
@@ -1599,7 +1602,7 @@ func validateLoadBalancerBackendPools(tc *utils.AzureTestClient, vmssName string
 	Expect(err).NotTo(HaveOccurred())
 	utils.PrintCreateSVCSuccessfully(serviceName, ns)
 
-	//wait and get service's public IP Address
+	// wait and get service's public IP Address
 	By("Waiting for service exposure")
 	publicIPs, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns, serviceName, []*string{})
 	Expect(err).NotTo(HaveOccurred())
@@ -1625,7 +1628,7 @@ func validateLoadBalancerBackendPools(tc *utils.AzureTestClient, vmssName string
 	}
 	Expect(pipFrontendConfigurationID).NotTo(Equal(""))
 
-	//Get Azure loadBalancer Name
+	// Get Azure loadBalancer Name
 	By("Getting loadBalancer name from pipFrontendConfigurationID")
 	match := lbNameRE.FindStringSubmatch(pipFrontendConfigurationID)
 	Expect(len(match)).To(Equal(2))
@@ -1633,7 +1636,7 @@ func validateLoadBalancerBackendPools(tc *utils.AzureTestClient, vmssName string
 	Expect(loadBalancerName).NotTo(Equal(""))
 	utils.Logf("Got loadBalancerName %q", loadBalancerName)
 
-	//Get backendpools list
+	// Get backendpools list
 	By("Getting loadBalancer")
 	lb, err := tc.GetLoadBalancer(resourceGroupName, loadBalancerName)
 	Expect(err).NotTo(HaveOccurred())
@@ -1727,7 +1730,7 @@ func testPIPTagAnnotationWithTags(
 	service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	service.Annotations = map[string]string{
-		consts.ServiceAnnotationAzurePIPTags: "a=c,x=y",
+		consts.ServiceAnnotationAzurePIPTags: "a=c,x=y,z=Null ",
 	}
 	_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
**Context:**

Previously, when adding tags to Azure resources (e.g., when creating a new load balancer service, the new Public IP (PIP) inherits tags from AKS), we would remove any leading or trailing whitespace from the tag keys and values.
However, since Azure itself does not remove whitespace characters when assigning tags, this behavior could result in invalid tag values during subsequent inheritance or updates.

**Problem:**

If a tag value is initially set as `" null "` or `" NuLL "` (with leading/trailing spaces), it is successfully assigned because the whitespace prevents it from being interpreted as the reserved value "null".
However, during tag inheritance or updates, our process trims the whitespace, resulting in tag values like `"null"` or `"NuLL"`. These values are then recognized by ARM as the reserved `"null"` value, causing assignment failures and errors.

This PR introduces a fix to specifically handle tag values related to "null". It ensures that any tag value resembling `"null"` or similar variations retains its leading and trailing whitespace during processing. For all other tags, the existing logic of trimming whitespace remains unchanged to minimize broader impact.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7048 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Tags with values resembling "null" (e.g., " null " or " NuLL ") will now retain their leading and trailing whitespace during inheritance or updates to avoid errors caused by ARM's reserved tag value "null". 
This change only affects tags with such specific values, ensuring all other tags continue to have whitespace trimmed as before.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
