### PR TITLE
fix(credential-provider): check acr pattern to avoid spoofing

### DIFF
--- a/pkg/credentialprovider/azure_credentials.go
+++ b/pkg/credentialprovider/azure_credentials.go
@@ -226,7 +226,7 @@ func (a *acrProvider) getFromACR(ctx context.Context, loginServer string) (strin
 func (a *acrProvider) parseACRLoginServerFromImage(image string) (string, string) {
 	targetImage, sourceRegistry := a.processImageWithRegistryMirror(image)
 	targetRegistry := acrRE.FindString(targetImage)
-	imageWithoutRegistry := strings.Trim(targetImage, targetRegistry)
+	imageWithoutRegistry := strings.TrimPrefix(targetImage, targetRegistry)
 	// for non customer cloud case, return registry only when:
 	//   - the acr pattern match
 	//   - the left string is empty or // credential provider authenticates the image pull request, but not validates the existence of the image

--- a/pkg/credentialprovider/azure_credentials.go
+++ b/pkg/credentialprovider/azure_credentials.go
@@ -47,7 +47,8 @@ const (
 
 var (
 	containerRegistryUrls = []string{"*.azurecr.io", "*.azurecr.cn", "*.azurecr.de", "*.azurecr.us"}
-	acrRE                 = regexp.MustCompile(`^.+?\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)`)
+	// a valid acr image starts with alphanumerics, followed by corresponding acr domain name.
+	acrRE = regexp.MustCompile(`^[a-zA-Z0-9]+\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)`)
 )
 
 // CredentialProvider is an interface implemented by the kubelet credential provider plugin to fetch
@@ -224,10 +225,16 @@ func (a *acrProvider) getFromACR(ctx context.Context, loginServer string) (strin
 // If the provided image is not an acr image, this function will return an empty string.
 func (a *acrProvider) parseACRLoginServerFromImage(image string) (string, string) {
 	targetImage, sourceRegistry := a.processImageWithRegistryMirror(image)
-
-	match := acrRE.FindAllString(targetImage, -1)
-	if len(match) == 1 {
-		targetRegistry := match[0]
+	targetRegistry := acrRE.FindString(targetImage)
+	imageWithoutRegistry := strings.Trim(targetImage, targetRegistry)
+	// for non customer cloud case, return registry only when:
+	//   - the acr pattern match
+	//   - the left string is empty or // credential provider authenticates the image pull request, but not validates the existence of the image
+	//   - the left string starts with a image repository, lead by "/"
+	// foo.azurecr.io/bar/image:version -> foo.azurecr.io
+	// foo.azurecr.io -> not match
+	// foo.azurecr.io.example -> not match
+	if len(targetRegistry) != 0 && (len(imageWithoutRegistry) == 0 || (len(imageWithoutRegistry) != 0 && strings.HasPrefix(imageWithoutRegistry, "/"))) {
 		return targetRegistry, sourceRegistry
 	}
 

--- a/pkg/credentialprovider/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure_credentials_test.go
@@ -205,8 +205,8 @@ func TestProcessImageWithMirrorMapping(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.description, func(t *testing.T) {
 			targetloginServer, sourceloginServer := acrProvider.parseACRLoginServerFromImage(test.image)
-			assert.Equal(t, targetloginServer, test.expectedLoginServer)
-			assert.Equal(t, sourceloginServer, test.expectedLoginServerMirror)
+			assert.Equal(t, test.expectedLoginServer, targetloginServer)
+			assert.Equal(t, test.expectedLoginServerMirror, sourceloginServer)
 		})
 	}
 }
@@ -261,11 +261,23 @@ func TestParseACRLoginServerFromImage(t *testing.T) {
 			image:    "foo.azurecr.us/foo.azurecr.io/bar/image:version",
 			expected: "foo.azurecr.us",
 		},
+		{
+			image:    "foo.azurecr.io.example/bar/image:version",
+			expected: "",
+		},
+		{
+			image:    "docker/foo.azurecr.io/bar/image:version",
+			expected: "",
+		},
+		{
+			image:    "foo.azurecr.io",
+			expected: "foo.azurecr.io",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.image, func(t *testing.T) {
 			targetloginServer, _ := provider.parseACRLoginServerFromImage(test.image)
-			assert.Equal(t, targetloginServer, test.expected)
+			assert.Equal(t, test.expected, targetloginServer)
 		})
 	}
 }

--- a/pkg/credentialprovider/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure_credentials_test.go
@@ -273,6 +273,14 @@ func TestParseACRLoginServerFromImage(t *testing.T) {
 			image:    "foo.azurecr.io",
 			expected: "foo.azurecr.io",
 		},
+		{
+			image:    "foo.azurecr.io.azurecr.cn",
+			expected: "",
+		},
+		{
+			image:    "foo-azurecr-io.azurecr.cn",
+			expected: "",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.image, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
There's a potential spoofing when the image 
"<my-test>.azurecr.io.example.com/ubuntu2:latest" is sent to the credential provider plugin, it will fetch credential from <my-test>.azurecr.io unexpectedly.
Currently it's not possible considering kubelet will not call credential provider plugin since the "<my-test>.azurecr.io.example.com/ubuntu2:latest" does not match the matchImages defined below.
Also the credential provider plugin as a binary is installed on k8s node, is currently only called by kubelet if there's no manual operation.

```
apiVersion: kubelet.config.k8s.io/v1
kind: CredentialProviderConfig
providers:
  - name: acr-credential-provider
    matchImages:
      - "*.azurecr.io"
      - "*.azurecr.cn"
      - "*.azurecr.de"
      - "*.azurecr.us"
    defaultCacheDuration: "10m" // follow in-tree setting
    apiVersion: credentialprovider.kubelet.k8s.io/v1
    args:
      - /etc/kubernetes/azure.json
 ```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix(credential-provider): check acr pattern to avoid spoofing
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
