### PR TITLE
[release-1.30] fix: Skip ensuring host in pool if the vm is not found

### DIFF
--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1056,6 +1056,12 @@ func (ss *ScaleSet) EnsureHostInPool(ctx context.Context, _ *v1.Service, nodeNam
 			return "", "", "", nil, err
 		}
 	}
+	// In some cases (e.g., BYO nodes), we may get an ErrorNotVmssInstance error,
+	// but it has been ignored above, so a nil check is needed here to prevent panic.
+	if vm == nil {
+		logger.Info("vmss vm not found, skip adding to backend pool", "vmName", vmName)
+		return "", "", "", nil, nil
+	}
 	statuses := vm.GetInstanceViewStatus()
 	vmPowerState := vmutil.GetVMPowerState(vm.Name, statuses)
 	provisioningState := vm.GetProvisioningState()

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -2135,6 +2135,7 @@ func TestEnsureHostInPool(t *testing.T) {
 		isNilVMNetworkConfigs     bool
 		isVMBeingDeleted          bool
 		isVMNotActive             bool
+		isVMNotFound              bool
 		expectedNodeResourceGroup string
 		expectedVMSSName          string
 		expectedInstanceID        string
@@ -2173,6 +2174,11 @@ func TestEnsureHostInPool(t *testing.T) {
 			description:      "EnsureHostInPool should skip the current node if it is being deleted",
 			nodeName:         "vmss-vm-000000",
 			isVMBeingDeleted: true,
+		},
+		{
+			description:  "EnsureHostInPool should skip the current node if the vm is not found",
+			nodeName:     "vmss-vm-000000",
+			isVMNotFound: true,
 		},
 		{
 			description:               "EnsureHostInPool should add a new backend pool to the vm",
@@ -2257,6 +2263,9 @@ func TestEnsureHostInPool(t *testing.T) {
 			(*expectedVMSSVMs[0].InstanceView.Statuses)[0] = compute.InstanceViewStatus{
 				Code: ptr.To("PowerState/deallocated"),
 			}
+		}
+		if test.isVMNotFound {
+			expectedVMSSVMs = nil
 		}
 		mockVMSSVMClient := ss.VirtualMachineScaleSetVMsClient.(*mockvmssvmclient.MockInterface)
 		mockVMSSVMClient.EXPECT().List(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

If the vm is not found from the cache, we would skip returning the not found error and in this case, the code will move on with a nil vm, causing a panic. This PR skips ensuring the host in the pool if the vm is not found.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Skip ensuring host in pool if the vm is not found
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
