### PR TITLE
[release-1.30] fix: VirtualNetworkRule match issue during account search

### DIFF
--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -111,7 +111,6 @@ func (az *Cloud) getStorageAccounts(ctx context.Context, accountOptions *Account
 			if !(isStorageTypeEqual(acct, accountOptions) &&
 				isAccountKindEqual(acct, accountOptions) &&
 				isLocationEqual(acct, accountOptions) &&
-				AreVNetRulesEqual(acct, accountOptions) &&
 				isLargeFileSharesPropertyEqual(acct, accountOptions) &&
 				isTagsEqual(acct, accountOptions) &&
 				isTaggedWithSkip(acct) &&
@@ -122,6 +121,7 @@ func (az *Cloud) getStorageAccounts(ctx context.Context, accountOptions *Account
 				isRequireInfrastructureEncryptionEqual(acct, accountOptions) &&
 				isAllowSharedKeyAccessEqual(acct, accountOptions) &&
 				isAccessTierEqual(acct, accountOptions) &&
+				AreVNetRulesEqual(acct, accountOptions) &&
 				isPrivateEndpointAsExpected(acct, accountOptions)) {
 				continue
 			}
@@ -862,10 +862,10 @@ func AreVNetRulesEqual(account storage.Account, accountOptions *AccountOptions) 
 				}
 			}
 			if !found {
-				klog.V(2).Infof("subnetID(%s) not found in account(%s) virtual network rules", subnetID, ptr.Deref(account.Name, ""))
 				return false
 			}
 		}
+		klog.V(2).Infof("found all vnet rules(%v) in account %s", accountOptions.VirtualNetworkResourceIDs, pointer.StringDeref(account.Name, ""))
 	}
 	return true
 }
@@ -884,7 +884,7 @@ func isTaggedWithSkip(account storage.Account) bool {
 	if account.Tags != nil {
 		// skip account with SkipMatchingTag tag
 		if _, ok := account.Tags[SkipMatchingTag]; ok {
-			klog.V(2).Infof("found %s tag for account %s, skip matching", SkipMatchingTag, ptr.Deref(account.Name, ""))
+			klog.V(2).Infof("found %s tag for account %s, skip matching", SkipMatchingTag, pointer.StringDeref(account.Name, ""))
 			return false
 		}
 	}
@@ -975,7 +975,7 @@ func (az *Cloud) isMultichannelEnabledEqual(ctx context.Context, account storage
 		return false, nil
 	}
 
-	prop, err := az.getFileServicePropertiesCache(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, ptr.Deref(account.Name, ""))
+	prop, err := az.getFileServicePropertiesCache(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, pointer.StringDeref(account.Name, ""))
 	if err != nil {
 		return false, err
 	}
@@ -1000,7 +1000,7 @@ func (az *Cloud) isDisableFileServiceDeleteRetentionPolicyEqual(ctx context.Cont
 		return false, nil
 	}
 
-	prop, err := az.FileClient.WithSubscriptionID(accountOptions.SubscriptionID).GetServiceProperties(ctx, accountOptions.ResourceGroup, ptr.Deref(account.Name, ""))
+	prop, err := az.FileClient.WithSubscriptionID(accountOptions.SubscriptionID).GetServiceProperties(ctx, accountOptions.ResourceGroup, pointer.StringDeref(account.Name, ""))
 	if err != nil {
 		return false, err
 	}
@@ -1022,7 +1022,7 @@ func (az *Cloud) isEnableBlobDataProtectionEqual(ctx context.Context, account st
 		return true, nil
 	}
 
-	property, err := az.BlobClient.GetServiceProperties(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, ptr.Deref(account.Name, ""))
+	property, err := az.BlobClient.GetServiceProperties(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, pointer.StringDeref(account.Name, ""))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/provider/azure_storageaccount.go
+++ b/pkg/provider/azure_storageaccount.go
@@ -853,17 +853,18 @@ func AreVNetRulesEqual(account storage.Account, accountOptions *AccountOptions) 
 			return false
 		}
 
-		found := false
 		for _, subnetID := range accountOptions.VirtualNetworkResourceIDs {
+			found := false
 			for _, rule := range *account.AccountProperties.NetworkRuleSet.VirtualNetworkRules {
 				if strings.EqualFold(pointer.StringDeref(rule.VirtualNetworkResourceID, ""), subnetID) && rule.Action == storage.ActionAllow {
 					found = true
 					break
 				}
 			}
-		}
-		if !found {
-			return false
+			if !found {
+				klog.V(2).Infof("subnetID(%s) not found in account(%s) virtual network rules", subnetID, ptr.Deref(account.Name, ""))
+				return false
+			}
 		}
 	}
 	return true
@@ -883,7 +884,7 @@ func isTaggedWithSkip(account storage.Account) bool {
 	if account.Tags != nil {
 		// skip account with SkipMatchingTag tag
 		if _, ok := account.Tags[SkipMatchingTag]; ok {
-			klog.V(2).Infof("found %s tag for account %s, skip matching", SkipMatchingTag, *account.Name)
+			klog.V(2).Infof("found %s tag for account %s, skip matching", SkipMatchingTag, ptr.Deref(account.Name, ""))
 			return false
 		}
 	}
@@ -974,7 +975,7 @@ func (az *Cloud) isMultichannelEnabledEqual(ctx context.Context, account storage
 		return false, nil
 	}
 
-	prop, err := az.getFileServicePropertiesCache(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, *account.Name)
+	prop, err := az.getFileServicePropertiesCache(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, ptr.Deref(account.Name, ""))
 	if err != nil {
 		return false, err
 	}
@@ -999,7 +1000,7 @@ func (az *Cloud) isDisableFileServiceDeleteRetentionPolicyEqual(ctx context.Cont
 		return false, nil
 	}
 
-	prop, err := az.FileClient.WithSubscriptionID(accountOptions.SubscriptionID).GetServiceProperties(ctx, accountOptions.ResourceGroup, *account.Name)
+	prop, err := az.FileClient.WithSubscriptionID(accountOptions.SubscriptionID).GetServiceProperties(ctx, accountOptions.ResourceGroup, ptr.Deref(account.Name, ""))
 	if err != nil {
 		return false, err
 	}
@@ -1021,7 +1022,7 @@ func (az *Cloud) isEnableBlobDataProtectionEqual(ctx context.Context, account st
 		return true, nil
 	}
 
-	property, err := az.BlobClient.GetServiceProperties(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, *account.Name)
+	property, err := az.BlobClient.GetServiceProperties(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, ptr.Deref(account.Name, ""))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -1861,7 +1861,7 @@ func TestIsDisableFileServiceDeleteRetentionPolicyEqual(t *testing.T) {
 	}
 }
 
-func Test_isSoftDeleteBlobsEqual(t *testing.T) {
+func TestIsSoftDeleteBlobsEqual(t *testing.T) {
 	type args struct {
 		property       storage.BlobServiceProperties
 		accountOptions *AccountOptions
@@ -2109,5 +2109,107 @@ func TestParseServiceAccountToken(t *testing.T) {
 	}
 	if token != expectedToken {
 		t.Errorf("ParseServiceAccountToken(%s) = %s, want %s", saTokens, token, expectedToken)
+	}
+}
+
+func TestAreVNetRulesEqual(t *testing.T) {
+	type args struct {
+		account       storage.Account
+		accountOption *AccountOptions
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "account option is empty",
+			args: args{
+				account: storage.Account{
+					AccountProperties: &storage.AccountProperties{},
+				},
+				accountOption: &AccountOptions{
+					VirtualNetworkResourceIDs: []string{},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "VirtualNetworkRules are equal",
+			args: args{
+				account: storage.Account{
+					AccountProperties: &storage.AccountProperties{
+						NetworkRuleSet: &storage.NetworkRuleSet{
+							VirtualNetworkRules: &[]storage.VirtualNetworkRule{
+								{
+									VirtualNetworkResourceID: ptr.To("id"),
+									Action:                   storage.ActionAllow,
+									State:                    "state",
+								},
+							},
+						},
+					},
+				},
+				accountOption: &AccountOptions{
+					VirtualNetworkResourceIDs: []string{"id"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "VirtualNetworkRules are equal with multiple NetworkRules",
+			args: args{
+				account: storage.Account{
+					AccountProperties: &storage.AccountProperties{
+						NetworkRuleSet: &storage.NetworkRuleSet{
+							VirtualNetworkRules: &[]storage.VirtualNetworkRule{
+								{
+									VirtualNetworkResourceID: ptr.To("id1"),
+									Action:                   storage.ActionAllow,
+								},
+								{
+									VirtualNetworkResourceID: ptr.To("id2"),
+									Action:                   storage.ActionAllow,
+								},
+							},
+						},
+					},
+				},
+				accountOption: &AccountOptions{
+					VirtualNetworkResourceIDs: []string{"id2"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "VirtualNetworkRules not equal",
+			args: args{
+				account: storage.Account{
+					AccountProperties: &storage.AccountProperties{
+						NetworkRuleSet: &storage.NetworkRuleSet{
+							VirtualNetworkRules: &[]storage.VirtualNetworkRule{
+								{
+									VirtualNetworkResourceID: ptr.To("id1"),
+									Action:                   storage.ActionAllow,
+									State:                    "state",
+								},
+							},
+						},
+					},
+				},
+				accountOption: &AccountOptions{
+					VirtualNetworkResourceIDs: []string{"id2"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AreVNetRulesEqual(tt.args.account, tt.args.accountOption); got != tt.want {
+				t.Errorf("areVNetRulesEqual() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/provider/azure_storageaccount_test.go
+++ b/pkg/provider/azure_storageaccount_test.go
@@ -2142,7 +2142,7 @@ func TestAreVNetRulesEqual(t *testing.T) {
 						NetworkRuleSet: &storage.NetworkRuleSet{
 							VirtualNetworkRules: &[]storage.VirtualNetworkRule{
 								{
-									VirtualNetworkResourceID: ptr.To("id"),
+									VirtualNetworkResourceID: pointer.StringPtr("id"),
 									Action:                   storage.ActionAllow,
 									State:                    "state",
 								},
@@ -2164,11 +2164,11 @@ func TestAreVNetRulesEqual(t *testing.T) {
 						NetworkRuleSet: &storage.NetworkRuleSet{
 							VirtualNetworkRules: &[]storage.VirtualNetworkRule{
 								{
-									VirtualNetworkResourceID: ptr.To("id1"),
+									VirtualNetworkResourceID: pointer.StringPtr("id1"),
 									Action:                   storage.ActionAllow,
 								},
 								{
-									VirtualNetworkResourceID: ptr.To("id2"),
+									VirtualNetworkResourceID: pointer.StringPtr("id2"),
 									Action:                   storage.ActionAllow,
 								},
 							},
@@ -2189,7 +2189,7 @@ func TestAreVNetRulesEqual(t *testing.T) {
 						NetworkRuleSet: &storage.NetworkRuleSet{
 							VirtualNetworkRules: &[]storage.VirtualNetworkRule{
 								{
-									VirtualNetworkResourceID: ptr.To("id1"),
+									VirtualNetworkResourceID: pointer.StringPtr("id1"),
 									Action:                   storage.ActionAllow,
 									State:                    "state",
 								},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: VirtualNetworkRule match issue during account search
chore: refine logging in AreVNetRulesEqual func

cherrypick of https://github.com/kubernetes-sigs/cloud-provider-azure/pull/6741, https://github.com/kubernetes-sigs/cloud-provider-azure/pull/6744

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: VirtualNetworkRule match issue during account search
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: VirtualNetworkRule match issue during account search
```
