### PR TITLE
chore: configure timeouts for HTTP/2

### DIFF
--- a/pkg/azclient/utils/transport.go
+++ b/pkg/azclient/utils/transport.go
@@ -22,8 +22,11 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
+// DefaultTransport is the default transport used by the Azure SDK for Go.
 var DefaultTransport *http.Transport
 var once sync.Once
 
@@ -46,6 +49,12 @@ func init() {
 				MinVersion:    tls.VersionTLS12,
 				Renegotiation: tls.RenegotiateNever, // the same as default transport https://pkg.go.dev/crypto/tls#RenegotiationSupport
 			},
+		}
+
+		// Configure HTTP/2
+		if http2Transport, err := http2.ConfigureTransports(DefaultTransport); err == nil {
+			http2Transport.ReadIdleTimeout = 30 * time.Second
+			http2Transport.PingTimeout = 15 * time.Second
 		}
 	})
 }

--- a/pkg/azclient/utils/transport_test.go
+++ b/pkg/azclient/utils/transport_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+)
+
+func TestDefaultTransport(t *testing.T) {
+	if DefaultTransport == nil {
+		t.Fatal("DefaultTransport is nil")
+	}
+
+	if DefaultTransport.DialContext == nil {
+		t.Error("DialContext is nil")
+	}
+
+	if !DefaultTransport.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 is false")
+	}
+
+	if DefaultTransport.MaxIdleConns != 100 {
+		t.Errorf("Expected MaxIdleConns to be 100, got %d", DefaultTransport.MaxIdleConns)
+	}
+
+	if DefaultTransport.MaxConnsPerHost != 100 {
+		t.Errorf("Expected MaxConnsPerHost to be 100, got %d", DefaultTransport.MaxConnsPerHost)
+	}
+
+	if DefaultTransport.IdleConnTimeout != 90*time.Second {
+		t.Errorf("Expected IdleConnTimeout to be 90s, got %v", DefaultTransport.IdleConnTimeout)
+	}
+
+	if DefaultTransport.TLSHandshakeTimeout != 10*time.Second {
+		t.Errorf("Expected TLSHandshakeTimeout to be 10s, got %v", DefaultTransport.TLSHandshakeTimeout)
+	}
+
+	if DefaultTransport.ExpectContinueTimeout != 1*time.Second {
+		t.Errorf("Expected ExpectContinueTimeout to be 1s, got %v", DefaultTransport.ExpectContinueTimeout)
+	}
+
+	if DefaultTransport.ResponseHeaderTimeout != 60*time.Second {
+		t.Errorf("Expected ResponseHeaderTimeout to be 60s, got %v", DefaultTransport.ResponseHeaderTimeout)
+	}
+
+	if DefaultTransport.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig is nil")
+	}
+
+	if DefaultTransport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("Expected MinVersion to be TLS1.2, got %v", DefaultTransport.TLSClientConfig.MinVersion)
+	}
+
+	if DefaultTransport.TLSClientConfig.Renegotiation != tls.RenegotiateNever {
+		t.Errorf("Expected Renegotiation to be RenegotiateNever, got %v", DefaultTransport.TLSClientConfig.Renegotiation)
+	}
+
+	// NOTE: http2 transport settings are not exposed hence testing is skipped.
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Configure timeouts for HTTP/2
 
* http2.ReadIdleTimeout - The interval of health check for idle connections.
* http2.PingTimeout - The timeout for server to respond to a client ping.

Also added a unit test for the default transport.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
