### PR TITLE
fix: azure stack hub volume detach failed

### DIFF
--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
-	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/util/errutils"
 )
 
@@ -172,7 +171,7 @@ func (as *availabilitySet) DetachDisk(ctx context.Context, nodeName types.NodeNa
 		// only log here, next action is to update VM status with original meta data
 		klog.Warningf("detach azure disk on node(%s): disk list(%s) not found", nodeName, diskMap)
 	} else {
-		if strings.EqualFold(as.Environment.Name, consts.AzureStackCloudName) && !as.Config.DisableAzureStackCloud {
+		if as.IsStackCloud() {
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			newDisks := []*armcompute.DataDisk{}
 			for _, disk := range disks {

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -172,7 +172,7 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 		// only log here, next action is to update VM status with original meta data
 		klog.Warningf("detach azure disk on node(%s): disk list(%s) not found", nodeName, diskMap)
 	} else {
-		if strings.EqualFold(ss.Environment.Name, consts.AzureStackCloudName) && !ss.Config.DisableAzureStackCloud {
+		if ss.IsStackCloud() {
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			var newDisks []*armcompute.DataDisk
 			for _, disk := range disks {

--- a/pkg/provider/azure_controller_vmssflex.go
+++ b/pkg/provider/azure_controller_vmssflex.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
-	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
 
 // AttachDisk attaches a disk to vm
@@ -168,7 +167,7 @@ func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName,
 		// only log here, next action is to update VM status with original meta data
 		klog.Warningf("detach azure disk on node(%s): disk list(%s) not found", nodeName, diskMap)
 	} else {
-		if strings.EqualFold(fs.Environment.Name, consts.AzureStackCloudName) && !fs.Config.DisableAzureStackCloud {
+		if fs.IsStackCloud() {
 			// Azure stack does not support ToBeDetached flag, use original way to detach disk
 			newDisks := []*armcompute.DataDisk{}
 			for _, disk := range disks {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Correct the AzureStackCloud condition check.

Generally on Azure stack hub, the `Environment.Name` is `HybridEnvironment`, from the source codes we expected using the cloud name `AzureStackCloud` compares with its `utils.AzureStackCloudName`.

```console
# The AZURE_ENVIRONMENT_FILEPATH config in csi driver controller pod
$ cat $AZURE_ENVIRONMENT_FILEPATH
{
    "name": "HybridEnvironment",
    "managementPortalURL": "",
    "publishSettingsURL": "",
    "serviceManagementEndpoint": "",
    "resourceManagerEndpoint": "https://management.XXXXXX.com",
    "activeDirectoryEndpoint": "https://login.microsoftonline.com/",
    "galleryEndpoint": "https://providers.azs2.local:30016/",
    "keyVaultEndpoint": "https://vault.XXXXXX.com",
    "managedHSMEndpoint": "",
    "graphEndpoint": "https://graph.windows.net/",
    "serviceBusEndpoint": "",
    "batchManagementEndpoint": "",
    "microsoftGraphEndpoint": "",
    "storageEndpointSuffix": "XXXXXX.com",
    "cosmosDBDNSSuffix": "",
    "mariaDBDNSSuffix": "",
    "mySqlDatabaseDNSSuffix": "",
    "postgresqlDatabaseDNSSuffix": "",
    "sqlDatabaseDNSSuffix": "",
    "trafficManagerDNSSuffix": "",
    "keyVaultDNSSuffix": "vault.XXXXXX.com",
    "managedHSMDNSSuffix": "",
    "serviceBusEndpointSuffix": "",
    "serviceManagementVMDNSSuffix": "",
    "resourceManagerVMDNSSuffix": "",
    "containerRegistryDNSSuffix": "",
    "tokenAudience": "https://management.XXXXXX.onmicrosoft.com/1d974a95-a89d-4009-9aee-8d17ddf1971d",
    "apiManagementHostNameSuffix": "",
    "synapseEndpointSuffix": "",
    "datalakeSuffix": "",
    "resourceIdentifiers": {
        "graph": "",
        "keyVault": "",
        "datalake": "",
        "batch": "",
        "operationalInsights": "",
        "ossRDBMS": "",
        "storage": "",
        "synapse": "",
        "serviceBus": "",
        "sqlDatabase": "",
        "cosmosDB": "",
        "managedHSM": "",
        "microsoftGraph": ""
    }
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/cloud-provider-azure/issues/8919

```console
# Manual hack the azure disk vendor with the patch verify the fix works.

$ oc logs -l app=azure-disk-csi-driver-controller -c csi-driver --tail=-1|grep 'pvc-32924087-a780-4509-83d5-101371b8fd27'
I0421 05:16:57.508380       1 utils.go:106] GRPC request: {"node_id":"ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f","volume_id":"/subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27"}
I0421 05:16:57.508525       1 controllerserver.go:614] Trying to detach volume /subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27 from node ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f
I0421 05:16:57.965775       1 azure_controller_common.go:348] wait 1000ms for more requests on node ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f, current disk detach: /subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27
I0421 05:16:58.965897       1 azure_controller_common.go:356] Trying to detach volume /subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27 from node ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f, diskMap len:1, map[/subscriptions/XXXXXX/resourcegroups/ci-XXXXXX/providers/microsoft.compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27:pvc-32924087-a780-4509-83d5-101371b8fd27]
I0421 05:16:58.965942       1 azure_controller_standard.go:162] azureDisk - detach disk: name pvc-32924087-a780-4509-83d5-101371b8fd27 uri /subscriptions/XXXXXX/resourcegroups/ci-XXXXXX/providers/microsoft.compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27
I0421 05:16:58.965951       1 azure_controller_standard.go:196] azureDisk - update(ci-XXXXXX): vm(ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f) node(ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f)- detach disk list(map[/subscriptions/XXXXXX/resourcegroups/ci-XXXXXX/providers/microsoft.compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27:pvc-32924087-a780-4509-83d5-101371b8fd27])
I0421 05:17:14.783162       1 azure_controller_standard.go:217] azureDisk - update(ci-XXXXXX): vm(ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f) - detach disk list(map[/subscriptions/XXXXXX/resourcegroups/ci-XXXXXX/providers/microsoft.compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27:pvc-32924087-a780-4509-83d5-101371b8fd27]) returned with <nil>
I0421 05:17:14.783208       1 azure_controller_common.go:387] azureDisk - detach disk(pvc-32924087-a780-4509-83d5-101371b8fd27, /subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27) succeeded
I0421 05:17:14.783221       1 controllerserver.go:628] detach volume /subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27 from node ci-XXXXXX-vz2h2-worker-mtcazs-s8n2f successfully
I0421 05:17:20.135701       1 utils.go:106] GRPC request: {"volume_id":"/subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27"}
I0421 05:17:20.135793       1 controllerserver.go:385] deleting azure disk(/subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27)
I0421 05:17:35.860371       1 azure_managedDiskController.go:346] azureDisk - deleted a managed disk: /subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27
I0421 05:17:35.860393       1 controllerserver.go:387] delete azure disk(/subscriptions/XXXXXX/resourceGroups/ci-XXXXXX/providers/Microsoft.Compute/disks/pvc-32924087-a780-4509-83d5-101371b8fd27) returned with <nil>

```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
