### PR TITLE
fix: disk attach/detach failure with track2 sdk

### DIFF
--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -98,6 +98,7 @@ func (as *availabilitySet) AttachDisk(ctx context.Context, nodeName types.NodeNa
 				DataDisks: disks,
 			},
 		},
+		Location: vm.Location,
 	}
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk list(%v)", nodeResourceGroup, vmName, diskMap)
 
@@ -190,6 +191,7 @@ func (as *availabilitySet) DetachDisk(ctx context.Context, nodeName types.NodeNa
 				DataDisks: disks,
 			},
 		},
+		Location: vm.Location,
 	}
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) node(%s)- detach disk list(%s)", nodeResourceGroup, vmName, nodeName, diskMap)
 

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -159,8 +159,8 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 
 	var disks []*armcompute.DataDisk
 
-	if vm != nil && vm.VirtualMachineProperties != nil {
-		storageProfile := vm.VirtualMachineProperties.StorageProfile
+	if vm != nil && vm.VirtualMachineScaleSetVMProperties != nil {
+		storageProfile := vm.VirtualMachineScaleSetVMProperties.StorageProfile
 		if storageProfile != nil && storageProfile.DataDisks != nil {
 			disks = make([]*armcompute.DataDisk, len(storageProfile.DataDisks))
 			copy(disks, storageProfile.DataDisks)

--- a/pkg/provider/azure_controller_vmssflex.go
+++ b/pkg/provider/azure_controller_vmssflex.go
@@ -101,6 +101,7 @@ func (fs *FlexScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName,
 				DataDisks: disks,
 			},
 		},
+		Location: vm.Location,
 	}
 
 	klog.V(2).Infof("azureDisk - update: rg(%s) vm(%s) - attach disk list(%+v)", nodeResourceGroup, vmName, diskMap)
@@ -184,6 +185,7 @@ func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName,
 				DataDisks: disks,
 			},
 		},
+		Location: vm.Location,
 	}
 
 	var result *armcompute.VirtualMachine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: disk attach/detach failure with track2 sdk

location field is also essential in standard vm disk attach/detach:
```
E0206 11:32:58.995844       1 controllerserver.go:617] Could not detach volume /subscriptions/4xxx/resourceGroups/capz-pq67w2/providers/Microsoft.Compute/disks/pvc-d29d0f4c-2223-4675-bc23-e875e49b1945 from node capz-pq67w2-md-0-sk4w6-sj8wv: PUT https://management.azure.com/subscriptions/xxx/resourceGroups/capz-pq67w2/providers/Microsoft.Compute/virtualMachines/capz-pq67w2-md-0-sk4w6-sj8wv
--------------------------------------------------------------------------------
RESPONSE 400: 400 Bad Request
ERROR CODE: LocationRequired
--------------------------------------------------------------------------------
{
  "error": {
    "code": "LocationRequired",
    "message": "The location property is required for this definition."
  }
}

```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: disk attach/detach failure with track2 sdk
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: disk attach/detach failure with track2 sdk
```
