### PR TITLE
Add Interconnect Group infrastructure (placeholder implementation)

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -43,6 +43,8 @@ const (
 	LabelFailureDomainBetaRegion = "failure-domain.beta.kubernetes.io/region"
 	// LabelPlatformSubFaultDomain is the label key of platformSubFaultDomain
 	LabelPlatformSubFaultDomain = "topology.kubernetes.azure.com/sub-fault-domain"
+	// LabelInterconnectGroup is the label key of Interconnect Group
+	LabelInterconnectGroup = "topology.kubernetes.azure.com/interconnect-group"
 
 	// ADFSIdentitySystem is the override value for tenantID on Azure Stack clouds.
 	ADFSIdentitySystem = "adfs"

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -83,3 +83,7 @@ func (np *IMDSNodeProvider) GetZone(ctx context.Context, _ types.NodeName) (clou
 func (np *IMDSNodeProvider) GetPlatformSubFaultDomain(ctx context.Context) (string, error) {
 	return np.azure.GetPlatformSubFaultDomain(ctx)
 }
+
+func (np *IMDSNodeProvider) GetInterconnectGroupId(ctx context.Context) (string, error) {
+	return np.azure.GetInterconnectGroupId(ctx)
+}

--- a/pkg/node/nodearm.go
+++ b/pkg/node/nodearm.go
@@ -87,3 +87,9 @@ func (np *ARMNodeProvider) GetZone(ctx context.Context, name types.NodeName) (cl
 func (np *ARMNodeProvider) GetPlatformSubFaultDomain(_ context.Context) (string, error) {
 	return "", nil
 }
+
+// GetInterconnectGroupId returns the Interconnect Group ID from IMDS if set.
+// ARMNodeProvider doesn't use IMDS, so this always returns empty string.
+func (np *ARMNodeProvider) GetInterconnectGroupId(_ context.Context) (string, error) {
+	return "", nil
+}

--- a/pkg/nodemanager/nodemanager.go
+++ b/pkg/nodemanager/nodemanager.go
@@ -61,6 +61,8 @@ type NodeProvider interface {
 	GetZone(ctx context.Context, name types.NodeName) (cloudprovider.Zone, error)
 	// GetPlatformSubFaultDomain returns the PlatformSubFaultDomain from IMDS if set.
 	GetPlatformSubFaultDomain(ctx context.Context) (string, error)
+	// GetInterconnectGroupId returns the Interconnect Group ID from IMDS if set.
+	GetInterconnectGroupId(ctx context.Context) (string, error)
 }
 
 // labelReconcile holds information about a label to reconcile and how to reconcile it.
@@ -504,6 +506,14 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Co
 		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(consts.LabelPlatformSubFaultDomain, platformSubFaultDomain))
 	}
 
+	interconnectGroupId, err := cnc.getInterconnectGroupId(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get interconnect group ID: %w", err)
+	}
+	if interconnectGroupId != "" {
+		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(consts.LabelInterconnectGroup, interconnectGroupId))
+	}
+
 	return nodeModifiers, nil
 }
 
@@ -649,6 +659,14 @@ func (cnc *CloudNodeController) getPlatformSubFaultDomain(ctx context.Context) (
 		return "", fmt.Errorf("cnc.getPlatformSubfaultDomain: %w", err)
 	}
 	return subFD, nil
+}
+
+func (cnc *CloudNodeController) getInterconnectGroupId(ctx context.Context) (string, error) {
+	ig, err := cnc.nodeProvider.GetInterconnectGroupId(ctx)
+	if err != nil {
+		return "", fmt.Errorf("cnc.getInterconnectGroupId: %w", err)
+	}
+	return ig, nil
 }
 
 func (cnc *CloudNodeController) updateNetworkingCondition(node *v1.Node, networkReady bool) error {

--- a/pkg/provider/azure_instance_metadata.go
+++ b/pkg/provider/azure_instance_metadata.go
@@ -291,3 +291,12 @@ func (az *Cloud) GetPlatformSubFaultDomain(ctx context.Context) (string, error) 
 	}
 	return "", nil
 }
+
+// GetInterconnectGroupId returns the Interconnect Group ID from IMDS if set.
+// TODO: Implement actual IMDS parsing logic when format is finalized.
+// Currently returns empty string to allow infrastructure to be in place.
+func (az *Cloud) GetInterconnectGroupId(ctx context.Context) (string, error) {
+	// Placeholder implementation - returns empty until IMDS format is determined
+	klog.V(4).Infof("GetInterconnectGroupId: placeholder implementation, returning empty")
+	return "", nil
+}

--- a/pkg/provider/azure_instance_metadata_test.go
+++ b/pkg/provider/azure_instance_metadata_test.go
@@ -150,3 +150,17 @@ func TestGetPlatformSubFaultDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestGetInterconnectGroupId(t *testing.T) {
+	// Infrastructure-only test: verifies placeholder implementation returns empty
+	cloud := &Cloud{
+		Config: config.Config{
+			UseInstanceMetadata: true,
+		},
+	}
+
+	id, err := cloud.GetInterconnectGroupId(context.TODO())
+
+	assert.NoError(t, err, "GetInterconnectGroupId should not return error")
+	assert.Equal(t, "", id, "GetInterconnectGroupId should return empty string (placeholder)")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This adds the infrastructure/plumbing code for Interconnect Group node labeling but with a placeholder implementation that returns empty string. This allows the infrastructure to be in place and tested without breaking anything, while the actual IMDS parsing implementation can be added later when the format is finalized.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

N/A (New feature - infrastructure preparation)

#### Special notes for your reviewer:

**Changes:**
- pkg/consts: Add LabelInterconnectGroup constant
- pkg/provider: Add GetInterconnectGroupId method (returns empty)
- pkg/nodemanager: Add GetInterconnectGroupId to interface and integration code
- pkg/node: Implement GetInterconnectGroupId for both IMDS and ARM providers (both return empty)
- pkg/provider: Add minimal unit test

**Behavior:**
- GetInterconnectGroupId() always returns ("", nil)
- No label is applied to nodes
- No errors, nothing breaks
- Infrastructure is ready for future implementation

**This approach allows:**
1. Code review and testing of the infrastructure separately
2. Future IMDS parsing logic to be added without modifying the interface
3. Safe deployment - guaranteed not to break anything
4. No assumptions about IMDS format (no TagsList or other structures added)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```