### PR TITLE
test: Delete removed feature gates from CAPZ templates

### DIFF
--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ci-version-oot-credential-provider.yaml
@@ -67,7 +67,6 @@ spec:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
@@ -84,7 +84,6 @@ spec:
           cluster-cidr: 10.244.0.0/16,2001:1234:5678:9a40::/58
           cluster-name: ${CLUSTER_NAME}
           configure-cloud-routes: "true"
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:

--- a/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
@@ -84,7 +84,6 @@ spec:
           cluster-cidr: 2001:1234:5678:9a40::/58
           cluster-name: ${CLUSTER_NAME}
           configure-cloud-routes: "true"
-          feature-gates: HPAContainerMetrics=true
           v: "4"
       etcd:
         local:

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-local.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-local.yaml
@@ -74,7 +74,6 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "2"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win.yaml
@@ -74,7 +74,6 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "2"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
@@ -76,7 +76,6 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true
           v: "2"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
@@ -478,7 +477,6 @@ spec:
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
         cloud-provider: external
-        feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:

--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-multiple-zones-ci-version.yaml
@@ -76,7 +76,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: HPAContainerMetrics=true,ServiceTrafficDistribution=true
+          feature-gates: ServiceTrafficDistribution=true
           v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
@@ -530,7 +530,6 @@ spec:
         cloud-provider: external
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
-        feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR follows up from #7519 to remove feature gates that have graduated to GA and are no longer valid, causing control plane components to fail to start. Specifically the `HPAContainerMetrics` (removed in 1.32, default true since v1.27) and `WindowsHostProcessContainers` (removed in 1.28) are removed from cluster definitions.

It should improve the state of these CI jobs:
- https://testgrid.k8s.io/provider-azure-cloud-provider-azure#cloud-provider-azure-conformance-multiple-zones-vmss-capz
- https://testgrid.k8s.io/provider-azure-cloud-provider-azure#cloud-provider-azure-master-dualstack-vmss-capz
- https://testgrid.k8s.io/provider-azure-cloud-provider-azure#cloud-provider-azure-master-ipv6-vmss-capz
- https://testgrid.k8s.io/provider-azure-cloud-provider-azure-1-33#cloud-provider-azure-master-dualstack-vmss-capz-1-33
- https://testgrid.k8s.io/provider-azure-cloud-provider-azure-1-33#cloud-provider-azure-master-ipv6-vmss-capz-1-33
- https://testgrid.k8s.io/provider-azure-cloud-provider-azure-1-32#cloud-provider-azure-master-dualstack-vmss-capz-1-32
- https://testgrid.k8s.io/provider-azure-cloud-provider-azure-1-32#cloud-provider-azure-master-ipv6-vmss-capz-1-32

<!--
/test pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz
/test pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
