### PR TITLE
Skip adding Internet service tag if IP ranges allow all

### DIFF
--- a/pkg/provider/azure_loadbalancer_accesscontrol_test.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol_test.go
@@ -94,7 +94,7 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 			testutil.ExpectEqualInJSON(t, azureFx.SecurityGroup().Build(), sg)
 		})
 
-		t.Run("add Internet allow rules if allow all", func(t *testing.T) {
+		t.Run("do not add Internet allow rules if allow all", func(t *testing.T) {
 			var (
 				ctrl                    = gomock.NewController(t)
 				az                      = GetTestCloud(ctrl)
@@ -121,42 +121,17 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					_, _ string,
 					properties armnetwork.SecurityGroup,
 				) (*armnetwork.SecurityGroup, error) {
-					serviceTags := []string{securitygroup.ServiceTagInternet}
 					rules := []*armnetwork.SecurityRule{
 						azureFx.
-							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, serviceTags, k8sFx.Service().TCPPorts()).
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"0.0.0.0/0"}, k8sFx.Service().TCPPorts()).
 							WithPriority(500).
 							WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).
 							Build(),
 
 						azureFx.
-							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"0.0.0.0/0"}, k8sFx.Service().TCPPorts()).
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"0.0.0.0/0"}, k8sFx.Service().UDPPorts()).
 							WithPriority(501).
 							WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).
-							Build(),
-
-						azureFx.
-							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, serviceTags, k8sFx.Service().TCPPorts()).
-							WithPriority(502).
-							WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).
-							Build(),
-
-						azureFx.
-							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, serviceTags, k8sFx.Service().UDPPorts()).
-							WithPriority(503).
-							WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).
-							Build(),
-
-						azureFx.
-							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"0.0.0.0/0"}, k8sFx.Service().UDPPorts()).
-							WithPriority(504).
-							WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).
-							Build(),
-
-						azureFx.
-							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, serviceTags, k8sFx.Service().UDPPorts()).
-							WithPriority(505).
-							WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).
 							Build(),
 					}
 

--- a/pkg/provider/loadbalancer/accesscontrol.go
+++ b/pkg/provider/loadbalancer/accesscontrol.go
@@ -203,7 +203,12 @@ func (ac *AccessControl) PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses [
 		allowedServiceTags = ac.AllowedServiceTags
 	)
 	if ac.IsAllowFromInternet() {
-		allowedServiceTags = append(allowedServiceTags, securitygroup.ServiceTagInternet)
+		allowedFromIPRanges := iputil.IsPrefixesAllowAll(ac.AllowedIPRanges)
+		allowedFromSourceRanges := iputil.IsPrefixesAllowAll(ac.SourceRanges)
+		if !allowedFromIPRanges && !allowedFromSourceRanges {
+			// If it's allowed from IP Ranges or Source Ranges, skip adding the internet service tag.
+			allowedServiceTags = append(allowedServiceTags, securitygroup.ServiceTagInternet)
+		}
 	}
 
 	{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

When the annotation `service.beta.kubernetes.io/azure-allowed-ip-ranges` or the field `spec.LoadBalancerSourceRanges` is set to `0.0.0.0/0` or `::/0`, adding the Internet service tag to the security group becomes unnecessary, as the specified IP ranges already permit all traffic. This approach can significantly reduce the number of security rules required.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Skip adding Internet service tag if IP ranges allow all
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
