### PR TITLE
Potential fix for code scanning alert no. 195: Use of a weak cryptographic key

### DIFF
--- a/pkg/azclient/managedclusterclient/custom_test.go
+++ b/pkg/azclient/managedclusterclient/custom_test.go
@@ -39,7 +39,7 @@ func init() {
 
 	beforeAllFunc = func(ctx context.Context) {
 		var generatedSSHKey string
-		privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 		Expect(err).NotTo(HaveOccurred())
 
 		// generate and write private key as PEM


### PR DESCRIPTION
Potential fix for [https://github.com/kubernetes-sigs/cloud-provider-azure/security/code-scanning/195](https://github.com/kubernetes-sigs/cloud-provider-azure/security/code-scanning/195)

To fix the problem, we need to increase the RSA key size from 1024 bits to 2048 bits. This change will ensure that the key meets the recommended security standards. The change should be made in the `pkg/azclient/managedclusterclient/custom_test.go` file, specifically on line 42 where the RSA key is generated. No additional methods or imports are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
