### PR TITLE
[release-1.30] fix: Remove managed pip if switched to another pip in a different res…

### DIFF
--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2022-08-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2022-07-01/network"
 	"github.com/stretchr/testify/assert"
@@ -3264,7 +3265,7 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 					ID: pointer.String("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/" +
 						"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/" + *identifier),
 					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-						PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+						PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 					},
 				},
 			},
@@ -3324,7 +3325,7 @@ func getTestLoadBalancerDualStack(name, rgName, clusterName, identifier *string,
 			"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/" + *identifier + ipv6Suffix),
 		FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
 			PublicIPAddress: &network.PublicIPAddress{
-				ID: pointer.String("testCluster-aservice1-IPv6"),
+				ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6"),
 			},
 		},
 	})
@@ -3384,14 +3385,14 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("bservice1"),
 			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1-IPv6"),
 			ID:   pointer.String("bservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3405,28 +3406,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 				Name: pointer.String("aservice1"),
 				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+					PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 				},
 			},
 			{
 				Name: pointer.String("bservice1"),
 				ID:   pointer.String("bservice1"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+					PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 				},
 			},
 			{
 				Name: pointer.String("aservice1-IPv6"),
 				ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+					PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 				},
 			},
 			{
 				Name: pointer.String("bservice1-IPv6"),
 				ID:   pointer.String("bservice1-IPv6"),
 				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-					PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1-IPv6")},
+					PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 				},
 			},
 		}
@@ -3467,28 +3468,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("aservice1"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1"),
 			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1-IPv6"),
 			ID:   pointer.String("bservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3507,21 +3508,21 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("bservice1"),
 			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1-IPv6"),
 			ID:   pointer.String("bservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3565,31 +3566,31 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[1].IdleTimeoutInMinutes = pointer.Int32(4)
 	expectedSLb.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
 		{
-			Name: pointer.String("aservice1"),
-			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			Name: ptr.To("bservice1"),
+			ID:   ptr.To("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
-			},
-		},
-		{
-			Name: pointer.String("bservice1"),
-			ID:   pointer.String("bservice1"),
-			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1-IPv6"),
 			ID:   pointer.String("bservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
+			},
+		},
+		{
+			Name: ptr.To("aservice1"),
+			ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 	}
@@ -3601,28 +3602,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("aservice1"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1"),
 			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1-IPv6"),
 			ID:   pointer.String("bservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3671,28 +3672,28 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("aservice1"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1"),
 			ID:   pointer.String("bservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 		{
 			Name: pointer.String("bservice1-IPv6"),
 			ID:   pointer.String("bservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-bservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-bservice1-IPv6")},
 			},
 		},
 	}
@@ -3712,14 +3713,14 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("aservice1"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 	}
@@ -3746,14 +3747,14 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("aservice1"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 	}
@@ -3794,14 +3795,14 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			Name: pointer.String("aservice1"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1")},
 			},
 		},
 		{
 			Name: pointer.String("aservice1-IPv6"),
 			ID:   pointer.String("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/frontendIPConfigurations/aservice1-IPv6"),
 			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.PublicIPAddress{ID: pointer.String("testCluster-aservice1-IPv6")},
+				PublicIPAddress: &network.PublicIPAddress{ID: ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-aservice1-IPv6")},
 			},
 		},
 	}
@@ -4014,6 +4015,11 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 				return false, false, lb, nil
 			}).AnyTimes()
 			mockLBBackendPool.EXPECT().EnsureHostsInPool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			mockPLSClient := mockprivatelinkserviceclient.NewMockInterface(ctrl)
+			mockPLSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]network.PrivateLinkService{}, nil).AnyTimes()
+			mockPLSClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(network.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil).MaxTimes(1)
+			az.PrivateLinkServiceClient = mockPLSClient
 
 			lb, rerr := az.reconcileLoadBalancer(context.TODO(), "testCluster", &service, clusterResources.nodes, test.wantLb)
 			assert.Equal(t, test.expectedError, rerr)
@@ -4283,7 +4289,8 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			wantLb: false,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("pip1"),
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 				},
 			},
 			expectedCreateOrUpdateCount: 0,
@@ -4294,15 +4301,17 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			wantLb: true,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						IPAddress: pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("pip1-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						IPAddress: pointer.String("fd00::eef0"),
 					},
@@ -4324,12 +4333,14 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			annotations: map[string]string{consts.ServiceAnnotationPIPNameDualStack[false]: "testPIP"},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 				},
 				{
-					Name: pointer.String("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 				},
 			},
 			expectedError:               true,
@@ -4345,32 +4356,36 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("testPIP-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv6,
 						PublicIPAllocationMethod: network.Dynamic,
@@ -4399,7 +4414,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					},
 				},
 			},
-			expectedCreateOrUpdateCount: 0, // Before the fix, this was 1 because IPv4's IP Version was not set. Same for other tests.
+			expectedCreateOrUpdateCount: 0,
 			expectedDeleteCount:         2,
 		},
 		{
@@ -4411,48 +4426,54 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
+					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("pip1-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv6,
 						IPAddress:              pointer.String("fd00::eef0"),
 					},
 				},
 				{
-					Name: pointer.String("pip2-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
+					Name: ptr.To("pip2-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv6,
 						IPAddress:              pointer.String("fd00::eef0"),
 					},
 				},
 				{
-					Name: pointer.String("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("testPIP-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv6,
 						PublicIPAllocationMethod: network.Dynamic,
@@ -4495,6 +4516,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			existingPIPs: []network.PublicIPAddress{
 				{
 					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					Tags: map[string]*string{
 						consts.ServiceTagKey:       ptr.To("default/test1"),
 						consts.LegacyServiceTagKey: ptr.To("foo"), // It should be ignored when ServiceTagKey is present.
@@ -4505,24 +4527,27 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					},
 				},
 				{
-					Name: pointer.String("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("testPIP-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv6,
 						PublicIPAllocationMethod: network.Dynamic,
@@ -4575,8 +4600,9 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("testPIP"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv4,
 						PublicIPAllocationMethod: network.Static,
@@ -4590,8 +4616,9 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					},
 				},
 				{
-					Name: pointer.String("testPIP-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv6,
 						PublicIPAllocationMethod: network.Dynamic,
@@ -4651,30 +4678,34 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			},
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("pip1"),
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("pip2"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip2"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("testPIP"),
+					Name: ptr.To("testPIP"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: network.IPv4,
 						IPAddress:              pointer.String("1.2.3.4"),
 					},
 				},
 				{
-					Name: pointer.String("pip2-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
+					Name: ptr.To("pip2-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv6,
 						PublicIPAllocationMethod: network.Dynamic,
@@ -4682,7 +4713,8 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					},
 				},
 				{
-					Name: pointer.String("testPIP-IPv6"),
+					Name: ptr.To("testPIP-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP-IPv6"),
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   network.IPv6,
 						PublicIPAllocationMethod: network.Dynamic,
@@ -4717,16 +4749,18 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			wantLb: false,
 			existingPIPs: []network.PublicIPAddress{
 				{
-					Name: pointer.String("pip1"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						IPAddress:              pointer.String("1.2.3.4"),
 						PublicIPAddressVersion: network.IPv4,
 					},
 				},
 				{
-					Name: pointer.String("pip1-IPv6"),
-					Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1,default/test2")},
+					Name: ptr.To("pip1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1,default/test2")},
 					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 						IPAddress:                pointer.String("fd00::eef0"),
 						PublicIPAllocationMethod: network.Dynamic,
@@ -4889,6 +4923,97 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				}
 			}
 			assert.Equal(t, test.expectedDeleteCount, deletedCount)
+		})
+	}
+
+}
+
+func TestReconcilePublicIPsDeleteUnwantedFromOtherRG(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		desc                string
+		annotations         map[string]string
+		existingPIPs        []network.PublicIPAddress
+		wantLb              bool
+		listFailed          bool
+		expectedError       bool
+		expectedDeleteCount int
+	}{
+		{
+			desc:   "shall delete managed pip when switching to user provided pip in another resource group",
+			wantLb: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationLoadBalancerResourceGroup: "rg-b",
+				consts.ServiceAnnotationPIPNameDualStack[false]:   "pip1",
+			},
+			existingPIPs: []network.PublicIPAddress{
+				{
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg-a/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Name: ptr.To("pip1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion: network.IPv4,
+					},
+				},
+				{
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip2"),
+					Name: ptr.To("pip2"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("2.3.4.5"),
+						PublicIPAddressVersion: network.IPv4,
+					},
+				},
+			},
+			expectedDeleteCount: 1,
+		},
+		{
+			desc:   "shall return an error if failed to list pips in rg",
+			wantLb: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationLoadBalancerResourceGroup: "rg-b",
+				consts.ServiceAnnotationPIPNameDualStack[false]:   "pip1",
+			},
+			existingPIPs:  []network.PublicIPAddress{{}},
+			listFailed:    true,
+			expectedError: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			az := GetTestCloud(ctrl)
+			service := getTestService("test1", v1.ProtocolTCP, nil, false, 80)
+			service.Annotations = test.annotations
+
+			// Set up mock clients
+			mockPIPsClient := az.PublicIPAddressesClient.(*mockpublicipclient.MockInterface)
+
+			// Set up mock List call to return the managed pip in rg-a
+			mockPIPsClient.EXPECT().List(gomock.Any(), "rg-b").Return(test.existingPIPs[:1], nil)
+			if test.listFailed {
+				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(nil, &retry.Error{RawError: errors.New("failed to list pips")})
+			} else {
+				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPIPs[1:], nil)
+				mockPIPsClient.EXPECT().Get(gomock.Any(), "rg-b", "pip1", gomock.Any()).Return(test.existingPIPs[0], nil)
+			}
+
+			// Set up mock Delete call for the managed pip
+			if test.expectedDeleteCount > 0 {
+				mockPIPsClient.EXPECT().Delete(gomock.Any(), "rg", "pip2").Return(nil).Times(test.expectedDeleteCount)
+			}
+
+			// No need to mock Get or CreateOrUpdate since we're using an existing pip
+
+			_, err := az.reconcilePublicIPs("testCluster", &service, "", test.wantLb)
+			if test.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/provider/azure_publicip_repo.go
+++ b/pkg/provider/azure_publicip_repo.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -224,4 +225,13 @@ func getExpectedPIPFromListByIPAddress(pips []network.PublicIPAddress, ip string
 	}
 
 	return nil, fmt.Errorf("getExpectedPIPFromListByIPAddress: cannot find public IP with IP address %s", ip)
+}
+
+func getPIPRGFromID(pipIDLower string) (string, error) {
+	re := regexp.MustCompile(strings.ToLower(`/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Network/publicIPAddresses/(?:.*)`))
+	matches := re.FindStringSubmatch(pipIDLower)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("failed to extract resource group name from public IP ID %s", pipIDLower)
+	}
+	return matches[1], nil
 }

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -38,6 +38,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
@@ -271,6 +272,90 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 
 		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, targetIPs)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should remove the unused managed IP when switching to a user-assigned public IP in a different resource group", func() {
+		v4Enabled, v6Enabled := utils.IfIPFamiliesEnabled(tc.IPFamily)
+		ipNameBase := basename + "-public-IP" + string(uuid.NewUUID())[0:4]
+		targetIPs := []*string{}
+
+		// Create a service with managed public IP first
+		By("Creating a service with managed public IP")
+		service := utils.CreateLoadBalancerServiceManifest(testServiceName, nil, labels, ns.Name, ports)
+		_, err := cs.CoreV1().Services(ns.Name).Create(context.Background(), service, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the managed public IP to be ready")
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, targetIPs)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a user-assigned public IP in a different resource group
+		By("Creating a user-assigned public IP in a different resource group")
+		rg, deleteRG := utils.CreateTestResourceGroup(tc)
+		otherRG := ptr.Deref(rg.Name, "")
+		Expect(rg).NotTo(BeNil())
+		defer deleteRG(otherRG)
+
+		var pipName, pipNameV6 string
+		if v4Enabled {
+			pipName = ipNameBase + "-v4"
+			pip := defaultPublicIPAddress(pipName, false)
+			createdPIP, err := utils.WaitCreatePIP(tc, pipName, otherRG, pip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdPIP).NotTo(BeNil())
+			Expect(createdPIP.Properties.IPAddress).NotTo(BeNil())
+			defer func() {
+				_ = utils.DeletePIPWithRetry(tc, pipName, otherRG)
+			}()
+			targetIPs = append(targetIPs, createdPIP.Properties.IPAddress)
+		}
+		if v6Enabled {
+			pipNameV6 = ipNameBase + "-v6"
+			pipV6 := defaultPublicIPAddress(pipNameV6, true)
+			createdPIPV6, err := utils.WaitCreatePIP(tc, pipNameV6, otherRG, pipV6)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdPIPV6).NotTo(BeNil())
+			Expect(createdPIPV6.Properties.IPAddress).NotTo(BeNil())
+			defer func() {
+				_ = utils.DeletePIPWithRetry(tc, pipNameV6, otherRG)
+			}()
+			targetIPs = append(targetIPs, createdPIPV6.Properties.IPAddress)
+		}
+
+		// Update service to use the user-assigned public IP in the other resource group
+		By("Updating service to use the user-assigned public IP in the other resource group")
+		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		service.Annotations = map[string]string{
+			consts.ServiceAnnotationLoadBalancerResourceGroup: otherRG,
+		}
+		if v4Enabled {
+			service.Annotations[consts.ServiceAnnotationPIPNameDualStack[false]] = pipName
+		}
+		if v6Enabled {
+			service.Annotations[consts.ServiceAnnotationPIPNameDualStack[true]] = pipNameV6
+		}
+		_, err = cs.CoreV1().Services(ns.Name).Update(context.Background(), service, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			By("Cleaning up Service")
+			err = utils.DeleteService(cs, ns.Name, testServiceName)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		By("Waiting for the service to be updated with the user-assigned public IP")
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, targetIPs)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the managed public IP is deleted")
+		pips, err := tc.ListPublicIPs(tc.GetResourceGroup())
+		Expect(err).NotTo(HaveOccurred())
+		for _, pip := range pips {
+			if pip.Tags != nil && pip.Tags[consts.ServiceTagKey] != nil && *pip.Tags[consts.ServiceTagKey] == ns.Name+"/"+testServiceName {
+				Fail("Found managed public IP that should have been deleted")
+			}
+		}
 	})
 
 	// Internal w/ IP -> Internal w/ IP


### PR DESCRIPTION
…ource group

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

We should remove managed pip when the service switches to a different pip in another resource group.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #8113

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Remove managed pip if switched to another pip in a different resource group
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
