### PR TITLE
[release-1.30] fix(credential-provider): check empty mirror mapping and add debugging info

### DIFF
--- a/cmd/acr-credential-provider/main.go
+++ b/cmd/acr-credential-provider/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/credentialprovider"
+	"sigs.k8s.io/cloud-provider-azure/pkg/version"
 )
 
 func main() {
@@ -37,10 +38,11 @@ func main() {
 	var RegistryMirrorStr string
 
 	command := &cobra.Command{
-		Use:   "acr-credential-provider configFile",
-		Short: "Acr credential provider for Kubelet",
-		Long:  `The acr credential provider is responsible for providing ACR credentials for kubelet`,
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "acr-credential-provider configFile",
+		Short:   "Acr credential provider for Kubelet",
+		Long:    `The acr credential provider is responsible for providing ACR credentials for kubelet`,
+		Args:    cobra.MinimumNArgs(1),
+		Version: version.Get().GitVersion,
 		Run: func(_ *cobra.Command, args []string) {
 			if len(args) != 1 {
 				klog.Errorf("Config file is not specified")
@@ -67,6 +69,7 @@ func main() {
 	command.Flags().StringVarP(&RegistryMirrorStr, "registry-mirror", "r", "",
 		"Mirror a source registry host to a target registry host, and image pull credential will be requested to the target registry host when the image is from source registry host")
 
+	logs.AddFlags(command.Flags())
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/credentialprovider/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure_acr_helper.go
@@ -58,6 +58,7 @@ import (
 	"unicode"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -172,6 +173,12 @@ func performTokenExchange(
 	var exchange *http.Response
 	if exchange, err = client.Do(r); err != nil {
 		return "", fmt.Errorf("Www-Authenticate: failed to reach auth url %s", authEndpoint)
+	}
+
+	if exchange.Header != nil {
+		if correlationID, ok := exchange.Header["X-Ms-Correlation-Request-Id"]; ok {
+			klog.V(4).Infof("correlationID: %s", correlationID)
+		}
 	}
 
 	defer exchange.Body.Close()

--- a/pkg/credentialprovider/azure_credentials.go
+++ b/pkg/credentialprovider/azure_credentials.go
@@ -271,6 +271,11 @@ func (a *acrProvider) processImageWithRegistryMirror(image string) (string, stri
 func parseRegistryMirror(registryMirrorStr string) map[string]string {
 	registryMirror := map[string]string{}
 
+	registryMirrorStr = strings.TrimSpace(registryMirrorStr)
+	if len(registryMirrorStr) == 0 {
+		return registryMirror
+	}
+
 	registryMirrorStr = strings.ReplaceAll(registryMirrorStr, " ", "")
 	for _, mapping := range strings.Split(registryMirrorStr, ",") {
 		parts := strings.Split(mapping, ":")

--- a/pkg/credentialprovider/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure_credentials_test.go
@@ -297,7 +297,12 @@ func TestProcessMirrorMapping(t *testing.T) {
 		expected         map[string]string
 	}{
 		{
-			"multiple",
+			"empty registry mirrors",
+			"",
+			map[string]string{},
+		},
+		{
+			"multiple registry mirrors",
 			"aaa:bbb,ccc:ddd",
 			map[string]string{
 				"aaa": "bbb",
@@ -305,7 +310,7 @@ func TestProcessMirrorMapping(t *testing.T) {
 			},
 		},
 		{
-			"multiple with some spaces",
+			"multiple registry mirrors joined with comma and extra spaces",
 			"aaa: bbb, ccc:ddd",
 			map[string]string{
 				"aaa": "bbb",
@@ -313,7 +318,7 @@ func TestProcessMirrorMapping(t *testing.T) {
 			},
 		},
 		{
-			"single",
+			"single registry mirror",
 			"aaa:bbb",
 			map[string]string{
 				"aaa": "bbb",


### PR DESCRIPTION
This is a manual cherry-pick of #8647

/assign mainred

```release-note
fix(credential-provider): check empty mirror mapping and add debugging info
```