### PR TITLE
[release-1.30] fix: Prevent panic when route table GET result is empty interface, or…

### DIFF
--- a/pkg/provider/azure_routes_test.go
+++ b/pkg/provider/azure_routes_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/routetableclient/mockroutetableclient"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
 	utilsets "sigs.k8s.io/cloud-provider-azure/pkg/util/sets"
 )
@@ -837,4 +838,105 @@ func TestEnsureRouteTableTagged(t *testing.T) {
 	tags, changed = cloud.ensureRouteTableTagged(rt)
 	assert.Nil(t, tags)
 	assert.False(t, changed)
+}
+
+func TestGetRouteTable(t *testing.T) {
+	ctx := context.TODO()
+
+	tests := []struct {
+		name           string
+		routeTableName string
+		rtExists       bool
+		rtError        *retry.Error
+		mockRT         network.RouteTable
+		expectedRT     network.RouteTable
+		expectedExists bool
+		expectedErr    bool
+		expectedErrMsg string
+	}{
+		{
+			name:           "RouteTable name not configured",
+			routeTableName: "",
+			rtExists:       false,
+			rtError:        nil,
+			mockRT:         network.RouteTable{},
+			expectedRT:     network.RouteTable{},
+			expectedExists: false,
+			expectedErr:    true,
+			expectedErrMsg: "route table name is not configured",
+		},
+		{
+			name:           "RouteTableClient.Get returns error",
+			routeTableName: "rt-test",
+			rtExists:       false,
+			rtError:        &retry.Error{RawError: fmt.Errorf("client error")},
+			mockRT:         network.RouteTable{},
+			expectedRT:     network.RouteTable{},
+			expectedExists: false,
+			expectedErr:    true,
+			expectedErrMsg: "client error",
+		},
+		{
+			name:           "RouteTable not found",
+			routeTableName: "rt-test",
+			rtExists:       false,
+			rtError:        &retry.Error{RawError: fmt.Errorf("NotFound"), HTTPStatusCode: http.StatusNotFound},
+			mockRT:         network.RouteTable{},
+			expectedRT:     network.RouteTable{},
+			expectedExists: false,
+			expectedErr:    false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "Successful case",
+			routeTableName: "rt-test",
+			rtExists:       true,
+			rtError:        nil,
+			mockRT:         network.RouteTable{Name: pointer.String("rt-test")},
+			expectedRT:     network.RouteTable{Name: pointer.String("rt-test")},
+			expectedExists: true,
+			expectedErr:    false,
+			expectedErrMsg: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			routeTableClient := mockroutetableclient.NewMockInterface(ctrl)
+			cloud := &Cloud{
+				Config: Config{
+					RouteTableName:          test.routeTableName,
+					RouteTableResourceGroup: "rg",
+				},
+				RouteTablesClient: routeTableClient,
+			}
+
+			cache, _ := cloud.newRouteTableCache()
+			cloud.rtCache = cache
+
+			if test.routeTableName != "" {
+				routeTableClient.EXPECT().Get(gomock.Any(), cloud.RouteTableResourceGroup, test.routeTableName, "").Return(test.mockRT, test.rtError)
+			}
+
+			crt := azcache.CacheReadTypeDefault
+			rt, exists, err := cloud.getRouteTable(ctx, crt)
+
+			if test.expectedErr {
+				assert.Error(t, err)
+				if test.expectedErrMsg != "" {
+					assert.Contains(t, err.Error(), test.expectedErrMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.expectedExists, exists)
+			if test.expectedExists {
+				assert.Equal(t, test.expectedRT, rt)
+			}
+		})
+	}
 }

--- a/pkg/provider/azure_vmsets_repo.go
+++ b/pkg/provider/azure_vmsets_repo.go
@@ -185,5 +185,11 @@ func (az *Cloud) getRouteTable(ctx context.Context, crt azcache.AzureCacheReadTy
 		return routeTable, false, nil
 	}
 
-	return *(cachedRt.(*network.RouteTable)), true, nil
+	res, ok := cachedRt.(*network.RouteTable)
+	if !ok {
+		return routeTable, false, fmt.Errorf("unexpected type for RouteTable: got %T, want *network.RouteTable", cachedRt)
+	}
+	routeTable = *res
+
+	return routeTable, true, nil
 }


### PR DESCRIPTION
… nil

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

If an empty interface is returned from Get, a panic will be thrown when asserting interface type to routeTable. This change prevent the panic by returning an error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Prevent panic when route table GET result is empty interface, or nil.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
