### PR TITLE
fix: Remove deprecated --cloud-provider and --cloud-config from apise…

### DIFF
--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
@@ -60,7 +60,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-md.yaml
@@ -70,8 +70,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
@@ -75,7 +75,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-md.yaml
@@ -70,7 +70,6 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
@@ -74,7 +74,6 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/tests/k8s-azure/manifest/cluster-api/linux-dualstack.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-dualstack.yaml
@@ -69,9 +69,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-ipv6.yaml
@@ -69,8 +69,6 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss-multiple-zones.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss-multiple-zones.yaml
@@ -57,9 +57,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-multiple-vmss.yaml
@@ -57,9 +57,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-local.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-local.yaml
@@ -61,8 +61,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
@@ -62,8 +62,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
@@ -61,8 +61,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
@@ -60,8 +60,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
@@ -63,8 +63,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
@@ -63,8 +63,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones.yaml
@@ -56,9 +56,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss.yaml
@@ -56,9 +56,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/vms-multi-nodepool-private.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/vms-multi-nodepool-private.yaml
@@ -57,8 +57,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/tests/k8s-azure/manifest/cluster-api/vmss-multi-nodepool-private.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/vmss-multi-nodepool-private.yaml
@@ -57,8 +57,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:


### PR DESCRIPTION
…rver configs in e2e templates

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

--cloud-provider and --cloud-config has been deprecated in v1.29 and removed in v1.33, we should remove them from our e2e templates as well.
Ref: https://github.com/kubernetes/kubernetes/pull/130162

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
