### PR TITLE
feat: add IsSmbOAuthEnabled parameter in storage account creation

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -77,6 +77,7 @@ type AccountOptions struct {
 	RequireInfrastructureEncryption         *bool
 	AllowSharedKeyAccess                    *bool
 	IsMultichannelEnabled                   *bool
+	IsSmbOAuthEnabled                       *bool
 	KeyName                                 *string
 	KeyVersion                              *string
 	KeyVaultURI                             *string
@@ -602,6 +603,18 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 					File: &armstorage.EncryptionService{Enabled: ptr.To(true)},
 					Blob: &armstorage.EncryptionService{Enabled: ptr.To(true)},
 				},
+			}
+		}
+
+		if accountOptions.IsSmbOAuthEnabled != nil {
+			klog.V(2).Infof("set IsSmbOAuthEnabled(%v) for storage account(%s)", *accountOptions.IsSmbOAuthEnabled, accountName)
+			if cp.Properties.AzureFilesIdentityBasedAuthentication == nil {
+				cp.Properties.AzureFilesIdentityBasedAuthentication = &armstorage.AzureFilesIdentityBasedAuthentication{
+					DirectoryServiceOptions: to.Ptr(armstorage.DirectoryServiceOptionsNone),
+				}
+			}
+			cp.Properties.AzureFilesIdentityBasedAuthentication.SmbOAuthSettings = &armstorage.SmbOAuthSettings{
+				IsSmbOAuthEnabled: accountOptions.IsSmbOAuthEnabled,
 			}
 		}
 

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -423,6 +423,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 		accessTier                      string
 		storageType                     Type
 		requireInfrastructureEncryption *bool
+		isSmbOAuthEnabled               *bool
 		keyVaultURL                     *string
 		sourceAccountName               string
 		accountName                     string
@@ -441,6 +442,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 			storageType:                     StorageTypeBlob,
 			requireInfrastructureEncryption: ptr.To(true),
 			keyVaultURL:                     ptr.To("keyVaultURL"),
+			isSmbOAuthEnabled:               ptr.To(true),
 			resourceGroup:                   "rg",
 			accessTier:                      "AccessTierHot",
 			accountName:                     "",
@@ -565,20 +567,23 @@ func TestEnsureStorageAccount(t *testing.T) {
 			var testAccountOptions *AccountOptions
 			if test.setAccountOptions {
 				testAccountOptions = &AccountOptions{
-					ResourceGroup:             test.resourceGroup,
-					CreatePrivateEndpoint:     test.createPrivateEndpoint,
-					VNetLinkName:              test.vNetLinkName,
-					PublicNetworkAccess:       test.publicNetworkAccess,
-					Name:                      test.accountName,
-					CreateAccount:             test.createAccount,
-					SubscriptionID:            test.subscriptionID,
-					AccessTier:                test.accessTier,
-					StorageType:               test.storageType,
-					EnableBlobVersioning:      ptr.To(true),
-					SoftDeleteBlobs:           7,
-					SoftDeleteContainers:      7,
-					PickRandomMatchingAccount: test.pickRandomMatchingAccount,
-					SourceAccountName:         test.sourceAccountName,
+					ResourceGroup:                   test.resourceGroup,
+					CreatePrivateEndpoint:           test.createPrivateEndpoint,
+					VNetLinkName:                    test.vNetLinkName,
+					PublicNetworkAccess:             test.publicNetworkAccess,
+					Name:                            test.accountName,
+					CreateAccount:                   test.createAccount,
+					SubscriptionID:                  test.subscriptionID,
+					AccessTier:                      test.accessTier,
+					StorageType:                     test.storageType,
+					EnableBlobVersioning:            ptr.To(true),
+					IsSmbOAuthEnabled:               test.isSmbOAuthEnabled,
+					KeyVaultURI:                     test.keyVaultURL,
+					RequireInfrastructureEncryption: test.requireInfrastructureEncryption,
+					SoftDeleteBlobs:                 7,
+					SoftDeleteContainers:            7,
+					PickRandomMatchingAccount:       test.pickRandomMatchingAccount,
+					SourceAccountName:               test.sourceAccountName,
 				}
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
feat: add IsSmbOAuthEnabled parameter in storage account creation


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
