### PR TITLE
[release-1.32] fix: remove unnecessary get vmss call during disk attach

### DIFF
--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -50,24 +50,24 @@ func (as *availabilitySet) AttachDisk(ctx context.Context, nodeName types.NodeNa
 	copy(disks, vm.Properties.StorageProfile.DataDisks)
 
 	for k, v := range diskMap {
-		diSKURI := k
+		diskURI := k
 		opt := v
 		attached := false
 		for _, disk := range vm.Properties.StorageProfile.DataDisks {
-			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diSKURI) && disk.Lun != nil {
+			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diskURI) && disk.Lun != nil {
 				if *disk.Lun == opt.Lun {
 					attached = true
 					break
 				}
-				return fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diSKURI, nodeName, *disk.Lun, opt.Lun)
+				return fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.Lun)
 			}
 		}
 		if attached {
-			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diSKURI, nodeName, opt.Lun)
+			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.Lun)
 			continue
 		}
 
-		managedDisk := &armcompute.ManagedDiskParameters{ID: &diSKURI}
+		managedDisk := &armcompute.ManagedDiskParameters{ID: &diskURI}
 		if opt.DiskEncryptionSetID == "" {
 			if vm.Properties.StorageProfile.OSDisk != nil &&
 				vm.Properties.StorageProfile.OSDisk.ManagedDisk != nil &&
@@ -112,15 +112,13 @@ func (as *availabilitySet) AttachDisk(ctx context.Context, nodeName types.NodeNa
 		}
 	}
 
-	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk list(%v) returned with %v", nodeResourceGroup, vmName, diskMap, rerr)
-	if rerr != nil {
-		return rerr
-	}
+	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk list(%v) returned with %v", nodeResourceGroup, vmName, diskMap, err)
 
-	// clean node cache first and then update cache
 	_ = as.DeleteCacheForNode(ctx, vmName)
-	as.updateCache(vmName, result)
-	return nil
+	if rerr == nil && result != nil {
+		as.updateCache(vmName, result)
+	}
+	return rerr
 }
 
 func (as *availabilitySet) DeleteCacheForNode(_ context.Context, nodeName string) error {
@@ -153,12 +151,12 @@ func (as *availabilitySet) DetachDisk(ctx context.Context, nodeName types.NodeNa
 
 	bFoundDisk := false
 	for i, disk := range disks {
-		for diSKURI, diskName := range diskMap {
+		for diskURI, diskName := range diskMap {
 			if disk.Lun != nil && (disk.Name != nil && diskName != "" && strings.EqualFold(*disk.Name, diskName)) ||
-				(disk.Vhd != nil && disk.Vhd.URI != nil && diSKURI != "" && strings.EqualFold(*disk.Vhd.URI, diSKURI)) ||
-				(disk.ManagedDisk != nil && diSKURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diSKURI)) {
+				(disk.Vhd != nil && disk.Vhd.URI != nil && diskURI != "" && strings.EqualFold(*disk.Vhd.URI, diskURI)) ||
+				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
-				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diSKURI)
+				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diskURI)
 				disks[i].ToBeDetached = ptr.To(true)
 				if forceDetach {
 					disks[i].DetachOption = to.Ptr(armcompute.DiskDetachOptionTypesForceDetach)
@@ -194,14 +192,7 @@ func (as *availabilitySet) DetachDisk(ctx context.Context, nodeName types.NodeNa
 	}
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) node(%s)- detach disk list(%s)", nodeResourceGroup, vmName, nodeName, diskMap)
 
-	var result *armcompute.VirtualMachine
-	defer func() {
-		// invalidate the cache right after updating
-		_ = as.DeleteCacheForNode(ctx, vmName)
-		as.updateCache(vmName, result)
-	}()
-
-	result, err = as.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM)
+	result, err := as.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, vmName, newVM)
 	if err != nil {
 		klog.Errorf("azureDisk - detach disk list(%s) on rg(%s) vm(%s) failed, err: %v", diskMap, nodeResourceGroup, vmName, err)
 		var exists bool
@@ -214,6 +205,11 @@ func (as *availabilitySet) DetachDisk(ctx context.Context, nodeName types.NodeNa
 	}
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk list(%s) returned with %v", nodeResourceGroup, vmName, diskMap, err)
+
+	_ = as.DeleteCacheForNode(ctx, vmName)
+	if err == nil && result != nil {
+		as.updateCache(vmName, result)
+	}
 	return err
 }
 
@@ -231,12 +227,13 @@ func (as *availabilitySet) UpdateVM(ctx context.Context, nodeName types.NodeName
 			// if the VM does not exist, we should not update the cache
 			return nil
 		}
-		return rerr
 	}
-	// clean node cache first and then update cache
+
 	_ = as.DeleteCacheForNode(ctx, vmName)
-	as.updateCache(vmName, result)
-	return nil
+	if rerr == nil && result != nil {
+		as.updateCache(vmName, result)
+	}
+	return rerr
 }
 
 func (as *availabilitySet) updateCache(nodeName string, vm *armcompute.VirtualMachine) {

--- a/pkg/provider/azure_controller_vmss.go
+++ b/pkg/provider/azure_controller_vmss.go
@@ -48,32 +48,31 @@ func (ss *ScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName, dis
 	var disks []*armcompute.DataDisk
 
 	storageProfile := vm.AsVirtualMachineScaleSetVM().Properties.StorageProfile
-
 	if storageProfile != nil && storageProfile.DataDisks != nil {
 		disks = make([]*armcompute.DataDisk, len(storageProfile.DataDisks))
 		copy(disks, storageProfile.DataDisks)
 	}
 
 	for k, v := range diskMap {
-		diSKURI := k
+		diskURI := k
 		opt := v
 		attached := false
 		for _, disk := range storageProfile.DataDisks {
-			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diSKURI) && disk.Lun != nil {
+			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diskURI) && disk.Lun != nil {
 				if *disk.Lun == opt.Lun {
 					attached = true
 					break
 				}
-				return fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diSKURI, nodeName, *disk.Lun, opt.Lun)
+				return fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.Lun)
 
 			}
 		}
 		if attached {
-			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diSKURI, nodeName, opt.Lun)
+			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.Lun)
 			continue
 		}
 
-		managedDisk := &armcompute.ManagedDiskParameters{ID: &diSKURI}
+		managedDisk := &armcompute.ManagedDiskParameters{ID: &diskURI}
 		if opt.DiskEncryptionSetID == "" {
 			if storageProfile.OSDisk != nil &&
 				storageProfile.OSDisk.ManagedDisk != nil &&
@@ -117,27 +116,12 @@ func (ss *ScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName, dis
 		}
 	}
 
-	klog.V(2).Infof("azureDisk - update: rg(%s) vm(%s) - attach disk list(%+v) returned with %v", nodeResourceGroup, nodeName, diskMap, rerr)
-	if rerr != nil {
-		return rerr
-	}
+	klog.V(2).Infof("azureDisk - update: rg(%s) vm(%s) - attach disk list(%+v) returned with %v", nodeResourceGroup, nodeName, diskMap, err)
 
-	// clean node cache first and then update cache
 	_ = ss.DeleteCacheForNode(ctx, vmName)
-
-	var vmssName, instanceID string
-	if result != nil && result.Properties != nil {
-		// get vmssName, instanceID from cache first
-		vm, err := ss.getVmssVM(ctx, vmName, azcache.CacheReadTypeDefault)
-		if err == nil && vm != nil {
-			vmssName = vm.VMSSName
-			instanceID = vm.InstanceID
-		} else {
-			klog.Errorf("getVmssVM failed with error(%v) or nil pointer", err)
-		}
-
-		if err := ss.updateCache(ctx, vmName, nodeResourceGroup, vmssName, instanceID, result); err != nil {
-			klog.Errorf("updateCache(%s, %s, %s, %s) failed with error: %v", vmName, nodeResourceGroup, vmssName, instanceID, err)
+	if rerr == nil && result != nil && result.Properties != nil {
+		if err := ss.updateCache(ctx, vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, result); err != nil {
+			klog.Errorf("updateCache(%s, %s, %s, %s) failed with error: %v", vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, err)
 		}
 	}
 	return rerr
@@ -167,12 +151,12 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 	}
 	bFoundDisk := false
 	for i, disk := range disks {
-		for diSKURI, diskName := range diskMap {
+		for diskURI, diskName := range diskMap {
 			if disk.Lun != nil && (disk.Name != nil && diskName != "" && strings.EqualFold(*disk.Name, diskName)) ||
-				(disk.Vhd != nil && disk.Vhd.URI != nil && diSKURI != "" && strings.EqualFold(*disk.Vhd.URI, diSKURI)) ||
-				(disk.ManagedDisk != nil && diSKURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diSKURI)) {
+				(disk.Vhd != nil && disk.Vhd.URI != nil && diskURI != "" && strings.EqualFold(*disk.Vhd.URI, diskURI)) ||
+				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
-				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diSKURI)
+				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diskURI)
 				disks[i].ToBeDetached = ptr.To(true)
 				if forceDetach {
 					disks[i].DetachOption = to.Ptr(armcompute.DiskDetachOptionTypesForceDetach)
@@ -206,22 +190,10 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 		},
 	}
 
-	var result *armcompute.VirtualMachineScaleSetVM
-	var rerr error
-
-	defer func() {
-		_ = ss.DeleteCacheForNode(ctx, vmName)
-		if rerr == nil {
-			if err := ss.updateCache(ctx, vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, result); err != nil {
-				klog.Errorf("updateCache(%s, %s, %s, %s) failed with error: %v", vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, err)
-			}
-		}
-	}()
-
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk list(%s)", nodeResourceGroup, nodeName, diskMap)
-	result, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().Update(ctx, nodeResourceGroup, vm.VMSSName, vm.InstanceID, *newVM)
+	result, rerr := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().Update(ctx, nodeResourceGroup, vm.VMSSName, vm.InstanceID, *newVM)
 	if rerr != nil {
-		klog.Errorf("azureDisk - detach disk list(%s) on rg(%s) vm(%s) failed, err: %v", diskMap, nodeResourceGroup, nodeName, rerr)
+		klog.Errorf("azureDisk - detach disk list(%+v) on rg(%s) vm(%s) failed, err: %v", diskMap, nodeResourceGroup, nodeName, rerr)
 		if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); exists && err == nil {
 			klog.Errorf("azureDisk - begin to filterNonExistingDisks(%v) on rg(%s) vm(%s)", diskMap, nodeResourceGroup, nodeName)
 			disks := FilterNonExistingDisks(ctx, ss.ComputeClientFactory, newVM.Properties.StorageProfile.DataDisks)
@@ -230,7 +202,14 @@ func (ss *ScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName, dis
 		}
 	}
 
-	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%v) returned with %v", nodeResourceGroup, nodeName, diskMap, rerr)
+	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%v) returned with %v", nodeResourceGroup, nodeName, diskMap, err)
+
+	_ = ss.DeleteCacheForNode(ctx, vmName)
+	if rerr == nil && result != nil && result.Properties != nil {
+		if err := ss.updateCache(ctx, vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, result); err != nil {
+			klog.Errorf("updateCache(%s, %s, %s, %s) failed with error: %v", vmName, nodeResourceGroup, vm.VMSSName, vm.InstanceID, err)
+		}
+	}
 	return rerr
 }
 
@@ -247,11 +226,8 @@ func (ss *ScaleSet) UpdateVM(ctx context.Context, nodeName types.NodeName) error
 		return err
 	}
 
-	_, rerr := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().Update(ctx, nodeResourceGroup, vm.VMSSName, vm.InstanceID, armcompute.VirtualMachineScaleSetVM{})
-	if rerr != nil {
-		return rerr
-	}
-	return nil
+	_, err = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().Update(ctx, nodeResourceGroup, vm.VMSSName, vm.InstanceID, armcompute.VirtualMachineScaleSetVM{})
+	return err
 }
 
 // GetDataDisks gets a list of data disks attached to the node.

--- a/pkg/provider/azure_controller_vmssflex.go
+++ b/pkg/provider/azure_controller_vmssflex.go
@@ -53,24 +53,24 @@ func (fs *FlexScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName,
 	copy(disks, vm.Properties.StorageProfile.DataDisks)
 
 	for k, v := range diskMap {
-		diSKURI := k
+		diskURI := k
 		opt := v
 		attached := false
 		for _, disk := range vm.Properties.StorageProfile.DataDisks {
-			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diSKURI) && disk.Lun != nil {
+			if disk.ManagedDisk != nil && strings.EqualFold(*disk.ManagedDisk.ID, diskURI) && disk.Lun != nil {
 				if *disk.Lun == opt.Lun {
 					attached = true
 					break
 				}
-				return fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diSKURI, nodeName, *disk.Lun, opt.Lun)
+				return fmt.Errorf("disk(%s) already attached to node(%s) on LUN(%d), but target LUN is %d", diskURI, nodeName, *disk.Lun, opt.Lun)
 			}
 		}
 		if attached {
-			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diSKURI, nodeName, opt.Lun)
+			klog.V(2).Infof("azureDisk - disk(%s) already attached to node(%s) on LUN(%d)", diskURI, nodeName, opt.Lun)
 			continue
 		}
 
-		managedDisk := &armcompute.ManagedDiskParameters{ID: &diSKURI}
+		managedDisk := &armcompute.ManagedDiskParameters{ID: &diskURI}
 		if opt.DiskEncryptionSetID == "" {
 			if vm.Properties.StorageProfile.OSDisk != nil &&
 				vm.Properties.StorageProfile.OSDisk.ManagedDisk != nil &&
@@ -117,14 +117,14 @@ func (fs *FlexScaleSet) AttachDisk(ctx context.Context, nodeName types.NodeName,
 	}
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk list(%+v) returned with %v", nodeResourceGroup, vmName, diskMap, rerr)
-	if err != nil {
-		return err
-	}
+
 	_ = fs.DeleteCacheForNode(ctx, vmName)
-	if err := fs.updateCache(ctx, vmName, result); err != nil {
-		klog.Errorf("updateCache(%s) failed with error: %v", vmName, err)
+	if err == nil && result != nil {
+		if rerr := fs.updateCache(ctx, vmName, result); err != nil {
+			klog.Errorf("updateCache(%s) failed with error: %v", vmName, rerr)
+		}
 	}
-	return nil
+	return err
 }
 
 // DetachDisk detaches a disk from VM
@@ -147,12 +147,12 @@ func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName,
 
 	bFoundDisk := false
 	for i, disk := range disks {
-		for diSKURI, diskName := range diskMap {
+		for diskURI, diskName := range diskMap {
 			if disk.Lun != nil && (disk.Name != nil && diskName != "" && strings.EqualFold(*disk.Name, diskName)) ||
-				(disk.Vhd != nil && disk.Vhd.URI != nil && diSKURI != "" && strings.EqualFold(*disk.Vhd.URI, diSKURI)) ||
-				(disk.ManagedDisk != nil && diSKURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diSKURI)) {
+				(disk.Vhd != nil && disk.Vhd.URI != nil && diskURI != "" && strings.EqualFold(*disk.Vhd.URI, diskURI)) ||
+				(disk.ManagedDisk != nil && diskURI != "" && strings.EqualFold(*disk.ManagedDisk.ID, diskURI)) {
 				// found the disk
-				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diSKURI)
+				klog.V(2).Infof("azureDisk - detach disk: name %s uri %s", diskName, diskURI)
 				disks[i].ToBeDetached = ptr.To(true)
 				if forceDetach {
 					disks[i].DetachOption = to.Ptr(armcompute.DiskDetachOptionTypesForceDetach)
@@ -187,19 +187,9 @@ func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName,
 		Location: vm.Location,
 	}
 
-	var result *armcompute.VirtualMachine
-	defer func() {
-		_ = fs.DeleteCacheForNode(ctx, vmName)
-		if err == nil {
-			if err := fs.updateCache(ctx, vmName, result); err != nil {
-				klog.Errorf("updateCache(%s) failed with error: %v", vmName, err)
-			}
-		}
-	}()
-
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) node(%s)- detach disk list(%s)", nodeResourceGroup, vmName, nodeName, diskMap)
 
-	result, err = fs.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, *vm.Name, newVM)
+	result, err := fs.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, *vm.Name, newVM)
 	if err != nil {
 		klog.Errorf("azureDisk - detach disk list(%s) on rg(%s) vm(%s) failed, err: %v", diskMap, nodeResourceGroup, vmName, err)
 		var rerr *azcore.ResponseError
@@ -214,15 +204,14 @@ func (fs *FlexScaleSet) DetachDisk(ctx context.Context, nodeName types.NodeName,
 	}
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk list(%s) returned with %v", nodeResourceGroup, vmName, diskMap, err)
-	if err != nil {
-		return err
-	}
-	// clean node cache first and then update cache
+
 	_ = fs.DeleteCacheForNode(ctx, vmName)
-	if err := fs.updateCache(ctx, vmName, result); err != nil {
-		klog.Errorf("updateCache(%s) failed with error: %v", vmName, err)
+	if err == nil && result != nil {
+		if rerr := fs.updateCache(ctx, vmName, result); rerr != nil {
+			klog.Errorf("updateCache(%s) failed with error: %v", vmName, rerr)
+		}
 	}
-	return nil
+	return err
 }
 
 // UpdateVM updates a vm
@@ -239,11 +228,8 @@ func (fs *FlexScaleSet) UpdateVM(ctx context.Context, nodeName types.NodeName) e
 		return err
 	}
 
-	_, rerr := fs.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, *vm.Name, armcompute.VirtualMachine{})
-	if rerr != nil {
-		return rerr
-	}
-	return nil
+	_, err = fs.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, *vm.Name, armcompute.VirtualMachine{})
+	return err
 }
 
 func (fs *FlexScaleSet) updateCache(ctx context.Context, nodeName string, vm *armcompute.VirtualMachine) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
fix: remove unnecessary get vmss call during disk attach

cherrypick of https://github.com/kubernetes-sigs/cloud-provider-azure/pull/8874

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: remove unnecessary get vmss call during disk attach
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: remove unnecessary get vmss call during disk attach
```
