### PR TITLE
[release-1.31] fix: Remove the shared slb health probe after the last cluster servic…

### DIFF
--- a/pkg/provider/azure_loadbalancer_healthprobe_test.go
+++ b/pkg/provider/azure_loadbalancer_healthprobe_test.go
@@ -34,6 +34,11 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
+// Define a simple config struct for testing
+type testConfig struct {
+	UseSharedLBRuleHealthProbeMode *bool
+}
+
 // getTestProbes returns dualStack probes.
 func getTestProbes(protocol, path string, interval, servicePort, probePort, numOfProbe *int32) map[bool][]network.Probe {
 	return map[bool][]network.Probe{
@@ -206,12 +211,14 @@ func TestFindProbe(t *testing.T) {
 
 func TestShouldKeepSharedProbe(t *testing.T) {
 	testCases := []struct {
-		desc        string
-		service     *v1.Service
-		lb          network.LoadBalancer
-		wantLB      bool
-		expected    bool
-		expectedErr error
+		desc             string
+		service          *v1.Service
+		lb               network.LoadBalancer
+		wantLB           bool
+		expected         bool
+		expectedErr      error
+		expectedProbeMod bool // indicates if we expect the probe to be modified/removed
+		azConfig         testConfig
 	}{
 		{
 			desc:     "When the lb.Probes is nil",
@@ -363,16 +370,169 @@ func TestShouldKeepSharedProbe(t *testing.T) {
 			expected:    false,
 			expectedErr: fmt.Errorf("resource name was missing from identifier"),
 		},
+		{
+			desc: "When service switches from Cluster to Local with exactly one rule referencing the shared probe",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("uid"),
+				},
+				Spec: v1.ServiceSpec{
+					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			lb: network.LoadBalancer{
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+					Probes: &[]network.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To("id"),
+							ProbePropertiesFormat: &network.ProbePropertiesFormat{
+								LoadBalancingRules: &[]network.SubResource{
+									{
+										ID: ptr.To("auid"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:         false,
+			expectedProbeMod: true,
+		},
+		{
+			desc: "When service is Local but not owner of the rule - should not remove probe",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("uid"),
+				},
+				Spec: v1.ServiceSpec{
+					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			lb: network.LoadBalancer{
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+					Probes: &[]network.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To("id"),
+							ProbePropertiesFormat: &network.ProbePropertiesFormat{
+								LoadBalancingRules: &[]network.SubResource{
+									{
+										ID: ptr.To("otherService"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:         false,
+			expectedProbeMod: false,
+		},
+		{
+			desc: "When service is Cluster with a single rule - should not remove probe",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("uid"),
+				},
+				Spec: v1.ServiceSpec{
+					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+				},
+			},
+			lb: network.LoadBalancer{
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+					Probes: &[]network.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To("id"),
+							ProbePropertiesFormat: &network.ProbePropertiesFormat{
+								LoadBalancingRules: &[]network.SubResource{
+									{
+										ID: ptr.To("auid"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:         false,
+			expectedProbeMod: false,
+		},
+		{
+			desc: "Error case: When service is Local with a single rule that causes parse error",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("uid"),
+				},
+				Spec: v1.ServiceSpec{
+					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			lb: network.LoadBalancer{
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+					Probes: &[]network.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To("id"),
+							ProbePropertiesFormat: &network.ProbePropertiesFormat{
+								LoadBalancingRules: &[]network.SubResource{
+									{
+										ID: ptr.To(""),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:         false,
+			expectedProbeMod: false,
+			expectedErr:      fmt.Errorf("resource name was missing from identifier"),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			az := GetTestCloud(gomock.NewController(t))
-			var expectedProbes []network.Probe
-			result, err := az.keepSharedProbe(tc.service, tc.lb, expectedProbes, tc.wantLB)
+			ctrl := gomock.NewController(t)
+			az := GetTestCloud(ctrl)
+
+			// Set up test config if needed
+			if tc.azConfig.UseSharedLBRuleHealthProbeMode != nil {
+				// Set the cluster service load balancer health probe mode
+				if *tc.azConfig.UseSharedLBRuleHealthProbeMode {
+					az.ClusterServiceLoadBalancerHealthProbeMode = consts.ClusterServiceLoadBalancerHealthProbeModeShared
+				} else {
+					az.ClusterServiceLoadBalancerHealthProbeMode = consts.ClusterServiceLoadBalancerHealthProbeModeServiceNodePort
+				}
+			}
+
+			var expectedProbes = &[]network.Probe{}
+
+			// Make a copy of the original probe for checking modifications
+			originalProbes := &[]network.Probe{}
+			if tc.lb.LoadBalancerPropertiesFormat != nil && tc.lb.LoadBalancerPropertiesFormat.Probes != nil {
+				*originalProbes = append(*originalProbes, *tc.lb.LoadBalancerPropertiesFormat.Probes...)
+			}
+
+			result, err := az.keepSharedProbe(tc.service, tc.lb, *expectedProbes, tc.wantLB)
 			assert.Equal(t, tc.expectedErr, err)
 			if tc.expected {
 				assert.Equal(t, 1, len(result))
+			}
+
+			// Check if the probe was modified/removed as expected
+			if tc.expectedProbeMod {
+				// Check if the original probe was actually modified/removed
+				if tc.lb.LoadBalancerPropertiesFormat != nil && tc.lb.LoadBalancerPropertiesFormat.Probes != nil {
+					assert.NotEqual(t, len(*originalProbes), len(*tc.lb.LoadBalancerPropertiesFormat.Probes),
+						"Expected probe to be modified/removed but it was not")
+				}
+			} else if len(*originalProbes) > 0 && tc.lb.LoadBalancerPropertiesFormat != nil && tc.lb.LoadBalancerPropertiesFormat.Probes != nil {
+				// If not expecting modification, probe count should remain the same
+				assert.Equal(t, len(*originalProbes), len(*tc.lb.LoadBalancerPropertiesFormat.Probes),
+					"Probe was unexpectedly modified/removed")
 			}
 		})
 	}


### PR DESCRIPTION
…e is switched to local (#8732)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

fix: Remove the shared slb health probe after the last cluster service is switched to local.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Remove the shared slb health probe after the last cluster service is switched to local.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
