### PR TITLE
chore(acr): remove used login server

### DIFF
--- a/pkg/credentialprovider/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure_acr_helper.go
@@ -141,7 +141,6 @@ func receiveChallengeFromLoginServer(serverAddress, scheme string) (*authDirecti
 }
 
 func performTokenExchange(
-	_ string,
 	directive *authDirective,
 	tenant string,
 	accessToken string) (string, error) {

--- a/pkg/credentialprovider/azure_acr_helper_test.go
+++ b/pkg/credentialprovider/azure_acr_helper_test.go
@@ -136,7 +136,7 @@ func TestPerformTokenExchange(t *testing.T) {
 			}))
 			defer server.Close()
 
-			got, err := performTokenExchange(server.URL, &authDirective{realm: server.URL}, "tenant", "token")
+			got, err := performTokenExchange(&authDirective{realm: server.URL}, "tenant", "token")
 			assert.Equal(t, tt.want, got, tt.name)
 			if tt.wantErr != nil {
 				assert.Contains(t, err.Error(), tt.wantErr.Error(), tt.name)

--- a/pkg/credentialprovider/azure_credentials.go
+++ b/pkg/credentialprovider/azure_credentials.go
@@ -211,8 +211,7 @@ func (a *acrProvider) getFromACR(ctx context.Context, loginServer string) (strin
 	}
 
 	klog.V(4).Infof("exchanging an acr refresh_token")
-	registryRefreshToken, err := performTokenExchange(
-		loginServer, directive, a.config.TenantID, armAccessToken.Token)
+	registryRefreshToken, err := performTokenExchange(directive, a.config.TenantID, armAccessToken.Token)
 	if err != nil {
 		klog.Errorf("failed to perform token exchange: %s", err)
 		return "", "", err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This PR removes an unused variable for ACR token exchange. The target domain can be deferred from the realm in the challenge response.


#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
