### PR TITLE
chore: add option to list vmss vms without instance view

### DIFF
--- a/pkg/provider/azure_vmsets_repo.go
+++ b/pkg/provider/azure_vmsets_repo.go
@@ -55,14 +55,14 @@ func (az *Cloud) GetVirtualMachineWithRetry(ctx context.Context, name types.Node
 	return machine, err
 }
 
-// ListVirtualMachines invokes az.ComputeClientFactory.GetVirtualMachineScaleSetClient().List with exponential backoff retry
+// ListVirtualMachines invokes az.ComputeClientFactory.GetVirtualMachineClient().List with exponential backoff retry
 func (az *Cloud) ListVirtualMachines(ctx context.Context, resourceGroup string) ([]*armcompute.VirtualMachine, error) {
 	allNodes, err := az.ComputeClientFactory.GetVirtualMachineClient().List(ctx, resourceGroup)
 	if err != nil {
-		klog.Errorf("ComputeClientFactory.GetVirtualMachineScaleSetClient().List(%v) failure with err=%v", resourceGroup, err)
+		klog.Errorf("ComputeClientFactory.GetVirtualMachineClient().List(%v) failure with err=%v", resourceGroup, err)
 		return nil, err
 	}
-	klog.V(6).Infof("ComputeClientFactory.GetVirtualMachineScaleSetClient().List(%v) success", resourceGroup)
+	klog.V(6).Infof("ComputeClientFactory.GetVirtualMachineClient().List(%v) success", resourceGroup)
 	return allNodes, nil
 }
 

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -825,7 +825,15 @@ func (ss *ScaleSet) listScaleSetVMs(scaleSetName, resourceGroup string) ([]*armc
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	allVMs, rerr := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().ListVMInstanceView(ctx, resourceGroup, scaleSetName)
+	var allVMs []*armcompute.VirtualMachineScaleSetVM
+	var rerr error
+	if ss.Config.VmssVirtualMachineCacheInstanceView {
+		klog.V(4).Info("listScaleSetVMs called for scaleSetName with instanceView: ", scaleSetName, " resourceGroup: ", resourceGroup)
+		allVMs, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().ListVMInstanceView(ctx, resourceGroup, scaleSetName)
+	} else {
+		klog.V(4).Info("listScaleSetVMs called for scaleSetName: ", scaleSetName, " resourceGroup: ", resourceGroup)
+		allVMs, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().List(ctx, resourceGroup, scaleSetName)
+	}
 	if rerr != nil {
 		klog.Errorf("ComputeClientFactory.GetVirtualMachineScaleSetVMClient().List(%s, %s) failed: %v", resourceGroup, scaleSetName, rerr)
 		if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); !exists && err == nil {

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -827,12 +827,12 @@ func (ss *ScaleSet) listScaleSetVMs(scaleSetName, resourceGroup string) ([]*armc
 
 	var allVMs []*armcompute.VirtualMachineScaleSetVM
 	var rerr error
-	if ss.Config.VmssVirtualMachineCacheInstanceView {
-		klog.V(4).Info("listScaleSetVMs called for scaleSetName with instanceView: ", scaleSetName, " resourceGroup: ", resourceGroup)
-		allVMs, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().ListVMInstanceView(ctx, resourceGroup, scaleSetName)
-	} else {
+	if ss.Config.VmssVirtualMachineCacheWithoutInstanceView {
 		klog.V(4).Info("listScaleSetVMs called for scaleSetName: ", scaleSetName, " resourceGroup: ", resourceGroup)
 		allVMs, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().List(ctx, resourceGroup, scaleSetName)
+	} else {
+		klog.V(4).Info("listScaleSetVMs called for scaleSetName with instanceView: ", scaleSetName, " resourceGroup: ", resourceGroup)
+		allVMs, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().ListVMInstanceView(ctx, resourceGroup, scaleSetName)
 	}
 	if rerr != nil {
 		klog.Errorf("ComputeClientFactory.GetVirtualMachineScaleSetVMClient().List(%s, %s) failed: %v", resourceGroup, scaleSetName, rerr)

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -827,11 +827,11 @@ func (ss *ScaleSet) listScaleSetVMs(scaleSetName, resourceGroup string) ([]*armc
 
 	var allVMs []*armcompute.VirtualMachineScaleSetVM
 	var rerr error
-	if ss.Config.VmssVirtualMachineCacheWithoutInstanceView {
-		klog.V(4).Info("listScaleSetVMs called for scaleSetName: ", scaleSetName, " resourceGroup: ", resourceGroup)
+	if ss.Config.ListVmssVirtualMachinesWithoutInstanceView {
+		klog.V(6).Info("listScaleSetVMs called for scaleSetName: ", scaleSetName, " resourceGroup: ", resourceGroup)
 		allVMs, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().List(ctx, resourceGroup, scaleSetName)
 	} else {
-		klog.V(4).Info("listScaleSetVMs called for scaleSetName with instanceView: ", scaleSetName, " resourceGroup: ", resourceGroup)
+		klog.V(6).Info("listScaleSetVMs called for scaleSetName with instanceView: ", scaleSetName, " resourceGroup: ", resourceGroup)
 		allVMs, rerr = ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().ListVMInstanceView(ctx, resourceGroup, scaleSetName)
 	}
 	if rerr != nil {

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -483,32 +483,40 @@ func TestGetInstanceIDByNodeName(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
-
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-
-			expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
-			mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
-
-			expectedVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, "", 0, test.vmList, "", false)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
-
-			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
-
-			realValue, err := ss.GetInstanceIDByNodeName(context.Background(), test.nodeName)
-			if test.expectError {
-				assert.Error(t, err, test.description)
-			} else {
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
 				assert.NoError(t, err, test.description)
-				assert.Equal(t, test.expected, realValue, test.description)
-			}
-		})
+
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+
+				expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
+				mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
+
+				expectedVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, "", 0, test.vmList, "", false)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+				}
+
+				mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+
+				realValue, err := ss.GetInstanceIDByNodeName(context.Background(), test.nodeName)
+				if test.expectError {
+					assert.Error(t, err, test.description)
+				} else {
+					assert.NoError(t, err, test.description)
+					assert.Equal(t, test.expected, realValue, test.description)
+				}
+			})
+		}
 	}
 }
 
@@ -562,34 +570,42 @@ func TestGetZoneByNodeName(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		ctrl := gomock.NewController(t)
-		cloud := GetTestCloud(ctrl)
-		if test.location != "" {
-			cloud.Location = test.location
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			ctrl := gomock.NewController(t)
+			cloud := GetTestCloud(ctrl)
+			if test.location != "" {
+				cloud.Location = test.location
+			}
+			ss, err := NewTestScaleSet(ctrl)
+			assert.NoError(t, err, test.description)
+
+			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+			expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
+			mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
+
+			expectedVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, test.zone, test.faultDomain, test.vmList, "", false)
+			ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+			if ss.ListVmssVirtualMachinesWithoutInstanceView {
+				mockVMSSVMClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+			} else {
+				mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+			}
+			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+
+			realValue, err := ss.GetZoneByNodeName(context.TODO(), test.nodeName)
+			if test.expectError {
+				assert.Error(t, err, test.description)
+				continue
+			}
+
+			assert.NoError(t, err, test.description)
+			assert.Equal(t, test.expected, realValue.FailureDomain, test.description)
+			assert.Equal(t, strings.ToLower(cloud.Location), realValue.Region, test.description)
+			ctrl.Finish()
 		}
-		ss, err := NewTestScaleSet(ctrl)
-		assert.NoError(t, err, test.description)
-
-		mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-		mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-		mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-		expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
-		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
-
-		expectedVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, test.zone, test.faultDomain, test.vmList, "", false)
-		mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
-		mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
-
-		realValue, err := ss.GetZoneByNodeName(context.TODO(), test.nodeName)
-		if test.expectError {
-			assert.Error(t, err, test.description)
-			continue
-		}
-
-		assert.NoError(t, err, test.description)
-		assert.Equal(t, test.expected, realValue.FailureDomain, test.description)
-		assert.Equal(t, strings.ToLower(cloud.Location), realValue.Region, test.description)
-		ctrl.Finish()
 	}
 }
 
@@ -620,44 +636,50 @@ func TestGetIPByNodeName(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
-			mockPIPClient := ss.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
+				mockPIPClient := ss.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
 
-			expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
-			mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
+				expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
+				mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
 
-			expectedVMs, expectedInterface, expectedPIP := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, "", 0, test.vmList, "", false)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
-			mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedInterface, nil).AnyTimes()
-			mockPIPClient.EXPECT().GetVirtualMachineScaleSetPublicIPAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-				armnetwork.PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse{PublicIPAddress: *expectedPIP}, nil).AnyTimes()
-			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+				expectedVMs, expectedInterface, expectedPIP := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, "", 0, test.vmList, "", false)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+				}
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedInterface, nil).AnyTimes()
+				mockPIPClient.EXPECT().GetVirtualMachineScaleSetPublicIPAddress(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					armnetwork.PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse{PublicIPAddress: *expectedPIP}, nil).AnyTimes()
+				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
 
-			privateIP, publicIP, err := ss.GetIPByNodeName(context.Background(), test.nodeName)
-			if test.expectError {
-				assert.Error(t, err, test.description)
-				return
-			}
+				privateIP, publicIP, err := ss.GetIPByNodeName(context.Background(), test.nodeName)
+				if test.expectError {
+					assert.Error(t, err, test.description)
+					return
+				}
 
-			assert.NoError(t, err, test.description)
-			assert.Equal(t, test.expected, []string{privateIP, publicIP}, test.description)
-		})
+				assert.NoError(t, err, test.description)
+				assert.Equal(t, test.expected, []string{privateIP, publicIP}, test.description)
+			})
+		}
 	}
 }
 
 func TestGetNodeNameByIPConfigurationID(t *testing.T) {
-
 	ipConfigurationIDTemplate := "/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s/networkInterfaces/%s/ipConfigurations/ipconfig1"
-
 	testCases := []struct {
 		description          string
 		scaleSet             string
@@ -693,33 +715,40 @@ func TestGetNodeNameByIPConfigurationID(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
-			mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				expectedScaleSet := buildTestVMSS(test.scaleSet, "vmssee6c2")
+				mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil).AnyTimes()
 
-			expectedVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, "", 0, test.vmList, "", false)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+				expectedVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.scaleSet, "", 0, test.vmList, "", false)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
+				}
+				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
 
-			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+				nodeName, scalesetName, err := ss.GetNodeNameByIPConfigurationID(context.TODO(), test.ipConfigurationID)
+				if test.expectError {
+					assert.Error(t, err, test.description)
+					return
+				}
 
-			nodeName, scalesetName, err := ss.GetNodeNameByIPConfigurationID(context.TODO(), test.ipConfigurationID)
-			if test.expectError {
-				assert.Error(t, err, test.description)
-				return
-			}
-
-			assert.NoError(t, err, test.description)
-			assert.Equal(t, test.expectedNodeName, nodeName, test.description)
-			assert.Equal(t, test.expectedScaleSetName, scalesetName, test.description)
-		})
+				assert.NoError(t, err, test.description)
+				assert.Equal(t, test.expectedNodeName, nodeName, test.description)
+				assert.Equal(t, test.expectedScaleSetName, scalesetName, test.description)
+			})
+		}
 	}
 }
 
@@ -817,7 +846,6 @@ func TestGetVMSS(t *testing.T) {
 }
 
 func TestGetVmssVM(t *testing.T) {
-
 	testCases := []struct {
 		description      string
 		nodeName         string
@@ -841,38 +869,45 @@ func TestGetVmssVM(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			expectedVMSS := buildTestVMSS(test.existedVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := buildTestVMSS(test.existedVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.existedVMSSName, "", 0, test.existedNodeNames, "", false)
-			var expectedVMSSVM armcompute.VirtualMachineScaleSetVM
-			for _, expected := range expectedVMSSVMs {
-				if strings.EqualFold(*expected.Properties.OSProfile.ComputerName, test.nodeName) {
-					expectedVMSSVM = *expected
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, test.existedVMSSName, "", 0, test.existedNodeNames, "", false)
+				var expectedVMSSVM armcompute.VirtualMachineScaleSetVM
+				for _, expected := range expectedVMSSVMs {
+					if strings.EqualFold(*expected.Properties.OSProfile.ComputerName, test.nodeName) {
+						expectedVMSSVM = *expected
+					}
 				}
-			}
 
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, test.existedVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, test.existedVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, test.existedVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			vmssVM, err := ss.getVmssVM(context.TODO(), test.nodeName, azcache.CacheReadTypeDefault)
-			if vmssVM != nil {
-				assert.Equal(t, expectedVMSSVM, *vmssVM.AsVirtualMachineScaleSetVM(), test.description)
-			}
-			assert.Equal(t, test.expectedError, err, test.description)
-		})
+				vmssVM, err := ss.getVmssVM(context.TODO(), test.nodeName, azcache.CacheReadTypeDefault)
+				if vmssVM != nil {
+					assert.Equal(t, expectedVMSSVM, *vmssVM.AsVirtualMachineScaleSetVM(), test.description)
+				}
+				assert.Equal(t, test.expectedError, err, test.description)
+			})
+		}
 	}
 }
 
 func TestGetPowerStatusByNodeName(t *testing.T) {
-
 	testCases := []struct {
 		description        string
 		vmList             []string
@@ -895,31 +930,39 @@ func TestGetPowerStatusByNodeName(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			if test.nilStatus {
-				expectedVMSSVMs[0].Properties.InstanceView.Statuses = nil
-			}
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				if test.nilStatus {
+					expectedVMSSVMs[0].Properties.InstanceView.Statuses = nil
+				}
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+				mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
 
-			powerState, err := ss.GetPowerStatusByNodeName(context.TODO(), "vmss-vm-000001")
-			assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
-			assert.Equal(t, test.expectedPowerState, powerState, test.description)
-		})
+				powerState, err := ss.GetPowerStatusByNodeName(context.TODO(), "vmss-vm-000001")
+				assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
+				assert.Equal(t, test.expectedPowerState, powerState, test.description)
+			})
+		}
 	}
 }
 
@@ -949,28 +992,36 @@ func TestGetProvisioningStateByNodeName(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		ss, err := NewTestScaleSet(ctrl)
-		assert.NoError(t, err, "unexpected error when creating test VMSS")
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			ss, err := NewTestScaleSet(ctrl)
+			assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-		expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-		mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-		mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-		expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
-		mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-		if test.provisioningState != "" {
-			expectedVMSSVMs[0].Properties.ProvisioningState = ptr.To(test.provisioningState)
-		} else {
-			expectedVMSSVMs[0].Properties.ProvisioningState = nil
+			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+			if test.provisioningState != "" {
+				expectedVMSSVMs[0].Properties.ProvisioningState = ptr.To(test.provisioningState)
+			} else {
+				expectedVMSSVMs[0].Properties.ProvisioningState = nil
+			}
+			ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+			if ss.ListVmssVirtualMachinesWithoutInstanceView {
+				mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+			} else {
+				mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+			}
+
+			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+
+			provisioningState, err := ss.GetProvisioningStateByNodeName(context.TODO(), "vmss-vm-000001")
+			assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
+			assert.Equal(t, test.expectedProvisioningState, provisioningState, test.description)
 		}
-		mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
-
-		mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-		mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
-
-		provisioningState, err := ss.GetProvisioningStateByNodeName(context.TODO(), "vmss-vm-000001")
-		assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
-		assert.Equal(t, test.expectedProvisioningState, provisioningState, test.description)
 	}
 }
 
@@ -991,29 +1042,37 @@ func TestGetVmssVMByInstanceID(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			expectedVMSS := &armcompute.VirtualMachineScaleSet{
-				Name: ptr.To(testVMSSName),
-				Properties: &armcompute.VirtualMachineScaleSetProperties{
-					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{},
-				},
-			}
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := &armcompute.VirtualMachineScaleSet{
+					Name: ptr.To(testVMSSName),
+					Properties: &armcompute.VirtualMachineScaleSetProperties{
+						VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{},
+					},
+				}
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			vm, err := ss.getVmssVMByInstanceID(context.TODO(), ss.ResourceGroup, testVMSSName, test.instanceID, azcache.CacheReadTypeDefault)
-			assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
-			assert.Equal(t, *expectedVMSSVMs[0], *vm, test.description)
-		})
+				vm, err := ss.getVmssVMByInstanceID(context.TODO(), ss.ResourceGroup, testVMSSName, test.instanceID, azcache.CacheReadTypeDefault)
+				assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
+				assert.Equal(t, *expectedVMSSVMs[0], *vm, test.description)
+			})
+		}
 	}
 }
 
@@ -1042,57 +1101,65 @@ func TestGetVmssVMByNodeIdentity(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			expectedVMSS := &armcompute.VirtualMachineScaleSet{
-				Name: ptr.To(testVMSSName),
-				Properties: &armcompute.VirtualMachineScaleSetProperties{
-					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{},
-				},
-			}
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
-
-			cacheKey := getVMSSVMCacheKey(ss.ResourceGroup, testVMSSName)
-			virtualMachines, err := ss.getVMSSVMsFromCache(context.TODO(), ss.ResourceGroup, testVMSSName, azcache.CacheReadTypeDefault)
-			assert.Nil(t, err)
-			for _, vm := range test.goneVMList {
-				entry := VMSSVirtualMachineEntry{
-					ResourceGroup: ss.ResourceGroup,
-					VMSSName:      testVMSSName,
+				expectedVMSS := &armcompute.VirtualMachineScaleSet{
+					Name: ptr.To(testVMSSName),
+					Properties: &armcompute.VirtualMachineScaleSetProperties{
+						VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{},
+					},
 				}
-				virtualMachines.Store(vm, &entry)
-			}
-			ss.vmssVMCache.Update(cacheKey, virtualMachines)
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			for i := 0; i < len(test.vmList); i++ {
-				node := nodeIdentity{ss.ResourceGroup, testVMSSName, test.vmList[i]}
-				vm, err := ss.getVmssVMByNodeIdentity(context.TODO(), &node, azcache.CacheReadTypeDefault)
-				assert.Equal(t, test.expectedErr, err)
-				assert.Equal(t, *virtualmachine.FromVirtualMachineScaleSetVM(expectedVMSSVMs[i], virtualmachine.ByVMSS(testVMSSName)), *vm)
-			}
-			for i := 0; i < len(test.goneVMList); i++ {
-				node := nodeIdentity{ss.ResourceGroup, testVMSSName, test.goneVMList[i]}
-				_, err := ss.getVmssVMByNodeIdentity(context.TODO(), &node, azcache.CacheReadTypeDefault)
-				assert.Equal(t, test.goneVMExpectedErr, err)
-			}
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			virtualMachines, err = ss.getVMSSVMsFromCache(context.TODO(), ss.ResourceGroup, testVMSSName, azcache.CacheReadTypeDefault)
-			assert.Nil(t, err)
+				cacheKey := getVMSSVMCacheKey(ss.ResourceGroup, testVMSSName)
+				virtualMachines, err := ss.getVMSSVMsFromCache(context.TODO(), ss.ResourceGroup, testVMSSName, azcache.CacheReadTypeDefault)
+				assert.Nil(t, err)
+				for _, vm := range test.goneVMList {
+					entry := VMSSVirtualMachineEntry{
+						ResourceGroup: ss.ResourceGroup,
+						VMSSName:      testVMSSName,
+					}
+					virtualMachines.Store(vm, &entry)
+				}
+				ss.vmssVMCache.Update(cacheKey, virtualMachines)
 
-			for _, vm := range test.goneVMList {
-				_, ok := virtualMachines.Load(vm)
-				assert.True(t, ok)
-			}
-		})
+				for i := 0; i < len(test.vmList); i++ {
+					node := nodeIdentity{ss.ResourceGroup, testVMSSName, test.vmList[i]}
+					vm, err := ss.getVmssVMByNodeIdentity(context.TODO(), &node, azcache.CacheReadTypeDefault)
+					assert.Equal(t, test.expectedErr, err)
+					assert.Equal(t, *virtualmachine.FromVirtualMachineScaleSetVM(expectedVMSSVMs[i], virtualmachine.ByVMSS(testVMSSName)), *vm)
+				}
+				for i := 0; i < len(test.goneVMList); i++ {
+					node := nodeIdentity{ss.ResourceGroup, testVMSSName, test.goneVMList[i]}
+					_, err := ss.getVmssVMByNodeIdentity(context.TODO(), &node, azcache.CacheReadTypeDefault)
+					assert.Equal(t, test.goneVMExpectedErr, err)
+				}
+
+				virtualMachines, err = ss.getVMSSVMsFromCache(context.TODO(), ss.ResourceGroup, testVMSSName, azcache.CacheReadTypeDefault)
+				assert.Nil(t, err)
+
+				for _, vm := range test.goneVMList {
+					_, ok := virtualMachines.Load(vm)
+					assert.True(t, ok)
+				}
+			})
+		}
 	}
 }
 
@@ -1121,29 +1188,37 @@ func TestGetInstanceTypeByNodeName(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).AnyTimes()
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).AnyTimes()
 
-			SKU, err := ss.GetInstanceTypeByNodeName(context.Background(), "vmss-vm-000000")
-			if test.expectedErr != nil {
-				assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
-			}
-			assert.Equal(t, test.expectedType, SKU, test.description)
-		})
+				SKU, err := ss.GetInstanceTypeByNodeName(context.Background(), "vmss-vm-000000")
+				if test.expectedErr != nil {
+					assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
+				}
+				assert.Equal(t, test.expectedType, SKU, test.description)
+			})
+		}
 	}
 }
 
@@ -1219,7 +1294,6 @@ func TestGetPrimaryInterfaceID(t *testing.T) {
 }
 
 func TestGetPrimaryInterface(t *testing.T) {
-
 	testCases := []struct {
 		description         string
 		nodeName            string
@@ -1288,51 +1362,59 @@ func TestGetPrimaryInterface(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, test.vmssClientErr).AnyTimes()
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, test.vmssClientErr).AnyTimes()
 
-			expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
-			if !test.hasPrimaryInterface {
-				networkInterfaces := expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces
-				networkInterfaces[0].Properties.Primary = ptr.To(false)
-				networkInterfaces = append(networkInterfaces, &armcompute.NetworkInterfaceReference{
-					Properties: &armcompute.NetworkInterfaceReferenceProperties{Primary: ptr.To(false)},
-				})
-				expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces = networkInterfaces
-			}
-			if test.isInvalidNICID {
-				networkInterfaces := expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces
-				networkInterfaces[0].ID = ptr.To("invalid/id/")
-				expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces = networkInterfaces
-			}
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+				if !test.hasPrimaryInterface {
+					networkInterfaces := expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces
+					networkInterfaces[0].Properties.Primary = ptr.To(false)
+					networkInterfaces = append(networkInterfaces, &armcompute.NetworkInterfaceReference{
+						Properties: &armcompute.NetworkInterfaceReferenceProperties{Primary: ptr.To(false)},
+					})
+					expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces = networkInterfaces
+				}
+				if test.isInvalidNICID {
+					networkInterfaces := expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces
+					networkInterfaces[0].ID = ptr.To("invalid/id/")
+					expectedVMSSVMs[0].Properties.NetworkProfile.NetworkInterfaces = networkInterfaces
+				}
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).AnyTimes()
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).AnyTimes()
 
-			mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
-			mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName).Return(expectedInterface, test.nicClientErr).AnyTimes()
-			expectedInterface.Location = &ss.Location
+				mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName).Return(expectedInterface, test.nicClientErr).AnyTimes()
+				expectedInterface.Location = &ss.Location
 
-			if test.vmClientErr != nil || test.vmssClientErr != nil || test.nicClientErr != nil || !test.hasPrimaryInterface || test.isInvalidNICID {
-				expectedInterface = &armnetwork.Interface{}
-			}
+				if test.vmClientErr != nil || test.vmssClientErr != nil || test.nicClientErr != nil || !test.hasPrimaryInterface || test.isInvalidNICID {
+					expectedInterface = &armnetwork.Interface{}
+				}
 
-			nic, err := ss.GetPrimaryInterface(context.Background(), test.nodeName)
-			if test.expectedErr != nil {
-				assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
-			} else {
-				assert.Equal(t, expectedInterface, nic, test.description)
-			}
-		})
+				nic, err := ss.GetPrimaryInterface(context.Background(), test.nodeName)
+				if test.expectedErr != nil {
+					assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
+				} else {
+					assert.Equal(t, expectedInterface, nic, test.description)
+				}
+			})
+		}
 	}
 }
 
@@ -1373,62 +1455,70 @@ func TestGetPrimaryInterfaceRefactoring(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			// Setup expected VMSS
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				// Setup expected VMSS
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			// Setup expected VMSS VMs and interface
-			expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
-
-			// Setup VM client (for fallback scenarios)
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-
-			// CRITICAL: Test that ComputeClientFactory.GetInterfaceClient() is called exactly the expected number of times
-			mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
-
-			if test.expectSuccess {
-				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(
-					gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName,
-				).Return(expectedInterface, nil).Times(test.interfaceCallsCount)
-			} else {
-				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(
-					gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName,
-				).Return(nil, &azcore.ResponseError{ErrorCode: "interface client error"}).Times(test.interfaceCallsCount)
-			}
-
-			// CRITICAL: Verify that NetworkClientFactory.GetInterfaceClient() is NEVER called
-			// This ensures the refactoring is working correctly
-			mockNetworkInterfaceClient := ss.NetworkClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
-			mockNetworkInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-			).Times(0) // Should NEVER be called after refactoring
-
-			// Execute the test
-			nic, err := ss.GetPrimaryInterface(context.Background(), test.nodeName)
-
-			// Verify results
-			if test.expectSuccess {
-				assert.NoError(t, err, test.description)
-				assert.NotNil(t, nic, test.description)
-				assert.Equal(t, expectedInterface.Name, nic.Name, test.description)
-			} else {
-				assert.Error(t, err, test.description)
-				if test.expectedErr != nil {
-					assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
+				// Setup expected VMSS VMs and interface
+				expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
 				}
-			}
-		})
+
+				// Setup VM client (for fallback scenarios)
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+				// CRITICAL: Test that ComputeClientFactory.GetInterfaceClient() is called exactly the expected number of times
+				mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
+
+				if test.expectSuccess {
+					mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(
+						gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName,
+					).Return(expectedInterface, nil).Times(test.interfaceCallsCount)
+				} else {
+					mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(
+						gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName,
+					).Return(nil, &azcore.ResponseError{ErrorCode: "interface client error"}).Times(test.interfaceCallsCount)
+				}
+
+				// CRITICAL: Verify that NetworkClientFactory.GetInterfaceClient() is NEVER called
+				// This ensures the refactoring is working correctly
+				mockNetworkInterfaceClient := ss.NetworkClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
+				mockNetworkInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Times(0) // Should NEVER be called after refactoring
+
+				// Execute the test
+				nic, err := ss.GetPrimaryInterface(context.Background(), test.nodeName)
+
+				// Verify results
+				if test.expectSuccess {
+					assert.NoError(t, err, test.description)
+					assert.NotNil(t, nic, test.description)
+					assert.Equal(t, expectedInterface.Name, nic.Name, test.description)
+				} else {
+					assert.Error(t, err, test.description)
+					if test.expectedErr != nil {
+						assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
+					}
+				}
+			})
+		}
 	}
 }
 
@@ -1546,36 +1636,44 @@ func TestGetPrivateIPsByNodeName(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
+				expectedVMSSVMs, expectedInterface, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, test.vmList, "", false)
 
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).AnyTimes()
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).AnyTimes()
 
-			if test.isNilIPConfigs {
-				expectedInterface.Properties.IPConfigurations = nil
-			}
-			mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
-			mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName).Return(expectedInterface, nil).AnyTimes()
+				if test.isNilIPConfigs {
+					expectedInterface.Properties.IPConfigurations = nil
+				}
+				mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), ss.ResourceGroup, testVMSSName, "0", test.nodeName).Return(expectedInterface, nil).AnyTimes()
 
-			privateIPs, err := ss.GetPrivateIPsByNodeName(context.Background(), test.nodeName)
-			if test.expectedErr != nil {
-				assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
-			}
-			assert.Equal(t, test.expectedPrivateIPs, privateIPs, test.description)
-		})
+				privateIPs, err := ss.GetPrivateIPsByNodeName(context.Background(), test.nodeName)
+				if test.expectedErr != nil {
+					assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description)
+				}
+				assert.Equal(t, test.expectedPrivateIPs, privateIPs, test.description)
+			})
+		}
 	}
 }
 
@@ -1627,24 +1725,32 @@ func TestListScaleSetVMs(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(test.existedVMSSVMs, test.vmssVMClientErr).AnyTimes()
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(test.existedVMSSVMs, test.vmssVMClientErr).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(test.existedVMSSVMs, test.vmssVMClientErr).AnyTimes()
+				}
 
-			expectedVMSSVMs := test.existedVMSSVMs
+				expectedVMSSVMs := test.existedVMSSVMs
 
-			vmssVMs, err := ss.listScaleSetVMs(testVMSSName, ss.ResourceGroup)
-			if test.expectedErr != nil {
-				assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description+errMsgSuffix)
-			}
-			assert.Equal(t, expectedVMSSVMs, vmssVMs, test.description)
-		})
+				vmssVMs, err := ss.listScaleSetVMs(testVMSSName, ss.ResourceGroup)
+				if test.expectedErr != nil {
+					assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description+errMsgSuffix)
+				}
+				assert.Equal(t, expectedVMSSVMs, vmssVMs, test.description)
+			})
+		}
 	}
 }
 
@@ -1703,53 +1809,61 @@ func TestGetAgentPoolScaleSets(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
-			ss.excludeLoadBalancerNodes = utilsets.NewString(test.excludeLBNodes...)
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
+				ss.excludeLoadBalancerNodes = utilsets.NewString(test.excludeLBNodes...)
 
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			expectedVMSSVMs := []*armcompute.VirtualMachineScaleSetVM{
-				{
-					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-						OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000000")},
-						NetworkProfile: &armcompute.NetworkProfile{
-							NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+				expectedVMSSVMs := []*armcompute.VirtualMachineScaleSetVM{
+					{
+						Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+							OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000000")},
+							NetworkProfile: &armcompute.NetworkProfile{
+								NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+							},
 						},
 					},
-				},
-				{
-					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-						OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000001")},
-						NetworkProfile: &armcompute.NetworkProfile{
-							NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+					{
+						Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+							OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000001")},
+							NetworkProfile: &armcompute.NetworkProfile{
+								NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+							},
 						},
 					},
-				},
-				{
-					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-						OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000002")},
-						NetworkProfile: &armcompute.NetworkProfile{
-							NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+					{
+						Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+							OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000002")},
+							NetworkProfile: &armcompute.NetworkProfile{
+								NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+							},
 						},
 					},
-				},
-			}
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
-			vmssNames, err := ss.getAgentPoolScaleSets(context.TODO(), test.nodes)
-			assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
-			assert.Equal(t, test.expectedVMSSNames, vmssNames)
-		})
+				vmssNames, err := ss.getAgentPoolScaleSets(context.TODO(), test.nodes)
+				assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
+				assert.Equal(t, test.expectedVMSSNames, vmssNames)
+			})
+		}
 	}
 }
 
@@ -1769,130 +1883,104 @@ func TestGetVMSetNames(t *testing.T) {
 			expectedVMSetNames: to.SliceOfPtrs("vmss"),
 		},
 		{
-			description: "GetVMSetNames should return the primary vm set name when using the single SLB",
-			service: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: consts.ServiceAnnotationLoadBalancerAutoModeValue}},
-			},
+			description:        "GetVMSetNames should return the primary vm set name when using the single SLB",
+			service:            &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: consts.ServiceAnnotationLoadBalancerAutoModeValue}}},
 			useSingleSLB:       true,
 			expectedVMSetNames: to.SliceOfPtrs("vmss"),
 		},
 		{
-			description: "GetVMSetNames should return all scale sets if the service has auto mode annotation",
-			service: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: consts.ServiceAnnotationLoadBalancerAutoModeValue}},
-			},
-			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "vmss-vm-000002",
-					},
-				},
-			},
+			description:        "GetVMSetNames should return all scale sets if the service has auto mode annotation",
+			service:            &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: consts.ServiceAnnotationLoadBalancerAutoModeValue}}},
+			nodes:              []*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "vmss-vm-000002"}}},
 			expectedVMSetNames: to.SliceOfPtrs("vmss"),
 		},
 		{
 			description: "GetVMSetNames should report the error if there's no such vmss",
-			service: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "vmss-1"}},
-			},
-			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "vmss-vm-000002",
-					},
-				},
-			},
+			service:     &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "vmss-1"}}},
+			nodes:       []*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "vmss-vm-000002"}}},
 			expectedErr: ErrScaleSetNotFound,
 		},
 		{
 			description: "GetVMSetNames should report an error if vm's network profile is nil",
-			service: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "vmss"}},
-			},
-			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "vmss-vm-000003",
-					},
-				},
-			},
+			service:     &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "vmss"}}},
+			nodes:       []*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "vmss-vm-000003"}}},
 			expectedErr: cloudprovider.InstanceNotFound,
 		},
 		{
-			description: "GetVMSetNames should return the correct vmss names",
-			service: &v1.Service{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "vmss"}},
-			},
-			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "vmss-vm-000002",
-					},
-				},
-			},
+			description:        "GetVMSetNames should return the correct vmss names",
+			service:            &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{consts.ServiceAnnotationLoadBalancerMode: "vmss"}}},
+			nodes:              []*v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "vmss-vm-000002"}}},
 			expectedVMSetNames: to.SliceOfPtrs("vmss"),
 		},
 	}
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, "unexpected error when creating test VMSS")
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, "unexpected error when creating test VMSS")
 
-			if test.useSingleSLB {
-				ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
-			}
+				if test.useSingleSLB {
+					ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+				}
 
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			expectedVMSSVMs := []*armcompute.VirtualMachineScaleSetVM{
-				{
-					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-						OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000000")},
-						NetworkProfile: &armcompute.NetworkProfile{
-							NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+				expectedVMSSVMs := []*armcompute.VirtualMachineScaleSetVM{
+					{
+						Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+							OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000000")},
+							NetworkProfile: &armcompute.NetworkProfile{
+								NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+							},
 						},
 					},
-				},
-				{
-					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-						OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000001")},
-						NetworkProfile: &armcompute.NetworkProfile{
-							NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+					{
+						Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+							OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000001")},
+							NetworkProfile: &armcompute.NetworkProfile{
+								NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+							},
 						},
 					},
-				},
-				{
-					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-						OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000002")},
-						NetworkProfile: &armcompute.NetworkProfile{
-							NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+					{
+						Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+							OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000002")},
+							NetworkProfile: &armcompute.NetworkProfile{
+								NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
+							},
 						},
 					},
-				},
-				{
-					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-						OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000003")},
+					{
+						Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+							OSProfile: &armcompute.OSProfile{ComputerName: ptr.To("vmss-vm-000003")},
+						},
 					},
-				},
-			}
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
-			vmSetNames, err := ss.GetVMSetNames(context.TODO(), test.service, test.nodes)
-			if test.expectedErr != nil {
-				assert.True(t, errors.Is(err, test.expectedErr), "expected error %v, got %v", test.expectedErr, err)
-			}
-			assert.Equal(t, test.expectedVMSetNames, vmSetNames, test.description)
-		})
+				vmSetNames, err := ss.GetVMSetNames(context.TODO(), test.service, test.nodes)
+				if test.expectedErr != nil {
+					assert.True(t, errors.Is(err, test.expectedErr), "expected error %v, got %v", test.expectedErr, err)
+				}
+				assert.Equal(t, test.expectedVMSetNames, vmSetNames, test.description)
+			})
+		}
 	}
 }
 
@@ -2339,7 +2427,6 @@ func TestDeleteBackendPoolFromIPConfig(t *testing.T) {
 }
 
 func TestEnsureHostInPool(t *testing.T) {
-
 	testCases := []struct {
 		description               string
 		service                   *v1.Service
@@ -2448,58 +2535,62 @@ func TestEnsureHostInPool(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			if !test.isBasicLB {
-				ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
-			}
-
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-
-			provisionState := ""
-			if test.isVMBeingDeleted {
-				provisionState = "Deleting"
-			}
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(
-				ss.Cloud,
-				testVMSSName,
-				"",
-				0,
-				[]string{string(test.nodeName)},
-				provisionState,
-				false,
-			)
-			if test.isNilVMNetworkConfigs {
-				expectedVMSSVMs[0].Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations = nil
-			}
-			if test.isVMNotActive {
-				(expectedVMSSVMs[0].Properties.InstanceView.Statuses)[0] = &armcompute.InstanceViewStatus{
-					Code: ptr.To("PowerState/deallocated"),
+				if !test.isBasicLB {
+					ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 				}
-			}
-			if test.isVMNotFound {
-				expectedVMSSVMs = nil
-			}
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(
-				gomock.Any(),
-				ss.ResourceGroup,
-				testVMSSName,
-			).Return(expectedVMSSVMs, test.vmssVMListError).AnyTimes()
 
-			nodeResourceGroup, ssName, instanceID, vm, err := ss.EnsureHostInPool(context.Background(), test.service, test.nodeName, test.backendPoolID, test.vmSetName)
-			assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
-			assert.Equal(t, test.expectedNodeResourceGroup, nodeResourceGroup, test.description)
-			assert.Equal(t, test.expectedVMSSName, ssName, test.description)
-			assert.Equal(t, test.expectedInstanceID, instanceID, test.description)
-			assert.Equal(t, test.expectedVMSSVM, vm, test.description)
-		})
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+
+				provisionState := ""
+				if test.isVMBeingDeleted {
+					provisionState = "Deleting"
+				}
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(
+					ss.Cloud,
+					testVMSSName,
+					"",
+					0,
+					[]string{string(test.nodeName)},
+					provisionState,
+					false,
+				)
+				if test.isNilVMNetworkConfigs {
+					expectedVMSSVMs[0].Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations = nil
+				}
+				if test.isVMNotActive {
+					(expectedVMSSVMs[0].Properties.InstanceView.Statuses)[0] = &armcompute.InstanceViewStatus{
+						Code: ptr.To("PowerState/deallocated"),
+					}
+				}
+				if test.isVMNotFound {
+					expectedVMSSVMs = nil
+				}
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, test.vmssVMListError).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, test.vmssVMListError).AnyTimes()
+				}
+
+				nodeResourceGroup, ssName, instanceID, vm, err := ss.EnsureHostInPool(context.Background(), test.service, test.nodeName, test.backendPoolID, test.vmSetName)
+				assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
+				assert.Equal(t, test.expectedNodeResourceGroup, nodeResourceGroup, test.description)
+				assert.Equal(t, test.expectedVMSSName, ssName, test.description)
+				assert.Equal(t, test.expectedInstanceID, instanceID, test.description)
+				assert.Equal(t, test.expectedVMSSVM, vm, test.description)
+			})
+		}
 	}
 }
 
@@ -2879,55 +2970,62 @@ func TestEnsureHostsInPool(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			for _, node := range test.nodes {
-				if node.Labels[consts.ManagedByAzureLabel] == "false" {
-					ss.excludeLoadBalancerNodes = utilsets.NewString(node.Name)
+				for _, node := range test.nodes {
+					if node.Labels[consts.ManagedByAzureLabel] == "false" {
+						ss.excludeLoadBalancerNodes = utilsets.NewString(node.Name)
+					}
 				}
-			}
-			ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
-			ss.ExcludeMasterFromStandardLB = ptr.To(true)
-			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, nil).MaxTimes(1)
+				ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+				ss.ExcludeMasterFromStandardLB = ptr.To(true)
+				expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
+				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, nil).MaxTimes(1)
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000", "vmss-vm-000001", "vmss-vm-000002"}, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
-
-			mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
-					poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
-						&http.Response{
-							Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
-						},
-						runtime.Pipeline{},
-						&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
-							Handler: &vmssvmMockPutHandler{
-								resp: &http.Response{
-									StatusCode: http.StatusAccepted,
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000", "vmss-vm-000001", "vmss-vm-000002"}, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
+				mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
+						poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
+							&http.Response{
+								Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
+							},
+							runtime.Pipeline{},
+							&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
+								Handler: &vmssvmMockPutHandler{
+									resp: &http.Response{
+										StatusCode: http.StatusAccepted,
+									},
 								},
 							},
-						},
-					)
-					assert.NoError(t, err)
-					return poller, nil
-				}).Times(test.expectedVMSSVMPutTimes)
+						)
+						assert.NoError(t, err)
+						return poller, nil
+					}).Times(test.expectedVMSSVMPutTimes)
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
-			err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
-			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
-		})
+				err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
+				assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+			})
+		}
 	}
 }
 
@@ -3003,66 +3101,74 @@ func TestEnsureHostsInPoolEtagMismatch(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
-			ss.ExcludeMasterFromStandardLB = ptr.To(true)
-			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
-			expectedVMSS.Location = &ss.Location
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
+				ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+				ss.ExcludeMasterFromStandardLB = ptr.To(true)
+				expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+				expectedVMSS.Location = &ss.Location
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
 
-			copiedVMSS := deepcopy.Copy(expectedVMSS).(*armcompute.VirtualMachineScaleSet)
-			networkInterfaceConfigurations := copiedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-			ipConfig := networkInterfaceConfigurations[0].Properties.IPConfigurations
-			ipConfig[0].Properties.LoadBalancerBackendAddressPools = append(ipConfig[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(test.backendpoolID)})
-			vmssMatcher := vmssInputMatcher{
-				Location: copiedVMSS.Location,
-				Properties: &armcompute.VirtualMachineScaleSetProperties{
-					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
-						NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
-							NetworkInterfaceConfigurations: networkInterfaceConfigurations,
+				copiedVMSS := deepcopy.Copy(expectedVMSS).(*armcompute.VirtualMachineScaleSet)
+				networkInterfaceConfigurations := copiedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+				ipConfig := networkInterfaceConfigurations[0].Properties.IPConfigurations
+				ipConfig[0].Properties.LoadBalancerBackendAddressPools = append(ipConfig[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(test.backendpoolID)})
+				vmssMatcher := vmssInputMatcher{
+					Location: copiedVMSS.Location,
+					Properties: &armcompute.VirtualMachineScaleSetProperties{
+						VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
+							NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
+								NetworkInterfaceConfigurations: networkInterfaceConfigurations,
+							},
 						},
 					},
-				},
-				Etag: copiedVMSS.Etag,
-			}
+					Etag: copiedVMSS.Etag,
+				}
 
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, vmssMatcher).Return(nil, test.vmssClientPutError).Times(1)
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, vmssMatcher).Return(nil, test.vmssClientPutError).Times(1)
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			expectedVMSSVM := expectedVMSSVMs[0]
-			copiedVMSSVM := deepcopy.Copy(expectedVMSSVM).(*armcompute.VirtualMachineScaleSetVM)
+				expectedVMSSVM := expectedVMSSVMs[0]
+				copiedVMSSVM := deepcopy.Copy(expectedVMSSVM).(*armcompute.VirtualMachineScaleSetVM)
 
-			vmNetworkInterfaceConfigurations := copiedVMSSVM.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations
-			vmssVMIPConfigs := vmNetworkInterfaceConfigurations[0].Properties.IPConfigurations
-			vmssVMIPConfigs[0].Properties.LoadBalancerBackendAddressPools = append((vmssVMIPConfigs)[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(testLBBackendpoolID1)})
+				vmNetworkInterfaceConfigurations := copiedVMSSVM.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations
+				vmssVMIPConfigs := vmNetworkInterfaceConfigurations[0].Properties.IPConfigurations
+				vmssVMIPConfigs[0].Properties.LoadBalancerBackendAddressPools = append((vmssVMIPConfigs)[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(testLBBackendpoolID1)})
 
-			vmssVMMatcher := vmssVMInputMatcher{
-				Location: copiedVMSSVM.Location,
-				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-					NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
-						NetworkInterfaceConfigurations: vmNetworkInterfaceConfigurations,
+				vmssVMMatcher := vmssVMInputMatcher{
+					Location: copiedVMSSVM.Location,
+					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+						NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
+							NetworkInterfaceConfigurations: vmNetworkInterfaceConfigurations,
+						},
 					},
-				},
-				Etag: copiedVMSSVM.Etag,
-			}
-			mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), vmssVMMatcher, gomock.Any()).Return(nil, test.vmssvmClientPutError).Times(test.expectedVMSSVMPutTimes)
+					Etag: copiedVMSSVM.Etag,
+				}
+				mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), vmssVMMatcher, gomock.Any()).Return(nil, test.vmssvmClientPutError).Times(test.expectedVMSSVMPutTimes)
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
-			err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
-			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
-		})
+				err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
+				assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+			})
+		}
 	}
 }
 
@@ -3186,63 +3292,71 @@ func TestEnsureBackendPoolDeletedEtagMismatch(t *testing.T) {
 	}
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test for each case of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+				expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
 
-			copiedVMSS := deepcopy.Copy(expectedVMSS).(*armcompute.VirtualMachineScaleSet)
-			networkInterfaceConfigurations := copiedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-			ipConfig := networkInterfaceConfigurations[0].Properties.IPConfigurations
-			ipConfig[0].Properties.LoadBalancerBackendAddressPools = []*armcompute.SubResource{}
-			vmssMatcher := vmssInputMatcher{
-				Location: copiedVMSS.Location,
-				Properties: &armcompute.VirtualMachineScaleSetProperties{
-					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
-						NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
-							NetworkInterfaceConfigurations: networkInterfaceConfigurations,
+				copiedVMSS := deepcopy.Copy(expectedVMSS).(*armcompute.VirtualMachineScaleSet)
+				networkInterfaceConfigurations := copiedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+				ipConfig := networkInterfaceConfigurations[0].Properties.IPConfigurations
+				ipConfig[0].Properties.LoadBalancerBackendAddressPools = []*armcompute.SubResource{}
+				vmssMatcher := vmssInputMatcher{
+					Location: copiedVMSS.Location,
+					Properties: &armcompute.VirtualMachineScaleSetProperties{
+						VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
+							NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
+								NetworkInterfaceConfigurations: networkInterfaceConfigurations,
+							},
 						},
 					},
-				},
-				Etag: copiedVMSS.Etag,
-			}
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, vmssMatcher).Return(nil, test.vmssClientPutError).Times(1)
+					Etag: copiedVMSS.Etag,
+				}
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
+				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, vmssMatcher).Return(nil, test.vmssClientPutError).Times(1)
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
-			expectedVMSSVM := expectedVMSSVMs[0]
-			copiedVMSSVM := deepcopy.Copy(expectedVMSSVM).(*armcompute.VirtualMachineScaleSetVM)
-			vmNetworkInterfaceConfigurations := copiedVMSSVM.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations
-			vmssVMIPConfigs := vmNetworkInterfaceConfigurations[0].Properties.IPConfigurations
-			vmssVMIPConfigs[0].Properties.LoadBalancerBackendAddressPools = []*armcompute.SubResource{}
-			vmssVMMatcher := vmssVMInputMatcher{
-				Location: copiedVMSSVM.Location,
-				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
-					NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
-						NetworkInterfaceConfigurations: vmNetworkInterfaceConfigurations,
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
+				expectedVMSSVM := expectedVMSSVMs[0]
+				copiedVMSSVM := deepcopy.Copy(expectedVMSSVM).(*armcompute.VirtualMachineScaleSetVM)
+				vmNetworkInterfaceConfigurations := copiedVMSSVM.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations
+				vmssVMIPConfigs := vmNetworkInterfaceConfigurations[0].Properties.IPConfigurations
+				vmssVMIPConfigs[0].Properties.LoadBalancerBackendAddressPools = []*armcompute.SubResource{}
+				vmssVMMatcher := vmssVMInputMatcher{
+					Location: copiedVMSSVM.Location,
+					Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+						NetworkProfileConfiguration: &armcompute.VirtualMachineScaleSetVMNetworkProfileConfiguration{
+							NetworkInterfaceConfigurations: vmNetworkInterfaceConfigurations,
+						},
 					},
-				},
-				Etag: copiedVMSSVM.Etag,
-			}
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
-			mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), vmssVMMatcher, gomock.Any()).Return(nil, test.vmssvmClientPutError).Times(test.expectedVMSSVMPutTimes)
+					Etag: copiedVMSSVM.Etag,
+				}
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
+				mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), vmssVMMatcher, gomock.Any()).Return(nil, test.vmssvmClientPutError).Times(test.expectedVMSSVMPutTimes)
 
-			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+				mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
 
-			updated, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{test.backendpoolID}, testVMSSName, test.backendAddressPools, true)
-			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
-			if !test.expectedErr && test.expectedVMSSVMPutTimes > 0 {
-				assert.True(t, updated, test.description)
-			}
-		})
+				updated, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{test.backendpoolID}, testVMSSName, test.backendAddressPools, true)
+				assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+				if !test.expectedErr && test.expectedVMSSVMPutTimes > 0 {
+					assert.True(t, updated, test.description)
+				}
+			})
+		}
 	}
 }
 
@@ -3324,37 +3438,45 @@ func TestEnsureBackendPoolDeletedFromNodeCommon(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			test := test
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				expectedVMSS := buildTestVMSS(testVMSSName, "vmss-vm-")
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 
-			// isIPv6 true means it is a DualStack or IPv6 only cluster.
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", true)
-			if test.isNilVMNetworkConfigs {
-				expectedVMSSVMs[0].Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations = nil
-			}
-			if test.isVMNotActive {
-				(expectedVMSSVMs[0].Properties.InstanceView.Statuses)[0] = &armcompute.InstanceViewStatus{
-					Code: ptr.To("PowerState/deallocated"),
+				// isIPv6 true means it is a DualStack or IPv6 only cluster.
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", true)
+				if test.isNilVMNetworkConfigs {
+					expectedVMSSVMs[0].Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations = nil
 				}
-			}
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				if test.isVMNotActive {
+					(expectedVMSSVMs[0].Properties.InstanceView.Statuses)[0] = &armcompute.InstanceViewStatus{
+						Code: ptr.To("PowerState/deallocated"),
+					}
+				}
 
-			nodeResourceGroup, ssName, instanceID, vm, err := ss.ensureBackendPoolDeletedFromNode(context.TODO(), test.nodeName, test.backendpoolIDs)
-			assert.Equal(t, test.expectedErr, err)
-			assert.Equal(t, test.expectedNodeResourceGroup, nodeResourceGroup)
-			assert.Equal(t, test.expectedVMSSName, ssName)
-			assert.Equal(t, test.expectedInstanceID, instanceID)
-			assert.Equal(t, test.expectedVMSSVM, vm)
-		})
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
+
+				nodeResourceGroup, ssName, instanceID, vm, err := ss.ensureBackendPoolDeletedFromNode(context.TODO(), test.nodeName, test.backendpoolIDs)
+				assert.Equal(t, test.expectedErr, err)
+				assert.Equal(t, test.expectedNodeResourceGroup, nodeResourceGroup)
+				assert.Equal(t, test.expectedVMSSName, ssName)
+				assert.Equal(t, test.expectedInstanceID, instanceID)
+				assert.Equal(t, test.expectedVMSSVM, vm)
+			})
+		}
 	}
 }
 
@@ -3417,48 +3539,55 @@ func TestEnsureBackendPoolDeletedFromVMSS(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test both cases of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+				ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 
-			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
-			if test.isVMSSDeallocating {
-				expectedVMSS.Properties.ProvisioningState = ptr.To(consts.ProvisionStateDeleting)
-			}
-			if test.isVMSSNilNICConfig {
-				expectedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
-			}
-			if test.isVMSSNilVirtualMachineProfile {
-				expectedVMSS.Properties.VirtualMachineProfile = nil
-			}
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes().MinTimes(1)
-			vmssPutTimes := 0
-			if test.expectedPutVMSS {
-				vmssPutTimes = 1
-				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil)
-			}
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, test.vmssClientErr).Times(vmssPutTimes)
+				expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+				if test.isVMSSDeallocating {
+					expectedVMSS.Properties.ProvisioningState = ptr.To(consts.ProvisionStateDeleting)
+				}
+				if test.isVMSSNilNICConfig {
+					expectedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
+				}
+				if test.isVMSSNilVirtualMachineProfile {
+					expectedVMSS.Properties.VirtualMachineProfile = nil
+				}
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes().MinTimes(1)
+				vmssPutTimes := 0
+				if test.expectedPutVMSS {
+					vmssPutTimes = 1
+					mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil)
+				}
+				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, test.vmssClientErr).Times(vmssPutTimes)
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			err = ss.ensureBackendPoolDeletedFromVMSS(context.TODO(), []string{test.backendPoolID}, testVMSSName)
-			if test.expectedErr != nil {
-				assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description+errMsgSuffix)
-			}
-		})
+				err = ss.ensureBackendPoolDeletedFromVMSS(context.TODO(), []string{test.backendPoolID}, testVMSSName)
+				if test.expectedErr != nil {
+					assert.Contains(t, err.Error(), test.expectedErr.Error(), test.description+errMsgSuffix)
+				}
+			})
+		}
 	}
 }
 
 func TestEnsureBackendPoolDeleted(t *testing.T) {
-
 	testCases := []struct {
 		description            string
 		backendpoolID          string
@@ -3542,33 +3671,41 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test both cases of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, nil).Times(1)
+				expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
+				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, nil).Times(1)
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000", "vmss-vm-000001", "vmss-vm-000002"}, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
-			mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).Times(test.expectedVMSSVMPutTimes)
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000", "vmss-vm-000001", "vmss-vm-000002"}, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
+				mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, test.vmClientErr).Times(test.expectedVMSSVMPutTimes)
 
-			mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+				mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
 
-			updated, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{test.backendpoolID}, testVMSSName, test.backendAddressPools, true)
-			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
-			if !test.expectedErr && test.expectedVMSSVMPutTimes > 0 {
-				assert.True(t, updated, test.description)
-			}
-		})
+				updated, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{test.backendpoolID}, testVMSSName, test.backendAddressPools, true)
+				assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+				if !test.expectedErr && test.expectedVMSSVMPutTimes > 0 {
+					assert.True(t, updated, test.description)
+				}
+			})
+		}
 	}
 }
 
@@ -3637,58 +3774,66 @@ func TestEnsureHostsInPoolInParallel(t *testing.T) {
 
 	for _, test := range testCases {
 		test := test
-		t.Run(test.description, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+		// Test both cases of listVMSSVMsWithoutInstanceView
+		for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+			t.Run(test.description, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
 
-			ss, err := NewTestScaleSet(ctrl)
-			assert.NoError(t, err, test.description)
+				ss, err := NewTestScaleSet(ctrl)
+				assert.NoError(t, err, test.description)
 
-			for _, node := range test.nodes {
-				if node.Labels[consts.ManagedByAzureLabel] == "false" {
-					ss.excludeLoadBalancerNodes = utilsets.NewString(node.Name)
+				for _, node := range test.nodes {
+					if node.Labels[consts.ManagedByAzureLabel] == "false" {
+						ss.excludeLoadBalancerNodes = utilsets.NewString(node.Name)
+					}
 				}
-			}
-			ss.PutVMSSVMBatchSize = 2
-			ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
-			ss.ExcludeMasterFromStandardLB = ptr.To(true)
-			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
-			expectedVMSS.Tags = map[string]*string{
-				"aks-managed-coordination": to.Ptr("true"),
-			}
-			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
-			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, nil).MaxTimes(1)
+				ss.PutVMSSVMBatchSize = 2
+				ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+				ss.ExcludeMasterFromStandardLB = ptr.To(true)
+				expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+				expectedVMSS.Tags = map[string]*string{
+					"aks-managed-coordination": to.Ptr("true"),
+				}
+				mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+				mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).MaxTimes(1)
+				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, nil).MaxTimes(1)
 
-			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000", "vmss-vm-000001", "vmss-vm-000002"}, "", false)
-			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000", "vmss-vm-000001", "vmss-vm-000002"}, "", false)
+				mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+				ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+				if ss.ListVmssVirtualMachinesWithoutInstanceView {
+					mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				} else {
+					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+				}
 
-			mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
-					poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
-						&http.Response{
-							Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
-						},
-						runtime.Pipeline{},
-						&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
-							Handler: &vmssvmMockPutHandler{
-								resp: &http.Response{
-									StatusCode: http.StatusAccepted,
+				mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
+						poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
+							&http.Response{
+								Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
+							},
+							runtime.Pipeline{},
+							&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
+								Handler: &vmssvmMockPutHandler{
+									resp: &http.Response{
+										StatusCode: http.StatusAccepted,
+									},
 								},
 							},
-						},
-					)
-					assert.NoError(t, err)
-					return poller, nil
-				}).Times(test.expectedVMSSVMPutTimes)
+						)
+						assert.NoError(t, err)
+						return poller, nil
+					}).Times(test.expectedVMSSVMPutTimes)
 
-			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-			err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
-			assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
-		})
+				mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+				mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				err = ss.EnsureHostsInPool(context.Background(), &v1.Service{}, test.nodes, test.backendpoolID, test.vmSetName)
+				assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)
+			})
+		}
 	}
 }
 
@@ -3724,127 +3869,137 @@ func TestEnsureBackendPoolDeletedConcurrentlyLoop(t *testing.T) {
 }
 
 func TestEnsureBackendPoolDeletedConcurrently(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	ss, err := NewTestScaleSet(ctrl)
-	assert.NoError(t, err)
+		ss, err := NewTestScaleSet(ctrl)
+		assert.NoError(t, err)
 
-	backendAddressPools := []*armnetwork.BackendAddressPool{
-		{
-			ID: ptr.To(testLBBackendpoolID0),
-			Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
-				BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
-					{
-						Name: ptr.To("ip-1"),
-						ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
-					},
-				},
-			},
-		},
-		{
-			ID: ptr.To(testLBBackendpoolID1),
-			Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
-				BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
-					{
-						Name: ptr.To("ip-1"),
-						ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-1/virtualMachines/0/networkInterfaces/nic"),
-					},
-				},
-			},
-		},
-		{
-			ID: ptr.To(testLBBackendpoolID2),
-			Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
-				BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
-					{
-						Name: ptr.To("ip-1"),
-						ID:   ptr.To("/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
-					},
-				},
-			},
-		},
-	}
-
-	vmss0 := buildTestVMSSWithLB("vmss-0", "vmss-0-vm-", []string{testLBBackendpoolID0, testLBBackendpoolID1}, false)
-	vmss1 := buildTestVMSSWithLB("vmss-1", "vmss-1-vm-", []string{testLBBackendpoolID0, testLBBackendpoolID1}, false)
-
-	expectedVMSSVMsOfVMSS0, _, _ := buildTestVirtualMachineEnv(ss.Cloud, "vmss-0", "", 0, []string{"vmss-0-vm-000000"}, "succeeded", false)
-	expectedVMSSVMsOfVMSS1, _, _ := buildTestVirtualMachineEnv(ss.Cloud, "vmss-1", "", 0, []string{"vmss-1-vm-000001"}, "succeeded", false)
-	for _, expectedVMSSVMs := range [][]*armcompute.VirtualMachineScaleSetVM{expectedVMSSVMsOfVMSS0, expectedVMSSVMsOfVMSS1} {
-		vmssVMNetworkConfigs := expectedVMSSVMs[0].Properties.NetworkProfileConfiguration
-		vmssVMIPConfigs := (vmssVMNetworkConfigs.NetworkInterfaceConfigurations)[0].Properties.IPConfigurations
-		(vmssVMIPConfigs)[0].Properties.LoadBalancerBackendAddressPools = append((vmssVMIPConfigs)[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(testLBBackendpoolID1)})
-	}
-
-	mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-	mockVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
-
-	mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-	mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{vmss0, vmss1}, nil).AnyTimes()
-	mockVMSSClient.EXPECT().List(gomock.Any(), "rg1").Return(nil, nil).AnyTimes()
-	mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, "vmss-0", nil).Return(vmss0, nil).MaxTimes(2)
-	mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, "vmss-1", nil).Return(vmss1, nil).MaxTimes(2)
-	mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-
-	mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), "rg1", "vmss-0").Return(nil, nil).AnyTimes()
-	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, "vmss-0").Return(expectedVMSSVMsOfVMSS0, nil).AnyTimes()
-	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, "vmss-1").Return(expectedVMSSVMsOfVMSS1, nil).AnyTimes()
-	mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, "vmss-0", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
-			poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
-				&http.Response{
-					Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
-				},
-				runtime.Pipeline{},
-				&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
-					Handler: &vmssvmMockPutHandler{
-						resp: &http.Response{
-							StatusCode: http.StatusAccepted,
+		backendAddressPools := []*armnetwork.BackendAddressPool{
+			{
+				ID: ptr.To(testLBBackendpoolID0),
+				Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
+					BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+						{
+							Name: ptr.To("ip-1"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
 						},
 					},
 				},
-			)
-			assert.NoError(t, err)
-			return poller, nil
-		},
-	).Times(1)
-
-	mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, "vmss-1", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
-			poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
-				&http.Response{
-					Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
-				},
-				runtime.Pipeline{},
-				&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
-					Handler: &vmssvmMockPutHandler{
-						resp: &http.Response{
-							StatusCode: http.StatusAccepted,
+			},
+			{
+				ID: ptr.To(testLBBackendpoolID1),
+				Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
+					BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+						{
+							Name: ptr.To("ip-1"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-1/virtualMachines/0/networkInterfaces/nic"),
 						},
 					},
 				},
-			)
-			assert.NoError(t, err)
-			return poller, nil
-		},
-	).Times(1)
+			},
+			{
+				ID: ptr.To(testLBBackendpoolID2),
+				Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
+					BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+						{
+							Name: ptr.To("ip-1"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-0/virtualMachines/0/networkInterfaces/nic"),
+						},
+					},
+				},
+			},
+		}
 
-	backendpoolAddressIDs := []string{testLBBackendpoolID0, testLBBackendpoolID1, testLBBackendpoolID2}
-	testVMSSNames := []string{"vmss-0", "vmss-1", "vmss-2"}
-	testFunc := make([]func() error, 0)
-	for i, id := range backendpoolAddressIDs {
-		i := i
-		id := id
-		testFunc = append(testFunc, func() error {
-			_, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{id}, testVMSSNames[i], backendAddressPools, true)
-			return err
-		})
+		vmss0 := buildTestVMSSWithLB("vmss-0", "vmss-0-vm-", []string{testLBBackendpoolID0, testLBBackendpoolID1}, false)
+		vmss1 := buildTestVMSSWithLB("vmss-1", "vmss-1-vm-", []string{testLBBackendpoolID0, testLBBackendpoolID1}, false)
+
+		expectedVMSSVMsOfVMSS0, _, _ := buildTestVirtualMachineEnv(ss.Cloud, "vmss-0", "", 0, []string{"vmss-0-vm-000000"}, "succeeded", false)
+		expectedVMSSVMsOfVMSS1, _, _ := buildTestVirtualMachineEnv(ss.Cloud, "vmss-1", "", 0, []string{"vmss-1-vm-000001"}, "succeeded", false)
+		for _, expectedVMSSVMs := range [][]*armcompute.VirtualMachineScaleSetVM{expectedVMSSVMsOfVMSS0, expectedVMSSVMsOfVMSS1} {
+			vmssVMNetworkConfigs := expectedVMSSVMs[0].Properties.NetworkProfileConfiguration
+			vmssVMIPConfigs := (vmssVMNetworkConfigs.NetworkInterfaceConfigurations)[0].Properties.IPConfigurations
+			(vmssVMIPConfigs)[0].Properties.LoadBalancerBackendAddressPools = append((vmssVMIPConfigs)[0].Properties.LoadBalancerBackendAddressPools, &armcompute.SubResource{ID: ptr.To(testLBBackendpoolID1)})
+		}
+
+		mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+		mockVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+
+		mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{vmss0, vmss1}, nil).AnyTimes()
+		mockVMSSClient.EXPECT().List(gomock.Any(), "rg1").Return(nil, nil).AnyTimes()
+		mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, "vmss-0", nil).Return(vmss0, nil).MaxTimes(2)
+		mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, "vmss-1", nil).Return(vmss1, nil).MaxTimes(2)
+		mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+
+		mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+		ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+		if ss.ListVmssVirtualMachinesWithoutInstanceView {
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), "rg1", "vmss-0").Return(nil, nil).AnyTimes()
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, "vmss-0").Return(expectedVMSSVMsOfVMSS0, nil).AnyTimes()
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, "vmss-1").Return(expectedVMSSVMsOfVMSS1, nil).AnyTimes()
+		} else {
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), "rg1", "vmss-0").Return(nil, nil).AnyTimes()
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, "vmss-0").Return(expectedVMSSVMsOfVMSS0, nil).AnyTimes()
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), ss.ResourceGroup, "vmss-1").Return(expectedVMSSVMsOfVMSS1, nil).AnyTimes()
+
+		}
+		mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, "vmss-0", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
+				poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
+					&http.Response{
+						Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
+					},
+					runtime.Pipeline{},
+					&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
+						Handler: &vmssvmMockPutHandler{
+							resp: &http.Response{
+								StatusCode: http.StatusAccepted,
+							},
+						},
+					},
+				)
+				assert.NoError(t, err)
+				return poller, nil
+			},
+		).Times(1)
+
+		mockVMSSVMClient.EXPECT().BeginUpdate(gomock.Any(), ss.ResourceGroup, "vmss-1", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armcompute.VirtualMachineScaleSetVM, _ *armcompute.VirtualMachineScaleSetVMsClientBeginUpdateOptions) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
+				poller, err := runtime.NewPoller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse](
+					&http.Response{
+						Header: http.Header{"Fake-Poller-Status": []string{"https://fake/operation"}},
+					},
+					runtime.Pipeline{},
+					&runtime.NewPollerOptions[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]{
+						Handler: &vmssvmMockPutHandler{
+							resp: &http.Response{
+								StatusCode: http.StatusAccepted,
+							},
+						},
+					},
+				)
+				assert.NoError(t, err)
+				return poller, nil
+			},
+		).Times(1)
+
+		backendpoolAddressIDs := []string{testLBBackendpoolID0, testLBBackendpoolID1, testLBBackendpoolID2}
+		testVMSSNames := []string{"vmss-0", "vmss-1", "vmss-2"}
+		testFunc := make([]func() error, 0)
+		for i, id := range backendpoolAddressIDs {
+			i := i
+			id := id
+			testFunc = append(testFunc, func() error {
+				_, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{id}, testVMSSNames[i], backendAddressPools, true)
+				return err
+			})
+		}
+		errs := utilerrors.AggregateGoroutines(testFunc...)
+		assert.Equal(t, 1, len(errs.Errors()))
+		assert.Equal(t, "instance not found", errs.Error())
 	}
-	errs := utilerrors.AggregateGoroutines(testFunc...)
-	assert.Equal(t, 1, len(errs.Errors()))
-	assert.Equal(t, "instance not found", errs.Error())
 }
 
 func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
@@ -3916,65 +4071,72 @@ func TestGetNodeCIDRMasksByProviderID(t *testing.T) {
 }
 
 func TestGetAgentPoolVMSetNamesMixedInstances(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	for _, listVMSSVMsWithoutInstanceView := range []bool{false, true} {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	ss, err := NewTestScaleSet(ctrl)
-	assert.NoError(t, err)
+		ss, err := NewTestScaleSet(ctrl)
+		assert.NoError(t, err)
 
-	existingVMs := []*armcompute.VirtualMachine{
-		{
-			Name: ptr.To("vm-0"),
-			Properties: &armcompute.VirtualMachineProperties{
-				OSProfile: &armcompute.OSProfile{
-					ComputerName: ptr.To("vm-0"),
-				},
-				AvailabilitySet: &armcompute.SubResource{
-					ID: ptr.To("vmas-0"),
+		existingVMs := []*armcompute.VirtualMachine{
+			{
+				Name: ptr.To("vm-0"),
+				Properties: &armcompute.VirtualMachineProperties{
+					OSProfile: &armcompute.OSProfile{
+						ComputerName: ptr.To("vm-0"),
+					},
+					AvailabilitySet: &armcompute.SubResource{
+						ID: ptr.To("vmas-0"),
+					},
 				},
 			},
-		},
-		{
-			Name: ptr.To("vm-1"),
-			Properties: &armcompute.VirtualMachineProperties{
-				OSProfile: &armcompute.OSProfile{
-					ComputerName: ptr.To("vm-1"),
-				},
-				AvailabilitySet: &armcompute.SubResource{
-					ID: ptr.To("vmas-1"),
+			{
+				Name: ptr.To("vm-1"),
+				Properties: &armcompute.VirtualMachineProperties{
+					OSProfile: &armcompute.OSProfile{
+						ComputerName: ptr.To("vm-1"),
+					},
+					AvailabilitySet: &armcompute.SubResource{
+						ID: ptr.To("vmas-1"),
+					},
 				},
 			},
-		},
+		}
+		expectedScaleSet := buildTestVMSS(testVMSSName, "vmssee6c2")
+		vmList := []string{"vmssee6c2000000", "vmssee6c2000001", "vmssee6c2000002"}
+		existingVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, vmList, "", false)
+
+		mockVMClient := ss.Cloud.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+		mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(existingVMs, nil).AnyTimes()
+
+		mockVMSSClient := ss.Cloud.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil)
+
+		mockVMSSVMClient := ss.Cloud.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+		ss.ListVmssVirtualMachinesWithoutInstanceView = listVMSSVMsWithoutInstanceView
+		if ss.ListVmssVirtualMachinesWithoutInstanceView {
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), gomock.Any(), testVMSSName).Return(existingVMSSVMs, nil)
+		} else {
+			mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), testVMSSName).Return(existingVMSSVMs, nil)
+		}
+
+		nodes := []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vmssee6c2000000",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vm-0",
+				},
+			},
+		}
+		expectedVMSetNames := []*string{to.Ptr(testVMSSName), to.Ptr("vmas-0")}
+		vmSetNames, err := ss.GetAgentPoolVMSetNames(context.TODO(), nodes)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedVMSetNames, vmSetNames)
 	}
-	expectedScaleSet := buildTestVMSS(testVMSSName, "vmssee6c2")
-	vmList := []string{"vmssee6c2000000", "vmssee6c2000001", "vmssee6c2000002"}
-	existingVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, vmList, "", false)
-
-	mockVMClient := ss.Cloud.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
-	mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(existingVMs, nil).AnyTimes()
-
-	mockVMSSClient := ss.Cloud.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
-	mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachineScaleSet{expectedScaleSet}, nil)
-
-	mockVMSSVMClient := ss.Cloud.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
-	mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), testVMSSName).Return(existingVMSSVMs, nil)
-
-	nodes := []*v1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "vmssee6c2000000",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "vm-0",
-			},
-		},
-	}
-	expectedVMSetNames := []*string{to.Ptr(testVMSSName), to.Ptr("vmas-0")}
-	vmSetNames, err := ss.GetAgentPoolVMSetNames(context.TODO(), nodes)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedVMSetNames, vmSetNames)
 }
 
 func TestGetNodeVMSetNameVMSS(t *testing.T) {

--- a/pkg/provider/config/azure_cache.go
+++ b/pkg/provider/config/azure_cache.go
@@ -26,8 +26,8 @@ type CloudProviderCacheConfig struct {
 	VmssCacheTTLInSeconds int `json:"vmssCacheTTLInSeconds,omitempty" yaml:"vmssCacheTTLInSeconds,omitempty"`
 	// VmssVirtualMachinesCacheTTLInSeconds sets the cache TTL for vmssVirtualMachines
 	VmssVirtualMachinesCacheTTLInSeconds int `json:"vmssVirtualMachinesCacheTTLInSeconds,omitempty" yaml:"vmssVirtualMachinesCacheTTLInSeconds,omitempty"`
-	//VmssVirtualMachineCacheInstanceView sets the cache with instance view for vmssVirtualMachines
-	VmssVirtualMachineCacheInstanceView bool `json:"vmssVirtualMachineCacheInstanceView,omitempty" yaml:"vmssVirtualMachineCacheInstanceView,omitempty"`
+	//VmssVirtualMachineCacheWithoutInstanceView sets the cache without instance view for vmssVirtualMachines
+	VmssVirtualMachineCacheWithoutInstanceView bool `json:"vmssVirtualMachineCacheWithoutInstanceView,omitempty" yaml:"vmssVirtualMachineCacheWithoutInstanceView,omitempty"`
 
 	// VmssFlexCacheTTLInSeconds sets the cache TTL for VMSS Flex
 	VmssFlexCacheTTLInSeconds int `json:"vmssFlexCacheTTLInSeconds,omitempty" yaml:"vmssFlexCacheTTLInSeconds,omitempty"`

--- a/pkg/provider/config/azure_cache.go
+++ b/pkg/provider/config/azure_cache.go
@@ -26,8 +26,8 @@ type CloudProviderCacheConfig struct {
 	VmssCacheTTLInSeconds int `json:"vmssCacheTTLInSeconds,omitempty" yaml:"vmssCacheTTLInSeconds,omitempty"`
 	// VmssVirtualMachinesCacheTTLInSeconds sets the cache TTL for vmssVirtualMachines
 	VmssVirtualMachinesCacheTTLInSeconds int `json:"vmssVirtualMachinesCacheTTLInSeconds,omitempty" yaml:"vmssVirtualMachinesCacheTTLInSeconds,omitempty"`
-	//VmssVirtualMachineCacheWithoutInstanceView sets the cache without instance view for vmssVirtualMachines
-	VmssVirtualMachineCacheWithoutInstanceView bool `json:"vmssVirtualMachineCacheWithoutInstanceView,omitempty" yaml:"vmssVirtualMachineCacheWithoutInstanceView,omitempty"`
+	// ListVmssVirtualMachinesWithoutInstanceView makes the provider list VMSS virtual machines without instance view.
+	ListVmssVirtualMachinesWithoutInstanceView bool `json:"listVmssVirtualMachinesWithoutInstanceView,omitempty" yaml:"listVmssVirtualMachinesWithoutInstanceView,omitempty"`
 
 	// VmssFlexCacheTTLInSeconds sets the cache TTL for VMSS Flex
 	VmssFlexCacheTTLInSeconds int `json:"vmssFlexCacheTTLInSeconds,omitempty" yaml:"vmssFlexCacheTTLInSeconds,omitempty"`

--- a/pkg/provider/config/azure_cache.go
+++ b/pkg/provider/config/azure_cache.go
@@ -26,6 +26,8 @@ type CloudProviderCacheConfig struct {
 	VmssCacheTTLInSeconds int `json:"vmssCacheTTLInSeconds,omitempty" yaml:"vmssCacheTTLInSeconds,omitempty"`
 	// VmssVirtualMachinesCacheTTLInSeconds sets the cache TTL for vmssVirtualMachines
 	VmssVirtualMachinesCacheTTLInSeconds int `json:"vmssVirtualMachinesCacheTTLInSeconds,omitempty" yaml:"vmssVirtualMachinesCacheTTLInSeconds,omitempty"`
+	//VmssVirtualMachineCacheInstanceView sets the cache with instance view for vmssVirtualMachines
+	VmssVirtualMachineCacheInstanceView bool `json:"vmssVirtualMachineCacheInstanceView,omitempty" yaml:"vmssVirtualMachineCacheInstanceView,omitempty"`
 
 	// VmssFlexCacheTTLInSeconds sets the cache TTL for VMSS Flex
 	VmssFlexCacheTTLInSeconds int `json:"vmssFlexCacheTTLInSeconds,omitempty" yaml:"vmssFlexCacheTTLInSeconds,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
There are 2 API calls for [VMSS VM List](https://learn.microsoft.com/en-us/rest/api/compute/virtual-machine-scale-set-vms/list?view=rest-compute-2025-02-01&tabs=HTTP); however, the sdk only implements the one with instance-view parameter. 

VMSS VM List API with instance-view parameter times out when a cluster zone is not available and is not reliable for scenarios that require zonal redundance. I am adding an option of selecting which API to call to populate the cache in order to accommodate all scenarios. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # The implemented VMSS VM List API times out when a zone becomes unavailable. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
chore: add option to list vmss vms without instance view
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
chore: add option to list vmss vms without instance view
```
