### PR TITLE
fix: Retry after removing private link service

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -408,6 +408,10 @@ const (
 	CannotUpdateVMBeingDeletedMessageSuffix = "since it is marked for deletion"
 	// OperationPreemptedErrorMessage is the error message returned for vm operation preempted errors
 	OperationPreemptedErrorMessage = "Operation execution has been preempted by a more recent operation"
+	// PLSDeletionSuccessfulIntentionalRetryErrorMessage is the error message returned when PLS deletion is successful but we need to retry due to ETag mismatch
+	PLSDeletionSuccessfulIntentionalRetryErrorMessage = "successfully deleted the Private Link Service attached to the frontend IP configuration, " +
+		"this error is used to trigger a retry as the deletion will change the ETag of the Load Balancer, and we need to fetch the latest LB to proceed. " +
+		"Please ignore this error if the retry is successful. It is not expected if this error keeps happening"
 )
 
 // node ipam controller

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1928,6 +1928,9 @@ func (az *Cloud) reconcileLoadBalancer(ctx context.Context, clusterName string, 
 				fipConfigToDel := toDeleteConfigs[i]
 				err := az.reconcilePrivateLinkService(ctx, clusterName, service, fipConfigToDel, false /* wantPLS */)
 				if err != nil {
+					if strings.Contains(err.Error(), consts.PLSDeletionSuccessfulIntentionalRetryErrorMessage) {
+						return nil, err
+					}
 					klog.Errorf(
 						"reconcileLoadBalancer for service(%s): lb(%s) - failed to clean up PrivateLinkService for frontEnd(%s): %v",
 						serviceName,

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -178,7 +178,15 @@ func (az *Cloud) reconcilePrivateLinkService(
 				klog.Errorf("reconcilePrivateLinkService for service(%s): deletePLS for frontEnd(%s) failed: %v", serviceName, ptr.Deref(fipConfigID, ""), err)
 				return deleteErr
 			}
+
+			isOperationSucceeded = true
+			klog.V(2).Infof("reconcilePrivateLinkService for service(%s) finished", serviceName)
+			return fmt.Errorf(
+				"reconcilePrivateLinkService for service(%s) and frontend(%s): %s",
+				serviceName, ptr.Deref(fipConfigID, ""), consts.PLSDeletionSuccessfulIntentionalRetryErrorMessage,
+			)
 		}
+		klog.V(2).Infof("reconcilePrivateLinkService for service(%s): no private link service of frontend IP configuration (%s) to delete", serviceName, ptr.Deref(fipConfigID, ""))
 	}
 
 	isOperationSucceeded = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

LB ETag would change after deleting the PLS, causing 412 error when putting the LB. This PR adds an intentional error when deleting PLS successfully to trigger the retry of service reconciliation. In this way, 412 would be avoided.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9108

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Retry after removing private link service by adding an intentional error 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
