### PR TITLE
[azclient] Return default auth provider if no valid auth method

### DIFF
--- a/pkg/azclient/auth.go
+++ b/pkg/azclient/auth.go
@@ -68,7 +68,9 @@ func NewAuthProvider(
 	case len(config.AADMSIDataPlaneIdentityPath) > 0:
 		return newAuthProviderWithUserAssignedIdentity(config, clientOption, opts)
 	default:
-		return nil, ErrNoValidAuthMethodFound
+		return &AuthProvider{
+			CloudConfig: clientOption.Cloud,
+		}, nil
 	}
 }
 

--- a/pkg/azclient/auth_test.go
+++ b/pkg/azclient/auth_test.go
@@ -69,17 +69,12 @@ func TestNewAuthProvider(t *testing.T) {
 		ErrorContains string
 	}{
 		{
-			Name:          "error when GetAzCoreClientOption fails",
-			ARMConfig:     &ARMClientConfig{}, // This will cause validation failure
-			AuthConfig:    &AzureAuthConfig{},
-			ExpectErr:     ErrNoValidAuthMethodFound, // The error won't be this, but we expect an error
-			ErrorContains: "invalid ARM client config",
-		},
-		{
-			Name:       "error when no valid auth method found",
+			Name:       "return default auth provider when no valid auth method found",
 			ARMConfig:  testARMConfig,
 			AuthConfig: &AzureAuthConfig{},
-			ExpectErr:  ErrNoValidAuthMethodFound,
+			Assertions: []AuthProviderAssertions{
+				AssertCloudConfig(testCloudConfig),
+			},
 		},
 		{
 			Name:      "success with workload identity",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

keep the behavior the same as last version

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
