### PR TITLE
fix(helpers): fix documentation for no_lb_rule helper

### DIFF
--- a/pkg/consts/helpers.go
+++ b/pkg/consts/helpers.go
@@ -50,7 +50,7 @@ func IsHealthProbeRuleOnK8sServicePortDisabled(annotations map[string]string, po
 	return expectAttributeInSvcAnnotationBeEqualTo(annotations, BuildAnnotationKeyForPort(port, PortAnnotationNoHealthProbeRule), TrueAnnotationValue), nil
 }
 
-// IsHealthProbeRuleOnK8sServicePortDisabled return if port is for health probe only
+// IsLBRuleOnK8sServicePortDisabled return if port should have no rule in load balancer
 func IsLBRuleOnK8sServicePortDisabled(annotations map[string]string, port int32) (bool, error) {
 	return expectAttributeInSvcAnnotationBeEqualTo(annotations, BuildAnnotationKeyForPort(port, PortAnnotationNoLBRule), TrueAnnotationValue), nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
The documentation comment for the helper that checks whether the no_lb_rule annotation is present currently has copy-pasted code from the helper for checking if the annotation for the probe_rule is set.

This commit fixes the comment.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
