### PR TITLE
[flaky test] Generate non-overlapping and non-mergable CIDRs with best effort

### DIFF
--- a/internal/testutil/fixture/fixture.go
+++ b/internal/testutil/fixture/fixture.go
@@ -79,7 +79,8 @@ func (f *Fixture) RandomIPv4Prefixes(n int) []netip.Prefix {
 	)
 
 	for _, ip := range ips {
-		bits := int(f.RandomUint64(24)) + 8
+		const MinBits = 16
+		bits := int(f.RandomUint64(32-MinBits)) + MinBits
 		p, err := ip.Prefix(bits)
 		if err != nil {
 			panic("unreachable: it should always be a valid IP prefix")
@@ -118,7 +119,8 @@ func (f *Fixture) RandomIPv6Prefixes(n int) []netip.Prefix {
 	)
 
 	for _, ip := range ips {
-		bits := int(f.RandomUint64(120)) + 8
+		const MinBits = 32
+		bits := int(f.RandomUint64(128-MinBits)) + MinBits
 		p, err := ip.Prefix(bits)
 		if err != nil {
 			panic("unreachable: it should always be a valid IP prefix")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind testing

#### What this PR does / why we need it:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cloud-provider-azure/8521/pull-cloud-provider-azure-unit-1-31/1897178703616544768

The root cause of the flaky test is that the random fixture occasionally generates overlapping or mergeable CIDRs, which disrupts the comparison and assertions in the test. This PR resolves the issue in the access control flaky test by generating CIDRs with a larger bit size, ensuring that no overlapping CIDRs are produced in a single run—sufficient for the existing test case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
