### PR TITLE
Track2 sdk: replace expand with deleteoption in delete func of fileshare client

### DIFF
--- a/pkg/azclient/fileshareclient/custom.go
+++ b/pkg/azclient/fileshareclient/custom.go
@@ -58,15 +58,13 @@ func (client *Client) Update(ctx context.Context, resourceGroupName string, reso
 }
 
 // Delete deletes a FileShare by name.
-func (client *Client) Delete(ctx context.Context, resourceGroupName string, parentResourceName string, resourceName string, expand *string) error {
+func (client *Client) Delete(ctx context.Context, resourceGroupName string, parentResourceName string, resourceName string, option *armstorage.FileSharesClientDeleteOptions) error {
 	metricsCtx := metrics.BeginARMRequest(client.subscriptionID, resourceGroupName, "FileShare", "delete")
 	defer func() { metricsCtx.Observe(ctx, nil) }()
 	ctx, endSpan := runtime.StartSpan(ctx, DeleteOperationName, client.tracer, nil)
 	defer endSpan(nil)
 
-	_, err := client.FileSharesClient.Delete(ctx, resourceGroupName, parentResourceName, resourceName, &armstorage.FileSharesClientDeleteOptions{
-		Include: expand,
-	})
+	_, err := client.FileSharesClient.Delete(ctx, resourceGroupName, parentResourceName, resourceName, option)
 	return err
 }
 

--- a/pkg/azclient/fileshareclient/interface.go
+++ b/pkg/azclient/fileshareclient/interface.go
@@ -29,5 +29,5 @@ type Interface interface {
 	List(ctx context.Context, resourceGroupName string, accountName string, option *armstorage.FileSharesClientListOptions) (result []*armstorage.FileShareItem, err error)
 	Create(ctx context.Context, resourceGroupName string, resourceName string, parentResourceName string, resource armstorage.FileShare, expand *string) (*armstorage.FileShare, error)
 	Update(ctx context.Context, resourceGroupName string, resourceName string, parentResourceName string, resource armstorage.FileShare) (*armstorage.FileShare, error)
-	Delete(ctx context.Context, resourceGroupName string, parentResourceName string, resourceName string, expand *string) error
+	Delete(ctx context.Context, resourceGroupName string, parentResourceName string, resourceName string, option *armstorage.FileSharesClientDeleteOptions) error
 }

--- a/pkg/azclient/fileshareclient/mock_fileshareclient/interface.go
+++ b/pkg/azclient/fileshareclient/mock_fileshareclient/interface.go
@@ -100,17 +100,17 @@ func (c *MockInterfaceCreateCall) DoAndReturn(f func(context.Context, string, st
 }
 
 // Delete mocks base method.
-func (m *MockInterface) Delete(ctx context.Context, resourceGroupName, parentResourceName, resourceName string, expand *string) error {
+func (m *MockInterface) Delete(ctx context.Context, resourceGroupName, parentResourceName, resourceName string, option *armstorage.FileSharesClientDeleteOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, resourceGroupName, parentResourceName, resourceName, expand)
+	ret := m.ctrl.Call(m, "Delete", ctx, resourceGroupName, parentResourceName, resourceName, option)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockInterfaceMockRecorder) Delete(ctx, resourceGroupName, parentResourceName, resourceName, expand any) *MockInterfaceDeleteCall {
+func (mr *MockInterfaceMockRecorder) Delete(ctx, resourceGroupName, parentResourceName, resourceName, option any) *MockInterfaceDeleteCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, resourceGroupName, parentResourceName, resourceName, expand)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), ctx, resourceGroupName, parentResourceName, resourceName, option)
 	return &MockInterfaceDeleteCall{Call: call}
 }
 
@@ -126,13 +126,13 @@ func (c *MockInterfaceDeleteCall) Return(arg0 error) *MockInterfaceDeleteCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockInterfaceDeleteCall) Do(f func(context.Context, string, string, string, *string) error) *MockInterfaceDeleteCall {
+func (c *MockInterfaceDeleteCall) Do(f func(context.Context, string, string, string, *armstorage.FileSharesClientDeleteOptions) error) *MockInterfaceDeleteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockInterfaceDeleteCall) DoAndReturn(f func(context.Context, string, string, string, *string) error) *MockInterfaceDeleteCall {
+func (c *MockInterfaceDeleteCall) DoAndReturn(f func(context.Context, string, string, string, *armstorage.FileSharesClientDeleteOptions) error) *MockInterfaceDeleteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Track2 sdk: replace expand with deleteoption in delete func of fileshare client

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Track2 sdk: replace expand with deleteoption in delete func of fileshare client
```

