### PR TITLE
normalize the image building targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,24 @@ K8S_BRANCH ?=
 #The test args for Kubernetes e2e tests
 TEST_E2E_ARGS ?= '--ginkgo.focus=Port\sforwarding'
 
+WINDOWS_USE_HOST_PROCESS_CONTAINERS ?= false
+
 # Generate all combination of all OS, ARCH, and OSVERSIONS for iteration
 
-ALL_ARCH.linux = amd64 arm arm64
+ALL_OS ?= linux windows
+ALL_ARCH.linux ?= amd64 arm arm64
+ALL_OS_ARCH.linux=$(foreach arch, $(ALL_ARCH.linux), linux-$(arch))
 # as windows server core does not support arm64 windows image, trakced by the following link,
 # and only 1809 has arm64 nanoserver support, we support here only amd64 windows image
 # https://github.com/microsoft/Windows-Containers/issues/195
-ALL_ARCH.windows = amd64
-ALL_OSVERSIONS.windows := 1809 2004 20H2 ltsc2022
-ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), $(foreach osversion, ${ALL_OSVERSIONS.windows}, ${osversion}-${arch}))
+ALL_ARCH.windows ?= amd64
+ALL_OSVERSIONS.windows ?= 1809 ltsc2022
+ifeq ($(WINDOWS_USE_HOST_PROCESS_CONTAINERS), true)
+ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), windows-hpc-${arch})
+else
+ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-${osversion}-${arch}))
+endif
+ALL_OS_ARCH = $(foreach os, $(ALL_OS), $(ALL_OS_ARCH.$(os)))
 
 # The current context of image building
 # The architecture of the image
@@ -52,25 +61,16 @@ IMAGE_REGISTRY ?= local
 K8S_VERSION ?= v1.18.0-rc.1
 HYPERKUBE_IMAGE ?= gcrio.azureedge.net/google_containers/hyperkube-amd64:$(K8S_VERSION)
 
-# `docker buildx` and `docker manifest` requires enabling DOCKER_CLI_EXPERIMENTAL for docker version < 1.20
-export DOCKER_CLI_EXPERIMENTAL=enabled
-
 ifndef TAG
 	IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)
 else
 	IMAGE_TAG ?= $(TAG)
 endif
 
+# `docker buildx` and `docker manifest` requires enabling DOCKER_CLI_EXPERIMENTAL for docker version < 1.20
+export DOCKER_CLI_EXPERIMENTAL=enabled
 DOCKER_CLI_EXPERIMENTAL := enabled
-
 DOCKER_BUILDX ?= docker buildx
-
-# cloud controller manager image
-ifeq ($(ARCH), amd64)
-CONTROLLER_MANAGER_IMAGE_NAME=azure-cloud-controller-manager
-else
-CONTROLLER_MANAGER_IMAGE_NAME=azure-cloud-controller-manager-$(ARCH)
-endif
 
 # Cross-platform build with CGO_ENABLED=1
 ifeq ($(ARCH), amd64)
@@ -81,17 +81,19 @@ else ifeq ($(ARCH), arm)
 CGO_OPTION ?= CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc
 endif
 
-CONTROLLER_MANAGER_FULL_IMAGE_NAME=$(IMAGE_REGISTRY)/$(CONTROLLER_MANAGER_IMAGE_NAME)
-CONTROLLER_MANAGER_IMAGE=$(IMAGE_REGISTRY)/$(CONTROLLER_MANAGER_IMAGE_NAME):$(IMAGE_TAG)
-ALL_CONTROLLER_MANAGER_IMAGES = $(foreach arch, ${ALL_ARCH.linux}, $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-${arch}:$(IMAGE_TAG))
+# image name and variable pattern for the cloud-controller-manager and cloud-node-manager:
+# - XX_IMAGE only carries the registry and XX component image name without image tag
+# - The Linux image tag of specific ARCH will be in the format $(IMAGE_TAG)-linux-$(ARCH)
+# - The Windows image tag of specific ARCH and OS will be in the format $(IMAGE_TAG)-windows-$(WINDOWS_OSVERSION)-$(ARCH)
+# - The Windows hpc image tag of specific ARCH will be in the format $(IMAGE_TAG)-windows-hpc-$(ARCH)
+
+# cloud controller manager image
+CONTROLLER_MANAGER_IMAGE_NAME=azure-cloud-controller-manager
+CONTROLLER_MANAGER_IMAGE=$(IMAGE_REGISTRY)/$(CONTROLLER_MANAGER_IMAGE_NAME)
 
 # cloud node manager image
 NODE_MANAGER_IMAGE_NAME=azure-cloud-node-manager
-NODE_MANAGER_FULL_IMAGE_NAME=$(IMAGE_REGISTRY)/$(NODE_MANAGER_IMAGE_NAME)
-NODE_MANAGER_IMAGE=$(NODE_MANAGER_FULL_IMAGE_NAME):$(IMAGE_TAG)
-NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX=$(NODE_MANAGER_FULL_IMAGE_NAME):$(IMAGE_TAG)-linux
-NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX=$(NODE_MANAGER_FULL_IMAGE_NAME):$(IMAGE_TAG)-windows
-ALL_NODE_MANAGER_IMAGES = $(foreach arch, ${ALL_ARCH.linux}, $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-${arch}) $(foreach osversion-arch, ${ALL_OS_ARCH.windows}, $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-${osversion-arch})
+NODE_MANAGER_IMAGE=$(IMAGE_REGISTRY)/$(NODE_MANAGER_IMAGE_NAME)
 
 # ccm e2e test image
 CCM_E2E_TEST_IMAGE_NAME=cloud-provider-azure-e2e
@@ -149,12 +151,12 @@ build-ccm-image: buildx-setup ## Build controller-manager image.
 		--build-arg ARCH="$(ARCH)" \
 		--build-arg VERSION="$(VERSION)" \
 		--file Dockerfile \
-		--tag $(CONTROLLER_MANAGER_IMAGE) . \
+		--tag $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG)-linux-$(ARCH) . \
 		--provenance=false \
 		--sbom=false
 
 .PHONY: build-node-image-linux
-build-node-image-linux: buildx-setup ## Build node-manager image.
+build-node-image-linux: buildx-setup ## Build node-manager Linux image with specific ARCH.
 	$(DOCKER_BUILDX) build \
 		--pull \
 		--output=type=$(OUTPUT_TYPE) \
@@ -163,16 +165,16 @@ build-node-image-linux: buildx-setup ## Build node-manager image.
 		--build-arg ARCH="$(ARCH)" \
 		--build-arg VERSION="$(VERSION)" \
 		--file cloud-node-manager.Dockerfile \
-		--tag $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) . \
+		--tag $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-linux-$(ARCH) . \
 		--provenance=false \
 		--sbom=false
 
 .PHONY: build-node-image-windows
-build-node-image-windows: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ## Build node-manager image for Windows.
+build-node-image-windows: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ##  Build node-manager Windows image with specific ARCH and OS.
 	$(DOCKER_BUILDX) build --pull \
 		--output=type=$(OUTPUT_TYPE) \
 		--platform windows/$(ARCH) \
-		-t $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH) \
+		-t $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-windows-$(WINDOWS_OSVERSION)-$(ARCH) \
 		--build-arg OSVERSION=$(WINDOWS_OSVERSION) \
 		--build-arg ARCH=$(ARCH) \
 		-f cloud-node-manager-windows.Dockerfile . \
@@ -180,11 +182,11 @@ build-node-image-windows: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe #
 		--sbom=false
 
 .PHONY: build-node-image-windows-hpc
-build-node-image-windows-hpc: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ## Build node-manager image for Windows.
+build-node-image-windows-hpc: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ## Build node-manager Windows image for a specific ARCH.
 	$(DOCKER_BUILDX) build --pull \
 		--output=type=$(OUTPUT_TYPE) \
 		--platform windows/$(ARCH) \
-		-t $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH) \
+		-t $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-windows-hpc-$(ARCH) \
 		--build-arg ARCH=$(ARCH) \
 		-f cloud-node-manager-windows-hpc.Dockerfile . \
 		--provenance=false \
@@ -195,20 +197,12 @@ build-ccm-e2e-test-image: ## Build e2e test image.
 	docker build -t $(CCM_E2E_TEST_IMAGE) -f ./e2e.Dockerfile .
 
 .PHONY: push-ccm-image
-push-ccm-image: ## Push controller-manager image.
-	docker push $(CONTROLLER_MANAGER_IMAGE)
+push-ccm-image: ## Push controller-manager Linux image of a specific ARCH.
+	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=registry build-ccm-image
 
 .PHONY: push-node-image-linux
-push-node-image-linux: ## Push node-manager image for Linux.
-	docker push $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
-
-push-node-image-linux-push-name-%:
-	$(MAKE) ARCH=$* push-node-image-linux-push-name
-
-.PHONY: push-node-image-linux-push-name
- push-node-image-linux-push-name:
-	docker tag $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_IMAGE)
-	docker push $(NODE_MANAGER_IMAGE)
+push-node-image-linux: ## Push node-manager Linux image for a specific ARCH.
+	$(MAKE) ARCH=$(ARCH) OUTPUT_TYPE=registry build-node-image-linux
 
 .PHONY: release-ccm-e2e-test-image
 release-ccm-e2e-test-image: ## Build and release e2e test image.
@@ -225,60 +219,61 @@ endif
 ##@ All Arch or OS Version
 ## --------------------------------------
 
-# NOTE(mainred): build-images target is going to be deprecated
-.PHONY: build-images
-build-images: image
+.PHONY: manifest
+manifest: manifest-controller-manager manifest-node-manager ## Push cloud-controller-manager and cloud-node-manager manifests.
 
-# NOTE(mainred): push-images target is going to be deprecated
-.PHONY: push-images
-push-images: push
-
-.PHONY: image
-image: build-all-ccm-images build-all-node-images ## Build all images.
-
-.PHONY: push
-push: push-multi-arch-controller-manager-image push-multi-arch-node-manager-image ## Push all images.
-
-.PHONY: push-multi-arch-controller-manager-image ## Push multi-arch controller-manager image
-push-multi-arch-controller-manager-image: push-all-ccm-images ## Create and push a manifest list containing all the Linux ccm images.
-	## Linux amd64 ccm image name has no amd64
-	docker tag $(CONTROLLER_MANAGER_FULL_IMAGE_NAME):$(IMAGE_TAG) $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-amd64:$(IMAGE_TAG)
-	docker push $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-amd64:$(IMAGE_TAG)
-
-	docker manifest create --amend $(CONTROLLER_MANAGER_IMAGE) $(ALL_CONTROLLER_MANAGER_IMAGES)
+.PHONY: manifest-controller-manager
+manifest-controller-manager: push-all-ccm-images ## Push controller-manager manifest by creating and pushing a manifest list containing all the Linux ccm images.
+	docker manifest create --amend $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG) $(shell echo $(ALL_OS_ARCH.linux) | sed -e "s~[^ ]*~$(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG)\-&~g")
 	for arch in $(ALL_ARCH.linux); do \
-		docker manifest annotate --os linux --arch $${arch} $(CONTROLLER_MANAGER_IMAGE) $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-$${arch}:$(IMAGE_TAG); \
+		docker manifest annotate --os linux --arch $${arch} $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG) $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG)-linux-$${arch}; \
 	done
-	docker manifest push --purge $(CONTROLLER_MANAGER_IMAGE)
+	docker manifest push --purge $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG)
 
-.PHONY: push-multi-arch-node-manager-image ## Push multi-arch node-manager image
-push-multi-arch-node-manager-image: push-all-node-images ## Create and push a manifest list containing all the Windows and Linux images.
-	docker manifest create --amend $(NODE_MANAGER_IMAGE) $(ALL_NODE_MANAGER_IMAGES)
+.PHONY: manifest-node-manager
+manifest-node-manager: push-all-node-images ## Push node-manager manifest by creating and pushing a manifest list containing all the Windows and Linux images.
+	docker manifest create --amend $(NODE_MANAGER_IMAGE):$(IMAGE_TAG) $(shell echo $(ALL_OS_ARCH) | sed -e "s~[^ ]*~$(NODE_MANAGER_IMAGE):$(IMAGE_TAG)\-&~g")
 	for arch in $(ALL_ARCH.linux); do \
-		docker manifest annotate --os linux --arch $${arch} $(NODE_MANAGER_IMAGE)  $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$${arch}; \
+		docker manifest annotate --os linux --arch $${arch} $(NODE_MANAGER_IMAGE):$(IMAGE_TAG) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-linux-$${arch}; \
 	done
+ifeq ($(WINDOWS_USE_HOST_PROCESS_CONTAINERS),true)
+	for windowsarch in $(ALL_ARCH.windows); do \
+		docker manifest annotate --os windows --arch $${windowsarch} $(NODE_MANAGER_IMAGE):$(IMAGE_TAG) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-windows-hpc-$(ARCH); \
+	done
+else
 	# For Windows images, we also need to include the "os.version" in the manifest list, so the Windows node can pull the proper image it needs.
 	# we use awk to also trim the quotes around the OS version string.
 	set -x; \
 	for windowsarch in $(ALL_ARCH.windows); do \
 		for osversion in $(ALL_OSVERSIONS.windows); do \
 			full_version=`docker manifest inspect ${BASE.windows}:$${osversion} | jq -r '.manifests[0].platform["os.version"]'`; \
-			docker manifest annotate --os windows --arch $${windowsarch} --os-version $${full_version} $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$${osversion}-$${windowsarch}; \
+			docker manifest annotate --os windows --arch $${windowsarch} --os-version $${full_version} $(NODE_MANAGER_IMAGE):$(IMAGE_TAG) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-windows-$${osversion}-$${windowsarch}; \
 		done; \
 	done
-	docker manifest push --purge $(NODE_MANAGER_IMAGE)
+endif
 
-.PHONY: push-all-node-images ## Push node-manager image for os and archs.
+	docker manifest push --purge $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)
+
+.PHONY: push-all-ccm-images
+push-all-ccm-images: $(addprefix push-ccm-image-,$(ALL_ARCH.linux))
+
+push-ccm-image-%:
+	$(MAKE) ARCH=$* push-ccm-image
+# TODO(mainred): capz uses push-ccm-image-amd64 to push the image, to not break the test and image release, we want to keep the same capability.
+#                And remove this workaround after we onboard the new targets in capz.
+ifeq ($(IS_RELEASE),)
+	docker tag $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG)-linux-amd64 $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG)
+	docker push $(CONTROLLER_MANAGER_IMAGE):$(IMAGE_TAG)
+endif
+
+.PHONY: push-all-node-Images
 push-all-node-images: push-all-node-images-linux push-all-node-images-windows
 
-.PHONY: push-all-node-images-linux ## Push node-manager image for Linux.
-push-all-node-images-linux: $(addprefix push-node-image-linux-,$(ALL_ARCH.linux))
+.PHONY: push-all-node-images-Linux
+push-all-node-images-linux: $(addprefix push-node-image-,$(ALL_OS_ARCH.linux))
 
-.PHONY: push-all-node-images-windows ## Push node-manager image for Windows.
-push-all-node-images-windows: $(addprefix push-node-image-windows-,$(ALL_OS_ARCH.windows))
-
-.PHONY: push-all-node-images-windows-hpc ## Push node-manager image for Windows.
-push-all-node-images-windows-hpc: $(addprefix push-node-images-windows-hpc-,$(ALL_OS_ARCH.windows))
+.PHONY: push-all-node-images-windows
+push-all-node-images-windows: $(addprefix push-node-image-,$(ALL_OS_ARCH.windows))
 
 # split words on hyphen, access by 1-index
 word-hyphen = $(word $2,$(subst -, ,$1))
@@ -292,14 +287,11 @@ push-node-image-windows-%:
 push-node-image-windows-hpc-%:
 	$(MAKE) ARCH=$(call word-hyphen,$*,1) OUTPUT_TYPE=registry build-node-image-windows-hpc
 
-.PHONY: build-all-node-images ## Build node-manager image for all OS and archs.
-build-all-node-images: build-all-node-images-linux build-all-node-images-windows
+.PHONY: build-all-node-images-linux
+build-all-node-images-linux: $(addprefix build-node-image-,$(ALL_OS_ARCH.linux))
 
-.PHONY: build-all-node-images-linux ## Build node-manager image for Linux.
-build-all-node-images-linux: $(addprefix build-node-image-linux-,$(ALL_ARCH.linux))
-
-.PHONY: build-all-node-images-windows ## Build node-manager image for Windows.
-build-all-node-images-windows: $(addprefix build-node-image-windows-,$(ALL_OS_ARCH.windows))
+.PHONY: build-all-node-images-windows
+build-all-node-images-windows: $(addprefix build-node-image-,$(ALL_OS_ARCH.windows))
 
 build-node-image-linux-%:
 	$(MAKE) ARCH=$* build-node-image-linux
@@ -307,40 +299,26 @@ build-node-image-linux-%:
 build-node-image-windows-%:
 	$(MAKE) WINDOWS_OSVERSION=$(call word-hyphen,$*,1) ARCH=$(call word-hyphen,$*,2) build-node-image-windows
 
+build-node-image-windows-hpc-%:
+	$(MAKE) ARCH=$(call word-hyphen,$*,1) build-node-image-windows-hpc
+
 .PHONY: build-all-ccm-images
 build-all-ccm-images: $(addprefix build-ccm-image-,$(ALL_ARCH.linux))
 
 build-ccm-image-%:
 	$(MAKE) ARCH=$* build-ccm-image
 
-.PHONY: push-all-ccm-images
-push-all-ccm-images: $(addprefix push-ccm-image-,$(ALL_ARCH.linux))
-
-push-ccm-image-%:
-	$(MAKE) ARCH=$* push-ccm-image
-
-manifest-node-manager-image-windows-%:
-	$(MAKE) WINDOWS_OSVERSION=$(call word-hyphen,$*,1) ARCH=$(call word-hyphen,$*,2) manifest-node-manager-image-windows
+# TODO(mainred): remove this after we onboard new patterns in capz
 
 manifest-node-manager-image-windows-hpc-%:
 	$(MAKE) ARCH=$(call word-hyphen,$*,1) manifest-node-manager-image-windows-hpc
 
-.PHONY: manifest-node-manager-image-windows
-manifest-node-manager-image-windows:
-	set -x
-	docker manifest create --amend $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH)
-	docker manifest annotate --os linux --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
-	full_version=`docker manifest inspect ${BASE.windows}:$(WINDOWS_OSVERSION) | jq -r '.manifests[0].platform["os.version"]'`; \
-	docker manifest annotate --os windows --arch $(ARCH) --os-version $${full_version} $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH)
-	docker manifest push --purge $(NODE_MANAGER_IMAGE)
-
-.PHONY: manifest-node-manager-images-windows-hpc
 manifest-node-manager-image-windows-hpc:
 	set -x
-	docker manifest create --amend $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH)
-	docker manifest annotate --os linux --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
-	docker manifest annotate --os windows --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH)
-	docker manifest push --purge $(NODE_MANAGER_IMAGE)
+	docker manifest create --amend $(NODE_MANAGER_IMAGE):$(IMAGE_TAG) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-linux-$(ARCH) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-windows-hpc-$(ARCH)
+	docker manifest annotate --os linux --arch $(ARCH) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-linux-$(ARCH)
+	docker manifest annotate --os windows --arch $(ARCH) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG) $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)-windows-hpc-$(ARCH)
+	docker manifest push --purge $(NODE_MANAGER_IMAGE):$(IMAGE_TAG)
 
 ## --------------------------------------
 ##@ Tests
@@ -366,7 +344,7 @@ test-boilerplate: ## Run boilerplate test.
 	hack/verify-boilerplate.sh
 
 .PHONY: test-helm
-test-helm: ## Validate helm charts
+test-helm: ## Validate helm charts。
 	hack/verify-helm-repo.sh
 
 .PHONY: verify-vendor-licenses
@@ -374,7 +352,7 @@ verify-vendor-licenses: ## Verify vendor licenses
 	hack/verify-azure-vendor-licenses.sh
 
 .PHONY: update-helm
-update-helm: ## Update helm charts
+update-helm: ## Update helm charts.
 	hack/update-helm-repo.sh
 
 .PHONY: update-dependencies
@@ -390,7 +368,7 @@ update-mocks: ## Create or update mock clients.
 	@hack/update-mock-clients.sh
 
 .PHONY: update-vendor-licenses
-update-vendor-licenses: ## Update vendor licenses
+update-vendor-licenses: ## Update vendor licenses。
 	hack/update-azure-vendor-licenses.sh
 
 .PHONY: update
@@ -399,7 +377,7 @@ update: update-dependencies update-gofmt update-mocks update-vendor-licenses ## 
 test-e2e: ## Run k8s e2e tests.
 	hack/test_k8s_e2e.sh $(TEST_E2E_ARGS)
 
-test-e2e-capz: ## Run k8s e2e tests with capz
+test-e2e-capz: ## Run k8s e2e tests with capz.
 	hack/test_k8s_e2e_capz.sh $(TEST_E2E_ARGS)
 
 test-ccm-e2e: ## Run cloud provider e2e tests.
@@ -431,9 +409,9 @@ cloud-build-prerequisites:
 .PHONY: release-staging
 release-staging: ## Release the cloud provider images.
 ifeq ($(CLOUD_BUILD_IMAGE),ccm)
-	ENABLE_GIT_COMMAND=$(ENABLE_GIT_COMMAND) $(MAKE) build-all-ccm-images push-multi-arch-controller-manager-image
+	ENABLE_GIT_COMMAND=$(ENABLE_GIT_COMMAND) $(MAKE) IS_RELEASE=true manifest-controller-manager
 else
-	ENABLE_GIT_COMMAND=$(ENABLE_GIT_COMMAND) $(MAKE) cloud-build-prerequisites build-all-node-images push-multi-arch-node-manager-image
+	ENABLE_GIT_COMMAND=$(ENABLE_GIT_COMMAND) $(MAKE) cloud-build-prerequisites manifest-node-manager
 endif
 
 ## --------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes the [post-provider-azure-push-images job failure](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-provider-azure-push-images/1891194935462334464) which is caused by building windows images and out to Linux docker Engine. Fix this by normalizing the image building targets.
- removed makefile targets build-all-node-images which are not achievable on one OS platform
- push image artifacts will be triggered by `docker buildx --output=type=registry` which can reuse the build target but specify OUTPUT_TYPE=registry. pushing images does not relies on building image targets in the future.
Besides fixing the image building job issue. we also 
- simplified the makefile target name like replacing push-multi-arch-controller-manager-image with manifest-controller-manager
- removed redundant variable name like `$NODE_MANAGER_FULL_IMAGE_NAME` and `$ALL_NODE_MANAGER_IMAGES`, and use `$(NODE_MANAGER_IMAGE):$(IMAGE_TAG)` specificly to represent the image+tag, and use `foreach` to iterate the OS and ARCH to form the image tags for different OS and ARCH.
- expose only necessary makefile targets with comment, you may try this by `make help`
- we can build node manager with windows host process container image when `WINDOWS_USE_HOST_PROCESS_CONTAINERS` is set to true
- leave only windows 2022 and 2019

Finally, in order to not break the PR check-in and post-provider-azure-push-images, we introduced `IS_RELEASE` variable. [PR check-in in capz ci-build-azure-ccm.sh](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/scripts/ci-build-azure-ccm.sh#L62-L64) build and publish amd64 ccm images, but expect a arch-agnostic image inappropriately, we keep this ability and hope to replace it with `make ALL_ARCH.linux=amd64 manifest-controller-manager` after this PR is merged.

#### Tests have been done:

I have tested this change against ado pipeline, pr check-in, and post-provider-azure-push-images job.

##### ordinary image push

```
IMAGE_REGISTRY=mainred make manifest-controller-manager

docker manifest inspect mainred/azure-cloud-controller-manager:b4aebbe | jq '.manifests[].platform' | tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture":"amd64","os":"linux"}
{"architecture":"arm","os":"linux","variant":"v7"}
{"architecture":"arm64","os":"linux"}
```
```
IMAGE_REGISTRY=mainred make manifest-node-manager
 docker manifest inspect mainred/azure-cloud-node-manager:b4aebbe| tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture":"amd64","os":"linux"}
{"architecture":"arm","os":"linux","variant":"v7"}
{"architecture":"arm64","os":"linux"}
{"architecture":"amd64","os":"windows","os.version":"10.0.17763.6893"}
{"architecture":"amd64","os":"windows","os.version":"10.0.20348.3207"}
```
##### node manager manifest with windows host process contianer image

```
WINDOWS_USE_HOST_PROCESS_CONTAINERS=true IMAGE_REGISTRY=mainred  make manifest-node-manager-image

docker manifest inspect mainred/azure-cloud-node-manager:b4aebbe | jq '.manifests[].platform'| tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture":"amd64","os":"linux"}
{"architecture":"arm","os":"linux","variant":"v7"}
{"architecture":"arm64","os":"linux"}
{"architecture":"amd64","os":"windows"}
```
##### current capz support

```
IMAGE_REGISTRY=mainred make build-node-image-linux-amd64 push-node-image-linux-amd64 push-node-image-windows-hpc-amd64 manifest-node-manager-image-windows-hpc-amd64
 docker manifest inspect mainred/azure-cloud-node-manager:e5a7448| jq '.manifests[].platform'| tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture":"amd64","os":"linux"}
{"architecture":"amd64","os":"windows"}
```

```
IMAGE_REGISTRY=mainred make build-ccm-image-amd64 push-ccm-image-amd64 make ARCH=amd64 build-ccm-image
docker manifest inspect mainred/azure-cloud-controller-manager:e5a7448
{
        "schemaVersion": 2,
        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
        "config": {
                "mediaType": "application/vnd.docker.container.image.v1+json",
                "size": 2244,
                "digest": "sha256:6a2fc4890486748fc9d5b64af3a644b3a60baff87dd7a210dd7435688d9121a0"
        },
        "layers": [
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "size": 104238,
                        "digest": "sha256:688513194d7a0f0d77e4a3692748d21c4ccd1af6a5ff9012f18f053ed9573c13"
                },
             ... ...
        ]
}
```
##### future capz change

capz can still build only minimal amd64-based image for test as it has been doing so far.
```
make IMAGE_REGISTRY=mainred ALL_ARCH.linux=amd64 manifest-controller-manager

 docker manifest inspect mainred/azure-cloud-controller-manager:b4aebbe| jq '.manifests[].platform'| tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture": "amd64","os": "linux"}

make IMAGE_REGISTRY=mainred WINDOWS_USE_HOST_PROCESS_CONTAINERS=true ALL_ARCH.linux=amd64 manifest-node-manager

docker manifest inspect mainred/azure-cloud-node-manager:b4aebbe| jq '.manifests[].platform'| tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture":"amd64","os":"linux"}
{"architecture":"amd64","os":"windows"}
```

##### release

```
make IMAGE_REGISTRY=mainred release-staging 

docker manifest inspect mainred/azure-cloud-controller-manager:b4aebbe| jq '.manifests[].platform'| tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture":"amd64","os":"linux"}
{"architecture":"arm","os":"linux","variant":"v7"}
{"architecture":"arm64","os":"linux"}

make CLOUD_BUILD_IMAGE=cnm IMAGE_REGISTRY=mainred release-staging
docker manifest inspect mainred/azure-cloud-node-manager:b4aebbe| jq '.manifests[].platform'| tr -d "[:space:]"|sed 's/}/&\n/g'
{"architecture":"amd64","os":"linux"}
{"architecture":"arm","os":"linux","variant":"v7"}
{"architecture":"arm64","os":"linux"}
{"architecture":"amd64","os":"windows","os.version":"10.0.17763.6893"}
{"architecture":"amd64","os":"windows","os.version":"10.0.20348.3207"}

```

for ado pipelines,

```
OUTPUT_TYPE="docker,dest=azure-cloud-controller-manager.tar" ARCH=amd64 make build-ccm-image
ls -l azure-cloud-controller-manager.tar
-rw-rw-r-- 1 azureuser azureuser 31205376 Feb 20 15:22 azure-cloud-controller-manager.tar


OUTPUT_TYPE="docker,dest=azure-cloud-node-manager.tar" ARCH=amd64 make build-node-image-Linux
ls -l azure-cloud-node-manager.tar
-rw-rw-r-- 1 azureuser azureuser 30639616 Feb 20 15:29 azure-cloud-node-manager.tar

```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
