### PR TITLE
Updates linter version and args in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ test-check: test-boilerplate test-helm ## Run all static checks.
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint against code.
-	$(LINTER) run -v -E exportloopref
+	$(LINTER) run -v
 
 .PHONY: test-boilerplate
 test-boilerplate: ## Run boilerplate test.
@@ -454,7 +454,7 @@ delete-workload-cluster:
 ##@ Tools
 
 LINTER = $(shell pwd)/bin/golangci-lint
-LINTER_VERSION = v1.60.1
+LINTER_VERSION = v1.64.8
 .PHONY: golangci-lint
 golangci-lint:  ## Download golangci-lint locally if necessary.
 	@echo "Installing golangci-lint"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

This change:

- Updates the linter version defined in the Makefile to match what is being run on github actions (1.60.1 -> 1.64.8). Anyone using the makefile (e.g in a fork) is facing issues because of this :( 

  This means the linter is compiled with go 1.24, rather than 1.23, fixing typing issues.

- Removes the flag enabling exportloopref, which is deprecated as of go 1.22


#### Which issue(s) this PR fixes:
Anyone running `make lint` locally or in a fork.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
