### PR TITLE
[release-1.29] Fix : Enable system tag support prefix match

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -167,6 +167,7 @@ type Config struct {
 	// SystemTags determines the tag keys managed by cloud provider. If it is not set, no tags would be deleted if
 	// the `Tags` is changed. However, the old tags would be deleted if they are neither included in `Tags` nor
 	// in `SystemTags` after the update of `Tags`.
+	// SystemTags now support prefix match, which means that if a key in `SystemTags` is a prefix of a key in `Tags`, that tag will not be deleted
 	SystemTags string `json:"systemTags,omitempty" yaml:"systemTags,omitempty"`
 	// Sku of Load Balancer and Public IP. Candidate values are: basic and standard.
 	// If not set, it will be default to basic.

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -169,6 +169,23 @@ func findKeyInMapCaseInsensitive(targetMap map[string]*string, key string) (bool
 	return false, ""
 }
 
+// This function extends the functionality of findKeyInMapCaseInsensitive by supporting both
+// exact case-insensitive key matching and prefix-based key matching in the given map.
+// 1. If the key is found in the map (case-insensitively), the function returns true and the matching key in the map.
+// 2. If the key's prefix is found in the map (case-insensitively), the function also returns true and the matching key in the map.
+// This function is designed to enable systemTags to support prefix-based tag keys,
+// allowing more flexible and efficient tag key matching.
+func findKeyInMapWithPrefix(targetMap map[string]*string, key string) (bool, string) {
+	for k := range targetMap {
+		// use prefix-based key matching
+		// use case-insensitive comparison
+		if strings.HasPrefix(strings.ToLower(key), strings.ToLower(k)) {
+			return true, k
+		}
+	}
+	return false, ""
+}
+
 func (az *Cloud) reconcileTags(currentTagsOnResource, newTags map[string]*string) (reconciledTags map[string]*string, changed bool) {
 	var systemTags []string
 	systemTagsMap := make(map[string]*string)
@@ -201,7 +218,7 @@ func (az *Cloud) reconcileTags(currentTagsOnResource, newTags map[string]*string
 	if len(systemTagsMap) > 0 {
 		for k := range currentTagsOnResource {
 			if _, ok := newTags[k]; !ok {
-				if found, _ := findKeyInMapCaseInsensitive(systemTagsMap, k); !found {
+				if found, _ := findKeyInMapWithPrefix(systemTagsMap, k); !found {
 					klog.V(2).Infof("reconcileTags: delete tag %s: %s", k, pointer.StringDeref(currentTagsOnResource[k], ""))
 					delete(currentTagsOnResource, k)
 					changed = true

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -177,6 +177,69 @@ func TestReconcileTags(t *testing.T) {
 			},
 			expectedChanged: true,
 		},
+		{
+			description: "reconcileTags should support prefix matching in systemTags",
+			currentTagsOnResource: map[string]*string{
+				"prefix-a": pointer.String("b"),
+				"c":        pointer.String("d"),
+			},
+			systemTags: "prefix",
+			expectedTags: map[string]*string{
+				"prefix-a": pointer.String("b"),
+			},
+			expectedChanged: true,
+		},
+		{
+			description: "reconcileTags should support prefix matching in systemTags case insensitive",
+			currentTagsOnResource: map[string]*string{
+				"prefix-a": pointer.String("b"),
+				"c":        pointer.String("d"),
+			},
+			systemTags: "PrEFiX",
+			expectedTags: map[string]*string{
+				"prefix-a": pointer.String("b"),
+			},
+			expectedChanged: true,
+		},
+		{
+			description: "reconcileTags should support prefix matching in systemTags with multiple prefixes",
+			currentTagsOnResource: map[string]*string{
+				"prefix-a": pointer.String("b"),
+				"sys-b":    pointer.String("c"),
+			},
+			systemTags: "prefix, sys",
+			expectedTags: map[string]*string{
+				"prefix-a": pointer.String("b"),
+				"sys-b":    pointer.String("c"),
+			},
+			expectedChanged: false,
+		},
+		{
+			description: "reconcileTags should work with full length aks managed cluster tags",
+			currentTagsOnResource: map[string]*string{
+				"aks-managed-cluster-name": pointer.String("test-name"),
+				"aks-managed-cluster-rg":   pointer.String("test-rg"),
+			},
+			systemTags: "aks-managed-cluster-name, aks-managed-cluster-rg",
+			expectedTags: map[string]*string{
+				"aks-managed-cluster-name": pointer.String("test-name"),
+				"aks-managed-cluster-rg":   pointer.String("test-rg"),
+			},
+			expectedChanged: false,
+		},
+		{
+			description: "real case test for systemTags",
+			currentTagsOnResource: map[string]*string{
+				"aks-managed-cluster-name": pointer.String("test-name"),
+				"aks-managed-cluster-rg":   pointer.String("test-rg"),
+			},
+			systemTags: "aks-managed",
+			expectedTags: map[string]*string{
+				"aks-managed-cluster-name": pointer.String("test-name"),
+				"aks-managed-cluster-rg":   pointer.String("test-rg"),
+			},
+			expectedChanged: false,
+		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
 			cloud := &Cloud{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In the logic for updating tags, if we define `systemTags`, any tags not included in `systemTags` will be deleted. However, this behavior can cause some AKS-managed tags to be mistakenly deleted. Adding all AKS-managed tags individually to `systemTags` would make `systemTags` excessively long and difficult to maintain.

This PR enhances the comparison logic between tags and `systemTags` by introducing prefix matching. With this change, we can add a prefix like `aks-managed` to `systemTags`, and any tags starting with `aks-managed`, such as `aks-managed-cluster-name` or `aks-managed-cluster-rg`, will be successfully matched and retained, preventing accidental deletion.

This approach reduces the size of `systemTags` while maintaining flexibility and ensuring that AKS-managed tags are preserved.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8053 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Introduced **prefix-based matching** for `systemTags` during tag reconciliation.
- Tags starting with a prefix defined in `systemTags` (e.g., `aks-managed`) will now be matched and retained.
- For example:  Adding `aks-managed` to `systemTags` ensures tags like `aks-managed-cluster-name` and `aks-managed-cluster-rg` are preserved.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
