### PR TITLE
fix(credential-provider): check empty mirror mapping and add debugging info

### DIFF
--- a/cmd/acr-credential-provider/main.go
+++ b/cmd/acr-credential-provider/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/credentialprovider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/version"
 )
 
 func main() {
@@ -37,10 +38,11 @@ func main() {
 	var RegistryMirrorStr string
 
 	command := &cobra.Command{
-		Use:   "acr-credential-provider configFile",
-		Short: "Acr credential provider for Kubelet",
-		Long:  `The acr credential provider is responsible for providing ACR credentials for kubelet`,
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "acr-credential-provider configFile",
+		Short:   "Acr credential provider for Kubelet",
+		Long:    `The acr credential provider is responsible for providing ACR credentials for kubelet`,
+		Args:    cobra.MinimumNArgs(1),
+		Version: version.Get().GitVersion,
 		Run: func(_ *cobra.Command, args []string) {
 			if len(args) != 1 {
 				klog.Errorf("Config file is not specified")
@@ -67,6 +69,7 @@ func main() {
 	command.Flags().StringVarP(&RegistryMirrorStr, "registry-mirror", "r", "",
 		"Mirror a source registry host to a target registry host, and image pull credential will be requested to the target registry host when the image is from source registry host")
 
+	logs.AddFlags(command.Flags())
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/credentialprovider/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure_acr_helper.go
@@ -58,6 +58,7 @@ import (
 	"unicode"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -172,6 +173,12 @@ func performTokenExchange(
 	var exchange *http.Response
 	if exchange, err = client.Do(r); err != nil {
 		return "", fmt.Errorf("Www-Authenticate: failed to reach auth url %s", authEndpoint)
+	}
+
+	if exchange.Header != nil {
+		if correlationID, ok := exchange.Header["X-Ms-Correlation-Request-Id"]; ok {
+			klog.V(4).Infof("correlationID: %s", correlationID)
+		}
 	}
 
 	defer exchange.Body.Close()

--- a/pkg/credentialprovider/azure_credentials.go
+++ b/pkg/credentialprovider/azure_credentials.go
@@ -271,6 +271,11 @@ func (a *acrProvider) processImageWithRegistryMirror(image string) (string, stri
 func parseRegistryMirror(registryMirrorStr string) map[string]string {
 	registryMirror := map[string]string{}
 
+	registryMirrorStr = strings.TrimSpace(registryMirrorStr)
+	if len(registryMirrorStr) == 0 {
+		return registryMirror
+	}
+
 	registryMirrorStr = strings.ReplaceAll(registryMirrorStr, " ", "")
 	for _, mapping := range strings.Split(registryMirrorStr, ",") {
 		parts := strings.Split(mapping, ":")

--- a/pkg/credentialprovider/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure_credentials_test.go
@@ -297,6 +297,11 @@ func TestProcessMirrorMapping(t *testing.T) {
 		expected         map[string]string
 	}{
 		{
+			"empty",
+			"",
+			map[string]string{},
+		},
+		{
 			"multiple",
 			"aaa:bbb,ccc:ddd",
 			map[string]string{

--- a/pkg/credentialprovider/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure_credentials_test.go
@@ -297,12 +297,12 @@ func TestProcessMirrorMapping(t *testing.T) {
 		expected         map[string]string
 	}{
 		{
-			"empty",
+			"empty registry mirrors",
 			"",
 			map[string]string{},
 		},
 		{
-			"multiple",
+			"multiple registry mirrors",
 			"aaa:bbb,ccc:ddd",
 			map[string]string{
 				"aaa": "bbb",
@@ -310,7 +310,7 @@ func TestProcessMirrorMapping(t *testing.T) {
 			},
 		},
 		{
-			"multiple with some spaces",
+			"multiple registry mirrors joined with comma and extra spaces",
 			"aaa: bbb, ccc:ddd",
 			map[string]string{
 				"aaa": "bbb",
@@ -318,7 +318,7 @@ func TestProcessMirrorMapping(t *testing.T) {
 			},
 		},
 		{
-			"single",
+			"single registry mirror",
 			"aaa:bbb",
 			map[string]string{
 				"aaa": "bbb",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Run the binary will return error log `Invalid registry mirror format` without real harm since registryMirrorStr defaults to emtpy.
Fix this by checking the emptiness of registryMirrorStr and return when it's empty.
Besides this change, I added 3 small but debug-friendly changes in this PR to reduce the cherry-pick PR numbers.
- add klog verobse level flag `-v`
- add version flag `--version`
- add debug level log for correlationID.

##### Tests

- verbose log

```
The acr credential provider is responsible for providing ACR credentials for kubelet

Usage:
  acr-credential-provider configFile [flags]

Flags:
  -h, --help                           help for acr-credential-provider
      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
  -r, --registry-mirror string         Mirror a source registry host to a target registry host, and image pull credential will be requested to the target registry host when the image is from source registry host
  -v, --v Level                        number for the log level verbosity
      --version                        version for acr-credential-provider
      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
```

- print version
```
/var/lib/kubelet/credential-provider/acr-credential-provider --version
acr-credential-provider version v1.31.0-689-g2ca98fff7
```

- correlationID debug log

```
:\"qingchuanhao.azurecr.io/nginx:v1\"}" | ./azure-acr-credential-provider /etc/kubernetes/azure.json -v 9
I0317 22:32:35.090733 3420293 azure_credentials.go:205] discovering auth redirects for: qingchuanhao.azurecr.io
I0317 22:32:35.383245 3420293 azure_credentials.go:212] exchanging an acr refresh_token
I0317 22:32:35.398506 3420293 azure_acr_helper.go:180] correlationID: [72f5cc8e-aabc-4535-8957-eacd486e5e25]
{"kind":"CredentialProviderResponse","apiVersion":"credentialprovider.kubelet.k8s.io/v1","cacheKeyType":"Registry","cacheDuration":"5m0s","auth":{"*.azurecr.*":{"username":"","password":""},"qingchuanhao.azurecr.io":{"username":"00000000-0000-0000-0000-000000000000","password":"***"}}}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix(credential-provider): check empty mirror mapping and add debugging info
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
