### PR TITLE
fix(loadbalancer): invalidate PIP cache on external LB frontend IP config changes

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2025,7 +2025,7 @@ func (az *Cloud) reconcileLoadBalancer(ctx context.Context, clusterName string, 
 				pipResourceGroup := az.getPublicIPAddressResourceGroup(service)
 				err = az.pipCache.Delete(pipResourceGroup)
 				if err != nil {
-					logger.Error(err, "Failed to invalidate PIP cache", "lbName", lbName, "pipResourceGroup", pipResourceGroup)
+					logger.V(5).Info("Failed to invalidate PIP cache", "lbName", lbName, "pipResourceGroup", pipResourceGroup, "err", err)
 				} else {
 					logger.V(5).Info("Invalidated PIP cache due to frontend IP config changes in lb", "lbName", lbName, "pipResourceGroup", pipResourceGroup)
 				}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2023,8 +2023,12 @@ func (az *Cloud) reconcileLoadBalancer(ctx context.Context, clusterName string, 
 			// Internal LB changes (subnet/private IP) don't affect PIPs.
 			if fipChanged && !requiresInternalLoadBalancer(service) {
 				pipResourceGroup := az.getPublicIPAddressResourceGroup(service)
-				_ = az.pipCache.Delete(pipResourceGroup)
-				logger.V(2).Info("Invalidated PIP cache due to frontend IP config changes in lb", "lbName", lbName, "pipResourceGroup", pipResourceGroup)
+				err = az.pipCache.Delete(pipResourceGroup)
+				if err != nil {
+					logger.Error(err, "Failed to invalidate PIP cache", "lbName", lbName, "pipResourceGroup", pipResourceGroup)
+				} else {
+					logger.V(5).Info("Invalidated PIP cache due to frontend IP config changes in lb", "lbName", lbName, "pipResourceGroup", pipResourceGroup)
+				}
 			}
 		}
 	}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2018,7 +2018,7 @@ func (az *Cloud) reconcileLoadBalancer(ctx context.Context, clusterName string, 
 
 			addOrUpdateLBInList(&existingLBs, newLB)
 
-			// Invalidate PIP cache only when external PIPs are involved
+			// Invalidate PIP cache only when external LB's frontend IP config is changed
 			// because LB updates modify pip.properties.ipConfiguration.id which changes the PIP etag.
 			// Internal LB changes (subnet/private IP) don't affect PIPs.
 			if fipChanged && !requiresInternalLoadBalancer(service) {

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -3403,7 +3403,7 @@ func getTestLoadBalancer(name, rgName, clusterName, identifier *string, service 
 						DisableOutboundSnat:  ptr.To(false),
 						IdleTimeoutInMinutes: ptr.To(int32(4)),
 						Probe: &armnetwork.SubResource{
-							ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-80"),
+							ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/" + *name + "/probes/aservice1-TCP-80"),
 						},
 					},
 				},
@@ -3460,7 +3460,7 @@ func getTestLoadBalancerDualStack(name, rgName, clusterName, identifier *string,
 			DisableOutboundSnat:  ptr.To(false),
 			IdleTimeoutInMinutes: ptr.To(int32(4)),
 			Probe: &armnetwork.SubResource{
-				ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/testCluster/probes/aservice1-TCP-80-IPv6"),
+				ID: ptr.To("/subscriptions/subscription/resourceGroups/" + *rgName + "/providers/Microsoft.Network/loadBalancers/" + *name + "/probes/aservice1-TCP-80-IPv6"),
 			},
 		},
 	})

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -4221,6 +4221,9 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			expectLBDeleted:       true,
 			expectPIPCacheDeleted: false,
 		},
+		// The following internal LB test cases verify that cache invalidation does NOT occur for internal LBs.
+		// These serve as negative test cases to ensure the cache invalidation for external LBs
+		// doesn't inadvertently affect internal LB behavior.
 		{
 			desc:                  "reconcileLoadBalancer shall not invalidate PIP cache when internal LB creates new frontend",
 			loadBalancerSKU:       "standard",
@@ -4338,7 +4341,7 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 
 			// Populate PIP cache before reconciliation to test cache invalidation.
 			pipResourceGroup := az.getPublicIPAddressResourceGroup(&service)
-			pips, _ := az.listPIP(context.TODO(), pipResourceGroup, 0)
+			pips, _ := az.listPIP(context.TODO(), pipResourceGroup, cache.CacheReadTypeDefault)
 			store := az.pipCache.GetStore()
 			pipCacheEntryBefore, pipCacheExistsBefore, _ := store.GetByKey(pipResourceGroup)
 			assert.True(t, pipCacheExistsBefore, "Cache should exist before reconciliation")

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -247,7 +247,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		serviceDomainName = utils.GetServiceDomainName(serviceDomainNamePrefix)
+		serviceDomainName = utils.GetServiceDomainName(fmt.Sprintf("%s-new", serviceDomainNamePrefix))
 		By(fmt.Sprintf("Validating External domain name %q", serviceDomainName))
 		err = utils.ValidateServiceConnectivity(ns.Name, agnhostPod, serviceDomainName, int(ports[0].Port), v1.ProtocolTCP)
 		Expect(err).NotTo(HaveOccurred(), "Fail to get response from the domain name")

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -243,11 +243,12 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		Expect(err).NotTo(HaveOccurred(), "Fail to get response from the domain name")
 
 		By("Update service")
-		service.Annotations[consts.ServiceAnnotationDNSLabelName] = fmt.Sprintf("%s-new", serviceDomainNamePrefix)
+		newServiceDomainNamePrefix := fmt.Sprintf("%s-new", serviceDomainNamePrefix)
+		service.Annotations[consts.ServiceAnnotationDNSLabelName] = newServiceDomainNamePrefix
 		_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		serviceDomainName = utils.GetServiceDomainName(fmt.Sprintf("%s-new", serviceDomainNamePrefix))
+		serviceDomainName = utils.GetServiceDomainName(newServiceDomainNamePrefix)
 		By(fmt.Sprintf("Validating External domain name %q", serviceDomainName))
 		err = utils.ValidateServiceConnectivity(ns.Name, agnhostPod, serviceDomainName, int(ports[0].Port), v1.ProtocolTCP)
 		Expect(err).NotTo(HaveOccurred(), "Fail to get response from the domain name")

--- a/tests/e2e/utils/service_utils.go
+++ b/tests/e2e/utils/service_utils.go
@@ -37,8 +37,6 @@ import (
 const (
 	serviceTimeout        = 5 * time.Minute
 	serviceTimeoutBasicLB = 10 * time.Minute
-	pullInterval          = 10 * time.Second
-	pullTimeout           = 3 * time.Minute
 
 	ExecAgnhostPod = "exec-agnhost-pod"
 )
@@ -220,7 +218,7 @@ func ValidateServiceConnectivity(ns, execPod, serviceIP string, port int, protoc
 		udpOption = "-u"
 	}
 	cmd := fmt.Sprintf(`nc -vz -w 4 %s %s %d`, udpOption, serviceIP, port)
-	pollErr := wait.PollImmediate(pullInterval, 3*pullTimeout, func() (bool, error) {
+	pollErr := wait.PollImmediate(pollInterval, 2*pollTimeout, func() (bool, error) {
 		stdout, err := RunKubectl(ns, "exec", execPod, "--", "/bin/sh", "-x", "-c", cmd)
 		if err != nil {
 			Logf("got error %v, will retry, output: %s", err, stdout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a load balancer (LB) is reconciled and it changes its `frontendIPConfig`, the associated public IP (PIP) will also be updated which causes its etag to change. The following will reproduce PreconditionFailed error when doing `CreateOrUpdatePIP`:
1. create a user-assigned PIP.
1. create "old" service with dns label and ip annotation for the PIP.
1. delete the "old" service.
1. create a "new" service with the same annotation.
1. patch the "new" service dns label annotation.

`ensurePublicIPExists` has `changed` variable to track PIP changes. On the steps above, when creating the "new" service with the user-assigned PIP and the same DNS name, `changed` will be false. But LB will update its `frontendIPConfig` which affects the PIP to change the etag. The PIP etag is now stale.
When updating the "new" service to use a different DNS name, `changed` will be true and it updates using the stale etag which will result in this error.

This PR invalidates the PIP cache if external load balancer changes its `frontendIPConfig` and adds the corresponding unit tests. It also corrects the E2E DNS validation after a service changes its DNS annotation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9729

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: invalidate PIP cache on external LB frontend IP config changes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
