### PR TITLE
fix: Remove managed pip if switched to another pip in a different res…

### DIFF
--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -3251,7 +3251,7 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 					ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 						"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/" + *identifier),
 					Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+						PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 					},
 				},
 			},
@@ -3311,7 +3311,7 @@ func getTestLoadBalancerDualStack(name, rgName, clusterName, identifier *string,
 			"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/" + *identifier + ipv6Suffix),
 		Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
 			PublicIPAddress: &armnetwork.PublicIPAddress{
-				ID: ptr.To("testCluster-aservice1-IPv6"),
+				ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6"),
 			},
 		},
 	})
@@ -3369,7 +3369,7 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("bservice1"),
 			ID:   ptr.To("bservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
@@ -3390,28 +3390,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 				Name: ptr.To("aservice1"),
 				ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 				},
 			},
 			{
 				Name: ptr.To("bservice1"),
 				ID:   ptr.To("bservice1"),
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1")},
+					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 				},
 			},
 			{
 				Name: ptr.To("aservice1-IPv6"),
 				ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 				},
 			},
 			{
 				Name: ptr.To("bservice1-IPv6"),
 				ID:   ptr.To("bservice1-IPv6"),
 				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1-IPv6")},
+					PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 				},
 			},
 		}
@@ -3452,28 +3452,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1"),
 			ID:   ptr.To("bservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1-IPv6"),
 			ID:   ptr.To("bservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3485,28 +3485,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1"),
 			ID:   ptr.To("bservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1-IPv6"),
 			ID:   ptr.To("bservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3553,28 +3553,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1"),
 			ID:   ptr.To("bservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1-IPv6"),
 			ID:   ptr.To("bservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3586,28 +3586,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1"),
 			ID:   ptr.To("bservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1-IPv6"),
 			ID:   ptr.To("bservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3656,28 +3656,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1"),
 			ID:   ptr.To("bservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: ptr.To("bservice1-IPv6"),
 			ID:   ptr.To("bservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3697,14 +3697,14 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 	}
@@ -3731,14 +3731,14 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 	}
@@ -3779,14 +3779,14 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: ptr.To("aservice1"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: ptr.To("aservice1-IPv6"),
 			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 	}
@@ -4000,6 +4000,9 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 				return false, false, lb, nil
 			}).AnyTimes()
 			mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			mockPLSRepo := az.plsRepo.(*privatelinkservice.MockRepository)
+			mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil).AnyTimes()
 
 			lb, rerr := az.reconcileLoadBalancer(context.TODO(), "testCluster", &service, clusterResources.nodes, test.wantLb)
 			if test.expectedError != nil {
@@ -4269,6 +4272,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				},
 			},
 			expectedCreateOrUpdateCount: 0,
@@ -4280,6 +4284,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						IPAddress: ptr.To("1.2.3.4"),
@@ -4287,6 +4292,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						IPAddress: ptr.To("fd00::eef0"),
@@ -4310,10 +4316,12 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 				},
 				{
 					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 				},
 			},
@@ -4331,6 +4339,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4339,6 +4348,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4347,6 +4357,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4355,6 +4366,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
@@ -4384,7 +4396,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					},
 				},
 			},
-			expectedCreateOrUpdateCount: 0, // Before the fix, this was 1 because IPv4's IP Version was not set. Same for other tests.
+			expectedCreateOrUpdateCount: 0,
 			expectedDeleteCount:         2,
 		},
 		{
@@ -4397,6 +4409,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4405,6 +4418,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4413,6 +4427,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv6),
@@ -4421,6 +4436,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip2-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv6),
@@ -4429,6 +4445,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4437,6 +4454,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
@@ -4480,6 +4498,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{
 						consts.ServiceTagKey:       ptr.To("default/test1"),
 						consts.LegacyServiceTagKey: ptr.To("foo"), // It should be ignored when ServiceTagKey is present.
@@ -4491,6 +4510,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4499,6 +4519,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4507,6 +4528,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
@@ -4561,6 +4583,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
@@ -4576,6 +4599,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
@@ -4637,6 +4661,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
 						IPAddress:              ptr.To("1.2.3.4"),
@@ -4644,6 +4669,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
@@ -4652,6 +4678,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
 						IPAddress:              ptr.To("1.2.3.4"),
@@ -4659,6 +4686,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip2-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
@@ -4668,6 +4696,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
 						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
@@ -4703,6 +4732,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						IPAddress:              ptr.To("1.2.3.4"),
@@ -4711,6 +4741,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				},
 				{
 					Name: ptr.To("pip1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1-IPv6"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						IPAddress:                ptr.To("fd00::eef0"),
@@ -4874,6 +4905,97 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				}
 			}
 			assert.Equal(t, test.expectedDeleteCount, deletedCount)
+		})
+	}
+
+}
+
+func TestReconcilePublicIPsDeleteUnwantedFromOtherRG(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		desc                string
+		annotations         map[string]string
+		existingPIPs        []*armnetwork.PublicIPAddress
+		wantLb              bool
+		listFailed          bool
+		expectedError       bool
+		expectedDeleteCount int
+	}{
+		{
+			desc:   "shall delete managed pip when switching to user provided pip in another resource group",
+			wantLb: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationLoadBalancerResourceGroup: "rg-b",
+				consts.ServiceAnnotationPIPNameDualStack[false]:   "pip1",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg-a/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Name: ptr.To("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+					},
+				},
+				{
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
+					Name: ptr.To("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("2.3.4.5"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+					},
+				},
+			},
+			expectedDeleteCount: 1,
+		},
+		{
+			desc:   "shall return an error if failed to list pips in rg",
+			wantLb: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationLoadBalancerResourceGroup: "rg-b",
+				consts.ServiceAnnotationPIPNameDualStack[false]:   "pip1",
+			},
+			existingPIPs:  []*armnetwork.PublicIPAddress{{}},
+			listFailed:    true,
+			expectedError: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			az := GetTestCloud(ctrl)
+			service := getTestService("test1", v1.ProtocolTCP, nil, false, 80)
+			service.Annotations = test.annotations
+
+			// Set up mock clients
+			mockPIPsClient := az.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
+
+			// Set up mock List call to return the managed pip in rg-a
+			mockPIPsClient.EXPECT().List(gomock.Any(), "rg-b").Return(test.existingPIPs[:1], nil)
+			if test.listFailed {
+				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(nil, errors.New("failed to list pips"))
+			} else {
+				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPIPs[1:], nil)
+				mockPIPsClient.EXPECT().Get(gomock.Any(), "rg-b", "pip1", gomock.Any()).Return(test.existingPIPs[0], nil)
+			}
+
+			// Set up mock Delete call for the managed pip
+			if test.expectedDeleteCount > 0 {
+				mockPIPsClient.EXPECT().Delete(gomock.Any(), "rg", "pip2").Return(nil).Times(test.expectedDeleteCount)
+			}
+
+			// No need to mock Get or CreateOrUpdate since we're using an existing pip
+
+			_, err := az.reconcilePublicIPs(context.TODO(), "testCluster", &service, "", test.wantLb)
+			if test.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -273,6 +273,85 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should remove the unused managed IP when switching to a user-assigned public IP in a different resource group", func() {
+		v4Enabled, v6Enabled := utils.IfIPFamiliesEnabled(tc.IPFamily)
+		ipNameBase := basename + "-public-IP" + string(uuid.NewUUID())[0:4]
+		targetIPs := []*string{}
+
+		// Create a service with managed public IP first
+		By("Creating a service with managed public IP")
+		service := utils.CreateLoadBalancerServiceManifest(testServiceName, nil, labels, ns.Name, ports)
+		service, err := cs.CoreV1().Services(ns.Name).Create(context.Background(), service, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the managed public IP to be ready")
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, targetIPs)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a user-assigned public IP in a different resource group
+		By("Creating a user-assigned public IP in a different resource group")
+		rg, deleteRG := utils.CreateTestResourceGroup(tc)
+		otherRG := ptr.Deref(rg.Name, "")
+		Expect(rg).NotTo(BeNil())
+		defer deleteRG(otherRG)
+
+		var pipName, pipNameV6 string
+		if v4Enabled {
+			pipName = ipNameBase + "-v4"
+			pip := defaultPublicIPAddress(pipName, false)
+			createdPIP, err := utils.WaitCreatePIP(tc, pipName, otherRG, pip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdPIP).NotTo(BeNil())
+			Expect(createdPIP.Properties.IPAddress).NotTo(BeNil())
+			defer utils.DeletePIPWithRetry(tc, pipName, otherRG)
+			targetIPs = append(targetIPs, createdPIP.Properties.IPAddress)
+		}
+		if v6Enabled {
+			pipNameV6 = ipNameBase + "-v6"
+			pipV6 := defaultPublicIPAddress(pipNameV6, true)
+			createdPIPV6, err := utils.WaitCreatePIP(tc, pipNameV6, otherRG, pipV6)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdPIPV6).NotTo(BeNil())
+			Expect(createdPIPV6.Properties.IPAddress).NotTo(BeNil())
+			defer utils.DeletePIPWithRetry(tc, pipNameV6, otherRG)
+			targetIPs = append(targetIPs, createdPIPV6.Properties.IPAddress)
+		}
+
+		// Update service to use the user-assigned public IP in the other resource group
+		By("Updating service to use the user-assigned public IP in the other resource group")
+		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+		service.Annotations = map[string]string{
+			consts.ServiceAnnotationLoadBalancerResourceGroup: otherRG,
+		}
+		if v4Enabled {
+			service.Annotations[consts.ServiceAnnotationPIPNameDualStack[false]] = pipName
+		}
+		if v6Enabled {
+			service.Annotations[consts.ServiceAnnotationPIPNameDualStack[true]] = pipNameV6
+		}
+		service, err = cs.CoreV1().Services(ns.Name).Update(context.Background(), service, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			By("Cleaning up Service")
+			err = utils.DeleteService(cs, ns.Name, testServiceName)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		By("Waiting for the service to be updated with the user-assigned public IP")
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, targetIPs)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the managed public IP is deleted")
+		pips, err := tc.ListPublicIPs(tc.GetResourceGroup())
+		Expect(err).NotTo(HaveOccurred())
+		for _, pip := range pips {
+			if pip.Tags != nil && pip.Tags[consts.ServiceTagKey] != nil && *pip.Tags[consts.ServiceTagKey] == ns.Name+"/"+testServiceName {
+				Fail("Found managed public IP that should have been deleted")
+			}
+		}
+	})
+
 	// Internal w/ IP -> Internal w/ IP
 	It("should support updating internal IP when updating internal service", func() {
 		ips1, err := utils.SelectAvailablePrivateIPs(tc)


### PR DESCRIPTION
…ource group

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

We should remove managed pip when the service switches to a different pip in another resource group.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8113

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Remove managed pip if switched to another pip in a different resource group
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
