### PR TITLE
Container Load Balancer - Load Balancer

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -236,6 +236,8 @@ const (
 	LoadBalancerSKUBasic = "basic"
 	// LoadBalancerSKUStandard is the load balancer standard SKU
 	LoadBalancerSKUStandard = "standard"
+	// LoadBalancerSKUStandardV2 is the load balancer standardV2 SKU
+	LoadBalancerSKUStandardV2 = "standardV2"
 
 	// ServiceAnnotationLoadBalancerInternal is the annotation used on the service
 	ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/azure-load-balancer-internal"
@@ -382,8 +384,7 @@ const (
 	// LoadBalancerBackendPoolConfigurationTypeNodeIP is the lb backend pool config type node ip
 	LoadBalancerBackendPoolConfigurationTypeNodeIP = "nodeIP"
 	// LoadBalancerBackendPoolConfigurationTypePODIP is the lb backend pool config type pod ip
-	// TODO (nilo19): support pod IP in the future
-	LoadBalancerBackendPoolConfigurationTypePODIP = "podIP"
+	LoadBalancerBackendPoolConfigurationTypePodIP = "podIP"
 )
 
 // error messages

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -289,6 +289,31 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 			AddFunc: func(obj interface{}) {
 				es := obj.(*discovery_v1.EndpointSlice)
 				az.endpointSlicesCache.Store(strings.ToLower(fmt.Sprintf("%s/%s", es.Namespace, es.Name)), es)
+
+				if az.IsLBBackendPoolTypePodIP() && az.UseStandardV2LoadBalancer() {
+					serviceUID, loaded := getServiceUIDOfEndpointSlice(es)
+					if !loaded {
+						klog.Errorf("EndpointSlice %s/%s does not have service UID, skip updating load balancer backend pool", es.Namespace, es.Name)
+						return
+					}
+					if _, loaded := az.localServiceNameToNRPServiceMap.LoadOrStore(serviceUID, struct{}{}); loaded {
+						updateK8sEndpointsInputType := UpdateK8sEndpointsInputType{
+							inboundIdentity: serviceUID,
+							oldAddresses:    nil,
+							newAddresses:    az.getPodIPToNodeIPMapFromEndpointSlice(es, false),
+						}
+						az.difftracker.UpdateK8sEndpoints(updateK8sEndpointsInputType)
+					}
+
+					// TO BE DISCUSSED (enechitoaia): do we want to trigger the batch updater here too?
+					// select {
+					// case az.locationAndNRPServiceBatchUpdater.channelUpdateTrigger <- true:
+					// 	// trigger batch update
+					// default:
+					// 	// channel is full, do nothing
+					// 	klog.V(2).Info("az.locationAndNRPServiceBatchUpdater.channelUpdateTrigger is full. Batch update is already triggered.")
+					// }
+				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				previousES := oldObj.(*discovery_v1.EndpointSlice)
@@ -349,6 +374,32 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 					}
 					az.applyIPChangesAmongLocalServiceBackendPoolsByIPFamily(lbName, key, currentIPsInBackendPools, currentIPs)
 				}
+
+				if az.IsLBBackendPoolTypePodIP() && az.UseStandardV2LoadBalancer() {
+					serviceUID, loaded := getServiceUIDOfEndpointSlice(newES)
+					if !loaded {
+						klog.Errorf("EndpointSlice %s/%s does not have service UID, skip updating load balancer backend pool", newES.Namespace, newES.Name)
+						return
+					}
+
+					if _, loaded := az.localServiceNameToNRPServiceMap.LoadOrStore(serviceUID, serviceUID); loaded {
+						updateK8sEndpointsInputType := UpdateK8sEndpointsInputType{
+							inboundIdentity: serviceUID,
+							oldAddresses:    az.getPodIPToNodeIPMapFromEndpointSlice(previousES, false),
+							newAddresses:    az.getPodIPToNodeIPMapFromEndpointSlice(newES, false),
+						}
+						az.difftracker.UpdateK8sEndpoints(updateK8sEndpointsInputType)
+					}
+
+					// TO BE DISCUSSED (enechitoaia): do we want to trigger the batch updater here too?
+					// select {
+					// case az.locationAndNRPServiceBatchUpdater.channelUpdateTrigger <- true:
+					// 	// trigger batch update
+					// default:
+					// 	// channel is full, do nothing
+					// 	klog.V(2).Info("az.locationAndNRPServiceBatchUpdater.channelUpdateTrigger is full. Batch update is already triggered.")
+					// }
+				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var es *discovery_v1.EndpointSlice
@@ -369,6 +420,32 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 				}
 
 				az.endpointSlicesCache.Delete(strings.ToLower(fmt.Sprintf("%s/%s", es.Namespace, es.Name)))
+
+				if az.IsLBBackendPoolTypePodIP() && az.UseStandardV2LoadBalancer() {
+					serviceUID, loaded := getServiceUIDOfEndpointSlice(es)
+					if !loaded {
+						klog.Errorf("EndpointSlice %s/%s does not have service UID, skip updating load balancer backend pool", es.Namespace, es.Name)
+						return
+					}
+
+					if _, loaded := az.localServiceNameToNRPServiceMap.LoadOrStore(serviceUID, serviceUID); loaded {
+						updateK8sEndpointsInputType := UpdateK8sEndpointsInputType{
+							inboundIdentity: serviceUID,
+							oldAddresses:    az.getPodIPToNodeIPMapFromEndpointSlice(es, false),
+							newAddresses:    nil,
+						}
+						az.difftracker.UpdateK8sEndpoints(updateK8sEndpointsInputType)
+					}
+
+					// TO BE DISCUSSED (enechitoaia): do we want to trigger the batch updater here too?
+					// select {
+					// case az.locationAndNRPServiceBatchUpdater.channelUpdateTrigger <- true:
+					// 	// trigger batch update
+					// default:
+					// 	// channel is full, do nothing
+					// 	klog.V(2).Info("az.locationAndNRPServiceBatchUpdater.channelUpdateTrigger is full. Batch update is already triggered.")
+					// }
+				}
 			},
 		})
 }
@@ -398,6 +475,58 @@ func getServiceNameOfEndpointSlice(es *discovery_v1.EndpointSlice) string {
 		return es.Labels[consts.ServiceNameLabel]
 	}
 	return ""
+}
+
+// getServiceUIDOfEndpointSlice gets the service UID of an EndpointSlice.
+func getServiceUIDOfEndpointSlice(es *discovery_v1.EndpointSlice) (uid string, loaded bool) {
+	for _, owner := range es.ObjectMeta.OwnerReferences {
+		if owner.Kind == "Service" {
+			return string(owner.UID), true
+		}
+	}
+	return "", false
+}
+
+// getPodIPToNodeIPMapFromEndpointSlice returns a mapping from pod IP addresses to node IP addresses
+// matching the specified IP family (IPv6 when ipv6=true, IPv4 when ipv6=false)
+func (az *Cloud) getPodIPToNodeIPMapFromEndpointSlice(es *discovery_v1.EndpointSlice, ipv6 bool) map[string]string {
+	podIPToNodeIPMap := make(map[string]string)
+
+	for _, ep := range es.Endpoints {
+		// Skip endpoints without a node name
+		nodeName := ptr.Deref(ep.NodeName, "")
+		if nodeName == "" {
+			continue
+		}
+
+		// Get node IPs
+		nodeName = strings.ToLower(nodeName)
+		nodeIPsSet := az.nodePrivateIPs[nodeName]
+		if nodeIPsSet == nil {
+			continue
+		}
+
+		// Find the first node IP matching the requested IP family
+		var matchingNodeIP string
+		for _, nodeIP := range nodeIPsSet.UnsortedList() {
+			if utilnet.IsIPv6String(nodeIP) == ipv6 {
+				matchingNodeIP = nodeIP
+				break
+			}
+		}
+
+		// Skip if no matching IP found for this node
+		if matchingNodeIP == "" {
+			continue
+		}
+
+		// Map each pod IP address to the node IP
+		for _, podIP := range ep.Addresses {
+			podIPToNodeIPMap[podIP] = matchingNodeIP
+		}
+	}
+
+	return podIPToNodeIPMap
 }
 
 // compareNodeIPs compares the previous and current node IPs and returns the IPs to be deleted.

--- a/pkg/provider/azure_location_and_nrp_service_batch_updater.go
+++ b/pkg/provider/azure_location_and_nrp_service_batch_updater.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	discovery_v1 "k8s.io/api/discovery/v1"
+	"k8s.io/klog/v2"
+)
+
+// LocationAndNRPServiceBatchUpdater is a batch processor for updating NRP locations and services.
+type locationAndNRPServiceBatchUpdater struct {
+	az                   *Cloud
+	channelUpdateTrigger chan bool
+	lock                 sync.Mutex
+}
+
+func newLocationAndNRPServiceBatchUpdater(az *Cloud) *locationAndNRPServiceBatchUpdater {
+	return &locationAndNRPServiceBatchUpdater{
+		az:                   az,
+		channelUpdateTrigger: make(chan bool, 1),
+	}
+}
+
+func (updater *locationAndNRPServiceBatchUpdater) run(ctx context.Context) {
+	klog.V(2).Info("locationAndNRPServiceBatchUpdater.run: started")
+	for {
+		select {
+		case <-updater.channelUpdateTrigger:
+			updater.process(ctx)
+		case <-ctx.Done():
+			klog.Infof("locationAndNRPServiceBatchUpdater.run: stopped due to context cancellation")
+			return
+		}
+	}
+}
+
+func (updater *locationAndNRPServiceBatchUpdater) process(ctx context.Context) {
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+
+	serviceLoadBalancerList := updater.az.difftracker.GetSyncLoadBalancerServices()
+
+	// Add services
+	createServicesRequestDTO := MapLoadBalancerUpdatesToServiceDataDTO(serviceLoadBalancerList.Additions, updater.az.SubscriptionID, updater.az.ResourceGroup)
+	createServicesResponseDTO := NRPAPIClient.UpdateNRPServices(ctx, createServicesRequestDTO)
+
+	if createServicesResponseDTO.Error == nil {
+		az.difftracker.UpdateNRPLoadBalancers(serviceLoadBalancerList.Additions)
+	} else {
+		// discuss action upon failure
+	}
+
+	// Update locations and addresses for the added and deleted services
+	for _, serviceName := range serviceLoadBalancerList.Additions {
+		updater.az.localServiceNameToNRPServiceMap.LoadOrStore(serviceName, struct{}{})
+
+		updateK8sEndpointsInputType := UpdateK8sEndpointsInputType{
+			inboundIdentity: serviceName,
+			oldAddresses:    nil,
+			newAddresses:    map[string]string{},
+		}
+		updater.az.endpointSlicesCache.Range(func(_, value interface{}) bool {
+			endpointSlice := value.(*discovery_v1.EndpointSlice)
+			serviceUID, loaded := getServiceUIDOfEndpointSlice(endpointSlice)
+			if loaded && strings.EqualFold(serviceUID, serviceName) {
+				updateK8sEndpointsInputType.newAddresses = mergeMaps(updateK8sEndpointsInputType.newAddresses, updater.az.getPodIPToNodeIPMapFromEndpointSlice(endpointSlice, false))
+			}
+			return true
+		})
+
+		updater.az.difftracker.UpdateK8sEndpoints(updateK8sEndpointsInputType)
+	}
+
+	for _, serviceName := range serviceLoadBalancerList.Deletions {
+		updater.az.localServiceNameToNRPServiceMap.Delete(serviceName)
+
+		updateK8sEndpointsInputType := UpdateK8sEndpointsInputType{
+			inboundIdentity: serviceName,
+			oldAddresses:    map[string]string{},
+			newAddresses:    nil,
+		}
+		updater.az.endpointSlicesCache.Range(func(_, value interface{}) bool {
+			endpointSlice := value.(*discovery_v1.EndpointSlice)
+			serviceUID, loaded := getServiceUIDOfEndpointSlice(endpointSlice)
+			if loaded && strings.EqualFold(serviceUID, serviceName) {
+				updateK8sEndpointsInputType.oldAddresses = mergeMaps(updateK8sEndpointsInputType.oldAddresses, updater.az.getPodIPToNodeIPMapFromEndpointSlice(endpointSlice, false))
+			}
+			return true
+		})
+
+		updater.az.difftracker.UpdateK8sEndpoints(updateK8sEndpointsInputType)
+	}
+
+	// Update all locations and addresses
+	locationData := updater.az.difftracker.GetSyncLocationsAddresses()
+	locationDataRequestDTO := MapLocationDataToDTO(locationData)
+	locationDataResponseDTO := NRPAPIClient.UpdateNRPLocations(ctx, locationDataRequestDTO)
+
+	if locationDataResponseDTO.Error == nil {
+		az.difftracker.UpdateLocationsAddresses(locationData)
+	} else {
+		// discuss action upon failure
+	}
+
+	// Remove services
+	removeServicesRequestDTO := MapLoadBalancerUpdatesToServiceDataDTO(serviceLoadBalancerList.Removals, updater.az.SubscriptionID, updater.az.ResourceGroup)
+	removeServicesResponseDTO := NRPAPIClient.UpdateNRPServices(ctx, removeServicesRequestDTO)
+
+	if removeServicesResponseDTO.Error == nil {
+		az.difftracker.UpdateNRPLoadBalancers(serviceLoadBalancerList.Additions)
+	} else {
+		// discuss action upon failure
+	}
+}
+
+func mergeMaps[K comparable, V any](maps ...map[K]V) map[K]V {
+	result := make(map[K]V)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -325,6 +325,11 @@ func getServiceName(service *v1.Service) string {
 	return fmt.Sprintf("%s/%s", service.Namespace, service.Name)
 }
 
+// This returns a unique identifier for the Service used to tag some resources.
+func getServiceUID(service *v1.Service) string {
+	return string(service.UID)
+}
+
 // This returns a prefix for loadbalancer/security rules.
 func (az *Cloud) getRulePrefix(service *v1.Service) string {
 	return az.GetLoadBalancerName(context.TODO(), "", service)

--- a/pkg/provider/config/azure.go
+++ b/pkg/provider/config/azure.go
@@ -183,12 +183,20 @@ func (az *Config) IsLBBackendPoolTypeNodeIP() bool {
 	return strings.EqualFold(az.LoadBalancerBackendPoolConfigurationType, consts.LoadBalancerBackendPoolConfigurationTypeNodeIP)
 }
 
+func (az *Config) IsLBBackendPoolTypePodIP() bool {
+	return strings.EqualFold(az.LoadBalancerBackendPoolConfigurationType, consts.LoadBalancerBackendPoolConfigurationTypePodIP)
+}
+
 func (az *Config) GetPutVMSSVMBatchSize() int {
 	return az.PutVMSSVMBatchSize
 }
 
 func (az *Config) UseStandardLoadBalancer() bool {
 	return strings.EqualFold(az.LoadBalancerSKU, consts.LoadBalancerSKUStandard)
+}
+
+func (az *Config) UseStandardV2LoadBalancer() bool {
+	return strings.EqualFold(az.LoadBalancerSKU, consts.LoadBalancerSKUStandardV2)
 }
 
 func (az *Config) ExcludeMasterNodesFromStandardLB() bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
#### What this PR does / why we need it:
The key changes:
- NRP Service Operations - NRP service create/delete and hooking of LB BP to NRP service
- LocationAndNrpServiceBatchUpdater- Programming ServiceDto in NRP
- Location Update API for Inbound scenarios- Programming of LocationDataDto in NRP(offline POD IP population in BP Pool)
- Node Add/Remove to VMSS

<!--#### Which issue(s) this PR fixes:

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

Fixes #
-->
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the ability to set the type of backend pool to PodIP. 
This action allows the Load balancer attached to the service to route traffic directly to the containers, 
instead of routing to AKS nodes and then AKS node routing it to the PODs hosting the service.
```
