### PR TITLE
chore: bump lbclient to latest API version for AzureStackCloud

### DIFF
--- a/pkg/azclient/loadbalancerclient/interface.go
+++ b/pkg/azclient/loadbalancerclient/interface.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
 )
 
-// +azure:client:verbs=get;createorupdate;delete;list,resource=LoadBalancer,packageName=github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6,packageAlias=armnetwork,clientName=LoadBalancersClient,expand=true,rateLimitKey=loadBalancerRateLimit,etag=true,azureStackCloudAPIVersion="2018-11-01"
+// +azure:client:verbs=get;createorupdate;delete;list,resource=LoadBalancer,packageName=github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6,packageAlias=armnetwork,clientName=LoadBalancersClient,expand=true,rateLimitKey=loadBalancerRateLimit,etag=true,azureStackCloudAPIVersion="2024-07-01"
 type Interface interface {
 	utils.GetWithExpandFunc[armnetwork.LoadBalancer]
 	utils.CreateOrUpdateFunc[armnetwork.LoadBalancer]

--- a/pkg/azclient/loadbalancerclient/zz_generated_client.go
+++ b/pkg/azclient/loadbalancerclient/zz_generated_client.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
 )
 
-const AzureStackCloudAPIVersion = "2018-11-01"
+const AzureStackCloudAPIVersion = "2024-07-01"
 
 type Client struct {
 	*armnetwork.LoadBalancersClient


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind chore

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The current AzureStackCloud API version for the LoadBalancerClient, 2018-11-01, is
too old to view the `privateIPAddressVersion` on FrontEndIPConfiguration.

Bump to the latest API model.

`privateIPAddressVersion` was added in [2019-04-01](https://github.com/Azure/azure-rest-api-specs/blob/dfb1837bab3c6940fb0a0e745ee1db9bdbd440b3/specification/network/resource-manager/Microsoft.Network/stable/2019-04-01/loadBalancer.json#L1165C10-L1165C33). 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
chore: bump lbclient to latest API version for AzureStackCloud
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
chore: bump lbclient to latest API version for AzureStackCloud
```
