### PR TITLE
[release-1.30] feat: always match source account in restore and volume clone scenarios

### DIFF
--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -87,6 +87,8 @@ type AccountOptions struct {
 	SoftDeleteContainers                    int32
 	// indicate whether to get a random matching account, if false, will get the first matching account
 	PickRandomMatchingAccount bool
+	// provide the source account name in snapshot restore and volume clone scenarios
+	SourceAccountName string
 }
 
 type accountWithLocation struct {
@@ -341,6 +343,15 @@ func (az *Cloud) EnsureStorageAccount(ctx context.Context, accountOptions *Accou
 				}
 				accountName = accounts[index].Name
 				createNewAccount = false
+				if accountOptions.SourceAccountName != "" {
+					for _, acct := range accounts {
+						if acct.Name == accountOptions.SourceAccountName {
+							klog.V(2).Infof("found a matching account %s type %s location %s with source account name", acct.Name, acct.StorageType, acct.Location)
+							accountName = acct.Name
+							break
+						}
+					}
+				}
 				klog.V(4).Infof("found a matching account %s type %s location %s", accounts[index].Name, accounts[index].StorageType, accounts[index].Location)
 			}
 		}

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -394,14 +394,16 @@ func TestEnsureStorageAccount(t *testing.T) {
 	cloud.Location = location
 	cloud.SubscriptionID = "testSub"
 
-	name := "testStorageAccount"
 	sku := &storage.Sku{
 		Name: "testSku",
 		Tier: "testSkuTier",
 	}
 	testStorageAccounts :=
 		[]storage.Account{
-			{Name: &name, Kind: "kind", Location: &location, Sku: sku, AccountProperties: &storage.AccountProperties{NetworkRuleSet: &storage.NetworkRuleSet{}}}}
+			{Name: pointer.StringPtr("testStorageAccount"), Kind: "kind", Location: &location, Sku: sku, AccountProperties: &storage.AccountProperties{NetworkRuleSet: &storage.NetworkRuleSet{}}},
+			{Name: pointer.StringPtr("wantedAccount"), Kind: "kind", Location: &location, Sku: sku, AccountProperties: &storage.AccountProperties{NetworkRuleSet: &storage.NetworkRuleSet{}}},
+			{Name: pointer.StringPtr("otherAccount"), Kind: "kind", Location: &location, Sku: sku, AccountProperties: &storage.AccountProperties{NetworkRuleSet: &storage.NetworkRuleSet{}}},
+		}
 
 	value := "foo bar"
 	storageAccountListKeys := storage.AccountListKeysResult{
@@ -422,10 +424,12 @@ func TestEnsureStorageAccount(t *testing.T) {
 		storageType                     StorageType
 		requireInfrastructureEncryption *bool
 		keyVaultURL                     *string
+		sourceAccountName               string
 		accountName                     string
 		subscriptionID                  string
 		resourceGroup                   string
 		expectedErr                     string
+		expectedAccountName             string
 	}{
 		{
 			name:                            "[Success] EnsureStorageAccount with createPrivateEndpoint and storagetype blob",
@@ -453,6 +457,16 @@ func TestEnsureStorageAccount(t *testing.T) {
 			resourceGroup:                   "rg",
 			accessTier:                      "AccessTierHot",
 			accountName:                     "",
+			expectedErr:                     "",
+		},
+		{
+			name:                            "[Success] EnsureStorageAccount returns with source account",
+			mockStorageAccountsClient:       true,
+			setAccountOptions:               true,
+			requireInfrastructureEncryption: pointer.Bool(true),
+			resourceGroup:                   "rg",
+			sourceAccountName:               "wantedAccount",
+			accountName:                     "wantedAccount",
 			expectedErr:                     "",
 		},
 		{
@@ -536,6 +550,10 @@ func TestEnsureStorageAccount(t *testing.T) {
 			mockVirtualNetworkLinksClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 		}
 
+		if test.sourceAccountName != "" {
+			mockStorageAccountsClient.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(storageAccountListKeys, nil).AnyTimes()
+		}
+
 		var testAccountOptions *AccountOptions
 		if test.setAccountOptions {
 			testAccountOptions = &AccountOptions{
@@ -550,10 +568,14 @@ func TestEnsureStorageAccount(t *testing.T) {
 				SoftDeleteBlobs:           7,
 				SoftDeleteContainers:      7,
 				PickRandomMatchingAccount: test.pickRandomMatchingAccount,
+				SourceAccountName:         test.sourceAccountName,
 			}
 		}
 
-		_, _, err := cloud.EnsureStorageAccount(ctx, testAccountOptions, "test")
+		accountName, _, err := cloud.EnsureStorageAccount(ctx, testAccountOptions, "test")
+		if test.expectedAccountName != "" {
+			assert.Equal(t, accountName, test.expectedAccountName, test.name)
+		}
 		assert.Equal(t, err == nil, test.expectedErr == "", fmt.Sprintf("returned error: %v", err), test.name)
 		if test.expectedErr != "" {
 			assert.Equal(t, err != nil, strings.Contains(err.Error(), test.expectedErr), err.Error(), test.name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
feat: always match source account in restore and volume clone scenarios

cherrypick of https://github.com/kubernetes-sigs/cloud-provider-azure/pull/7699

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat: always match source account in restore and volume clone scenarios
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
feat: always match source account in restore and volume clone scenarios
```
