### PR TITLE
fix: Set default ipfamilies to ipv4 if the field is empty

### DIFF
--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -303,6 +303,9 @@ func getIPFamiliesEnabled(svc *v1.Service) (v4Enabled bool, v6Enabled bool) {
 			v6Enabled = true
 		}
 	}
+	if !v4Enabled && !v6Enabled {
+		v4Enabled = true
+	}
 	return
 }
 

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -560,9 +560,65 @@ func TestGetIPFamiliesEnabled(t *testing.T) {
 			false,
 		},
 		{
+			"IPv6",
+			&v1.Service{
+				Spec: v1.ServiceSpec{IPFamilies: []v1.IPFamily{v1.IPv6Protocol}},
+			},
+			false,
+			true,
+		},
+		{
 			"DualStack",
 			&v1.Service{
 				Spec: v1.ServiceSpec{IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}},
+			},
+			true,
+			true,
+		},
+		{
+			"DualStack IPv6 first",
+			&v1.Service{
+				Spec: v1.ServiceSpec{IPFamilies: []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol}},
+			},
+			true,
+			true,
+		},
+		{
+			"Empty IPFamilies - defaults to IPv4",
+			&v1.Service{
+				Spec: v1.ServiceSpec{IPFamilies: []v1.IPFamily{}},
+			},
+			true,
+			false,
+		},
+		{
+			"No IPFamilies field - defaults to IPv4",
+			&v1.Service{
+				Spec: v1.ServiceSpec{},
+			},
+			true,
+			false,
+		},
+		{
+			"Multiple IPv4 entries",
+			&v1.Service{
+				Spec: v1.ServiceSpec{IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv4Protocol}},
+			},
+			true,
+			false,
+		},
+		{
+			"Multiple IPv6 entries",
+			&v1.Service{
+				Spec: v1.ServiceSpec{IPFamilies: []v1.IPFamily{v1.IPv6Protocol, v1.IPv6Protocol}},
+			},
+			false,
+			true,
+		},
+		{
+			"Mixed multiple entries",
+			&v1.Service{
+				Spec: v1.ServiceSpec{IPFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol, v1.IPv4Protocol}},
 			},
 			true,
 			true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

In some cases service.spec.ipfamilies would be empty, and we need to set a default value.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9097

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Set default ipfamilies to ipv4 if the field is empty
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
