### PR TITLE
[release-1.29] fix: Remove all routes that have the node name as prefix (#8427)

### DIFF
--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -57,6 +58,7 @@ type delayedRouteOperation struct {
 	routeTableTags map[string]*string
 	operation      routeOperation
 	result         chan batchOperationResult
+	nodeName       string
 }
 
 // wait waits for the operation completion and returns the result.
@@ -181,6 +183,19 @@ func (d *delayedRouteUpdater) updateRoutes() {
 				break
 			}
 		}
+		// After removing the matched routes (if any), loop again to remove the outdated routes,
+		// whose name and IP addresses may not match but target the same node.
+		for i := len(routes) - 1; i >= 0; i-- {
+			existingRoute := routes[i]
+			// remove all routes that target the node when the operation is delete
+			if strings.HasPrefix(ptr.Deref(existingRoute.Name, ""), ptr.Deref(rt.route.Name, "")) {
+				if rt.operation == routeOperationDelete {
+					routes = append(routes[:i], routes[i+1:]...)
+					dirty = true
+					klog.V(2).Infof("updateRoutes: found outdated route %s targeting node %s, removing it", ptr.Deref(rt.route.Name, ""), rt.nodeName)
+				}
+			}
+		}
 		if rt.operation == routeOperationDelete && !dirty {
 			klog.Warningf("updateRoutes: route to be deleted %s does not match any of the existing route", pointer.StringDeref(rt.route.Name, ""))
 		}
@@ -241,17 +256,19 @@ func (d *delayedRouteUpdater) cleanupOutdatedRoutes(existingRoutes []network.Rou
 	return existingRoutes, changed
 }
 
-func getAddRouteOperation(route network.Route) batchOperation {
+func getAddRouteOperation(route network.Route, nodeName string) batchOperation {
 	return &delayedRouteOperation{
 		route:     route,
+		nodeName:  nodeName,
 		operation: routeOperationAdd,
 		result:    make(chan batchOperationResult),
 	}
 }
 
-func getDeleteRouteOperation(route network.Route) batchOperation {
+func getDeleteRouteOperation(route network.Route, nodeName string) batchOperation {
 	return &delayedRouteOperation{
 		route:     route,
+		nodeName:  nodeName,
 		operation: routeOperationDelete,
 		result:    make(chan batchOperationResult),
 	}
@@ -429,7 +446,7 @@ func (az *Cloud) CreateRoute(_ context.Context, clusterName string, _ string, ku
 	}
 
 	klog.V(2).Infof("CreateRoute: creating route for clusterName=%q instance=%q cidr=%q", clusterName, kubeRoute.TargetNode, kubeRoute.DestinationCIDR)
-	op := az.routeUpdater.addOperation(getAddRouteOperation(route))
+	op := az.routeUpdater.addOperation(getAddRouteOperation(route, string(kubeRoute.TargetNode)))
 
 	// Wait for operation complete.
 	err = op.wait().err
@@ -474,7 +491,7 @@ func (az *Cloud) DeleteRoute(_ context.Context, clusterName string, kubeRoute *c
 		Name:                  pointer.String(routeName),
 		RoutePropertiesFormat: &network.RoutePropertiesFormat{},
 	}
-	op := az.routeUpdater.addOperation(getDeleteRouteOperation(route))
+	op := az.routeUpdater.addOperation(getDeleteRouteOperation(route, string(kubeRoute.TargetNode)))
 
 	// Wait for operation complete.
 	err = op.wait().err
@@ -491,7 +508,7 @@ func (az *Cloud) DeleteRoute(_ context.Context, clusterName string, kubeRoute *c
 			Name:                  pointer.String(routeNameWithoutIPV6Suffix),
 			RoutePropertiesFormat: &network.RoutePropertiesFormat{},
 		}
-		op := az.routeUpdater.addOperation(getDeleteRouteOperation(route))
+		op := az.routeUpdater.addOperation(getDeleteRouteOperation(route, string(kubeRoute.TargetNode)))
 
 		// Wait for operation complete.
 		err = op.wait().err

--- a/pkg/provider/azure_routes_test.go
+++ b/pkg/provider/azure_routes_test.go
@@ -61,6 +61,7 @@ func TestDeleteRoute(t *testing.T) {
 		DestinationCIDR: "1.2.3.4/24",
 	}
 	routeName := mapNodeNameToRouteName(false, route.TargetNode, route.DestinationCIDR)
+	routeNameWithNodeNamePrefix := "node____bar"
 	routeTables := network.RouteTable{
 		Name:     &cloud.RouteTableName,
 		Location: &cloud.Location,
@@ -68,6 +69,9 @@ func TestDeleteRoute(t *testing.T) {
 			Routes: &[]network.Route{
 				{
 					Name: &routeName,
+				},
+				{
+					Name: &routeNameWithNodeNamePrefix,
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When a delete route operation comes in, not only the route with exactly the name should be deleted, but also all routes that have the node name as prefix should be deleted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8175

#### Special notes for your reviewer:

To reduce the potential impact, I separate the two deletion logic by adding a new for loop, instead of integrating them into one loop.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Remove all routes that have the node name as prefix
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
