### PR TITLE
fix: reduce get disk calls in disk attach/detach on VMSS

### DIFF
--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -110,7 +110,7 @@ func (ss *ScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName, dis
 	result, rerr := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().Update(ctx, nodeResourceGroup, vm.VMSSName, vm.InstanceID, *newVM)
 	if rerr != nil {
 		klog.Errorf("azureDisk - attach disk list(%+v) on rg(%s) vm(%s) failed, err: %v", diskMap, nodeResourceGroup, nodeName, rerr)
-		if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); exists && err == nil {
+		if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); !exists && !strings.Contains(rerr.Error(), consts.ParentResourceNotFoundMessageCode) && err == nil {
 			klog.Errorf("azureDisk - begin to filterNonExistingDisks(%v) on rg(%s) vm(%s)", diskMap, nodeResourceGroup, nodeName)
 			disks := FilterNonExistingDisks(ctx, ss.ComputeClientFactory, newVM.Properties.StorageProfile.DataDisks)
 			newVM.Properties.StorageProfile.DataDisks = disks
@@ -223,7 +223,7 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 	result, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().Update(ctx, nodeResourceGroup, vm.VMSSName, vm.InstanceID, *newVM)
 	if rerr != nil {
 		klog.Errorf("azureDisk - detach disk list(%s) on rg(%s) vm(%s) failed, err: %v", diskMap, nodeResourceGroup, nodeName, rerr)
-		if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); exists && err == nil {
+		if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); !exists && !strings.Contains(rerr.Error(), consts.ParentResourceNotFoundMessageCode) && err == nil {
 			klog.Errorf("azureDisk - begin to filterNonExistingDisks(%v) on rg(%s) vm(%s)", diskMap, nodeResourceGroup, nodeName)
 			disks := FilterNonExistingDisks(ctx, ss.ComputeClientFactory, newVM.Properties.StorageProfile.DataDisks)
 			newVM.Properties.StorageProfile.DataDisks = disks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix: reduce get disk call in disk attach/detach on VMSS, original code has a bug that when it's NotFound error, it would call getdisk, that's wrong, this PR fixes the issue.

<details>

```
I0314 13:36:11.257464       1 azure_armclient.go:380] Received error in WaitForAsyncOperationResult: '{"error":{"code":"ParentResourceNotFound","message":"Failed to perform 'read' on resource(s) of type 'virtualMachineScaleSets/virtualMachines', because the parent resource '/subscriptions/xxx/resourceGroups/subscription-81db8cb7-nodes/providers/Microsoft.Compute/virtualMachineScaleSets/aks-elastic-19571921-vmss' could not be found."}}', response code 404

I0314 13:36:11.257534       1 azure_vmssvmclient.go:346] Received error in vmssvm.put.request: resourceID: /subscriptions/xxx/resourceGroups/subscription-81db8cb7-nodes/providers/Microsoft.Compute/virtualMachineScaleSets/aks-elastic-19571921-vmss/virtualMachines/0, error: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 404, RawError: {"error":{"code":"ParentResourceNotFound","message":"Failed to perform 'read' on resource(s) of type 'virtualMachineScaleSets/virtualMachines', because the parent resource '/subscriptions/xxx/resourceGroups/subscription-81db8cb7-nodes/providers/Microsoft.Compute/virtualMachineScaleSets/aks-elastic-19571921-vmss' could not be found."}}

E0314 13:36:11.257799       1 azure_controller_vmss.go:249] azureDisk - begin to filterNonExistingDisks(map[/subscriptions/xxx/resourcegroups/subscription-81db8cb7-nodes/providers/microsoft.compute/disks/pvc-4c600a8c-a823-414b-84f7-ea5e670888cc:pvc-4c600a8c-a823-414b-84f7-ea5e670888cc]) on rg(subscription-81db8cb7-nodes) vm(aks-elastic-19571921-vmss000000)

```

</details>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: reduce get disk call in disk attach/detach on VMSS
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: reduce get disk call in disk attach/detach on VMSS
```
