### PR TITLE
fix: Prevent panic when route table GET result is empty interface, or…

### DIFF
--- a/pkg/provider/routetable/repo.go
+++ b/pkg/provider/routetable/repo.go
@@ -68,8 +68,14 @@ func (r *repo) Get(ctx context.Context, routeTableName string, crt cache.AzureCa
 	if err != nil {
 		return nil, fmt.Errorf("get RouteTable: %w", err)
 	}
-
-	return rt.(*armnetwork.RouteTable), nil
+	if rt == nil {
+		return nil, nil
+	}
+	routeTable, ok := rt.(*armnetwork.RouteTable)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for RouteTable: got %T, want *armnetwork.RouteTable", rt)
+	}
+	return routeTable, nil
 }
 
 func (r *repo) CreateOrUpdate(ctx context.Context, routeTable armnetwork.RouteTable) (*armnetwork.RouteTable, error) {

--- a/pkg/provider/routetable/repo_test.go
+++ b/pkg/provider/routetable/repo_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/routetableclient/mock_routetableclient"
@@ -104,6 +105,194 @@ func TestRepo_Get(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, expectedErr)
 	})
+
+	t.Run("type assertion failure", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		cli := mock_routetableclient.NewMockInterface(ctrl)
+
+		// Create a mock cache that will return a wrong type
+		mockCache := &mockCacheWithWrongType{}
+
+		// Create repo with the mock cache
+		r := &repo{
+			resourceGroup: ResourceGroup,
+			client:        cli,
+			cache:         mockCache,
+		}
+
+		ctx := context.Background()
+		const RouteTableName = "route-table-name"
+
+		// Should get type assertion error
+		_, err := r.Get(ctx, RouteTableName, cache.CacheReadTypeDefault)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected type for RouteTable")
+		assert.Contains(t, err.Error(), "string")
+	})
+
+	t.Run("empty interface value", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		cli := mock_routetableclient.NewMockInterface(ctrl)
+
+		// Create a mock cache that will return an empty interface{}
+		mockCache := &mockCacheWithEmptyInterface{}
+
+		// Create repo with the mock cache
+		r := &repo{
+			resourceGroup: ResourceGroup,
+			client:        cli,
+			cache:         mockCache,
+		}
+
+		ctx := context.Background()
+		const RouteTableName = "route-table-name"
+
+		// Should get type assertion error
+		_, err := r.Get(ctx, RouteTableName, cache.CacheReadTypeDefault)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected type for RouteTable")
+		assert.Contains(t, err.Error(), "struct {}") // empty struct
+	})
+
+	t.Run("nil value from cache", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		cli := mock_routetableclient.NewMockInterface(ctrl)
+
+		// Create a mock cache that will return nil
+		mockCache := &mockCacheWithNilValue{}
+
+		// Create repo with the mock cache
+		r := &repo{
+			resourceGroup: ResourceGroup,
+			client:        cli,
+			cache:         mockCache,
+		}
+
+		ctx := context.Background()
+		const RouteTableName = "route-table-name"
+
+		// Should return nil, nil
+		rt, err := r.Get(ctx, RouteTableName, cache.CacheReadTypeDefault)
+		assert.NoError(t, err)
+		assert.Nil(t, rt)
+	})
+}
+
+// mockCacheWithWrongType is a mock implementation of cache.Resource that returns a wrong type
+type mockCacheWithWrongType struct{}
+
+func (m *mockCacheWithWrongType) Get(_ context.Context, _ string, _ cache.AzureCacheReadType) (interface{}, error) {
+	// Return a string instead of *armnetwork.RouteTable to trigger type assertion failure
+	return "wrong type", nil
+}
+
+func (m *mockCacheWithWrongType) GetWithDeepCopy(_ context.Context, _ string, _ cache.AzureCacheReadType) (interface{}, error) {
+	// Return a string instead of *armnetwork.RouteTable to trigger type assertion failure
+	return "wrong type", nil
+}
+
+func (m *mockCacheWithWrongType) GetStore() kcache.Store {
+	return nil
+}
+
+func (m *mockCacheWithWrongType) Lock() {
+	// No-op for testing
+}
+
+func (m *mockCacheWithWrongType) Unlock() {
+	// No-op for testing
+}
+
+func (m *mockCacheWithWrongType) Delete(_ string) error {
+	return nil
+}
+
+func (m *mockCacheWithWrongType) Set(_ string, _ interface{}) {
+	// No-op for testing
+}
+
+func (m *mockCacheWithWrongType) Update(_ string, _ interface{}) {
+	// No-op for testing
+}
+
+// mockCacheWithEmptyInterface is a mock implementation of cache.Resource that returns an empty interface value
+type mockCacheWithEmptyInterface struct{}
+
+func (m *mockCacheWithEmptyInterface) Get(_ context.Context, _ string, _ cache.AzureCacheReadType) (interface{}, error) {
+	// Return an empty struct as interface{} to trigger type assertion failure
+	return struct{}{}, nil
+}
+
+func (m *mockCacheWithEmptyInterface) GetWithDeepCopy(_ context.Context, _ string, _ cache.AzureCacheReadType) (interface{}, error) {
+	// Return an empty struct as interface{} to trigger type assertion failure
+	return struct{}{}, nil
+}
+
+func (m *mockCacheWithEmptyInterface) GetStore() kcache.Store {
+	return nil
+}
+
+func (m *mockCacheWithEmptyInterface) Lock() {
+	// No-op for testing
+}
+
+func (m *mockCacheWithEmptyInterface) Unlock() {
+	// No-op for testing
+}
+
+func (m *mockCacheWithEmptyInterface) Delete(_ string) error {
+	return nil
+}
+
+func (m *mockCacheWithEmptyInterface) Set(_ string, _ interface{}) {
+	// No-op for testing
+}
+
+func (m *mockCacheWithEmptyInterface) Update(_ string, _ interface{}) {
+	// No-op for testing
+}
+
+// mockCacheWithNilValue is a mock implementation of cache.Resource that returns nil values
+type mockCacheWithNilValue struct{}
+
+func (m *mockCacheWithNilValue) Get(_ context.Context, _ string, _ cache.AzureCacheReadType) (interface{}, error) {
+	// Return nil to test nil handling
+	return nil, nil
+}
+
+func (m *mockCacheWithNilValue) GetWithDeepCopy(_ context.Context, _ string, _ cache.AzureCacheReadType) (interface{}, error) {
+	// Return nil to test nil handling
+	return nil, nil
+}
+
+func (m *mockCacheWithNilValue) GetStore() kcache.Store {
+	return nil
+}
+
+func (m *mockCacheWithNilValue) Lock() {
+	// No-op for testing
+}
+
+func (m *mockCacheWithNilValue) Unlock() {
+	// No-op for testing
+}
+
+func (m *mockCacheWithNilValue) Delete(_ string) error {
+	return nil
+}
+
+func (m *mockCacheWithNilValue) Set(_ string, _ interface{}) {
+	// No-op for testing
+}
+
+func (m *mockCacheWithNilValue) Update(_ string, _ interface{}) {
+	// No-op for testing
 }
 
 func TestRepo_CreateOrUpdate(t *testing.T) {


### PR DESCRIPTION
… nil

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

If an empty interface is returned from Get, a panic will be thrown when asserting interface type to routeTable. This change prevent the panic by returning an error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Prevent panic when route table GET result is empty interface, or nil.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
