### PR TITLE
[release-1.34] Clean backend pool node destination while reconciling security group

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -142,6 +142,7 @@ type Cloud struct {
 	pipCache azcache.Resource
 	// Add service lister to always get latest service
 	serviceLister corelisters.ServiceLister
+	nodeLister    corelisters.NodeLister
 	// node-sync-loop routine and service-reconcile routine should not update LoadBalancer at the same time
 	serviceReconcileLock sync.Mutex
 
@@ -722,6 +723,7 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	az.nodeInformerSynced = nodeInformer.HasSynced
 
 	az.serviceLister = informerFactory.Core().V1().Services().Lister()
+	az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
 
 	az.setUpEndpointSlicesInformer(informerFactory)
 }

--- a/pkg/provider/azure_fakes.go
+++ b/pkg/provider/azure_fakes.go
@@ -172,6 +172,7 @@ func GetTestCloud(ctrl *gomock.Controller) (az *Cloud) {
 		kubeClient := fake.NewSimpleClientset() // FIXME: inject kubeClient
 		informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 		az.serviceLister = informerFactory.Core().V1().Services().Lister()
+		az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
 		informerFactory.Start(wait.NeverStop)
 		informerFactory.WaitForCacheSync(wait.NeverStop)
 	}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3201,6 +3201,25 @@ func (az *Cloud) reconcileSecurityGroup(
 		}
 	}
 
+	{
+		// Retain all destinations that are managed by cloud-provider.
+		managedDestinations, err := az.listAvailableSecurityGroupDestinations(ctx)
+		if err != nil {
+			logger.Error(err, "Failed to list available security group destinations")
+			return nil, err
+		}
+
+		managedDestinations = append(managedDestinations, lbIPAddresses...)
+		managedDestinations = append(managedDestinations, additionalIPs...)
+		logger.Info("Retaining security group", "managed-destinations", managedDestinations)
+
+		ipv4Addresses, ipv6Addresses := iputil.GroupAddressesByFamily(managedDestinations)
+		if err := accessControl.RetainSecurityGroup(ipv4Addresses, ipv6Addresses); err != nil {
+			logger.Error(err, "Failed to retain security group")
+			return nil, err
+		}
+	}
+
 	rv, updated, err := accessControl.SecurityGroup()
 	if err != nil {
 		err = fmt.Errorf("unable to apply access control configuration to security group: %w", err)

--- a/pkg/provider/loadbalancer/accesscontrol.go
+++ b/pkg/provider/loadbalancer/accesscontrol.go
@@ -326,6 +326,28 @@ func (ac *AccessControl) CleanSecurityGroup(
 	return nil
 }
 
+// RetainSecurityGroup retains the given destination IP addresses from the SecurityGroup.
+func (ac *AccessControl) RetainSecurityGroup(dstIPv4Addresses, dstIPv6Addresses []netip.Addr) error {
+	logger := ac.logger.WithName("RetainSecurityGroup").
+		WithValues("num-dst-ipv4-addresses", len(dstIPv4Addresses)).
+		WithValues("num-dst-ipv6-addresses", len(dstIPv6Addresses))
+	logger.V(10).Info("Start retaining")
+	defer logger.V(10).Info("Completed retaining")
+
+	var (
+		ipv4Prefixes     = fnutil.Map(func(addr netip.Addr) string { return addr.String() }, dstIPv4Addresses)
+		ipv6Prefixes     = fnutil.Map(func(addr netip.Addr) string { return addr.String() }, dstIPv6Addresses)
+		retainedPrefixes = append(ipv4Prefixes, ipv6Prefixes...)
+	)
+
+	if err := ac.sgHelper.RetainDestinationFromRules(retainedPrefixes); err != nil {
+		logger.Error(err, "Failed to retain destination from rules")
+		return err
+	}
+
+	return nil
+}
+
 // SecurityGroup returns the SecurityGroup object with patched rules and indicates if the rules had been changed.
 // There are mainly two operations to alter the SecurityGroup:
 // 1. `PatchSecurityGroup`: Add rules for the given destination IP addresses.

--- a/pkg/provider/securitygroup/securityrule_test.go
+++ b/pkg/provider/securitygroup/securityrule_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securitygroup
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetDestinationPortRanges(t *testing.T) {
+	t.Parallel()
+
+	var (
+		makeSecurityRule = func(mutates ...func(*armnetwork.SecurityRule)) *armnetwork.SecurityRule {
+			rv := &armnetwork.SecurityRule{
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Access:                     to.Ptr(armnetwork.SecurityRuleAccessAllow),
+					Direction:                  to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					Protocol:                   to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+					Priority:                   to.Ptr(int32(100)),
+					SourcePortRange:            to.Ptr("*"),
+					SourceAddressPrefixes:      to.SliceOfPtrs("10.0.0.1", "192.168.0.0/16", "AzureLoadBalancer"),
+					DestinationAddressPrefixes: to.SliceOfPtrs("10.0.0.2", "20.0.0.0/16", "AzureContainerRegistry"),
+					DestinationPortRanges:      to.SliceOfPtrs("80", "443"),
+				},
+			}
+			for _, mutate := range mutates {
+				mutate(rv)
+			}
+			return rv
+		}
+	)
+
+	tests := []struct {
+		Name       string
+		Rule       *armnetwork.SecurityRule
+		PortRanges []int32
+		Assertions []func(t *testing.T, rule *armnetwork.SecurityRule)
+	}{
+		{
+			Name:       "set one port",
+			Rule:       makeSecurityRule(),
+			PortRanges: []int32{80},
+			Assertions: []func(t *testing.T, rule *armnetwork.SecurityRule){
+				func(t *testing.T, actual *armnetwork.SecurityRule) {
+					expected := makeSecurityRule(func(rule *armnetwork.SecurityRule) {
+						rule.Properties.DestinationPortRanges = to.SliceOfPtrs("80")
+					})
+					assert.Equal(t, expected, actual)
+				},
+			},
+		},
+		{
+			Name:       "set multiple ports",
+			Rule:       makeSecurityRule(),
+			PortRanges: []int32{80, 443},
+			Assertions: []func(t *testing.T, rule *armnetwork.SecurityRule){
+				func(t *testing.T, actual *armnetwork.SecurityRule) {
+					expected := makeSecurityRule(func(rule *armnetwork.SecurityRule) {
+						rule.Properties.DestinationPortRanges = to.SliceOfPtrs("443", "80")
+					})
+					assert.Equal(t, expected, actual)
+				},
+			},
+		},
+		{
+			Name:       "set empty ports",
+			Rule:       makeSecurityRule(),
+			PortRanges: []int32{},
+			Assertions: []func(t *testing.T, rule *armnetwork.SecurityRule){
+				func(t *testing.T, actual *armnetwork.SecurityRule) {
+					expected := makeSecurityRule(func(rule *armnetwork.SecurityRule) {
+						rule.Properties.DestinationPortRanges = []*string{}
+					})
+					assert.Equal(t, expected, actual)
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			SetDestinationPortRanges(tt.Rule, tt.PortRanges)
+
+			for _, assertion := range tt.Assertions {
+				assertion(t, tt.Rule)
+			}
+		})
+	}
+}
+
+func TestSetAsteriskDestinationPortRanges(t *testing.T) {
+	t.Parallel()
+
+	var (
+		makeSecurityRule = func(mutates ...func(*armnetwork.SecurityRule)) *armnetwork.SecurityRule {
+			rv := &armnetwork.SecurityRule{
+				Properties: &armnetwork.SecurityRulePropertiesFormat{
+					Access:                     to.Ptr(armnetwork.SecurityRuleAccessAllow),
+					Direction:                  to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					Protocol:                   to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+					Priority:                   to.Ptr(int32(100)),
+					SourcePortRange:            to.Ptr("*"),
+					SourceAddressPrefixes:      to.SliceOfPtrs("10.0.0.1", "192.168.0.0/16", "AzureLoadBalancer"),
+					DestinationAddressPrefixes: to.SliceOfPtrs("10.0.0.2", "20.0.0.0/16", "AzureContainerRegistry"),
+					DestinationPortRanges:      to.SliceOfPtrs("80", "443"),
+				},
+			}
+			for _, mutate := range mutates {
+				mutate(rv)
+			}
+			return rv
+		}
+	)
+
+	tests := []struct {
+		Name       string
+		Rule       *armnetwork.SecurityRule
+		Assertions []func(t *testing.T, rule *armnetwork.SecurityRule)
+	}{
+		{
+			Name: "set asterisk ports",
+			Rule: makeSecurityRule(),
+			Assertions: []func(t *testing.T, rule *armnetwork.SecurityRule){
+				func(t *testing.T, actual *armnetwork.SecurityRule) {
+					expected := makeSecurityRule(func(rule *armnetwork.SecurityRule) {
+						rule.Properties.DestinationPortRange = to.Ptr("*")
+						rule.Properties.DestinationPortRanges = nil
+					})
+					assert.Equal(t, expected, actual)
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			SetAsteriskDestinationPortRange(tt.Rule)
+
+			for _, assertion := range tt.Assertions {
+				assertion(t, tt.Rule)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

cherry-pick #9417 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Clean backend pool node destination while reconciling security group
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
