### PR TITLE
[release-1.31] fix: Do not return early when pip.publicIPAddress is empty when check…

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3794,20 +3794,23 @@ func serviceOwnsPublicIP(service *v1.Service, pip *network.PublicIPAddress, clus
 		return false, false
 	}
 
-	if pip.PublicIPAddressPropertiesFormat == nil || pointer.StringDeref(pip.IPAddress, "") == "" {
-		klog.Warningf("serviceOwnsPublicIP: empty pip.IPAddress")
-		return false, false
-	}
-
 	serviceName := getServiceName(service)
 
-	isIPv6 := pip.PublicIPAddressVersion == network.IPv6
+	var isIPv6 bool
+	if pip.PublicIPAddressPropertiesFormat != nil {
+		isIPv6 = pip.PublicIPAddressVersion == network.IPv6
+	}
 	if pip.Tags != nil {
 		serviceTag := getServiceFromPIPServiceTags(pip.Tags)
 		clusterTag := getClusterFromPIPClusterTags(pip.Tags)
 
 		// if there is no service tag on the pip, it is user-created pip
 		if serviceTag == "" {
+			// For user-created PIPs, we need a valid IP address to match against
+			if pip.PublicIPAddressPropertiesFormat == nil || pointer.StringDeref(pip.IPAddress, "") == "" {
+				klog.V(4).Infof("serviceOwnsPublicIP: empty pip.IPAddress for user-created PIP")
+				return false, true
+			}
 			return isServiceSelectPIP(service, pip, isIPv6), true
 		}
 
@@ -3825,10 +3828,20 @@ func serviceOwnsPublicIP(service *v1.Service, pip *network.PublicIPAddress, clus
 
 		// if the service is not included in the tags of the system-created pip, check the ip address
 		// or pip name, this could happen for secondary services
+		// For secondary services, we need a valid IP address to match against
+		if pip.PublicIPAddressPropertiesFormat == nil || pointer.StringDeref(pip.IPAddress, "") == "" {
+			klog.V(4).Infof("serviceOwnsPublicIP: empty pip.IPAddress for secondary service check")
+			return false, false
+		}
 		return isServiceSelectPIP(service, pip, isIPv6), false
 	}
 
 	// if the pip has no tags, it should be user-created
+	// For user-created PIPs, we need a valid IP address to match against
+	if pip.PublicIPAddressPropertiesFormat == nil || pointer.StringDeref(pip.IPAddress, "") == "" {
+		klog.V(4).Infof("serviceOwnsPublicIP: empty pip.IPAddress for untagged PIP")
+		return false, true
+	}
 	return isServiceSelectPIP(service, pip, isIPv6), true
 }
 

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -5425,10 +5425,19 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 		{
 			desc:         "shall update pip tags if there is any change",
 			pipName:      "pip1",
-			existingPIPs: []network.PublicIPAddress{{Name: pointer.String("pip1"), Tags: map[string]*string{"a": pointer.String("b")}}},
+			existingPIPs: []network.PublicIPAddress{{
+				Name: pointer.String("pip1"), 
+				Tags: map[string]*string{
+					"a": pointer.String("b"),
+					consts.ServiceTagKey: pointer.String("default/test1"),
+				},
+			}},
 			expectedPIP: &network.PublicIPAddress{
 				Name: pointer.String("pip1"),
-				Tags: map[string]*string{"a": pointer.String("c")},
+				Tags: map[string]*string{
+					"a": pointer.String("c"),
+					consts.ServiceTagKey: pointer.String("default/test1"),
+				},
 				ID:   pointer.String(expectedPIPID),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv4,

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -5176,6 +5176,7 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			foundDNSLabelAnnotation: true,
 			existingPIPs: []network.PublicIPAddress{{
 				Name:                            pointer.String("pip1"),
+				Tags:                            map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{},
 			}},
 			expectedPIP: &network.PublicIPAddress{
@@ -5187,7 +5188,10 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 					},
 					PublicIPAddressVersion: network.IPv4,
 				},
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("default/test1")},
+				Tags: map[string]*string{
+					consts.ServiceUsingDNSKey: pointer.String("default/test1"),
+					consts.ServiceTagKey:      pointer.String("default/test1"),
+				},
 			},
 			shouldPutPIP: true,
 		},
@@ -5245,6 +5249,7 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			isIPv6:                  true,
 			existingPIPs: []network.PublicIPAddress{{
 				Name:                            pointer.String("pip1"),
+				Tags:                            map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{},
 			}},
 			expectedPIP: &network.PublicIPAddress{
@@ -5257,7 +5262,10 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 					PublicIPAllocationMethod: network.Dynamic,
 					PublicIPAddressVersion:   network.IPv6,
 				},
-				Tags: map[string]*string{consts.ServiceUsingDNSKey: pointer.String("default/test1")},
+				Tags: map[string]*string{
+					consts.ServiceUsingDNSKey: pointer.String("default/test1"),
+					consts.ServiceTagKey:      pointer.String("default/test1"),
+				},
 			},
 			shouldPutPIP: true,
 		},
@@ -5269,6 +5277,7 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			isIPv6:                  true,
 			existingPIPs: []network.PublicIPAddress{{
 				Name: pointer.String("pip1"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
 						DomainNameLabel: pointer.String("previousdns"),
@@ -5287,6 +5296,7 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 				},
 				Tags: map[string]*string{
 					"k8s-azure-dns-label-service": pointer.String("default/test1"),
+					consts.ServiceTagKey:          pointer.String("default/test1"),
 				},
 			},
 			shouldPutPIP: true,
@@ -5298,8 +5308,8 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			foundDNSLabelAnnotation: true,
 			isIPv6:                  false,
 			existingPIPs: []network.PublicIPAddress{{
-
 				Name: pointer.String("pip1"),
+				Tags: map[string]*string{consts.ServiceTagKey: pointer.String("default/test1")},
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					DNSSettings: &network.PublicIPAddressDNSSettings{
 						DomainNameLabel: pointer.String("previousdns"),
@@ -5320,6 +5330,7 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 				},
 				Tags: map[string]*string{
 					"k8s-azure-dns-label-service": pointer.String("default/test1"),
+					consts.ServiceTagKey:          pointer.String("default/test1"),
 				},
 			},
 			shouldPutPIP: true,
@@ -5423,22 +5434,22 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			shouldPutPIP: true,
 		},
 		{
-			desc:         "shall update pip tags if there is any change",
-			pipName:      "pip1",
+			desc:    "shall update pip tags if there is any change",
+			pipName: "pip1",
 			existingPIPs: []network.PublicIPAddress{{
-				Name: pointer.String("pip1"), 
+				Name: pointer.String("pip1"),
 				Tags: map[string]*string{
-					"a": pointer.String("b"),
+					"a":                  pointer.String("b"),
 					consts.ServiceTagKey: pointer.String("default/test1"),
 				},
 			}},
 			expectedPIP: &network.PublicIPAddress{
 				Name: pointer.String("pip1"),
 				Tags: map[string]*string{
-					"a": pointer.String("c"),
+					"a":                  pointer.String("c"),
 					consts.ServiceTagKey: pointer.String("default/test1"),
 				},
-				ID:   pointer.String(expectedPIPID),
+				ID: pointer.String(expectedPIPID),
 				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 					PublicIPAddressVersion:   network.IPv4,
 					PublicIPAllocationMethod: network.Static,


### PR DESCRIPTION
…ing the ownership

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

We shouldn't return early when pip.publicIPAddress is empty when checking the ownership because there could be pip in failed state without this field. In this case, we need to remove them when reconciling the corresponding service.
Original change: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/9357/files
Fixed the unit test failures introduced by above change.
Manually tested to ensure effective.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Do not return early when pip.publicIPAddress is empty when checking the ownership
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

