### PR TITLE
feat: add option to override ARM retry-after if the value is lower than the configured minimum

### DIFF
--- a/pkg/azclient/arm_conf.go
+++ b/pkg/azclient/arm_conf.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryaftermin"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/useragent"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
 )
@@ -49,6 +50,8 @@ type ARMClientConfig struct {
 	// when setting AzureAuthConfig.Cloud with "AZURESTACKCLOUD" to customize ARM endpoints
 	// while the cluster is not running on AzureStack.
 	DisableAzureStackCloud bool `json:"disableAzureStackCloud,omitempty" yaml:"disableAzureStackCloud,omitempty"`
+	// If true, HTTP responses' retry-after header will be overridden with the configured minimum retry-after value if lower than the configured minimum
+	EnableMinimumRetryAfter bool `json:"enableMinimumRetryAfter,omitempty" yaml:"enableMinimumRetryAfter,omitempty"`
 }
 
 func (config *ARMClientConfig) GetTenantID() string {
@@ -80,6 +83,10 @@ func GetAzCoreClientOption(armConfig *ARMClientConfig) (*policy.ClientOptions, *
 		}
 		if armConfig.CloudProviderBackoff && armConfig.CloudProviderBackoffRetries > 0 {
 			clientConfig.Retry.MaxRetries = armConfig.CloudProviderBackoffRetries
+		}
+		if armConfig.EnableMinimumRetryAfter {
+			// Add the minimum retry-after policy to enforce a a minimum retry-after value configured in clientConfig.Retry.RetryDelay (default 5s)
+			clientConfig.PerRetryPolicies = append(clientConfig.PerRetryPolicies, retryaftermin.NewRetryAfterMinPolicy(clientConfig.Retry.RetryDelay))
 		}
 	}
 	return &clientConfig, env, nil

--- a/pkg/azclient/arm_conf.go
+++ b/pkg/azclient/arm_conf.go
@@ -85,7 +85,7 @@ func GetAzCoreClientOption(armConfig *ARMClientConfig) (*policy.ClientOptions, *
 			clientConfig.Retry.MaxRetries = armConfig.CloudProviderBackoffRetries
 		}
 		if armConfig.EnableMinimumRetryAfter {
-			// Add the minimum retry-after policy to enforce a a minimum retry-after value configured in clientConfig.Retry.RetryDelay (default 5s)
+			// Add the minimum retry-after policy to enforce a minimum retry-after value configured in clientConfig.Retry.RetryDelay (default 5s)
 			clientConfig.PerRetryPolicies = append(clientConfig.PerRetryPolicies, retryaftermin.NewRetryAfterMinPolicy(clientConfig.Retry.RetryDelay))
 		}
 	}

--- a/pkg/azclient/go.mod
+++ b/pkg/azclient/go.mod
@@ -32,6 +32,7 @@ require (
 	golang.org/x/sync v0.12.0
 	golang.org/x/time v0.11.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0
+	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 

--- a/pkg/azclient/go.sum
+++ b/pkg/azclient/go.sum
@@ -56,6 +56,7 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-faker/faker/v4 v4.6.0 h1:6aOPzNptRiDwD14HuAnEtlTa+D1IfFuEHO8+vEFwjTs=
 github.com/go-faker/faker/v4 v4.6.0/go.mod h1:ZmrHuVtTTm2Em9e0Du6CJ9CADaLEzGXW62z1YqFH0m0=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -130,5 +131,7 @@ gopkg.in/dnaeon/go-vcr.v3 v3.2.0 h1:Rltp0Vf+Aq0u4rQXgmXgtgoRDStTnFN83cWgSGSoRzM=
 gopkg.in/dnaeon/go-vcr.v3 v3.2.0/go.mod h1:2IMOnnlx9I6u9x+YBsM3tAMx6AlOxnJ0pWxQAzZ79Ag=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/pkg/azclient/policy/retryaftermin/retryaftermin.go
+++ b/pkg/azclient/policy/retryaftermin/retryaftermin.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retryaftermin
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"k8s.io/klog/v2"
+)
+
+// RetryAfterMinPolicy is a policy that enforces a minimum retry-after value
+type RetryAfterMinPolicy struct {
+	minRetryAfter time.Duration
+}
+
+// NewRetryAfterMinPolicy creates a new RetryAfterMinPolicy with the specified minimum retry-after value
+func NewRetryAfterMinPolicy(minRetryAfter time.Duration) policy.Policy {
+	return &RetryAfterMinPolicy{
+		minRetryAfter: minRetryAfter,
+	}
+}
+
+// GetMinRetryAfter returns the minimum retry-after value
+func (p *RetryAfterMinPolicy) GetMinRetryAfter() time.Duration {
+	return p.minRetryAfter
+}
+
+// Do implements the policy.Policy interface
+func (p *RetryAfterMinPolicy) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	// If the request failed or the status code is >= 300, return
+	if err != nil || resp == nil || resp.StatusCode >= 300 {
+		return resp, err
+	}
+
+	// Check if the response retry-after header is less than the minimum
+	overrideRetryAfter := func(header http.Header, headerName string, retryAfter time.Duration) {
+		if retryAfter < p.minRetryAfter {
+			klog.V(5).Infof("RetryAfterMinPolicy: retry-after value %s is less than minimum %s, removing retry-after header..", retryAfter, p.minRetryAfter)
+			header.Del(headerName)
+		}
+	}
+
+	// Process all "Retry-After" headers (case-insensitive)
+	for headerName := range resp.Header {
+		if strings.EqualFold(headerName, "Retry-After") {
+			retryAfter := resp.Header.Get(headerName)
+			// Try to parse as duration (e.g., "1s", "30s", "1m")
+			retryDuration, err := time.ParseDuration(retryAfter)
+			if err == nil {
+				// If the retry-after value is less than the minimum, remove it
+				overrideRetryAfter(resp.Header, headerName, retryDuration)
+			} else {
+				// Try to parse as seconds (integer)
+				seconds, err := strconv.Atoi(retryAfter)
+				if err == nil {
+					retryDuration := time.Duration(seconds) * time.Second
+					// If the retry-after value is less than the minimum, remove it
+					overrideRetryAfter(resp.Header, headerName, retryDuration)
+				} else {
+					klog.V(5).Infof("RetryAfterMinPolicy: not modifying %s header with unrecognized format: %s", headerName, retryAfter)
+				}
+			}
+		}
+	}
+
+	return resp, err
+}

--- a/pkg/azclient/policy/retryaftermin/retryaftermin.go
+++ b/pkg/azclient/policy/retryaftermin/retryaftermin.go
@@ -26,25 +26,25 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// RetryAfterMinPolicy is a policy that enforces a minimum retry-after value
-type RetryAfterMinPolicy struct {
+// Policy is a policy that enforces a minimum retry-after value
+type Policy struct {
 	minRetryAfter time.Duration
 }
 
-// NewRetryAfterMinPolicy creates a new RetryAfterMinPolicy with the specified minimum retry-after value
+// NewRetryAfterMinPolicy creates a new Policy with the specified minimum retry-after value
 func NewRetryAfterMinPolicy(minRetryAfter time.Duration) policy.Policy {
-	return &RetryAfterMinPolicy{
+	return &Policy{
 		minRetryAfter: minRetryAfter,
 	}
 }
 
 // GetMinRetryAfter returns the minimum retry-after value
-func (p *RetryAfterMinPolicy) GetMinRetryAfter() time.Duration {
+func (p *Policy) GetMinRetryAfter() time.Duration {
 	return p.minRetryAfter
 }
 
 // Do implements the policy.Policy interface
-func (p *RetryAfterMinPolicy) Do(req *policy.Request) (*http.Response, error) {
+func (p *Policy) Do(req *policy.Request) (*http.Response, error) {
 	resp, err := req.Next()
 	// If the request failed or the status code is >= 300, return
 	if err != nil || resp == nil || resp.StatusCode >= 300 {

--- a/pkg/azclient/policy/retryaftermin/retryaftermin_test.go
+++ b/pkg/azclient/policy/retryaftermin/retryaftermin_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retryaftermin_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryaftermin"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
+)
+
+// TestRetryAfterMinPolicy tests Policy functionality
+func TestRetryAfterMinPolicy(t *testing.T) {
+	t.Run("should remove retry-after headers below minimum threshold", func(t *testing.T) {
+		minRetryAfter := 5 * time.Second
+		retryPolicy := retryaftermin.NewRetryAfterMinPolicy(minRetryAfter)
+
+		pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, &policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{
+				retryPolicy,
+				utils.FuncPolicyWrapper(
+					func(_ *policy.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     make(http.Header),
+							Body:       http.NoBody,
+						}
+						resp.Header.Set("Retry-After", "2")
+						return resp, nil
+					},
+				),
+			},
+		})
+
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.microsoft.com")
+		assert.NoError(t, err)
+
+		response, err := pipeline.Do(req)
+		assert.NoError(t, err)
+		assert.Empty(t, response.Header.Get("Retry-After"))
+	})
+
+	t.Run("should keep retry-after headers above minimum threshold", func(t *testing.T) {
+		minRetryAfter := 5 * time.Second
+		retryPolicy := retryaftermin.NewRetryAfterMinPolicy(minRetryAfter)
+
+		pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, &policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{
+				retryPolicy,
+				utils.FuncPolicyWrapper(
+					func(_ *policy.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     make(http.Header),
+							Body:       http.NoBody,
+						}
+						resp.Header.Set("Retry-After", "10")
+						return resp, nil
+					},
+				),
+			},
+		})
+
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.microsoft.com")
+		assert.NoError(t, err)
+
+		response, err := pipeline.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "10", response.Header.Get("Retry-After"))
+	})
+
+	t.Run("should propagate errors", func(t *testing.T) {
+		minRetryAfter := 5 * time.Second
+		testErr := errors.New("test error")
+		retryPolicy := retryaftermin.NewRetryAfterMinPolicy(minRetryAfter)
+
+		pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, &policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{
+				retryPolicy,
+				utils.FuncPolicyWrapper(
+					func(_ *policy.Request) (*http.Response, error) {
+						return nil, testErr
+					},
+				),
+			},
+		})
+
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.microsoft.com")
+		assert.NoError(t, err)
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.Equal(t, testErr, err)
+	})
+
+	t.Run("should handle duration format", func(t *testing.T) {
+		minRetryAfter := 5 * time.Second
+		retryPolicy := retryaftermin.NewRetryAfterMinPolicy(minRetryAfter)
+
+		pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, &policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{
+				retryPolicy,
+				utils.FuncPolicyWrapper(
+					func(_ *policy.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     make(http.Header),
+							Body:       http.NoBody,
+						}
+						resp.Header.Set("Retry-After", "2s")
+						return resp, nil
+					},
+				),
+			},
+		})
+
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.microsoft.com")
+		assert.NoError(t, err)
+
+		response, err := pipeline.Do(req)
+		assert.NoError(t, err)
+		assert.Empty(t, response.Header.Get("Retry-After"))
+	})
+
+	t.Run("should preserve unrecognized format", func(t *testing.T) {
+		minRetryAfter := 5 * time.Second
+		retryPolicy := retryaftermin.NewRetryAfterMinPolicy(minRetryAfter)
+
+		pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, &policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{
+				retryPolicy,
+				utils.FuncPolicyWrapper(
+					func(_ *policy.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusOK,
+							Header:     make(http.Header),
+							Body:       http.NoBody,
+						}
+						resp.Header.Set("Retry-After", "invalid-format")
+						return resp, nil
+					},
+				),
+			},
+		})
+
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.microsoft.com")
+		assert.NoError(t, err)
+
+		response, err := pipeline.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "invalid-format", response.Header.Get("Retry-After"))
+	})
+}
+
+// TestNewRetryAfterMinPolicy tests the creation of retryaftermin.Policy
+func TestNewRetryAfterMinPolicy(t *testing.T) {
+	t.Parallel()
+
+	minRetryAfter := 5 * time.Second
+	policy := retryaftermin.NewRetryAfterMinPolicy(minRetryAfter)
+
+	assert.NotNil(t, policy)
+
+	// Type assertion to check the concrete type
+	retryPolicy, ok := policy.(*retryaftermin.Policy)
+	assert.True(t, ok)
+	assert.Equal(t, minRetryAfter, retryPolicy.GetMinRetryAfter())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
There is a CRP Extension bug that adversely impacts csi-driver's attach/detach latency. The symptom of the issue is that a high retry-after value of 37 seconds is returned on 4th GET request for async operation tracking. To mitigate the impact, we need to issue GET requests with more delay in between. So, this PR adds option to add custom retry policy that will remove the retry-after header from the http response if the value is lower than the configured minimum.

Example HTTP Header:
Headers:
{
  Retry-After: 37
  x-ms-ratelimit-remaining-resource: Microsoft.Compute/GetOperationResource;41
  x-ms-ratelimit-remaining-resource: Microsoft.Compute/GetOperationSubscriptionMaximum;14994
  x-ms-need-to-refresh-epl-cache: False
  Content-Type: application/json; charset=utf-8
}

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat: add option to override ARM retry-after if the value is lower than the configured minimum
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
feat: add option to override ARM retry-after if the value is lower than the configured minimum
```
