### PR TITLE
test: add vm etag in ensureBackendPoolDeletedFromNode and add UT

### DIFF
--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1337,7 +1337,7 @@ func (ss *ScaleSet) ensureVMSSInPool(ctx context.Context, _ *v1.Service, nodes [
 		klog.V(2).Infof("ensureVMSSInPool begins to update vmss(%s) with new backendPoolID %s", vmssName, backendPoolID)
 		rerr := ss.CreateOrUpdateVMSS(ss.ResourceGroup, vmssName, newVMSS)
 		if rerr != nil {
-			klog.Errorf("ensureVMSSInPool CreateOrUpdateVMSS(%s) with new backendPoolID %s, err: %v", vmssName, backendPoolID, err)
+			klog.Errorf("ensureVMSSInPool CreateOrUpdateVMSS(%s) with new backendPoolID %s, err: %v", vmssName, backendPoolID, rerr)
 			return rerr
 		}
 	}
@@ -1636,6 +1636,7 @@ func (ss *ScaleSet) ensureBackendPoolDeletedFromNode(ctx context.Context, nodeNa
 				NetworkInterfaceConfigurations: networkInterfaceConfigurations,
 			},
 		},
+		Etag: vm.Etag,
 	}
 
 	// Get the node resource group.

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -46,6 +48,7 @@ import (
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/virtualmachine"
+	"sigs.k8s.io/cloud-provider-azure/pkg/util/deepcopy"
 	utilsets "sigs.k8s.io/cloud-provider-azure/pkg/util/sets"
 )
 
@@ -72,6 +75,71 @@ const (
 	windows2022
 	ubuntu
 )
+
+type vmssInputMatcher struct {
+	Location   *string
+	Properties *armcompute.VirtualMachineScaleSetProperties
+	Etag       *string
+}
+
+func (mim vmssInputMatcher) Matches(arg interface{}) bool {
+
+	vmssVM, ok := arg.(armcompute.VirtualMachineScaleSet)
+	if !ok {
+		return false
+	}
+
+	if !reflect.DeepEqual(mim.Location, vmssVM.Location) {
+		return false
+	}
+	if !reflect.DeepEqual(mim.Etag, vmssVM.Etag) {
+		return false
+	}
+
+	if !reflect.DeepEqual(mim.Properties, vmssVM.Properties) {
+		return false
+	}
+
+	return true
+}
+
+func (mim vmssInputMatcher) String() string {
+	backendPools := []string{}
+	for _, backendPool := range mim.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations[0].Properties.IPConfigurations[0].Properties.LoadBalancerBackendAddressPools {
+		backendPools = append(backendPools, *backendPool.ID)
+	}
+	return fmt.Sprintf("Etag: %s, Location: %s, loadBalancerBackendAddressPools: %s", *mim.Etag, *mim.Location, backendPools)
+}
+
+type vmssVMInputMatcher struct {
+	Location   *string
+	Properties *armcompute.VirtualMachineScaleSetVMProperties
+	Etag       *string
+}
+
+func (vvim vmssVMInputMatcher) Matches(arg interface{}) bool {
+	vmssVM, ok := arg.(armcompute.VirtualMachineScaleSetVM)
+	if !ok {
+		return false
+	}
+	if !reflect.DeepEqual(vvim.Location, vmssVM.Location) {
+		return false
+	}
+	if !reflect.DeepEqual(vvim.Etag, vmssVM.Etag) {
+		return false
+	}
+	return reflect.DeepEqual(vvim.Properties, vmssVM.Properties)
+}
+
+func (vvim vmssVMInputMatcher) String() string {
+	backendPools := []string{}
+
+	for _, backendPool := range vvim.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations[0].Properties.IPConfigurations[0].Properties.LoadBalancerBackendAddressPools {
+		backendPools = append(backendPools, *backendPool.ID)
+	}
+
+	return fmt.Sprintf("Etag: %s, Location: %s, loadBalancerBackendAddressPools: %s", *vvim.Etag, *vvim.Location, backendPools)
+}
 
 func buildTestOSSpecificVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, os osVersion, ipv6 bool) *armcompute.VirtualMachineScaleSet {
 	vmss := buildTestVMSSWithLB(name, namePrefix, lbBackendpoolIDs, ipv6)
@@ -122,6 +190,7 @@ func buildTestVMSSWithLB(name, namePrefix string, lbBackendpoolIDs []string, ipv
 
 	expectedVMSS := &armcompute.VirtualMachineScaleSet{
 		Name: &name,
+		Etag: to.Ptr("1"),
 		Properties: &armcompute.VirtualMachineScaleSetProperties{
 			OrchestrationMode: to.Ptr(armcompute.OrchestrationModeUniform),
 			ProvisioningState: ptr.To("Running"),
@@ -213,6 +282,7 @@ func buildTestVirtualMachineEnv(ss *Cloud, scaleSetName, zone string, faultDomai
 		}
 
 		vmssVM := &armcompute.VirtualMachineScaleSetVM{
+			Etag: ptr.To("1"),
 			Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 				ProvisioningState: ptr.To(state),
 				OSProfile: &armcompute.OSProfile{
@@ -2702,6 +2772,321 @@ func TestEnsureHostsInPool(t *testing.T) {
 
 			err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
 			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+		})
+	}
+}
+
+func TestEnsureHostsInPoolEtagMismatch(t *testing.T) {
+	testCases := []struct {
+		description            string
+		nodes                  []*v1.Node
+		backendpoolID          string
+		vmssClientPutError     error
+		vmssvmClientPutError   error
+		vmSetName              string
+		expectedVMSSVMPutTimes int
+		expectedErr            bool
+	}{
+		{
+			description: "EnsureHostsInPool should raise error when vmss put hits EtagMismatch Error",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmss-vm-000000",
+					},
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			backendpoolID:          testLBBackendpoolID1,
+			vmssClientPutError:     &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+			vmssvmClientPutError:   nil,
+			vmSetName:              "vmss",
+			expectedVMSSVMPutTimes: 0,
+			expectedErr:            true,
+		},
+		{
+			description: "EnsureHostsInPool should raise error when vmss vm put hits EtagMismatch Error",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmss-vm-000000",
+					},
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			backendpoolID:          testLBBackendpoolID1,
+			vmssClientPutError:     nil,
+			vmssvmClientPutError:   &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+			vmSetName:              "vmss",
+			expectedVMSSVMPutTimes: 1,
+			expectedErr:            true,
+		},
+		{
+			description: "EnsureHostsInPool should raise not error when put vm and vmss raise no error",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmss-vm-000000",
+					},
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			backendpoolID:          testLBBackendpoolID1,
+			vmssClientPutError:     nil,
+			vmssvmClientPutError:   nil,
+			vmSetName:              "vmss",
+			expectedVMSSVMPutTimes: 1,
+			expectedErr:            false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ss, err := NewTestScaleSet(ctrl)
+			assert.NoError(t, err, test.description)
+
+			ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+			ss.ExcludeMasterFromStandardLB = ptr.To(true)
+			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+			expectedVMSS.Location = &ss.Location
+			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
+
+			copiedVMSS := deepcopy.Copy(expectedVMSS).(*armcompute.VirtualMachineScaleSet)
+			networkInterfaceConfigurations := copiedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+			ipConfig := networkInterfaceConfigurations[0].Properties.IPConfigurations
+			ipConfig[0].Properties.LoadBalancerBackendAddressPools = append(ipConfig[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(test.backendpoolID)})
+			vmssMatcher := vmssInputMatcher{
+				Location: copiedVMSS.Location,
+				Properties: &armcompute.VirtualMachineScaleSetProperties{
+					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
+						NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
+							NetworkInterfaceConfigurations: networkInterfaceConfigurations,
+						},
+					},
+				},
+				Etag: copiedVMSS.Etag,
+			}
+
+			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, vmssMatcher).Return(nil, test.vmssClientPutError).Times(1)
+			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
+			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+
+			expectedVMSSVM := expectedVMSSVMs[0]
+			copiedVMSSVM := deepcopy.Copy(expectedVMSSVM).(*armcompute.VirtualMachineScaleSetVM)
+
+			vmNetworkInterfaceConfigurations := copiedVMSSVM.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations
+			vmssVMIPConfigs := vmNetworkInterfaceConfigurations[0].Properties.IPConfigurations
+			vmssVMIPConfigs[0].Properties.LoadBalancerBackendAddressPools = append((vmssVMIPConfigs)[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(testLBBackendpoolID1)})
+
+			vmssVMMatcher := vmssVMInputMatcher{
+				Location: copiedVMSSVM.Location,
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
+						NetworkInterfaceConfigurations: vmNetworkInterfaceConfigurations,
+					},
+				},
+				Etag: copiedVMSSVM.Etag,
+			}
+			mockVMSSVMClient.EXPECT().Update(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), vmssVMMatcher).Return(nil, test.vmssvmClientPutError).Times(test.expectedVMSSVMPutTimes)
+
+			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+			err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
+			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+		})
+	}
+}
+
+func TestEnsureBackendPoolDeletedEtagMismatch(t *testing.T) {
+	testCases := []struct {
+		description            string
+		nodes                  []*v1.Node
+		backendpoolID          string
+		backendAddressPools    []*armnetwork.BackendAddressPool
+		vmssClientPutError     error
+		vmssvmClientPutError   error
+		vmSetName              string
+		expectedVMSSVMPutTimes int
+		expectedErr            bool
+	}{
+		{
+			description: "EnsureBackendPoolDeleted should raise error when vmss put hits EtagMismatch Error",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmss-vm-000000",
+					},
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			vmssClientPutError:   &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+			vmssvmClientPutError: nil,
+			backendpoolID:        testLBBackendpoolID0,
+			backendAddressPools: []*armnetwork.BackendAddressPool{
+				{
+					ID: ptr.To(testLBBackendpoolID0),
+					Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
+						BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Name: ptr.To("ip-1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+							},
+						},
+					},
+				},
+				{
+					ID: ptr.To(testLBBackendpoolID1),
+				},
+			},
+			vmSetName:              "vmss",
+			expectedVMSSVMPutTimes: 0,
+			expectedErr:            true,
+		},
+		{
+			description: "EnsureBackendPoolDeleted should raise error when vmss vm put hits EtagMismatch Error",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmss-vm-000000",
+					},
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			vmssClientPutError:   nil,
+			vmssvmClientPutError: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+			backendpoolID:        testLBBackendpoolID0,
+			backendAddressPools: []*armnetwork.BackendAddressPool{
+				{
+					ID: ptr.To(testLBBackendpoolID0),
+					Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
+						BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Name: ptr.To("ip-1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+							},
+						},
+					},
+				},
+				{
+					ID: ptr.To(testLBBackendpoolID1),
+				},
+			},
+			vmSetName:              "vmss",
+			expectedVMSSVMPutTimes: 1,
+			expectedErr:            true,
+		},
+		{
+			description: "EnsureBackendPoolDeleted should raise not error when put vm and vmss raise no error",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmss-vm-000000",
+					},
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			vmssClientPutError:   nil,
+			vmssvmClientPutError: nil,
+			backendpoolID:        testLBBackendpoolID0,
+			backendAddressPools: []*armnetwork.BackendAddressPool{
+				{
+					ID: ptr.To(testLBBackendpoolID0),
+					Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
+						BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Name: ptr.To("ip-1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+							},
+						},
+					},
+				},
+				{
+					ID: ptr.To(testLBBackendpoolID1),
+				},
+			},
+			vmSetName:              "vmss",
+			expectedVMSSVMPutTimes: 1,
+			expectedErr:            false,
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ss, err := NewTestScaleSet(ctrl)
+			assert.NoError(t, err, test.description)
+
+			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+
+			copiedVMSS := deepcopy.Copy(expectedVMSS).(*armcompute.VirtualMachineScaleSet)
+			networkInterfaceConfigurations := copiedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+			ipConfig := networkInterfaceConfigurations[0].Properties.IPConfigurations
+			ipConfig[0].Properties.LoadBalancerBackendAddressPools = []*armcompute.SubResource{}
+			vmssMatcher := vmssInputMatcher{
+				Location: copiedVMSS.Location,
+				Properties: &armcompute.VirtualMachineScaleSetProperties{
+					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
+						NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
+							NetworkInterfaceConfigurations: networkInterfaceConfigurations,
+						},
+					},
+				},
+				Etag: copiedVMSS.Etag,
+			}
+			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
+			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, vmssMatcher).Return(nil, test.vmssClientPutError).Times(1)
+
+			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
+			expectedVMSSVM := expectedVMSSVMs[0]
+			copiedVMSSVM := deepcopy.Copy(expectedVMSSVM).(*armcompute.VirtualMachineScaleSetVM)
+			vmNetworkInterfaceConfigurations := copiedVMSSVM.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations
+			vmssVMIPConfigs := vmNetworkInterfaceConfigurations[0].Properties.IPConfigurations
+			vmssVMIPConfigs[0].Properties.LoadBalancerBackendAddressPools = []*armcompute.SubResource{}
+			vmssVMMatcher := vmssVMInputMatcher{
+				Location: copiedVMSSVM.Location,
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
+						NetworkInterfaceConfigurations: vmNetworkInterfaceConfigurations,
+					},
+				},
+				Etag: copiedVMSSVM.Etag,
+			}
+			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+			mockVMSSVMClient.EXPECT().Update(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), vmssVMMatcher).Return(nil, test.vmssvmClientPutError).Times(test.expectedVMSSVMPutTimes)
+
+			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+
+			updated, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{test.backendpoolID}, testVMSSName, test.backendAddressPools, true)
+			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+			if !test.expectedErr && test.expectedVMSSVMPutTimes > 0 {
+				assert.True(t, updated, test.description)
+			}
 		})
 	}
 }

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -2274,6 +2274,7 @@ func TestEnsureHostInPool(t *testing.T) {
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &armcompute.VirtualMachineScaleSetVM{
 				Location: ptr.To("westus"),
+				Etag:     ptr.To("1"),
 				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: []*armcompute.VirtualMachineScaleSetNetworkConfiguration{
@@ -3128,6 +3129,7 @@ func TestEnsureBackendPoolDeletedFromNodeCommon(t *testing.T) {
 			expectedInstanceID:        "0",
 			expectedVMSSVM: &armcompute.VirtualMachineScaleSetVM{
 				Location: ptr.To("westus"),
+				Etag:     ptr.To("1"),
 				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 					NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
 						NetworkInterfaceConfigurations: []*armcompute.VirtualMachineScaleSetNetworkConfiguration{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is a follow-up of https://github.com/kubernetes-sigs/cloud-provider-azure/pull/8106 to add Etag in ensureBackendPoolDeletedFromNode, and add UT to protect the input fields, like Etag, of vmss and vmss vm put operations.

I think a better test will be on top of service controller, which can retry on EtagMismatch error by mocking the go SDK. But this level of test is not covered in cloud-provider-azure yet, and we can put this into future test enhancement if necessary.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
