### PR TITLE
fix(multi-slb): support IP sharing across multiple services

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2541,8 +2541,11 @@ func (az *Cloud) recordExistingNodesOnLoadBalancers(clusterName string, lbs []*a
 	return nil
 }
 
-// lbHasServiceOwnedResources returns true if any load-balancing rule or probe
-// on the given LB is owned by the service (matched by name prefix).
+// lbHasServiceOwnedResources returns true if any load-balancing rule or
+// probe on the given LB is owned by the service (matched by name prefix).
+// The shared health probe is skipped: if the service uses it, there must
+// also be a service-owned rule referencing it, which the rule check
+// already catches.
 func (az *Cloud) lbHasServiceOwnedResources(lb *armnetwork.LoadBalancer, service *v1.Service) bool {
 	if lb.Properties == nil {
 		return false
@@ -2553,7 +2556,9 @@ func (az *Cloud) lbHasServiceOwnedResources(lb *armnetwork.LoadBalancer, service
 		}
 	}
 	for _, probe := range lb.Properties.Probes {
-		if probe.Name != nil && az.serviceOwnsRule(service, *probe.Name) {
+		if probe.Name != nil &&
+			!strings.EqualFold(*probe.Name, consts.SharedProbeName) &&
+			az.serviceOwnsRule(service, *probe.Name) {
 			return true
 		}
 	}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -846,11 +846,8 @@ func (az *Cloud) getServiceLoadBalancer(
 
 				deletedLBName, deletedPLS, err := az.removeStaleServiceLBResources(ctx, existingLB, existingLBs, clusterName, service)
 				if err != nil {
-					logger.Error(err, "failed to remove stale service resources from old load balancer",
-						"service", service.Name,
-						"oldLB", ptr.Deref(existingLB.Name, ""),
-					)
-					return nil, nil, nil, nil, false, false, err
+					return nil, nil, nil, nil, false, false, fmt.Errorf("remove stale service resources from load balancer %q for service %q: %w",
+						ptr.Deref(existingLB.Name, ""), getServiceName(service), err)
 				}
 				if deletedPLS {
 					return nil, nil, nil, nil, false, true, nil
@@ -877,13 +874,14 @@ func (az *Cloud) getServiceLoadBalancer(
 					if az.backendPoolUpdater != nil {
 						az.backendPoolUpdater.removeOperation(svcName)
 					}
-					newLBs, err := az.cleanupLocalServiceBackendPool(ctx, service, nodes, existingLBs, clusterName)
-					if err != nil {
-						logger.Error(err, "failed to clean up backend pool for local service",
-							"service", service.Name, "oldLB", ptr.Deref(existingLB.Name, ""))
-						return nil, nil, nil, nil, false, false, err
+					if deletedLBName == "" {
+						newLBs, err := az.cleanupLocalServiceBackendPool(ctx, service, nodes, existingLBs, clusterName)
+						if err != nil {
+							return nil, nil, nil, nil, false, false, fmt.Errorf("clean up backend pool for local service %q on load balancer %q: %w",
+								getServiceName(service), ptr.Deref(existingLB.Name, ""), err)
+						}
+						existingLBs = newLBs
 					}
-					existingLBs = newLBs
 				}
 			}
 			continue
@@ -913,7 +911,7 @@ func (az *Cloud) getServiceLoadBalancer(
 					}
 					if unsafe {
 						return nil, nil, nil, nil, false, false, fmt.Errorf(
-							"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+							"service %q cannot migrate from load balancer %q to %q because frontend IP %q is also referenced by other resources; "+
 								"remove the %s annotation to stay on load balancer %q",
 							service.Name, ptr.Deref(existingLB.Name, ""), defaultLBName, ptr.Deref(fip.Name, ""),
 							consts.ServiceAnnotationLoadBalancerConfigurations, ptr.Deref(existingLB.Name, ""))
@@ -2607,11 +2605,8 @@ func (az *Cloud) removeStaleServiceLBResources(
 			}
 			unsafe, err := az.isFrontendIPConfigUnsafeToDelete(lb, service, fip.ID)
 			if err != nil {
-				logger.Error(err, "failed to check if FIP is safe to delete",
-					"fipID", ptr.Deref(fip.ID, ""),
-					"lbName", ptr.Deref(lb.Name, ""),
-				)
-				continue
+				return "", false, fmt.Errorf("check if frontend IP configuration %q on load balancer %q is safe to delete: %w",
+					ptr.Deref(fip.ID, ""), ptr.Deref(lb.Name, ""), err)
 			}
 			if !unsafe {
 				orphanedFIPs = append(orphanedFIPs, fip)
@@ -2624,21 +2619,13 @@ func (az *Cloud) removeStaleServiceLBResources(
 	if len(orphanedFIPs) > 0 {
 		deletedLBName, deletedPLS, err := az.removeFrontendIPConfigurationFromLoadBalancer(ctx, lb, existingLBs, orphanedFIPs, clusterName, service)
 		if err != nil {
-			logger.Error(err, "failed to remove orphaned frontend IP configurations",
-				"lbName", ptr.Deref(lb.Name, ""),
-				"serviceName", serviceName,
-			)
-			return "", false, err
+			return "", false, fmt.Errorf("remove orphaned frontend IP configurations: %w", err)
 		}
 		return deletedLBName, deletedPLS, nil
 	}
 
 	// 5. No orphaned FIPs, just update the LB with the rule/probe changes.
 	if err := az.CreateOrUpdateLB(ctx, service, *lb); err != nil {
-		logger.Error(err, "failed to update load balancer to remove stale service resources",
-			"lbName", ptr.Deref(lb.Name, ""),
-			"serviceName", serviceName,
-		)
 		return "", false, err
 	}
 	logger.V(2).Info("Updated load balancer to remove stale service resources",
@@ -4514,7 +4501,7 @@ func getMostEligibleLBForService(
 ) string {
 	logger := log.Background().WithName("getMostEligibleLBForService")
 	// 1. If the LB is eligible and being used, choose it.
-	if StringInSlice(currentLBName, eligibleLBs) {
+	if StringInSliceIgnoreCase(currentLBName, eligibleLBs) {
 		logger.V(4).Info("choose LB as it is eligible and being used", "currentLBName", currentLBName)
 		return currentLBName
 	}
@@ -4542,7 +4529,7 @@ func getMostEligibleLBForService(
 	ruleCount := 301
 	for i := range existingLBs {
 		existingLB := existingLBs[i]
-		if StringInSlice(trimSuffixIgnoreCase(ptr.Deref(existingLB.Name, ""), consts.InternalLoadBalancerNameSuffix), eligibleLBs) &&
+		if StringInSliceIgnoreCase(trimSuffixIgnoreCase(ptr.Deref(existingLB.Name, ""), consts.InternalLoadBalancerNameSuffix), eligibleLBs) &&
 			isInternalLoadBalancer(existingLB) == isInternal {
 			if existingLB.Properties != nil &&
 				existingLB.Properties.LoadBalancingRules != nil {

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -844,13 +844,16 @@ func (az *Cloud) getServiceLoadBalancer(
 				az.shouldChangeLoadBalancer(service, ptr.Deref(existingLB.Name, ""), clusterName, defaultLBName) &&
 				az.lbHasServiceOwnedResources(existingLB, service) {
 
-				deletedLBName, err := az.removeStaleServiceLBResources(ctx, existingLB, existingLBs, clusterName, service)
+				deletedLBName, deletedPLS, err := az.removeStaleServiceLBResources(ctx, existingLB, existingLBs, clusterName, service)
 				if err != nil {
 					logger.Error(err, "failed to remove stale service resources from old load balancer",
 						"service", service.Name,
 						"oldLB", ptr.Deref(existingLB.Name, ""),
 					)
 					return nil, nil, nil, nil, false, false, err
+				}
+				if deletedPLS {
+					return nil, nil, nil, nil, false, true, nil
 				}
 				logger.V(2).Info("Removed stale service resources from old load balancer",
 					"service", service.Name,
@@ -2570,7 +2573,7 @@ func (az *Cloud) removeStaleServiceLBResources(
 	existingLBs []*armnetwork.LoadBalancer,
 	clusterName string,
 	service *v1.Service,
-) (string, error) {
+) (string, bool /* deletedPLS */, error) {
 	logger := log.FromContextOrBackground(ctx).WithName("removeStaleServiceLBResources")
 	serviceName := getServiceName(service)
 
@@ -2592,7 +2595,7 @@ func (az *Cloud) removeStaleServiceLBResources(
 	dirtyRules := az.reconcileLBRules(lb, service, serviceName, false, nil)
 
 	if !dirtyProbes && !dirtyRules {
-		return "", nil
+		return "", false, nil
 	}
 
 	// 3. Check if any affected FIPs are now safe to delete.
@@ -2619,21 +2622,15 @@ func (az *Cloud) removeStaleServiceLBResources(
 	// 4. If there are orphaned FIPs, delegate to removeFrontendIPConfigurationFromLoadBalancer
 	// which handles FIP removal, PLS cleanup, empty-LB deletion, and the LB API call.
 	if len(orphanedFIPs) > 0 {
-		deletedLBName, _, err := az.removeFrontendIPConfigurationFromLoadBalancer(ctx, lb, existingLBs, orphanedFIPs, clusterName, service)
+		deletedLBName, deletedPLS, err := az.removeFrontendIPConfigurationFromLoadBalancer(ctx, lb, existingLBs, orphanedFIPs, clusterName, service)
 		if err != nil {
 			logger.Error(err, "failed to remove orphaned frontend IP configurations",
 				"lbName", ptr.Deref(lb.Name, ""),
 				"serviceName", serviceName,
 			)
-			return "", err
+			return "", false, err
 		}
-		logger.V(2).Info("Removed orphaned frontend IP configurations along with stale service resources",
-			"lbName", ptr.Deref(lb.Name, ""),
-			"serviceName", serviceName,
-			"orphanedFIPs", len(orphanedFIPs),
-			"deletedLB", deletedLBName,
-		)
-		return deletedLBName, nil
+		return deletedLBName, deletedPLS, nil
 	}
 
 	// 5. No orphaned FIPs, just update the LB with the rule/probe changes.
@@ -2642,7 +2639,7 @@ func (az *Cloud) removeStaleServiceLBResources(
 			"lbName", ptr.Deref(lb.Name, ""),
 			"serviceName", serviceName,
 		)
-		return "", err
+		return "", false, err
 	}
 	logger.V(2).Info("Updated load balancer to remove stale service resources",
 		"lbName", ptr.Deref(lb.Name, ""),
@@ -2661,7 +2658,7 @@ func (az *Cloud) removeStaleServiceLBResources(
 			"lbName", lbName,
 		)
 	}
-	return "", nil
+	return "", false, nil
 }
 
 func (az *Cloud) reconcileMultipleStandardLoadBalancerConfigurationStatus(wantLb bool, svcName, lbName string) {

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -4362,11 +4362,15 @@ func (az *Cloud) getAzureLoadBalancerName(
 
 		// If service specifies an IP, find which LB has that IP. The service should use the LB where the IP resides.
 		// This also detects secondary services sharing an IP with a primary service already on an LB.
-		if pinsIP {
+		// Skip when cleaning up (wantLb=false), ActiveServices should have the correct currentLBName.
+		if wantLb && pinsIP {
 			if requiresInternalLoadBalancer(service) {
 				currentLBName = az.getLoadBalancerNameByPrivateIP(ctx, service, existingLBs)
 			} else {
-				currentLBName = az.getLoadBalancerNameByPublicIP(ctx, service, clusterName)
+				currentLBName, err = az.getLoadBalancerNameByPublicIP(ctx, service, clusterName)
+				if err != nil {
+					return "", fmt.Errorf("look up load balancer by public IP for service %q: %w", service.Name, err)
+				}
 			}
 			// Block service if the IP resides on an LB that's not eligible.
 			if currentLBName != "" && !StringInSliceIgnoreCase(currentLBName, eligibleLBs) {
@@ -4428,7 +4432,7 @@ func (az *Cloud) getLoadBalancerNameByPublicIP(
 	ctx context.Context,
 	service *v1.Service,
 	clusterName string,
-) string {
+) (string, error) {
 	logger := log.FromContextOrBackground(ctx).WithName("getLoadBalancerNameByPublicIP")
 
 	loadBalancerIPs := getServiceLoadBalancerIPs(service)
@@ -4439,12 +4443,11 @@ func (az *Cloud) getLoadBalancerNameByPublicIP(
 		}
 		pip, err := az.findMatchedPIP(ctx, ip, "", pipResourceGroup)
 		if err != nil {
-			logger.V(2).Info("Failed to find PIP by IP", "ip", ip, "error", err)
-			continue
+			return "", fmt.Errorf("find public IP by address %q: %w", ip, err)
 		}
 		if lbName := az.getLoadBalancerNameFromPIP(pip, clusterName); lbName != "" {
 			logger.V(2).Info("Found LB from PIP by IP", "service", service.Name, "pip", ptr.Deref(pip.Name, ""), "lbName", lbName)
-			return lbName
+			return lbName, nil
 		}
 	}
 
@@ -4455,16 +4458,15 @@ func (az *Cloud) getLoadBalancerNameByPublicIP(
 		}
 		pip, err := az.findMatchedPIP(ctx, "", pipName, pipResourceGroup)
 		if err != nil {
-			logger.V(2).Info("Failed to find PIP by name", "pipName", pipName, "error", err)
-			continue
+			return "", fmt.Errorf("find public IP by name %q: %w", pipName, err)
 		}
 		if lbName := az.getLoadBalancerNameFromPIP(pip, clusterName); lbName != "" {
 			logger.V(2).Info("Found LB from PIP by name", "service", service.Name, "pip", pipName, "lbName", lbName)
-			return lbName
+			return lbName, nil
 		}
 	}
 
-	return ""
+	return "", nil
 }
 
 // getLoadBalancerNameFromPIP extracts the LB name from the PIP's IPConfiguration.

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -793,7 +793,7 @@ func (az *Cloud) getServiceLoadBalancer(
 	isInternal := requiresInternalLoadBalancer(service)
 	var defaultLB *armnetwork.LoadBalancer
 	primaryVMSetName := az.VMSet.GetPrimaryVMSetName()
-	defaultLBName, err := az.getAzureLoadBalancerName(ctx, service, existingLBs, clusterName, primaryVMSetName, isInternal)
+	defaultLBName, err := az.getAzureLoadBalancerName(ctx, service, existingLBs, clusterName, primaryVMSetName, isInternal, wantLb)
 	if err != nil {
 		return nil, nil, nil, nil, false, false, err
 	}
@@ -807,10 +807,20 @@ func (az *Cloud) getServiceLoadBalancer(
 		existingLBs = lbs
 	}
 
+	// A service must use the LB that owns its IP. In IP-pinned multi-SLB scenario,
+	// The service may currently exist on a different LB needing migration,
+	// so all LBs should be scanned instead of returning on the first match.
+	lbIPs := getServiceLoadBalancerIPs(service)
+	pipNames := getServicePIPNames(service)
+	pinsIP := len(lbIPs) > 0 || len(pipNames) > 0
+	isPinnedIPMultiSLB := wantLb && az.UseMultipleStandardLoadBalancers() && pinsIP
+	var defaultLBStatus *v1.LoadBalancerStatus
+	var defaultLBIPsPrimaryPIPs []string
+
 	// check if the service already has a load balancer
 	var shouldChangeLB bool
-	for i := range existingLBs {
-		existingLB := (existingLBs)[i]
+	for i := len(existingLBs) - 1; i >= 0; i-- {
+		existingLB := existingLBs[i]
 
 		if strings.EqualFold(*existingLB.Name, defaultLBName) {
 			defaultLB = existingLB
@@ -825,7 +835,54 @@ func (az *Cloud) getServiceLoadBalancer(
 			return nil, nil, nil, nil, false, false, err
 		}
 		if status == nil {
-			// service is not on this load balancer
+			// Service is not on this LB by frontend IP ownership.
+			// However, if multi-SLB is enabled and the service should move to a
+			// different LB, the old LB may still have stale rules/probes left
+			// from when the service shared a frontend IP. Remove them to
+			// prevent orphaned rules and probes on the old LB.
+			if wantLb && az.UseMultipleStandardLoadBalancers() &&
+				az.shouldChangeLoadBalancer(service, ptr.Deref(existingLB.Name, ""), clusterName, defaultLBName) &&
+				az.lbHasServiceOwnedResources(existingLB, service) {
+
+				deletedLBName, err := az.removeStaleServiceLBResources(ctx, existingLB, existingLBs, clusterName, service)
+				if err != nil {
+					logger.Error(err, "failed to remove stale service resources from old load balancer",
+						"service", service.Name,
+						"oldLB", ptr.Deref(existingLB.Name, ""),
+					)
+					return nil, nil, nil, nil, false, false, err
+				}
+				logger.V(2).Info("Removed stale service resources from old load balancer",
+					"service", service.Name,
+					"oldLB", ptr.Deref(existingLB.Name, ""),
+					"targetLB", defaultLBName,
+				)
+
+				if deletedLBName != "" {
+					removeLBFromList(&existingLBs, deletedLBName)
+				}
+
+				az.reconcileMultipleStandardLoadBalancerConfigurationStatus(
+					false,
+					getServiceName(service),
+					ptr.Deref(existingLB.Name, ""),
+				)
+
+				// Same backend pool cleanup as the normal LB migration path below.
+				if isLocalService(service) {
+					svcName := getServiceName(service)
+					if az.backendPoolUpdater != nil {
+						az.backendPoolUpdater.removeOperation(svcName)
+					}
+					newLBs, err := az.cleanupLocalServiceBackendPool(ctx, service, nodes, existingLBs, clusterName)
+					if err != nil {
+						logger.Error(err, "failed to clean up backend pool for local service",
+							"service", service.Name, "oldLB", ptr.Deref(existingLB.Name, ""))
+						return nil, nil, nil, nil, false, false, err
+					}
+					existingLBs = newLBs
+				}
+			}
 			continue
 		}
 		logger.V(4).Info(
@@ -843,6 +900,24 @@ func (az *Cloud) getServiceLoadBalancer(
 			err           error
 		)
 		if wantLb && az.shouldChangeLoadBalancer(service, ptr.Deref(existingLB.Name, ""), clusterName, defaultLBName) {
+			// Block migration if the frontend IP is unsafe to delete
+			// (shared with other services, or referenced by outbound/NAT rules).
+			if az.UseMultipleStandardLoadBalancers() {
+				for _, fip := range fipConfigs {
+					unsafe, err := az.isFrontendIPConfigUnsafeToDelete(existingLB, service, fip.ID)
+					if err != nil {
+						return nil, nil, nil, nil, false, false, err
+					}
+					if unsafe {
+						return nil, nil, nil, nil, false, false, fmt.Errorf(
+							"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+								"remove the %s annotation to stay on load balancer %q",
+							service.Name, ptr.Deref(existingLB.Name, ""), defaultLBName, ptr.Deref(fip.Name, ""),
+							consts.ServiceAnnotationLoadBalancerConfigurations, ptr.Deref(existingLB.Name, ""))
+					}
+				}
+			}
+
 			shouldChangeLB = true
 			fipConfigNames := []string{}
 			for _, fipConfig := range fipConfigs {
@@ -884,10 +959,25 @@ func (az *Cloud) getServiceLoadBalancer(
 					existingLBs = newLBs
 				}
 			}
+
+			if isPinnedIPMultiSLB {
+				continue
+			}
+
 			break
 		}
 
+		if isPinnedIPMultiSLB {
+			defaultLBStatus = status
+			defaultLBIPsPrimaryPIPs = lbIPsPrimaryPIPs
+			continue
+		}
+
 		return existingLB, existingLBs, status, lbIPsPrimaryPIPs, true, false, nil
+	}
+
+	if isPinnedIPMultiSLB && defaultLB != nil && defaultLBStatus != nil {
+		return defaultLB, existingLBs, defaultLBStatus, defaultLBIPsPrimaryPIPs, true, false, nil
 	}
 
 	// Service does not have a load balancer, select one.
@@ -963,7 +1053,8 @@ func (az *Cloud) selectLoadBalancer(ctx context.Context, clusterName string, ser
 	}
 	selectedLBRuleCount := math.MaxInt32
 	for _, currVMSetName := range vmSetNames {
-		currLBName, _ := az.getAzureLoadBalancerName(ctx, service, existingLBs, clusterName, *currVMSetName, isInternal)
+		// selectLoadBalancer is only called when wantLb=true (see caller check), so pass true for wantLb.
+		currLBName, _ := az.getAzureLoadBalancerName(ctx, service, existingLBs, clusterName, *currVMSetName, isInternal, true /* wantLb */)
 		lb, exists := mapExistingLBs[currLBName]
 		if !exists {
 			// select this LB as this is a new LB and will have minimum rules
@@ -1968,7 +2059,8 @@ func (az *Cloud) reconcileLoadBalancer(ctx context.Context, clusterName string, 
 		dirtyLb = true
 	}
 
-	if changed := az.reconcileLBRules(lb, service, serviceName, wantLb, expectedRules); changed {
+	lbRulesChanged := az.reconcileLBRules(lb, service, serviceName, wantLb, expectedRules)
+	if lbRulesChanged {
 		dirtyLb = true
 	}
 	if changed := az.ensureLoadBalancerTagged(lb); changed {
@@ -2074,7 +2166,12 @@ func (az *Cloud) reconcileLoadBalancer(ctx context.Context, clusterName string, 
 		}
 	}
 
-	if fipChanged {
+	// Update multi-SLB ActiveServices tracking. Two signals indicate a real change:
+	//   - fipChanged: FIP added/removed (service is sole owner of its IP)
+	//   - lbRulesChanged: rules added/removed but FIP kept (shared-IP scenario)
+	// The "flipped" reconcile pass (wantLb=false for the opposite LB type)
+	// triggers neither, so it won't incorrectly remove the service.
+	if fipChanged || (az.UseMultipleStandardLoadBalancers() && lbRulesChanged) {
 		az.reconcileMultipleStandardLoadBalancerConfigurationStatus(wantLb, serviceName, lbName)
 	}
 
@@ -2441,6 +2538,130 @@ func (az *Cloud) recordExistingNodesOnLoadBalancers(clusterName string, lbs []*a
 		}
 	}
 	return nil
+}
+
+// lbHasServiceOwnedResources returns true if any load-balancing rule or probe
+// on the given LB is owned by the service (matched by name prefix).
+func (az *Cloud) lbHasServiceOwnedResources(lb *armnetwork.LoadBalancer, service *v1.Service) bool {
+	if lb.Properties == nil {
+		return false
+	}
+	for _, rule := range lb.Properties.LoadBalancingRules {
+		if rule.Name != nil && az.serviceOwnsRule(service, *rule.Name) {
+			return true
+		}
+	}
+	for _, probe := range lb.Properties.Probes {
+		if probe.Name != nil && az.serviceOwnsRule(service, *probe.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// removeStaleServiceLBResources removes only this service's rules and probes
+// from the old LB. After removal, if any frontend IP configurations that were
+// referenced by the removed rules are now safe to delete (no remaining references
+// from other services), they are also removed. If the LB has no remaining FIPs,
+// it is deleted entirely. Returns the name of the deleted LB (empty if not deleted).
+func (az *Cloud) removeStaleServiceLBResources(
+	ctx context.Context,
+	lb *armnetwork.LoadBalancer,
+	existingLBs []*armnetwork.LoadBalancer,
+	clusterName string,
+	service *v1.Service,
+) (string, error) {
+	logger := log.FromContextOrBackground(ctx).WithName("removeStaleServiceLBResources")
+	serviceName := getServiceName(service)
+
+	// 1. Collect FIP IDs referenced by this service's rules before removal.
+	affectedFIPIDs := utilsets.NewString()
+	if lb.Properties != nil && lb.Properties.LoadBalancingRules != nil {
+		for _, rule := range lb.Properties.LoadBalancingRules {
+			if rule.Name != nil && az.serviceOwnsRule(service, *rule.Name) &&
+				rule.Properties != nil &&
+				rule.Properties.FrontendIPConfiguration != nil &&
+				rule.Properties.FrontendIPConfiguration.ID != nil {
+				affectedFIPIDs.Insert(*rule.Properties.FrontendIPConfiguration.ID)
+			}
+		}
+	}
+
+	// 2. Remove this service's probes and rules from the in-memory LB.
+	dirtyProbes := az.reconcileLBProbes(lb, service, serviceName, false, nil)
+	dirtyRules := az.reconcileLBRules(lb, service, serviceName, false, nil)
+
+	if !dirtyProbes && !dirtyRules {
+		return "", nil
+	}
+
+	// 3. Check if any affected FIPs are now safe to delete.
+	var orphanedFIPs []*armnetwork.FrontendIPConfiguration
+	if lb.Properties != nil && lb.Properties.FrontendIPConfigurations != nil {
+		for _, fip := range lb.Properties.FrontendIPConfigurations {
+			if fip.ID == nil || !affectedFIPIDs.Has(*fip.ID) {
+				continue
+			}
+			unsafe, err := az.isFrontendIPConfigUnsafeToDelete(lb, service, fip.ID)
+			if err != nil {
+				logger.Error(err, "failed to check if FIP is safe to delete",
+					"fipID", ptr.Deref(fip.ID, ""),
+					"lbName", ptr.Deref(lb.Name, ""),
+				)
+				continue
+			}
+			if !unsafe {
+				orphanedFIPs = append(orphanedFIPs, fip)
+			}
+		}
+	}
+
+	// 4. If there are orphaned FIPs, delegate to removeFrontendIPConfigurationFromLoadBalancer
+	// which handles FIP removal, PLS cleanup, empty-LB deletion, and the LB API call.
+	if len(orphanedFIPs) > 0 {
+		deletedLBName, _, err := az.removeFrontendIPConfigurationFromLoadBalancer(ctx, lb, existingLBs, orphanedFIPs, clusterName, service)
+		if err != nil {
+			logger.Error(err, "failed to remove orphaned frontend IP configurations",
+				"lbName", ptr.Deref(lb.Name, ""),
+				"serviceName", serviceName,
+			)
+			return "", err
+		}
+		logger.V(2).Info("Removed orphaned frontend IP configurations along with stale service resources",
+			"lbName", ptr.Deref(lb.Name, ""),
+			"serviceName", serviceName,
+			"orphanedFIPs", len(orphanedFIPs),
+			"deletedLB", deletedLBName,
+		)
+		return deletedLBName, nil
+	}
+
+	// 5. No orphaned FIPs, just update the LB with the rule/probe changes.
+	if err := az.CreateOrUpdateLB(ctx, service, *lb); err != nil {
+		logger.Error(err, "failed to update load balancer to remove stale service resources",
+			"lbName", ptr.Deref(lb.Name, ""),
+			"serviceName", serviceName,
+		)
+		return "", err
+	}
+	logger.V(2).Info("Updated load balancer to remove stale service resources",
+		"lbName", ptr.Deref(lb.Name, ""),
+		"serviceName", serviceName,
+		"dirtyProbes", dirtyProbes,
+		"dirtyRules", dirtyRules,
+	)
+	lbName := ptr.Deref(lb.Name, "")
+	if err := az.lbCache.Delete(lbName); err != nil {
+		logger.Info("Failed to invalidate load balancer cache",
+			"lbName", lbName,
+			"err", err,
+		)
+	} else {
+		logger.V(5).Info("Invalidated load balancer cache",
+			"lbName", lbName,
+		)
+	}
+	return "", nil
 }
 
 func (az *Cloud) reconcileMultipleStandardLoadBalancerConfigurationStatus(wantLb bool, svcName, lbName string) {
@@ -4091,7 +4312,9 @@ func (az *Cloud) getAzureLoadBalancerName(
 	existingLBs []*armnetwork.LoadBalancer,
 	clusterName, vmSetName string,
 	isInternal bool,
+	wantLb bool,
 ) (string, error) {
+	logger := log.FromContextOrBackground(ctx).WithName("getAzureLoadBalancerName")
 	if az.LoadBalancerName != "" {
 		clusterName = az.LoadBalancerName
 	}
@@ -4107,12 +4330,58 @@ func (az *Cloud) getAzureLoadBalancerName(
 	// 1. Filter out the eligible load balancers.
 	// 2. Choose the most eligible load balancer.
 	if az.UseMultipleStandardLoadBalancers() {
+		lbIPs := getServiceLoadBalancerIPs(service)
+		pipNames := getServicePIPNames(service)
+		pinsIP := len(lbIPs) > 0 || len(pipNames) > 0
+
+		// Only block when creating resources (wantLb=true).
+		// Cleanup operations (wantLb=false) don't need this constraint.
+		if wantLb {
+			// Block the combination of LB configuration annotation and IP spec.
+			// When specifying an IP, the LB is determined by where the IP resides.
+			// Specifying a different LB is contradictory. This early check also
+			// avoids unnecessary PIP lookups on every reconcile.
+			annotatedLBs := consts.GetLoadBalancerConfigurationsNames(service)
+			logger.V(5).Info("checking LB and IP config", "service", service.Name, "annotatedLBs", annotatedLBs, "lbIPs", lbIPs, "pipNames", pipNames, "pinsIP", pinsIP)
+			if len(annotatedLBs) > 0 && pinsIP {
+				return "", fmt.Errorf(
+					"service %q has conflicting load balancer configuration: "+
+						"both a load balancer name (%s) and an IP address are specified. "+
+						"When an IP address is specified (via spec.loadBalancerIP, azure-load-balancer-ipv4/ipv6, or azure-pip-name), "+
+						"the service must use the load balancer where that IP resides. "+
+						"To fix, either (1) remove the %s annotation to stay on the load balancer where the IP resides, "+
+						"or (2) remove the IP annotation to move to the specified load balancer (external services only)",
+					service.Name, consts.ServiceAnnotationLoadBalancerConfigurations,
+					consts.ServiceAnnotationLoadBalancerConfigurations)
+			}
+		}
+
 		eligibleLBs, err := az.getEligibleLoadBalancersForService(ctx, service)
 		if err != nil {
 			return "", err
 		}
 
 		currentLBName := az.getServiceCurrentLoadBalancerName(service)
+
+		// If service specifies an IP, find which LB has that IP. The service should use the LB where the IP resides.
+		// This also detects secondary services sharing an IP with a primary service already on an LB.
+		if pinsIP {
+			if requiresInternalLoadBalancer(service) {
+				currentLBName = az.getLoadBalancerNameByPrivateIP(ctx, service, existingLBs)
+			} else {
+				currentLBName = az.getLoadBalancerNameByPublicIP(ctx, service, clusterName)
+			}
+			// Block service if the IP resides on an LB that's not eligible.
+			if currentLBName != "" && !StringInSliceIgnoreCase(currentLBName, eligibleLBs) {
+				return "", fmt.Errorf(
+					"service %q specifies an IP that resides on load balancer %q, "+
+						"which is not in the eligible set %v; "+
+						"check or adjust the load balancer eligibility configuration "+
+						"(ServiceLabelSelector, ServiceNamespaceSelector, or AllowServicePlacement)",
+					service.Name, currentLBName, eligibleLBs)
+			}
+		}
+
 		lbNamePrefix = getMostEligibleLBForService(currentLBName, eligibleLBs, existingLBs, requiresInternalLoadBalancer(service))
 	}
 
@@ -4120,6 +4389,122 @@ func (az *Cloud) getAzureLoadBalancerName(
 		return fmt.Sprintf("%s%s", lbNamePrefix, consts.InternalLoadBalancerNameSuffix), nil
 	}
 	return lbNamePrefix, nil
+}
+
+// getLoadBalancerNameByPrivateIP finds the LB by scanning frontend IPs for a matching private address.
+func (az *Cloud) getLoadBalancerNameByPrivateIP(
+	ctx context.Context,
+	service *v1.Service,
+	existingLBs []*armnetwork.LoadBalancer,
+) string {
+	logger := log.FromContextOrBackground(ctx).WithName("getLoadBalancerNameByPrivateIP")
+	loadBalancerIPs := getServiceLoadBalancerIPs(service)
+	if len(loadBalancerIPs) == 0 {
+		return ""
+	}
+
+	for _, lb := range existingLBs {
+		if !isInternalLoadBalancer(lb) {
+			continue
+		}
+		if lb.Properties == nil || lb.Properties.FrontendIPConfigurations == nil {
+			continue
+		}
+		for _, fip := range lb.Properties.FrontendIPConfigurations {
+			if fip.Properties == nil || fip.Properties.PrivateIPAddress == nil {
+				continue
+			}
+			for _, ip := range loadBalancerIPs {
+				if ip != "" && strings.EqualFold(*fip.Properties.PrivateIPAddress, ip) {
+					logger.V(2).Info("Found LB from frontend IP by private IP", "service", service.Name, "privateIP", ip, "lbName", ptr.Deref(lb.Name, ""))
+					return trimSuffixIgnoreCase(ptr.Deref(lb.Name, ""), consts.InternalLoadBalancerNameSuffix)
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// getLoadBalancerNameByPublicIP finds the LB by reading the PIP's IPConfiguration.
+func (az *Cloud) getLoadBalancerNameByPublicIP(
+	ctx context.Context,
+	service *v1.Service,
+	clusterName string,
+) string {
+	logger := log.FromContextOrBackground(ctx).WithName("getLoadBalancerNameByPublicIP")
+
+	loadBalancerIPs := getServiceLoadBalancerIPs(service)
+	pipResourceGroup := az.getPublicIPAddressResourceGroup(service)
+	for _, ip := range loadBalancerIPs {
+		if ip == "" {
+			continue
+		}
+		pip, err := az.findMatchedPIP(ctx, ip, "", pipResourceGroup)
+		if err != nil {
+			logger.V(2).Info("Failed to find PIP by IP", "ip", ip, "error", err)
+			continue
+		}
+		if lbName := az.getLoadBalancerNameFromPIP(pip, clusterName); lbName != "" {
+			logger.V(2).Info("Found LB from PIP by IP", "service", service.Name, "pip", ptr.Deref(pip.Name, ""), "lbName", lbName)
+			return lbName
+		}
+	}
+
+	pipNames := getServicePIPNames(service)
+	for _, pipName := range pipNames {
+		if pipName == "" {
+			continue
+		}
+		pip, err := az.findMatchedPIP(ctx, "", pipName, pipResourceGroup)
+		if err != nil {
+			logger.V(2).Info("Failed to find PIP by name", "pipName", pipName, "error", err)
+			continue
+		}
+		if lbName := az.getLoadBalancerNameFromPIP(pip, clusterName); lbName != "" {
+			logger.V(2).Info("Found LB from PIP by name", "service", service.Name, "pip", pipName, "lbName", lbName)
+			return lbName
+		}
+	}
+
+	return ""
+}
+
+// getLoadBalancerNameFromPIP extracts the LB name from the PIP's IPConfiguration.
+func (az *Cloud) getLoadBalancerNameFromPIP(pip *armnetwork.PublicIPAddress, clusterName string) string {
+	if pip == nil || pip.Properties == nil || pip.Properties.IPConfiguration == nil || pip.Properties.IPConfiguration.ID == nil {
+		return ""
+	}
+
+	if pip.Tags != nil {
+		if clusterTag := getClusterFromPIPClusterTags(pip.Tags); clusterTag != "" && !strings.EqualFold(clusterTag, clusterName) {
+			return ""
+		}
+	}
+
+	return parseLoadBalancerNameFromFrontendConfigID(ptr.Deref(pip.Properties.IPConfiguration.ID, ""))
+}
+
+// parseLoadBalancerNameFromFrontendConfigID extracts the load balancer name from a frontend IP config ID.
+// Example ID: "/subscriptions/{subId}/resourceGroups/{rg}/providers/Microsoft.Network/loadBalancers/{lbName}/frontendIPConfigurations/{fipName}"
+func parseLoadBalancerNameFromFrontendConfigID(id string) string {
+	if id == "" {
+		return ""
+	}
+
+	const marker = "/providers/microsoft.network/loadbalancers/"
+	idx := strings.Index(strings.ToLower(id), marker)
+	if idx == -1 {
+		return ""
+	}
+
+	// rest should be "{lbName}/frontendIPConfigurations/{fipName}".
+	rest := id[idx+len(marker):]
+	before, _, ok := strings.Cut(rest, "/")
+	if !ok {
+		return ""
+	}
+	return before
 }
 
 func getMostEligibleLBForService(

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1940,6 +1940,842 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "external: block migration when primary svc shares IP with secondary",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+					},
+				},
+			},
+			service: getTestService("primary", v1.ProtocolTCP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			}, false, 80),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/primary"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedError: fmt.Errorf(
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+					"remove the %s annotation to stay on load balancer %q",
+				"primary", "lb1", "lb2", "aprimary",
+				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1"),
+		},
+		{
+			description: "internal: block migration when primary svc shares IP with secondary",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			service: func() v1.Service {
+				svc := getInternalTestService("primary", 80)
+				svc.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb2"
+				return svc
+			}(),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/primary"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedError: fmt.Errorf(
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+					"remove the %s annotation to stay on load balancer %q",
+				"primary", "lb1-internal", "lb2-internal", "aprimary",
+				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1-internal"),
+		},
+		{
+			description: "external: allow migration when svc has its own frontend",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvc1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asvc1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip1")},
+								},
+							},
+							{
+								Name: ptr.To("asvc2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asvc2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip2")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asvc1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asvc1"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asvc2-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asvc2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvc2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asvc2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip2")},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+					},
+				},
+			},
+			service: getTestService("svc1", v1.ProtocolTCP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			}, false, 80),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/svc1"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb2"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvc2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asvc2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip2")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asvc2-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asvc2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "internal: allow migration when svc has its own frontend",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvc1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+							{
+								Name: ptr.To("asvc2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.2"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asvc1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc1"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asvc2-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvc2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			service: func() v1.Service {
+				svc := getInternalTestService("svc1", 80)
+				svc.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb2"
+				return svc
+			}(),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/svc1"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb2-internal"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvc2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.2"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asvc2-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "external: block shared IP svc migration, same LB has independent svc",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-shared")},
+								},
+							},
+							{
+								Name: ptr.To("aindependent"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aindependent"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-independent")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asharedprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asharedsecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("aindependent-TCP-82"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aindependent"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip-shared"),
+					ID:   ptr.To("pip-shared"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+					},
+				},
+			},
+			service: getTestService("sharedprimary", v1.ProtocolTCP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			}, false, 80),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/sharedprimary"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedError: fmt.Errorf(
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+					"remove the %s annotation to stay on load balancer %q",
+				"sharedprimary", "lb1", "lb2", "asharedprimary",
+				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1"),
+		},
+		{
+			description: "external: allow independent svc migration, same LB has shared IP services",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-shared")},
+								},
+							},
+							{
+								Name: ptr.To("aindependent"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aindependent"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-independent")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asharedprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asharedsecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("aindependent-TCP-82"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aindependent"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-shared")},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip-independent"),
+					ID:   ptr.To("pip-independent"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("5.6.7.8"),
+					},
+				},
+			},
+			service: getTestService("independent", v1.ProtocolTCP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			}, false, 82),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/independent"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb2"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-shared")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asharedprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asharedsecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "internal: block shared IP svc migration, same LB has independent svc",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+							{
+								Name: ptr.To("aindependent"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aindependent"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.2"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asharedprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asharedsecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("aindependent-TCP-82"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aindependent"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			service: func() v1.Service {
+				svc := getInternalTestService("sharedprimary", 80)
+				svc.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb2"
+				return svc
+			}(),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/sharedprimary"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedError: fmt.Errorf(
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+					"remove the %s annotation to stay on load balancer %q",
+				"sharedprimary", "lb1-internal", "lb2-internal", "asharedprimary",
+				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1-internal"),
+		},
+		{
+			description: "internal: allow independent svc migration, same LB has shared IP services",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+							{
+								Name: ptr.To("aindependent"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aindependent"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.2"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asharedprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asharedsecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("aindependent-TCP-82"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aindependent"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			service: func() v1.Service {
+				svc := getInternalTestService("independent", 82)
+				svc.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb2"
+				return svc
+			}(),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/independent"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb2-internal"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asharedprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asharedprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("asharedsecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asharedprimary"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// When isPinnedIPMultiSLB is true and the source LB is deleted
+			// during migration (its only FIP removed), removeLBFromList shrinks existingLBs
+			// while the for-range loop still iterates with the original length leads to index panic.
+			description: "internal: pinned IP migration deletes source LB without panic",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvc1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asvc1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/asvc1"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvcother"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2-internal/frontendIPConfigurations/asvcother"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.99"),
+								},
+							},
+						},
+					},
+				},
+			},
+			service: func() v1.Service {
+				svc := getInternalTestService("svc1", 80)
+				svc.Annotations[consts.ServiceAnnotationLoadBalancerIPDualStack[false]] = "10.0.0.99"
+				return svc
+			}(),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/svc1"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name: ptr.To("lb2-internal"),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name: ptr.To("asvcother"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2-internal/frontendIPConfigurations/asvcother"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								PrivateIPAddress: ptr.To("10.0.0.99"),
+							},
+						},
+					},
+				},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvcother"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2-internal/frontendIPConfigurations/asvcother"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.99"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
@@ -1953,11 +2789,13 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 			lbClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.refreshedLBs, nil).MaxTimes(1)
 			lbClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).MaxTimes(1)
 
-			mockPLSRepo := cloud.plsRepo.(*privatelinkservice.MockRepository)
-			mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil)
+			if tc.expectedError == nil {
+				mockPLSRepo := cloud.plsRepo.(*privatelinkservice.MockRepository)
+				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil)
+			}
 
 			mockPIPClient := cloud.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
-			mockPIPClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armnetwork.PublicIPAddress{}, nil).MaxTimes(2)
+			mockPIPClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.existingPIPs, nil).MaxTimes(2)
 
 			if tc.local {
 				tc.service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
@@ -7952,11 +8790,6 @@ func TestGetEligibleLoadBalancers(t *testing.T) {
 }
 
 func TestGetAzureLoadBalancerName(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	az := GetTestCloud(ctrl)
-	az.PrimaryAvailabilitySetName = primary
-
 	cases := []struct {
 		description       string
 		vmSet             string
@@ -7967,6 +8800,9 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 		multiSLBConfigs   []config.MultipleStandardLoadBalancerConfiguration
 		serviceAnnotation map[string]string
 		serviceLabel      map[string]string
+		specLBIP          string
+		existingLBs       []*armnetwork.LoadBalancer
+		existingPIPs      []*armnetwork.PublicIPAddress
 		expected          string
 		expectedErr       error
 	}{
@@ -8090,10 +8926,451 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 			},
 			expectedErr: errors.New(`service "default/test" selects 1 load balancers (a), but 0 of them () have AllowServicePlacement set to false and the service is not using any of them, 1 of them (a) do not match the service label selector, and 0 of them () do not match the service namespace selector`),
 		},
+		{
+			description:   "multi-slb external: IP annotation returns lb2 where IP resides",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "1.2.3.4",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+						IPConfiguration: &armnetwork.IPConfiguration{
+							ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/aprimary-svc-uid"),
+						},
+					},
+				},
+			},
+			expected: "lb2",
+		},
+		{
+			description:   "multi-slb external: PIP name annotation returns lb2 where IP resides",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationPIPNameDualStack[false]: "pip1",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+						IPConfiguration: &armnetwork.IPConfiguration{
+							ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/aprimary-svc-uid"),
+						},
+					},
+				},
+			},
+			expected: "lb2",
+		},
+		{
+			description:   "multi-slb external: spec.loadBalancerIP returns lb2 where IP resides",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			specLBIP: "1.2.3.4",
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+						IPConfiguration: &armnetwork.IPConfiguration{
+							ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/aprimary-svc-uid"),
+						},
+					},
+				},
+			},
+			expected: "lb2",
+		},
+		{
+			description:   "multi-slb external: LB annotation lb2 returns lb2",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			},
+			expected: "lb2",
+		},
+		{
+			description:   "multi-slb external: new IP not on LB returns fewest rules lb2",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "5.6.7.8",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary-svc-uid"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+					},
+				},
+			},
+			expected: "lb2",
+		},
+		{
+			description:   "multi-slb external: IP annotation and LB annotation conflicts",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "1.2.3.4",
+				consts.ServiceAnnotationLoadBalancerConfigurations:     "lb1",
+			},
+			expectedErr: errors.New(
+				`service "test" has conflicting load balancer configuration: ` +
+					`both a load balancer name (service.beta.kubernetes.io/azure-load-balancer-configurations) and an IP address are specified. ` +
+					`When an IP address is specified (via spec.loadBalancerIP, azure-load-balancer-ipv4/ipv6, or azure-pip-name), ` +
+					`the service must use the load balancer where that IP resides. ` +
+					`To fix, either (1) remove the service.beta.kubernetes.io/azure-load-balancer-configurations annotation to stay on the load balancer where the IP resides, ` +
+					`or (2) remove the IP annotation to move to the specified load balancer (external services only)`,
+			),
+		},
+		{
+			description:   "multi-slb external: PIP name annotation and LB annotation conflicts",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationPIPNameDualStack[false]:    "pip1",
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb1",
+			},
+			expectedErr: errors.New(
+				`service "test" has conflicting load balancer configuration: ` +
+					`both a load balancer name (service.beta.kubernetes.io/azure-load-balancer-configurations) and an IP address are specified. ` +
+					`When an IP address is specified (via spec.loadBalancerIP, azure-load-balancer-ipv4/ipv6, or azure-pip-name), ` +
+					`the service must use the load balancer where that IP resides. ` +
+					`To fix, either (1) remove the service.beta.kubernetes.io/azure-load-balancer-configurations annotation to stay on the load balancer where the IP resides, ` +
+					`or (2) remove the IP annotation to move to the specified load balancer (external services only)`,
+			),
+		},
+		{
+			description:   "multi-slb external: spec.loadBalancerIP and LB annotation conflicts",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			specLBIP: "1.2.3.4",
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb1",
+			},
+			expectedErr: errors.New(
+				`service "test" has conflicting load balancer configuration: ` +
+					`both a load balancer name (service.beta.kubernetes.io/azure-load-balancer-configurations) and an IP address are specified. ` +
+					`When an IP address is specified (via spec.loadBalancerIP, azure-load-balancer-ipv4/ipv6, or azure-pip-name), ` +
+					`the service must use the load balancer where that IP resides. ` +
+					`To fix, either (1) remove the service.beta.kubernetes.io/azure-load-balancer-configurations annotation to stay on the load balancer where the IP resides, ` +
+					`or (2) remove the IP annotation to move to the specified load balancer (external services only)`,
+			),
+		},
+		{
+			description:   "multi-slb external: IP resides on LB excluded by label selector should error",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationSpec: config.MultipleStandardLoadBalancerConfigurationSpec{
+						ServiceLabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "web"},
+						},
+					},
+				},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "1.2.3.4",
+			},
+			serviceLabel: map[string]string{"app": "api"},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+						IPConfiguration: &armnetwork.IPConfiguration{
+							ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/fip1"),
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(
+				`service "test" specifies an IP that resides on load balancer "lb1", ` +
+					`which is not in the eligible set [lb2]; ` +
+					`check or adjust the load balancer eligibility configuration ` +
+					`(ServiceLabelSelector, ServiceNamespaceSelector, or AllowServicePlacement)`,
+			),
+		},
+		{
+			description:   "multi-slb internal: IP annotation returns lb2-internal where IP resides",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:           "true",
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary-svc-uid"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.5"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "lb2-internal",
+		},
+		{
+			description:   "multi-slb internal: spec.loadBalancerIP returns lb2-internal where IP resides",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			specLBIP: "10.0.0.5",
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary-svc-uid"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.5"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "lb2-internal",
+		},
+		{
+			description:   "multi-slb internal: LB annotation lb2 returns lb2-internal",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:       "true",
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			},
+			expected: "lb2-internal",
+		},
+		{
+			description:   "multi-slb internal: new IP not on LB returns fewest rules lb2-internal",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:           "true",
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.99",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary-svc-uid"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.5"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "lb2-internal",
+		},
+		{
+			description:   "multi-slb internal: IP annotation and LB annotation conflicts",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:           "true",
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+				consts.ServiceAnnotationLoadBalancerConfigurations:     "lb1",
+			},
+			expectedErr: errors.New(
+				`service "test" has conflicting load balancer configuration: ` +
+					`both a load balancer name (service.beta.kubernetes.io/azure-load-balancer-configurations) and an IP address are specified. ` +
+					`When an IP address is specified (via spec.loadBalancerIP, azure-load-balancer-ipv4/ipv6, or azure-pip-name), ` +
+					`the service must use the load balancer where that IP resides. ` +
+					`To fix, either (1) remove the service.beta.kubernetes.io/azure-load-balancer-configurations annotation to stay on the load balancer where the IP resides, ` +
+					`or (2) remove the IP annotation to move to the specified load balancer (external services only)`,
+			),
+		},
+		{
+			description:   "multi-slb internal: spec.loadBalancerIP and LB annotation conflicts",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			specLBIP: "10.0.0.5",
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:       "true",
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb1",
+			},
+			expectedErr: errors.New(
+				`service "test" has conflicting load balancer configuration: ` +
+					`both a load balancer name (service.beta.kubernetes.io/azure-load-balancer-configurations) and an IP address are specified. ` +
+					`When an IP address is specified (via spec.loadBalancerIP, azure-load-balancer-ipv4/ipv6, or azure-pip-name), ` +
+					`the service must use the load balancer where that IP resides. ` +
+					`To fix, either (1) remove the service.beta.kubernetes.io/azure-load-balancer-configurations annotation to stay on the load balancer where the IP resides, ` +
+					`or (2) remove the IP annotation to move to the specified load balancer (external services only)`,
+			),
+		},
+		{
+			description:   "multi-slb internal: IP resides on LB excluded by label selector should error",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationSpec: config.MultipleStandardLoadBalancerConfigurationSpec{
+						ServiceLabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "web"},
+						},
+					},
+				},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:           "true",
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+			},
+			serviceLabel: map[string]string{"app": "api"},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("fip1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.5"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(
+				`service "test" specifies an IP that resides on load balancer "lb1", ` +
+					`which is not in the eligible set [lb2]; ` +
+					`check or adjust the load balancer eligibility configuration ` +
+					`(ServiceLabelSelector, ServiceNamespaceSelector, or AllowServicePlacement)`,
+			),
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			az := GetTestCloud(ctrl)
+			az.PrimaryAvailabilitySetName = primary
+
 			if c.useStandardLB {
 				az.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			} else {
@@ -8104,12 +9381,25 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 				az.MultipleStandardLoadBalancerConfigurations = c.multiSLBConfigs
 			}
 
+			// Mock PIP client for external LB cases.
+			if len(c.existingPIPs) > 0 {
+				mockPIPsClient := az.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
+				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(c.existingPIPs, nil).MaxTimes(2)
+			}
+
 			az.LoadBalancerName = c.lbName
 			svc := getTestService("test", v1.ProtocolTCP, c.serviceAnnotation, false)
+			if c.specLBIP != "" {
+				svc.Spec.LoadBalancerIP = c.specLBIP
+			}
 			if c.serviceLabel != nil {
 				svc.Labels = c.serviceLabel
 			}
-			loadbalancerName, err := az.getAzureLoadBalancerName(context.TODO(), &svc, []*armnetwork.LoadBalancer{}, c.clusterName, c.vmSet, c.isInternal)
+			existingLBs := c.existingLBs
+			if existingLBs == nil {
+				existingLBs = []*armnetwork.LoadBalancer{}
+			}
+			loadbalancerName, err := az.getAzureLoadBalancerName(context.TODO(), &svc, existingLBs, c.clusterName, c.vmSet, c.isInternal, true /* wantLb */)
 			assert.Equal(t, c.expected, loadbalancerName)
 			if c.expectedErr != nil {
 				assert.EqualError(t, err, c.expectedErr.Error())
@@ -9588,5 +10878,321 @@ func fakeEnsureHostsInPool() func(context.Context, *v1.Service, []*v1.Node, stri
 			},
 		}
 		return nil
+	}
+}
+
+func TestLbHasServiceOwnedResources(t *testing.T) {
+	svcUID := "testuid"
+	clusterSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(svcUID)},
+		Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
+	}
+	localSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(svcUID)},
+		Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal},
+	}
+	prefix := "a" + svcUID
+	otherPrefix := "a" + "otheruid"
+
+	tests := []struct {
+		name     string
+		svc      *v1.Service
+		lb       *armnetwork.LoadBalancer
+		expected bool
+	}{
+		{
+			name:     "nil properties",
+			svc:      clusterSvc,
+			lb:       &armnetwork.LoadBalancer{},
+			expected: false,
+		},
+		{
+			name: "empty rules and probes",
+			svc:  clusterSvc,
+			lb: &armnetwork.LoadBalancer{
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expected: false,
+		},
+		{
+			name: "LB only has rules from another service",
+			svc:  clusterSvc,
+			lb: &armnetwork.LoadBalancer{
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "LB shared by multiple services including ours",
+			svc:  clusterSvc,
+			lb: &armnetwork.LoadBalancer{
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+						{Name: ptr.To(prefix + "-TCP-443")},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+						{Name: ptr.To(prefix + "-TCP-443")},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "shared probe matches for cluster traffic policy",
+			svc:  clusterSvc,
+			lb: &armnetwork.LoadBalancer{
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(consts.SharedProbeName)},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "shared probe does not match for local traffic policy",
+			svc:  localSvc,
+			lb: &armnetwork.LoadBalancer{
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(consts.SharedProbeName)},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	az := &Cloud{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := az.lbHasServiceOwnedResources(tc.lb, tc.svc)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestRemoveStaleServiceLBResources(t *testing.T) {
+	const (
+		rgName      = "rg"
+		lbName      = "lb-1"
+		clusterName = "testCluster"
+	)
+
+	svcUID := "svc2uid"
+	svc2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "svc2",
+			Namespace:   "default",
+			UID:         types.UID(svcUID),
+			Annotations: map[string]string{},
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+			Ports: []v1.ServicePort{
+				{Name: "port1", Protocol: v1.ProtocolTCP, Port: 443},
+			},
+			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			ClusterIP:  "10.0.0.3",
+		},
+	}
+
+	svc2Prefix := "a" + svcUID
+	otherPrefix := "asvcother"
+	fipID := "/subscriptions/sub/resourceGroups/" + rgName + "/providers/Microsoft.Network/loadBalancers/" + lbName + "/frontendIPConfigurations/fip1"
+	fipID2 := "/subscriptions/sub/resourceGroups/" + rgName + "/providers/Microsoft.Network/loadBalancers/" + lbName + "/frontendIPConfigurations/fip2"
+
+	tests := []struct {
+		name                  string
+		lb                    *armnetwork.LoadBalancer
+		setupMocks            func(cloud *Cloud)
+		expectedDeletedLBName string
+		expectedFIPNames      []string
+		expectedRuleNames     []string
+	}{
+		{
+			name: "no dirty rules or probes, no API call",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{Name: ptr.To("fip1"), ID: ptr.To(fipID)},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+					},
+				},
+			},
+			setupMocks:            func(_ *Cloud) { /* no API calls expected */ },
+			expectedDeletedLBName: "",
+			expectedFIPNames:      []string{"fip1"},
+			expectedRuleNames:     []string{otherPrefix + "-TCP-80"},
+		},
+		{
+			name: "FIP still has other services rules, FIP stays, LB updated with rules only",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{Name: ptr.To("fip1"), ID: ptr.To(fipID)},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(svc2Prefix + "-TCP-443"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(443))}},
+						{Name: ptr.To(otherPrefix + "-TCP-80"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(80))}},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockLBClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), rgName, lbName, gomock.Any()).Return(nil, nil).Times(1)
+			},
+			expectedDeletedLBName: "",
+			expectedFIPNames:      []string{"fip1"},
+			expectedRuleNames:     []string{otherPrefix + "-TCP-80"},
+		},
+		{
+			name: "FIP becomes empty and LB has other FIPs, FIP removed, LB updated",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name:       ptr.To("fip1"),
+							ID:         ptr.To(fipID),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pipID")}},
+						},
+						{Name: ptr.To("fip2"), ID: ptr.To(fipID2)},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID2)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(svc2Prefix + "-TCP-443"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(443))}},
+						{Name: ptr.To(otherPrefix + "-TCP-80"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(80))}},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockLBClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), rgName, lbName, gomock.Any()).Return(nil, nil).Times(1)
+				mockPLSRepo := cloud.plsRepo.(*privatelinkservice.MockRepository)
+				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil).Times(1)
+			},
+			expectedDeletedLBName: "",
+			expectedFIPNames:      []string{"fip2"},
+			expectedRuleNames:     []string{otherPrefix + "-TCP-80"},
+		},
+		{
+			name: "FIP becomes empty and LB has no other FIPs, LB deleted",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name:       ptr.To("fip1"),
+							ID:         ptr.To(fipID),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pipID")}},
+						},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(svc2Prefix + "-TCP-443"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(443))}},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockLBClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				mockLBClient.EXPECT().Delete(gomock.Any(), rgName, lbName).Return(nil).Times(1)
+				mockPLSRepo := cloud.plsRepo.(*privatelinkservice.MockRepository)
+				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil).Times(1)
+			},
+			expectedDeletedLBName: lbName,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			cloud := GetTestCloud(ctrl)
+
+			tc.setupMocks(cloud)
+			existingLBs := []*armnetwork.LoadBalancer{tc.lb}
+
+			deletedLBName, err := cloud.removeStaleServiceLBResources(context.TODO(), tc.lb, existingLBs, clusterName, svc2)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedDeletedLBName, deletedLBName)
+
+			if tc.expectedFIPNames != nil {
+				var fipNames []string
+				for _, fip := range tc.lb.Properties.FrontendIPConfigurations {
+					fipNames = append(fipNames, *fip.Name)
+				}
+				assert.Equal(t, tc.expectedFIPNames, fipNames)
+			}
+			if tc.expectedRuleNames != nil {
+				var ruleNames []string
+				for _, rule := range tc.lb.Properties.LoadBalancingRules {
+					ruleNames = append(ruleNames, *rule.Name)
+				}
+				assert.Equal(t, tc.expectedRuleNames, ruleNames)
+			}
+		})
 	}
 }

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -11128,40 +11128,28 @@ func fakeEnsureHostsInPool() func(context.Context, *v1.Service, []*v1.Node, stri
 
 func TestLbHasServiceOwnedResources(t *testing.T) {
 	svcUID := "testuid"
-	clusterSvc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID(svcUID)},
-		Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster},
-	}
-	localSvc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID(svcUID)},
-		Spec:       v1.ServiceSpec{ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal},
-	}
 	prefix := "a" + svcUID
 	otherPrefix := "a" + "otheruid"
 
 	tests := []struct {
 		name     string
-		svc      *v1.Service
 		lb       *armnetwork.LoadBalancer
 		expected bool
 	}{
 		{
 			name:     "nil properties",
-			svc:      clusterSvc,
 			lb:       &armnetwork.LoadBalancer{},
 			expected: false,
 		},
 		{
 			name: "empty rules and probes",
-			svc:  clusterSvc,
 			lb: &armnetwork.LoadBalancer{
 				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
 			},
 			expected: false,
 		},
 		{
-			name: "LB only has rules from another service",
-			svc:  clusterSvc,
+			name: "LB has rules and probes only from another service",
 			lb: &armnetwork.LoadBalancer{
 				Properties: &armnetwork.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
@@ -11176,7 +11164,6 @@ func TestLbHasServiceOwnedResources(t *testing.T) {
 		},
 		{
 			name: "LB shared by multiple services including ours",
-			svc:  clusterSvc,
 			lb: &armnetwork.LoadBalancer{
 				Properties: &armnetwork.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
@@ -11192,23 +11179,22 @@ func TestLbHasServiceOwnedResources(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "shared probe matches for cluster traffic policy",
-			svc:  clusterSvc,
+			name: "LB has orphaned service probe without rule",
 			lb: &armnetwork.LoadBalancer{
 				Properties: &armnetwork.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
 						{Name: ptr.To(otherPrefix + "-TCP-80")},
 					},
 					Probes: []*armnetwork.Probe{
-						{Name: ptr.To(consts.SharedProbeName)},
+						{Name: ptr.To(otherPrefix + "-TCP-80")},
+						{Name: ptr.To(prefix + "-TCP-443")},
 					},
 				},
 			},
 			expected: true,
 		},
 		{
-			name: "shared probe does not match for local traffic policy",
-			svc:  localSvc,
+			name: "shared probe without service rules is not service-owned",
 			lb: &armnetwork.LoadBalancer{
 				Properties: &armnetwork.LoadBalancerPropertiesFormat{
 					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
@@ -11223,12 +11209,22 @@ func TestLbHasServiceOwnedResources(t *testing.T) {
 		},
 	}
 
+	policies := []v1.ServiceExternalTrafficPolicy{
+		v1.ServiceExternalTrafficPolicyTypeCluster,
+		v1.ServiceExternalTrafficPolicyTypeLocal,
+	}
 	az := &Cloud{}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := az.lbHasServiceOwnedResources(tc.lb, tc.svc)
-			assert.Equal(t, tc.expected, got)
-		})
+	for _, policy := range policies {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID(svcUID)},
+			Spec:       v1.ServiceSpec{ExternalTrafficPolicy: policy},
+		}
+		for _, tc := range tests {
+			t.Run(string(policy)+"/"+tc.name, func(t *testing.T) {
+				got := az.lbHasServiceOwnedResources(tc.lb, svc)
+				assert.Equal(t, tc.expected, got)
+			})
+		}
 	}
 }
 
@@ -11240,37 +11236,25 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 	)
 
 	svcUID := "svc2uid"
-	svc2 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "svc2",
-			Namespace:   "default",
-			UID:         types.UID(svcUID),
-			Annotations: map[string]string{},
-		},
-		Spec: v1.ServiceSpec{
-			Type:                  v1.ServiceTypeLoadBalancer,
-			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-			Ports: []v1.ServicePort{
-				{Name: "port1", Protocol: v1.ProtocolTCP, Port: 443},
-			},
-			IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
-			ClusterIP:  "10.0.0.3",
-		},
-	}
-
 	svc2Prefix := "a" + svcUID
 	otherPrefix := "asvcother"
 	fipID := "/subscriptions/sub/resourceGroups/" + rgName + "/providers/Microsoft.Network/loadBalancers/" + lbName + "/frontendIPConfigurations/fip1"
 	fipID2 := "/subscriptions/sub/resourceGroups/" + rgName + "/providers/Microsoft.Network/loadBalancers/" + lbName + "/frontendIPConfigurations/fip2"
 
+	sharedProbeID := "/subscriptions/sub/resourceGroups/" + rgName + "/providers/Microsoft.Network/loadBalancers/" + lbName + "/probes/" + consts.SharedProbeName
+	svc2RuleID := "/subscriptions/sub/resourceGroups/" + rgName + "/providers/Microsoft.Network/loadBalancers/" + lbName + "/loadBalancingRules/" + svc2Prefix + "-TCP-443"
+	otherRuleID := "/subscriptions/sub/resourceGroups/" + rgName + "/providers/Microsoft.Network/loadBalancers/" + lbName + "/loadBalancingRules/" + otherPrefix + "-TCP-80"
+
 	tests := []struct {
 		name                  string
 		lb                    *armnetwork.LoadBalancer
+		isLocalService        bool
 		setupMocks            func(cloud *Cloud)
 		expectedDeletedLBName string
 		expectedDeletedPLS    bool
 		expectedFIPNames      []string
 		expectedRuleNames     []string
+		expectedProbeNames    []string
 	}{
 		{
 			name: "no dirty rules or probes, no API call",
@@ -11458,6 +11442,243 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 			},
 			expectedDeletedPLS: true,
 		},
+		{
+			name: "shared probe kept when other services reference it",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{Name: ptr.To("fip1"), ID: ptr.To(fipID)},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To(sharedProbeID),
+							Properties: &armnetwork.ProbePropertiesFormat{
+								Protocol:          to.Ptr(armnetwork.ProbeProtocolHTTP),
+								IntervalInSeconds: ptr.To(consts.HealthProbeDefaultProbeInterval),
+								ProbeThreshold:    ptr.To(consts.HealthProbeDefaultNumOfProbe),
+								LoadBalancingRules: []*armnetwork.SubResource{
+									{ID: ptr.To(svc2RuleID)},
+									{ID: ptr.To(otherRuleID)},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockLBClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), rgName, lbName, gomock.Any()).Return(nil, nil).Times(1)
+			},
+			expectedDeletedLBName: "",
+			expectedFIPNames:      []string{"fip1"},
+			expectedRuleNames:     []string{otherPrefix + "-TCP-80"},
+			expectedProbeNames:    []string{consts.SharedProbeName},
+		},
+		{
+			name: "shared probe removed when departing service is the last one referring to it",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name:       ptr.To("fip1"),
+							ID:         ptr.To(fipID),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pipID")}},
+						},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To(sharedProbeID),
+							Properties: &armnetwork.ProbePropertiesFormat{
+								Protocol:          to.Ptr(armnetwork.ProbeProtocolHTTP),
+								IntervalInSeconds: ptr.To(consts.HealthProbeDefaultProbeInterval),
+								ProbeThreshold:    ptr.To(consts.HealthProbeDefaultNumOfProbe),
+								LoadBalancingRules: []*armnetwork.SubResource{
+									{ID: ptr.To(svc2RuleID)},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockLBClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), rgName, lbName, gomock.Any()).Return(nil, nil).Times(1)
+			},
+			expectedDeletedLBName: "",
+			expectedFIPNames:      []string{"fip1"},
+			expectedRuleNames:     []string{otherPrefix + "-TCP-80"},
+			expectedProbeNames:    []string{},
+		},
+		{
+			name: "no API call when service has no rules on LB and shared probe exists",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{Name: ptr.To("fip1"), ID: ptr.To(fipID)},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To(sharedProbeID),
+							Properties: &armnetwork.ProbePropertiesFormat{
+								Protocol:          to.Ptr(armnetwork.ProbeProtocolHTTP),
+								IntervalInSeconds: ptr.To(consts.HealthProbeDefaultProbeInterval),
+								ProbeThreshold:    ptr.To(consts.HealthProbeDefaultNumOfProbe),
+								LoadBalancingRules: []*armnetwork.SubResource{
+									{ID: ptr.To(otherRuleID)},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMocks:         func(_ *Cloud) { /* no API calls expected */ },
+			expectedFIPNames:   []string{"fip1"},
+			expectedRuleNames:  []string{otherPrefix + "-TCP-80"},
+			expectedProbeNames: []string{consts.SharedProbeName},
+		},
+		{
+			name:           "shared probe untouched when departing service uses Local traffic policy",
+			isLocalService: true,
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{Name: ptr.To("fip1"), ID: ptr.To(fipID)},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(svc2Prefix + "-TCP-443"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(443))}},
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To(sharedProbeID),
+							Properties: &armnetwork.ProbePropertiesFormat{
+								Protocol:          to.Ptr(armnetwork.ProbeProtocolHTTP),
+								IntervalInSeconds: ptr.To(consts.HealthProbeDefaultProbeInterval),
+								ProbeThreshold:    ptr.To(consts.HealthProbeDefaultNumOfProbe),
+								LoadBalancingRules: []*armnetwork.SubResource{
+									{ID: ptr.To(otherRuleID)},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockLBClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), rgName, lbName, gomock.Any()).Return(nil, nil).Times(1)
+			},
+			expectedDeletedLBName: "",
+			expectedFIPNames:      []string{"fip1"},
+			expectedRuleNames:     []string{otherPrefix + "-TCP-80"},
+			expectedProbeNames:    []string{consts.SharedProbeName},
+		},
+		{
+			name:           "shared probe removed when service switches from Cluster to Local and is the last one referring to it",
+			isLocalService: true,
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name:       ptr.To("fip1"),
+							ID:         ptr.To(fipID),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pipID")}},
+						},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{
+							Name: ptr.To(consts.SharedProbeName),
+							ID:   ptr.To(sharedProbeID),
+							Properties: &armnetwork.ProbePropertiesFormat{
+								Protocol:          to.Ptr(armnetwork.ProbeProtocolHTTP),
+								IntervalInSeconds: ptr.To(consts.HealthProbeDefaultProbeInterval),
+								ProbeThreshold:    ptr.To(consts.HealthProbeDefaultNumOfProbe),
+								LoadBalancingRules: []*armnetwork.SubResource{
+									{ID: ptr.To(svc2RuleID)},
+								},
+							},
+						},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockLBClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), rgName, lbName, gomock.Any()).Return(nil, nil).Times(1)
+			},
+			expectedDeletedLBName: "",
+			expectedFIPNames:      []string{"fip1"},
+			expectedRuleNames:     []string{otherPrefix + "-TCP-80"},
+			expectedProbeNames:    []string{},
+		},
 	}
 
 	for _, tc := range tests {
@@ -11465,6 +11686,28 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			cloud := GetTestCloud(ctrl)
+
+			trafficPolicy := v1.ServiceExternalTrafficPolicyTypeCluster
+			if tc.isLocalService {
+				trafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+			}
+			svc2 := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "svc2",
+					Namespace:   "default",
+					UID:         types.UID(svcUID),
+					Annotations: map[string]string{},
+				},
+				Spec: v1.ServiceSpec{
+					Type:                  v1.ServiceTypeLoadBalancer,
+					ExternalTrafficPolicy: trafficPolicy,
+					Ports: []v1.ServicePort{
+						{Name: "port1", Protocol: v1.ProtocolTCP, Port: 443},
+					},
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+					ClusterIP:  "10.0.0.3",
+				},
+			}
 
 			tc.setupMocks(cloud)
 			existingLBs := []*armnetwork.LoadBalancer{tc.lb}
@@ -11487,6 +11730,13 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 					ruleNames = append(ruleNames, *rule.Name)
 				}
 				assert.Equal(t, tc.expectedRuleNames, ruleNames)
+			}
+			if tc.expectedProbeNames != nil {
+				probeNames := []string{}
+				for _, probe := range tc.lb.Properties.Probes {
+					probeNames = append(probeNames, *probe.Name)
+				}
+				assert.Equal(t, tc.expectedProbeNames, probeNames)
 			}
 		})
 	}

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -8803,6 +8803,7 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 		specLBIP          string
 		existingLBs       []*armnetwork.LoadBalancer
 		existingPIPs      []*armnetwork.PublicIPAddress
+		notWantLb         bool
 		expected          string
 		expectedErr       error
 	}{
@@ -9017,7 +9018,7 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 			expected: "lb2",
 		},
 		{
-			description:   "multi-slb external: new IP not on LB returns fewest rules lb2",
+			description:   "multi-slb external: new IP not on LB returns error",
 			vmSet:         primary,
 			useStandardLB: true,
 			clusterName:   "azure",
@@ -9054,7 +9055,30 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 					},
 				},
 			},
-			expected: "lb2",
+			expectedErr: fmt.Errorf(`look up load balancer by public IP for service "test": find public IP by address "5.6.7.8": findMatchedPIPByLoadBalancerIP: cannot find public IP with IP address 5.6.7.8 in resource group rg`),
+		},
+		{
+			description:   "multi-slb external: PIP name not found returns error",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationPIPNameDualStack[false]: "nonexistent",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+					},
+				},
+			},
+			expectedErr: fmt.Errorf(`look up load balancer by public IP for service "test": find public IP by name "nonexistent": findMatchedPIPByName: failed to find PIP nonexistent in resource group rg`),
 		},
 		{
 			description:   "multi-slb external: IP annotation and LB annotation conflicts",
@@ -9362,6 +9386,53 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 					`(ServiceLabelSelector, ServiceNamespaceSelector, or AllowServicePlacement)`,
 			),
 		},
+		{
+			// Service is originally internal on lb2.
+			// Flipped service removes the internal annotation.
+			// IP annotation has the internal LB's private IP.
+			description:   "multi-slb internal: flip cleanup uses current LB",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+			},
+			notWantLb: true,
+			expected:  "lb2",
+		},
+		{
+			// Service is originally external on lb2.
+			// Flipped service adds the internal annotation.
+			// IP annotation has the external LB's public IP.
+			description:   "multi-slb external: flip cleanup uses current LB",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			isInternal:    true,
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "40.1.2.3",
+			},
+			notWantLb: true,
+			expected:  "lb2-internal",
+		},
 	}
 
 	for _, c := range cases {
@@ -9399,7 +9470,7 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 			if existingLBs == nil {
 				existingLBs = []*armnetwork.LoadBalancer{}
 			}
-			loadbalancerName, err := az.getAzureLoadBalancerName(context.TODO(), &svc, existingLBs, c.clusterName, c.vmSet, c.isInternal, true /* wantLb */)
+			loadbalancerName, err := az.getAzureLoadBalancerName(context.TODO(), &svc, existingLBs, c.clusterName, c.vmSet, c.isInternal, !c.notWantLb)
 			assert.Equal(t, c.expected, loadbalancerName)
 			if c.expectedErr != nil {
 				assert.EqualError(t, err, c.expectedErr.Error())

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -11023,6 +11023,7 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 		lb                    *armnetwork.LoadBalancer
 		setupMocks            func(cloud *Cloud)
 		expectedDeletedLBName string
+		expectedDeletedPLS    bool
 		expectedFIPNames      []string
 		expectedRuleNames     []string
 	}{
@@ -11164,6 +11165,54 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 			},
 			expectedDeletedLBName: lbName,
 		},
+		{
+			name: "FIP becomes empty, PLS exists and gets deleted, deletedPLS returned",
+			lb: &armnetwork.LoadBalancer{
+				Name: ptr.To(lbName),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name:       ptr.To("fip1"),
+							ID:         ptr.To(fipID),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pipID")}},
+						},
+						{Name: ptr.To("fip2"), ID: ptr.To(fipID2)},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To(svc2Prefix + "-TCP-443"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+							},
+						},
+						{
+							Name: ptr.To(otherPrefix + "-TCP-80"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID2)},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To(svc2Prefix + "-TCP-443"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(443))}},
+						{Name: ptr.To(otherPrefix + "-TCP-80"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(80))}},
+					},
+				},
+			},
+			setupMocks: func(cloud *Cloud) {
+				mockPLSRepo := cloud.plsRepo.(*privatelinkservice.MockRepository)
+				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{
+					Name: ptr.To("pls-fip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/pls-fip1"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{ID: ptr.To(fipID)},
+						},
+					},
+				}, nil).Times(1)
+				mockPLSRepo.EXPECT().Delete(gomock.Any(), gomock.Any(), "pls-fip1", gomock.Any()).Return(nil).Times(1)
+			},
+			expectedDeletedPLS: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -11175,9 +11224,10 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 			tc.setupMocks(cloud)
 			existingLBs := []*armnetwork.LoadBalancer{tc.lb}
 
-			deletedLBName, err := cloud.removeStaleServiceLBResources(context.TODO(), tc.lb, existingLBs, clusterName, svc2)
+			deletedLBName, deletedPLS, err := cloud.removeStaleServiceLBResources(context.TODO(), tc.lb, existingLBs, clusterName, svc2)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedDeletedLBName, deletedLBName)
+			assert.Equal(t, tc.expectedDeletedPLS, deletedPLS)
 
 			if tc.expectedFIPNames != nil {
 				var fipNames []string

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1941,6 +1941,180 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 			},
 		},
 		{
+			description: "remove backend pool when a local secondary service changes its load balancer",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary-svc"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary-svc"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-primary")},
+								},
+							},
+							{
+								Name: ptr.To("atest2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test2")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("atest1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary-svc"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("atest1-TCP-80"), Properties: &armnetwork.ProbePropertiesFormat{Port: ptr.To(int32(80))}},
+						},
+						BackendAddressPools: []*armnetwork.BackendAddressPool{
+							{Name: ptr.To("kubernetes")},
+							{Name: ptr.To("default-test1")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb2"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvcother"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/asvcother"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-other")},
+								},
+							},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test2")},
+								},
+							},
+						},
+						BackendAddressPools: []*armnetwork.BackendAddressPool{
+							{Name: ptr.To("kubernetes")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb2"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvcother"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/asvcother"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-other")},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip-primary"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-primary"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+						IPConfiguration: &armnetwork.IPConfiguration{
+							ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary-svc"),
+						},
+					},
+				},
+				{
+					Name: ptr.To("pip-other"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-other"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("5.6.7.8"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+						IPConfiguration: &armnetwork.IPConfiguration{
+							ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/asvcother"),
+						},
+					},
+				},
+			},
+			service: getTestService("test1", v1.ProtocolTCP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "5.6.7.8",
+			}, false, 80),
+			local: true,
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name: ptr.To("lb2"),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name: ptr.To("asvcother"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/asvcother"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-other")},
+							},
+						},
+					},
+				},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest2"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest2"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test2")},
+								},
+							},
+						},
+						BackendAddressPools: []*armnetwork.BackendAddressPool{
+							{Name: ptr.To("kubernetes")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb2"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("asvcother"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/asvcother"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-other")},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			description: "external: block migration when primary svc shares IP with secondary",
 			existingLBs: []*armnetwork.LoadBalancer{
 				{
@@ -1998,7 +2172,7 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 				{Name: "lb2"},
 			},
 			expectedError: fmt.Errorf(
-				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is also referenced by other resources; "+
 					"remove the %s annotation to stay on load balancer %q",
 				"primary", "lb1", "lb2", "aprimary",
 				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1"),
@@ -2054,7 +2228,7 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 				{Name: "lb2"},
 			},
 			expectedError: fmt.Errorf(
-				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is also referenced by other resources; "+
 					"remove the %s annotation to stay on load balancer %q",
 				"primary", "lb1-internal", "lb2-internal", "aprimary",
 				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1-internal"),
@@ -2355,7 +2529,7 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 				{Name: "lb2"},
 			},
 			expectedError: fmt.Errorf(
-				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is also referenced by other resources; "+
 					"remove the %s annotation to stay on load balancer %q",
 				"sharedprimary", "lb1", "lb2", "asharedprimary",
 				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1"),
@@ -2557,7 +2731,7 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 				{Name: "lb2"},
 			},
 			expectedError: fmt.Errorf(
-				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is shared with other services; "+
+				"service %q cannot migrate from load balancer %q to %q because frontend IP %q is also referenced by other resources; "+
 					"remove the %s annotation to stay on load balancer %q",
 				"sharedprimary", "lb1-internal", "lb2-internal", "asharedprimary",
 				consts.ServiceAnnotationLoadBalancerConfigurations, "lb1-internal"),

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -397,7 +397,9 @@ func getServicePIPName(service *v1.Service, isIPv6 bool) string {
 func getServicePIPNames(service *v1.Service) []string {
 	var ips []string
 	for _, ipVersion := range []bool{IPVersionIPv4, IPVersionIPv6} {
-		ips = append(ips, getServicePIPName(service, ipVersion))
+		if name := getServicePIPName(service, ipVersion); name != "" {
+			ips = append(ips, name)
+		}
 	}
 	return ips
 }
@@ -492,6 +494,16 @@ func countIPsOnBackendPool(backendPool *armnetwork.BackendAddressPool) int {
 func StringInSlice(s string, list []string) bool {
 	for _, item := range list {
 		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+// StringInSliceIgnoreCase checks if a string is in a list, ignoring case.
+func StringInSliceIgnoreCase(s string, list []string) bool {
+	for _, item := range list {
+		if strings.EqualFold(item, s) {
 			return true
 		}
 	}

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -954,19 +954,57 @@ func TestGetServicePIPPrefixID(t *testing.T) {
 }
 
 func TestGetServicePIPNames(t *testing.T) {
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
+	testcases := []struct {
+		desc        string
+		annotations map[string]string
+		ipFamilies  []v1.IPFamily
+		expected    []string
+	}{
+		{
+			desc:       "no annotations returns empty slice",
+			ipFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			expected:   nil,
+		},
+		{
+			desc: "IPv4 only",
+			annotations: map[string]string{
+				consts.ServiceAnnotationPIPNameDualStack[false]: "pip-name-ipv4",
+			},
+			ipFamilies: []v1.IPFamily{v1.IPv4Protocol},
+			expected:   []string{"pip-name-ipv4", "pip-name-ipv4"},
+		},
+		{
+			desc: "IPv6 only",
+			annotations: map[string]string{
 				consts.ServiceAnnotationPIPNameDualStack[true]: "pip-name-ipv6",
 			},
+			ipFamilies: []v1.IPFamily{v1.IPv6Protocol},
+			expected:   []string{"pip-name-ipv6"},
 		},
-		Spec: v1.ServiceSpec{
-			IPFamilies: []v1.IPFamily{v1.IPv6Protocol},
+		{
+			desc: "dual-stack both set",
+			annotations: map[string]string{
+				consts.ServiceAnnotationPIPNameDualStack[false]: "pip-name-ipv4",
+				consts.ServiceAnnotationPIPNameDualStack[true]:  "pip-name-ipv6",
+			},
+			ipFamilies: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			expected:   []string{"pip-name-ipv4", "pip-name-ipv6"},
 		},
 	}
 
-	names := getServicePIPNames(svc)
-	assert.Equal(t, []string{"", "pip-name-ipv6"}, names)
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+				Spec: v1.ServiceSpec{
+					IPFamilies: tc.ipFamilies,
+				},
+			}
+			assert.Equal(t, tc.expected, getServicePIPNames(svc))
+		})
+	}
 }
 
 func TestGetResourceByIPFamily(t *testing.T) {

--- a/tests/e2e/network/multiple_standard_lb.go
+++ b/tests/e2e/network/multiple_standard_lb.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -325,7 +323,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 			}
 
 			By("Verifying first FIP has all services' rules")
-			err := verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
+			err := utils.VerifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
 			Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all services sharing the IP")
 		},
 		Entry("external with user-assigned PIP", "external-user-pip"),
@@ -453,7 +451,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				}
 
 				By("Verifying primary service is still working")
-				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
 
 				allPorts := sets.New(primaryPort)
@@ -470,7 +468,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				}
 
 				By("Verifying primary FIP has rules for all services")
-				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, allPorts, "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, primaryFIPID, allPorts, "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
 
 				By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
@@ -514,7 +512,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 					Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be reconciled after re-adding IP and removing LB annotation")
 
 					By("Verifying primary FIP still has rules for all services")
-					err = verifyFIPHasRulesForPorts(tc, primaryFIPID, allPorts, "TCP")
+					err = utils.VerifyFIPHasRulesForPorts(tc, primaryFIPID, allPorts, "TCP")
 					Expect(err).NotTo(HaveOccurred(), "Primary FIP should still have rules for all services sharing the IP")
 				} else {
 					By("Waiting for " + svcNameIPv4 + " to get a new IP on " + targetLBAnnotation)
@@ -525,11 +523,11 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 
 					By("Verifying primary FIP no longer has " + svcNameIPv4 + "'s rules")
 					remainingPorts := allPorts.Difference(sets.New(svcIPv4Port))
-					err = verifyFIPHasRulesForPorts(tc, primaryFIPID, remainingPorts, "TCP")
+					err = utils.VerifyFIPHasRulesForPorts(tc, primaryFIPID, remainingPorts, "TCP")
 					Expect(err).NotTo(HaveOccurred(), "Primary FIP should only have remaining services' rules")
 
 					By("Verifying " + svcNameIPv4 + " has rules on the new FIP")
-					err = verifyFIPHasRulesForPorts(tc, newFIPID, sets.New(svcIPv4Port), "TCP")
+					err = utils.VerifyFIPHasRulesForPorts(tc, newFIPID, sets.New(svcIPv4Port), "TCP")
 					Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should have its rule on the new FIP")
 				}
 			},
@@ -587,7 +585,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying both services share the same FIP")
-				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Primary service changes LB annotation to lb-1, expecting blocked")
@@ -602,7 +600,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				Expect(err).NotTo(HaveOccurred(), "Expected warning event for primary service trying to move")
 
 				By("Verifying both services still share IP on original LB")
-				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Services should still share IP on original LB")
 
 				By("Primary service removes LB annotation")
@@ -613,7 +611,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying primary FIP still has rules for all services after removing LB annotation")
-				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Services should still share IP after removing LB annotation")
 			},
 			Entry("external", false),
@@ -717,7 +715,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
 
 				By("Verifying Service 1 is still working")
-				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
 
 				By("Service 2 removes IP annotation instead, keeping LB annotation")
@@ -735,11 +733,11 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				By("Verifying Service 2 stays on its original LB with its original IP")
 				_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
 				Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
-				err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
 
 				By("Verifying Service 1 is unaffected")
-				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
 
 				By("Service 2 adds back IP annotation, expecting conflict again")
@@ -762,11 +760,11 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
 
 				By("Verifying primary FIP has rules for all services")
-				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Both services should share IP on the primary LB")
 
 				By("Verifying Service 2's old FIP has no rules for its port")
-				err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+				err = utils.VerifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
 			},
 			Entry("external with user-assigned PIP", "external-user-pip"),
@@ -849,7 +847,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying both services have rules on the shared FIP")
-				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP")
 
 				By("Deleting Service 1")
@@ -857,7 +855,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying FIP still has Service 2's rules but not Service 1's")
-				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc2Port), "TCP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc2Port), "TCP")
 				Expect(err).NotTo(HaveOccurred(), "FIP should retain Service 2's rules after Service 1 deletion")
 
 				targetLBAnnotation := "lb-1"
@@ -892,7 +890,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 				}
 
 				By("Verifying old FIP is removed")
-				err = verifyFIPRemoved(tc, svc1FIPID)
+				err = utils.VerifyFIPRemoved(tc, svc1FIPID)
 				Expect(err).NotTo(HaveOccurred(), "FIP should be removed after last service moved away")
 
 				if useUserPIP {
@@ -977,7 +975,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after adding label")
 
 			By("Verifying FIP has rules for both services")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+			err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
 			Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP on lb-2")
 		})
 	})
@@ -1048,163 +1046,11 @@ func getLBsFromPublicIPs(tc *utils.AzureTestClient, pips []*string) sets.Set[str
 	return lbNames
 }
 
-// verifyFIPRemoved checks that the specified frontend IP configuration no longer exists on the LB.
-// Returns nil if the FIP is gone (or the entire LB is gone). Returns an error if the FIP still exists.
-func verifyFIPRemoved(tc *utils.AzureTestClient, fipID string) error {
-	if fipID == "" {
-		return fmt.Errorf("empty FIP ID")
-	}
-
-	match := lbNameRE.FindStringSubmatch(fipID)
-	if len(match) != 2 {
-		return fmt.Errorf("could not parse LB name from FIP ID: %s", fipID)
-	}
-	lbName := match[1]
-
-	lb, err := tc.GetLoadBalancer(tc.GetResourceGroup(), lbName)
-	if err != nil {
-		if strings.Contains(err.Error(), "NotFound") {
-			utils.Logf("LB %s not found, FIP %s is removed", lbName, fipID)
-			return nil
-		}
-		return fmt.Errorf("failed to get load balancer %s: %w", lbName, err)
-	}
-
-	if lb.Properties != nil && lb.Properties.FrontendIPConfigurations != nil {
-		for _, fip := range lb.Properties.FrontendIPConfigurations {
-			if strings.EqualFold(ptr.Deref(fip.ID, ""), fipID) {
-				var ruleIDs []string
-				if fip.Properties != nil {
-					for _, r := range fip.Properties.LoadBalancingRules {
-						ruleIDs = append(ruleIDs, ptr.Deref(r.ID, "<unknown>"))
-					}
-				}
-				return fmt.Errorf("FIP %s still exists on LB %s with rules %v", fipID, lbName, ruleIDs)
-			}
-		}
-	}
-
-	utils.Logf("FIP %s has been removed from LB %s", fipID, lbName)
-	return nil
-}
-
-// getFIPRulePorts returns all ports that have load balancing rules for the given FIP and protocol.
-// Returns (ports, lbExists, error). If lbExists is false, the LB doesn't exist (ports will be empty).
-func getFIPRulePorts(tc *utils.AzureTestClient, fipID string, protocol string) (sets.Set[int32], bool, error) {
-	if fipID == "" {
-		return nil, false, fmt.Errorf("empty FIP ID")
-	}
-
-	// Extract LB name from FIP ID.
-	match := lbNameRE.FindStringSubmatch(fipID)
-	if len(match) != 2 {
-		return nil, false, fmt.Errorf("could not parse LB name from FIP ID: %s", fipID)
-	}
-	lbName := match[1]
-
-	lb, err := tc.GetLoadBalancer(tc.GetResourceGroup(), lbName)
-	if err != nil {
-		errStr := err.Error()
-		if strings.Contains(errStr, "NotFound") {
-			return sets.New[int32](), false, nil
-		}
-		return nil, false, fmt.Errorf("failed to get load balancer %s: %w", lbName, err)
-	}
-
-	// Find all rules that reference the target FIP ID with matching protocol.
-	ports := sets.New[int32]()
-	if lb.Properties != nil && lb.Properties.LoadBalancingRules != nil {
-		for _, rule := range lb.Properties.LoadBalancingRules {
-			if rule.Properties == nil || rule.Properties.FrontendIPConfiguration == nil {
-				continue
-			}
-			ruleFIPID := ptr.Deref(rule.Properties.FrontendIPConfiguration.ID, "")
-			if !strings.EqualFold(ruleFIPID, fipID) {
-				continue
-			}
-
-			rulePort := ptr.Deref(rule.Properties.FrontendPort, 0)
-			ruleProtocol := string(ptr.Deref(rule.Properties.Protocol, ""))
-
-			if strings.EqualFold(ruleProtocol, protocol) {
-				utils.Logf("Found rule %q for port %d/%s on FIP", ptr.Deref(rule.Name, ""), rulePort, ruleProtocol)
-				ports.Insert(rulePort)
-			}
-		}
-	}
-
-	return ports, true, nil
-}
-
-// verifyFIPHasRulesForPorts checks that the specified frontend IP config has rules for exactly all expected ports.
-func verifyFIPHasRulesForPorts(tc *utils.AzureTestClient, fipID string, expectedPorts sets.Set[int32], protocol string) error {
-	utils.Logf("Verifying FIP ID %q has rules for ports %v", fipID, expectedPorts.UnsortedList())
-
-	actualPorts, lbExists, err := getFIPRulePorts(tc, fipID, protocol)
-	if err != nil {
-		return err
-	}
-	if !lbExists {
-		return fmt.Errorf("load balancer for FIP %q does not exist", fipID)
-	}
-
-	// Check for exact match.
-	missingPorts := expectedPorts.Difference(actualPorts)
-	extraPorts := actualPorts.Difference(expectedPorts)
-
-	if missingPorts.Len() > 0 || extraPorts.Len() > 0 {
-		return fmt.Errorf("FIP %q port mismatch: missing=%v, extra=%v, expected=%v, actual=%v",
-			fipID, missingPorts.UnsortedList(), extraPorts.UnsortedList(),
-			expectedPorts.UnsortedList(), actualPorts.UnsortedList())
-	}
-
-	utils.Logf("FIP %q has exactly the expected rules for ports %v", fipID, expectedPorts.UnsortedList())
-	return nil
-}
-
-// verifyFIPHasNoRulesForPorts checks that the specified frontend IP config has no rules for the specified ports.
-// If the LB does not exist, that counts as success (no rules).
-func verifyFIPHasNoRulesForPorts(tc *utils.AzureTestClient, fipID string, absentPorts sets.Set[int32], protocol string) error {
-	utils.Logf("Verifying FIP ID %q has NO rules for ports %v", fipID, absentPorts.UnsortedList())
-
-	actualPorts, lbExists, err := getFIPRulePorts(tc, fipID, protocol)
-	if err != nil {
-		return err
-	}
-	if !lbExists {
-		utils.Logf("LB for FIP %q not found, treating as no rules", fipID)
-		return nil
-	}
-
-	// Check no intersection.
-	foundPorts := absentPorts.Intersection(actualPorts)
-	if foundPorts.Len() > 0 {
-		return fmt.Errorf("FIP %q still has rules for ports %v", fipID, foundPorts.UnsortedList())
-	}
-
-	utils.Logf("FIP %q has no rules for ports %v (as expected)", fipID, absentPorts.UnsortedList())
-	return nil
-}
-
-// getFIPIDForPrivateIP finds the frontend IP configuration ID for a given private IP.
-func getFIPIDForPrivateIP(lb *armnetwork.LoadBalancer, privateIP string) string {
-	if lb.Properties == nil || lb.Properties.FrontendIPConfigurations == nil {
-		return ""
-	}
-	for _, fip := range lb.Properties.FrontendIPConfigurations {
-		if fip.Properties != nil && fip.Properties.PrivateIPAddress != nil {
-			if *fip.Properties.PrivateIPAddress == privateIP {
-				return ptr.Deref(fip.ID, "")
-			}
-		}
-	}
-	return ""
-}
-
+// getFIPIDAndLBName returns the frontend IP configuration ID and load balancer name for the given IP.
 func getFIPIDAndLBName(tc *utils.AzureTestClient, ip string, isInternal bool) (fipID, lbName string) {
 	if isInternal {
 		lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &ip, tc.GetResourceGroup())
-		return getFIPIDForPrivateIP(lb, ip), ptr.Deref(lb.Name, "")
+		return utils.GetFIPIDForPrivateIP(lb, ip), ptr.Deref(lb.Name, "")
 	}
 	fipID = getPIPFrontendConfigurationID(tc, ip, tc.GetResourceGroup(), true)
 	lb := getAzureLoadBalancerFromPIP(tc, &ip, tc.GetResourceGroup(), tc.GetResourceGroup())

--- a/tests/e2e/network/multiple_standard_lb.go
+++ b/tests/e2e/network/multiple_standard_lb.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +34,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/tests/e2e/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -232,6 +235,1406 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("should place all external services sharing a user-assigned public IP on the same load balancer", func() {
+		By("Creating a user-assigned public IP")
+		ipName := fmt.Sprintf("%s-shared-pip-%s", basename, ns.Name[:8])
+		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), defaultPublicIPAddress(ipName, false))
+		Expect(err).NotTo(HaveOccurred())
+		targetIP := ptr.Deref(pip.Properties.IPAddress, "")
+		utils.Logf("Created user-assigned PIP with address %s", targetIP)
+		defer func() {
+			By("Cleaning up PIP")
+			err = utils.DeletePIPWithRetry(tc, ipName, "")
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		var firstFIPID string
+		serviceCount := 2
+		serviceNames := []string{}
+		servicePorts := sets.New[int32]()
+
+		for i := range serviceCount {
+			serviceLabels := labels
+			deploymentName := testDeploymentName
+			tcpPort := int32(serverPort + i)
+			servicePorts.Insert(tcpPort)
+
+			if i != 0 {
+				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
+				utils.Logf("Creating deployment %q", deploymentName)
+				serviceLabels = map[string]string{
+					"app": deploymentName,
+				}
+				tcpPortPtr := tcpPort
+				extraDeployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPortPtr, nil)
+				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), extraDeployment, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				defer func(name string) {
+					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}(deploymentName)
+			}
+
+			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
+			serviceNames = append(serviceNames, serviceName)
+			utils.Logf("Creating Service %q with shared IP %s", serviceName, targetIP)
+
+			servicePort := []v1.ServicePort{{
+				Port:       tcpPort,
+				TargetPort: intstr.FromInt(int(tcpPort)),
+			}}
+			service := utils.CreateLoadBalancerServiceManifest(serviceName, nil, serviceLabels, ns.Name, servicePort)
+			service = updateServiceLBIPs(service, false, []*string{&targetIP})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func(name string) {
+				err = utils.DeleteService(cs, ns.Name, name)
+				Expect(err).NotTo(HaveOccurred())
+			}(serviceName)
+
+			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []*string{&targetIP})
+			Expect(err).NotTo(HaveOccurred())
+			utils.Logf("Service %q is exposed with IP %s", serviceName, targetIP)
+
+			// Log FIP state after each service.
+			fipID := getPIPFrontendConfigurationID(tc, targetIP, tc.GetResourceGroup(), true)
+			utils.Logf("After service %d: IP %s has FIP ID %q", i, targetIP, fipID)
+			if i == 0 {
+				firstFIPID = fipID
+			}
+		}
+
+		By("Verifying first FIP has all services' rules")
+		err = verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
+		Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all services sharing the IP")
+	})
+
+	It("should place all external services sharing a managed public IP on the same load balancer", func() {
+		var firstFIPID string
+		var sharedIP string
+		serviceCount := 2
+		serviceNames := []string{}
+		servicePorts := sets.New[int32]()
+
+		for i := range serviceCount {
+			serviceLabels := labels
+			deploymentName := testDeploymentName
+			tcpPort := int32(serverPort + i)
+			servicePorts.Insert(tcpPort)
+
+			if i != 0 {
+				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
+				utils.Logf("Creating deployment %q", deploymentName)
+				serviceLabels = map[string]string{
+					"app": deploymentName,
+				}
+				tcpPortPtr := tcpPort
+				extraDeployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPortPtr, nil)
+				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), extraDeployment, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				defer func(name string) {
+					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}(deploymentName)
+			}
+
+			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
+			serviceNames = append(serviceNames, serviceName)
+
+			servicePort := []v1.ServicePort{{
+				Port:       tcpPort,
+				TargetPort: intstr.FromInt(int(tcpPort)),
+			}}
+			service := utils.CreateLoadBalancerServiceManifest(serviceName, nil, serviceLabels, ns.Name, servicePort)
+			if sharedIP != "" {
+				service = updateServiceLBIPs(service, false, []*string{&sharedIP})
+				utils.Logf("Creating Service %q with shared managed IP %s", serviceName, sharedIP)
+			} else {
+				utils.Logf("Creating Service %q (will get managed IP)", serviceName)
+			}
+
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func(name string) {
+				err = utils.DeleteService(cs, ns.Name, name)
+				Expect(err).NotTo(HaveOccurred())
+			}(serviceName)
+
+			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips)).NotTo(BeZero())
+
+			// Record shared IP on first service.
+			if i == 0 {
+				sharedIP = *ips[0]
+				utils.Logf("First service got managed IP: %s", sharedIP)
+			}
+
+			// Log FIP state after each service.
+			fipID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			utils.Logf("After service %d: IP %s has FIP ID %q", i, sharedIP, fipID)
+			if i == 0 {
+				firstFIPID = fipID
+			}
+		}
+
+		By("Verifying first FIP has all services' rules")
+		err := verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
+		Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all services sharing the IP")
+	})
+
+	It("should place all internal services sharing a private IP on the same load balancer", func() {
+		var firstFIPID string
+		var sharedIP string
+		serviceCount := 2
+		serviceNames := []string{}
+		servicePorts := sets.New[int32]()
+
+		for i := range serviceCount {
+			serviceLabels := labels
+			deploymentName := testDeploymentName
+			tcpPort := int32(serverPort + i)
+			servicePorts.Insert(tcpPort)
+
+			if i != 0 {
+				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
+				utils.Logf("Creating deployment %q", deploymentName)
+				serviceLabels = map[string]string{
+					"app": deploymentName,
+				}
+				tcpPortPtr := tcpPort
+				extraDeployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPortPtr, nil)
+				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), extraDeployment, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				defer func(name string) {
+					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}(deploymentName)
+			}
+
+			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
+			serviceNames = append(serviceNames, serviceName)
+
+			servicePort := []v1.ServicePort{{
+				Port:       tcpPort,
+				TargetPort: intstr.FromInt(int(tcpPort)),
+			}}
+			service := utils.CreateLoadBalancerServiceManifest(serviceName, serviceAnnotationLoadBalancerInternalTrue, serviceLabels, ns.Name, servicePort)
+			if sharedIP != "" {
+				service = updateServiceLBIPs(service, true, []*string{&sharedIP})
+				utils.Logf("Creating internal Service %q with shared IP %s", serviceName, sharedIP)
+			} else {
+				utils.Logf("Creating internal Service %q (will get new IP)", serviceName)
+			}
+
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func(name string) {
+				err = utils.DeleteService(cs, ns.Name, name)
+				Expect(err).NotTo(HaveOccurred())
+			}(serviceName)
+
+			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips)).NotTo(BeZero())
+
+			// Record shared IP on first service.
+			if i == 0 {
+				sharedIP = *ips[0]
+				utils.Logf("First internal service got IP: %s", sharedIP)
+			}
+
+			// Log FIP state after each service.
+			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
+			fipID := getFIPIDForPrivateIP(lb, sharedIP)
+			utils.Logf("After service %d: IP %s has FIP ID %q", i, sharedIP, fipID)
+			if i == 0 {
+				firstFIPID = fipID
+			}
+		}
+
+		By("Verifying first FIP has all internal services' rules")
+		err := verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
+		Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all internal services sharing the IP")
+	})
+
+	Describe("LB Placement Conflicts", func() {
+		const (
+			eventTimeout    = 30 * time.Second
+			ipChangeTimeout = 150 * time.Second
+
+			svcNamePrimary = "svc-primary"
+			svcNameLBIP    = "svc-lbip"
+			svcNamePIPName = "svc-pipname"
+			svcNameIPv4    = "svc-ipv4"
+
+			msgConflictingLBConfig = "conflicting load balancer configuration"
+		)
+
+		It("should block external services with conflicting IP and LB config for user-assigned PIP", func() {
+			By("Creating user-assigned PIP")
+			pipName := "conflict-test-pip"
+			pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
+			Expect(err).NotTo(HaveOccurred())
+			sharedIP := ptr.Deref(pip.Properties.IPAddress, "")
+			Expect(sharedIP).NotTo(BeEmpty())
+			defer func() {
+				utils.Logf("Cleaning up PIP %s", pipName)
+				err := utils.DeletePIPWithRetry(tc, pipName, "")
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			By("Creating primary service with azure-load-balancer-ipv4 annotation")
+			primaryPort := int32(serverPort)
+			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       primaryPort,
+				TargetPort: intstr.FromInt(int(primaryPort)),
+			}})
+			primaryService = updateServiceLBIPs(primaryService, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred())
+			primaryFIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			utils.Logf("Primary service exposed on FIP: %s", primaryFIPID)
+
+			By("Creating service with spec.loadBalancerIP and LB config, expecting blocked")
+			svc1Port := int32(serverPort + 1)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNameLBIP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
+			}, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			svc1.Spec.LoadBalancerIP = sharedIP
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameLBIP)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameLBIP, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameLBIP)
+
+			By("Creating service with azure-pip-name and LB config, expecting blocked")
+			svc2Port := int32(serverPort + 2)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNamePIPName, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			svc2 = updateServicePIPNames(tc.IPFamily, svc2, []string{pipName})
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePIPName)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNamePIPName, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNamePIPName)
+
+			By("Creating service with azure-load-balancer-ipv4 and LB config, expecting blocked")
+			svc3Port := int32(serverPort + 3)
+			svc3 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc3Port,
+				TargetPort: intstr.FromInt(int(svc3Port)),
+			}})
+			svc3 = updateServiceLBIPs(svc3, false, []*string{&sharedIP})
+			svc3.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc3, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Verifying primary service is still working")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
+
+			By("Resolving " + svcNameIPv4 + " by removing LB config annotation")
+			svc3, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc3.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc3, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
+
+			By("Resolving " + svcNamePIPName + " by removing LB config annotation")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePIPName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePIPName, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNamePIPName+" should be exposed after removing LB config")
+
+			By("Resolving " + svcNameLBIP + " by removing LB config annotation")
+			svc1, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameLBIP, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc1.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc1, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameLBIP, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameLBIP+" should be exposed after removing LB config")
+
+			By("Verifying primary FIP has rules for all services")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port, svc3Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
+
+			By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
+			primaryLB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
+			primaryLBName := ptr.Deref(primaryLB.Name, "")
+			targetLBAnnotation := "lb-1"
+			if primaryLBName == "lb-1" {
+				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
+			}
+			beforeUpdate := time.Now()
+			svc3, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc3.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc3, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeUpdate, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Removing IP annotation from " + svcNameIPv4 + " to resolve conflict and move to " + targetLBAnnotation)
+			svc3, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc3.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			delete(svc3.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[true])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc3, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for " + svcNameIPv4 + " to get a new IP on " + targetLBAnnotation)
+			newIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
+			Expect(err).NotTo(HaveOccurred())
+			newFIPID := getPIPFrontendConfigurationID(tc, newIP, tc.GetResourceGroup(), true)
+			utils.Logf("%s moved to new IP %s on FIP: %s", svcNameIPv4, newIP, newFIPID)
+
+			By("Verifying primary FIP no longer has " + svcNameIPv4 + "'s rules")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary FIP should only have remaining services' rules")
+
+			By("Verifying " + svcNameIPv4 + " has rules on the new FIP")
+			err = verifyFIPHasRulesForPorts(tc, newFIPID, sets.New(svc3Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should have its rule on the new FIP")
+		})
+
+		It("should block external services with conflicting IP and LB config for managed PIP", func() {
+			By("Creating primary service that gets a managed PIP")
+			primaryPort := int32(serverPort)
+			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       primaryPort,
+				TargetPort: intstr.FromInt(int(primaryPort)),
+			}})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips)).NotTo(BeZero())
+			sharedIP := *ips[0]
+			primaryFIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			utils.Logf("Primary service exposed with managed IP %s on FIP: %s", sharedIP, primaryFIPID)
+
+			By("Creating service with spec.loadBalancerIP and LB config, expecting blocked")
+			svc1Port := int32(serverPort + 1)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNameLBIP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
+			}, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			svc1.Spec.LoadBalancerIP = sharedIP
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameLBIP)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameLBIP, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameLBIP)
+
+			By("Creating service with azure-load-balancer-ipv4 and LB config, expecting blocked")
+			svc2Port := int32(serverPort + 2)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Verifying primary service is still working")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
+
+			By("Resolving " + svcNameIPv4 + " by removing LB config annotation")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
+
+			By("Resolving " + svcNameLBIP + " by removing LB config annotation")
+			svc1, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameLBIP, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc1.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc1, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameLBIP, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameLBIP+" should be exposed after removing LB config")
+
+			By("Verifying primary FIP has rules for all services")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
+
+			By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
+			primaryLB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
+			primaryLBName := ptr.Deref(primaryLB.Name, "")
+			targetLBAnnotation := "lb-1"
+			if primaryLBName == "lb-1" {
+				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
+			}
+			beforeUpdate := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeUpdate, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Removing IP annotation from " + svcNameIPv4 + " to resolve conflict and move to " + targetLBAnnotation)
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[true])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for " + svcNameIPv4 + " to get a new IP on " + targetLBAnnotation)
+			newIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
+			Expect(err).NotTo(HaveOccurred())
+			newFIPID := getPIPFrontendConfigurationID(tc, newIP, tc.GetResourceGroup(), true)
+			utils.Logf("%s moved to new IP %s on FIP: %s", svcNameIPv4, newIP, newFIPID)
+
+			By("Verifying primary FIP no longer has " + svcNameIPv4 + "'s rules")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary FIP should only have remaining services' rules")
+
+			By("Verifying " + svcNameIPv4 + " has rules on the new FIP")
+			err = verifyFIPHasRulesForPorts(tc, newFIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should have its rule on the new FIP")
+		})
+
+		It("should block internal services with conflicting IP and LB config", func() {
+			By("Creating primary internal service")
+			primaryPort := int32(serverPort)
+			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
+				Port:       primaryPort,
+				TargetPort: intstr.FromInt(int(primaryPort)),
+			}})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips)).NotTo(BeZero())
+			sharedIP := *ips[0]
+			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
+			primaryFIPID := getFIPIDForPrivateIP(lb, sharedIP)
+			utils.Logf("Primary internal service exposed with IP %s on FIP: %s", sharedIP, primaryFIPID)
+
+			By("Creating service with spec.loadBalancerIP and LB config, expecting blocked")
+			svc1Port := int32(serverPort + 1)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNameLBIP, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			svc1.Spec.LoadBalancerIP = sharedIP
+			svc1.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameLBIP)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameLBIP, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameLBIP)
+
+			By("Creating service with azure-load-balancer-ipv4 and LB config, expecting blocked")
+			svc2Port := int32(serverPort + 2)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			svc2 = updateServiceLBIPs(svc2, true, []*string{&sharedIP})
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Verifying primary service is still working")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
+
+			By("Resolving " + svcNameIPv4 + " by removing LB config annotation")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
+
+			By("Resolving " + svcNameLBIP + " by removing LB config annotation")
+			svc1, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameLBIP, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc1.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc1, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameLBIP, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameLBIP+" should be exposed after removing LB config")
+
+			By("Verifying primary FIP has rules for all services")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
+
+			By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
+			primaryLB := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
+			primaryLBName := ptr.Deref(primaryLB.Name, "")
+			targetLBAnnotation := "lb-1"
+			if primaryLBName == "lb-1-internal" {
+				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
+			}
+			beforeUpdate := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeUpdate, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Removing IP annotation from " + svcNameIPv4 + ", expecting failure because the old private IP is still allocated")
+			beforeIPRemove := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[true])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Expecting SyncLoadBalancerFailed with PrivateIPAddressIsAllocated since internal services cannot release the old private IP")
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", "PrivateIPAddressIsAllocated", beforeIPRemove, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Internal service should fail to move because the private IP is still allocated on the old LB")
+
+			By("Re-adding IP annotation and removing LB annotation to resolve conflict")
+			beforeResolve := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerIPDualStack[false]] = sharedIP
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeResolve, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be reconciled after re-adding IP and removing LB annotation")
+
+			By("Verifying primary FIP still has rules for all services")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Primary FIP should still have rules for all services sharing the IP")
+		})
+
+		It("should block external primary service from moving LB when there is IP sharing", func() {
+			By("Creating primary service that gets a managed PIP")
+			primaryPort := int32(serverPort)
+			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       primaryPort,
+				TargetPort: intstr.FromInt(int(primaryPort)),
+			}})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips)).NotTo(BeZero())
+			sharedIP := *ips[0]
+			primaryFIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			primaryLB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
+			primaryLBName := ptr.Deref(primaryLB.Name, "")
+			utils.Logf("Primary service exposed with managed IP %s on LB %s, FIP: %s", sharedIP, primaryLBName, primaryFIPID)
+
+			By("Creating secondary service sharing the IP with azure-load-balancer-ipv4")
+			secondaryPort := int32(serverPort + 1)
+			secondaryService := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       secondaryPort,
+				TargetPort: intstr.FromInt(int(secondaryPort)),
+			}})
+			secondaryService = updateServiceLBIPs(secondaryService, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), secondaryService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying both services share the same FIP")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred())
+
+			targetLBAnnotation := "lb-1"
+			if primaryLBName == "lb-1" {
+				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
+			}
+			By(fmt.Sprintf("Primary service adds LB annotation pointing to %s, expecting blocked", targetLBAnnotation))
+			beforeUpdate := time.Now()
+			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if primaryService.Annotations == nil {
+				primaryService.Annotations = map[string]string{}
+			}
+			primaryService.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNamePrimary, "SyncLoadBalancerFailed", "cannot migrate", beforeUpdate, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected warning event for primary service trying to move")
+
+			By("Verifying both services still share IP on original LB")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Services should still share IP on original LB")
+
+			By("Primary service removes LB annotation")
+			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(primaryService.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying primary FIP still has rules for all services after removing LB annotation")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Services should still share IP after removing LB annotation")
+		})
+
+		It("should block internal primary service from moving LB when there is IP sharing", func() {
+			By("Creating primary internal service")
+			primaryPort := int32(serverPort)
+			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
+				Port:       primaryPort,
+				TargetPort: intstr.FromInt(int(primaryPort)),
+			}})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips)).NotTo(BeZero())
+			sharedIP := *ips[0]
+			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
+			primaryFIPID := getFIPIDForPrivateIP(lb, sharedIP)
+			primaryLBName := ptr.Deref(lb.Name, "")
+			utils.Logf("Primary internal service exposed with IP %s on LB %s, FIP: %s", sharedIP, primaryLBName, primaryFIPID)
+
+			By("Creating secondary service sharing the IP with azure-load-balancer-ipv4")
+			secondaryPort := int32(serverPort + 1)
+			secondaryService := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
+				Port:       secondaryPort,
+				TargetPort: intstr.FromInt(int(secondaryPort)),
+			}})
+			secondaryService = updateServiceLBIPs(secondaryService, true, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), secondaryService, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying both services share the same FIP")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred())
+
+			targetLBAnnotation := "lb-1"
+			if primaryLBName == "lb-1-internal" {
+				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
+			}
+			By(fmt.Sprintf("Primary service adds LB annotation pointing to %s, expecting blocked", targetLBAnnotation))
+			beforeUpdate := time.Now()
+			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if primaryService.Annotations == nil {
+				primaryService.Annotations = map[string]string{}
+			}
+			primaryService.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNamePrimary, "SyncLoadBalancerFailed", "cannot migrate", beforeUpdate, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected warning event for primary service trying to move")
+
+			By("Verifying both services still share IP on original internal LB")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Services should still share IP on original LB")
+
+			By("Primary service removes LB annotation")
+			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(primaryService.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying primary FIP still has rules for all services after removing LB annotation")
+			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Services should still share IP after removing LB annotation")
+		})
+
+		It("should allow external service with no prior IP sharing to share user-assigned PIP", func() {
+			By("Creating user-assigned PIP")
+			pipName := "cross-lb-test-pip"
+			pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
+			Expect(err).NotTo(HaveOccurred())
+			sharedIP := ptr.Deref(pip.Properties.IPAddress, "")
+			Expect(sharedIP).NotTo(BeEmpty())
+			defer func() {
+				utils.Logf("Cleaning up PIP %s", pipName)
+				err := utils.DeletePIPWithRetry(tc, pipName, "")
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			By("Creating Service 1 with user-assigned PIP")
+			svc1Port := int32(serverPort)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			svc1 = updateServicePIPNames(tc.IPFamily, svc1, []string{pipName})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred())
+			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			svc1LB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
+			svc1LBName := ptr.Deref(svc1LB.Name, "")
+			utils.Logf("Service 1 exposed with user-assigned PIP %s on LB %s, FIP: %s", sharedIP, svc1LBName, svc1FIPID)
+
+			svc2LBAnnotation := "lb-1"
+			if svc1LBName == "lb-1" {
+				svc2LBAnnotation = os.Getenv("CLUSTER_NAME")
+			}
+			By(fmt.Sprintf("Creating Service 2 with LB annotation pointing to %s", svc2LBAnnotation))
+			svc2Port := int32(serverPort + 1)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: svc2LBAnnotation,
+			}, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips2, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNameIPv4)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips2)).NotTo(BeZero())
+			svc2IP := *ips2[0]
+			Expect(svc2IP).NotTo(Equal(sharedIP), "Service 2 should have a different IP on "+svc2LBAnnotation)
+			svc2OldFIPID := getPIPFrontendConfigurationID(tc, svc2IP, tc.GetResourceGroup(), true)
+			utils.Logf("Service 2 exposed with IP %s on %s, FIP: %s", svc2IP, svc2LBAnnotation, svc2OldFIPID)
+
+			By("Service 2 adds azure-load-balancer-ipv4 pointing to Service 1's IP, expecting blocked")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Verifying Service 1 is still working")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+			By("Service 2 removes IP annotation instead, keeping LB annotation")
+			beforeIPRemove := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for successful reconcile after removing IP annotation")
+			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected EnsuredLoadBalancer event after removing IP annotation")
+
+			By("Verifying Service 2 stays on its original LB with its original IP")
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
+			err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
+
+			By("Verifying Service 1 is unaffected")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+			By("Service 2 adds back IP annotation, expecting conflict again")
+			beforeIPReAdd := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeIPReAdd, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected conflict warning after re-adding IP annotation")
+
+			By("Service 2 removes LB annotation to resolve conflict")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
+
+			By("Verifying primary FIP has rules for all services")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Both services should share the user-assigned PIP on the primary LB")
+
+			By("Verifying Service 2's old FIP has no rules for its port")
+			err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
+		})
+
+		It("should allow external service with no prior IP sharing to share managed PIP", func() {
+			clusterName := os.Getenv("CLUSTER_NAME")
+
+			By("Creating Service 1 with cluster LB annotation")
+			svc1Port := int32(serverPort)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: clusterName,
+			}, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips1)).NotTo(BeZero())
+			sharedIP := *ips1[0]
+			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			utils.Logf("Service 1 exposed with IP %s on cluster LB FIP: %s", sharedIP, svc1FIPID)
+
+			By("Creating Service 2 with lb-1 annotation")
+			svc2Port := int32(serverPort + 1)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
+			}, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips2, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNameIPv4)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips2)).NotTo(BeZero())
+			svc2IP := *ips2[0]
+			Expect(svc2IP).NotTo(Equal(sharedIP), "Service 2 should have a different IP on lb-1")
+			svc2OldFIPID := getPIPFrontendConfigurationID(tc, svc2IP, tc.GetResourceGroup(), true)
+			utils.Logf("Service 2 exposed with IP %s on lb-1, FIP: %s", svc2IP, svc2OldFIPID)
+
+			By("Service 2 adds azure-load-balancer-ipv4 annotation pointing to Service 1's IP, expecting blocked")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Verifying Service 1 is still working")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+			By("Service 2 removes IP annotation instead, keeping LB annotation")
+			beforeIPRemove := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for successful reconcile after removing IP annotation")
+			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected EnsuredLoadBalancer event after removing IP annotation")
+
+			By("Verifying Service 2 stays on its original LB with its original IP")
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
+			err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
+
+			By("Verifying Service 1 is unaffected")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+			By("Service 2 adds back IP annotation, expecting conflict again")
+			beforeIPReAdd := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeIPReAdd, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected conflict warning after re-adding IP annotation")
+
+			By("Service 2 removes LB annotation to resolve conflict")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
+
+			By("Verifying primary FIP has rules for all services")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Both services should share IP on the primary LB")
+
+			By("Verifying Service 2's old FIP has no rules for its port")
+			err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
+		})
+
+		It("should allow internal service with no prior IP sharing to share IP", func() {
+			clusterName := os.Getenv("CLUSTER_NAME")
+
+			By("Creating Service 1 with cluster LB annotation")
+			svc1Port := int32(serverPort)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			svc1.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = clusterName
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips1)).NotTo(BeZero())
+			sharedIP := *ips1[0]
+			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
+			svc1FIPID := getFIPIDForPrivateIP(lb, sharedIP)
+			utils.Logf("Service 1 exposed with internal IP %s on cluster LB FIP: %s", sharedIP, svc1FIPID)
+
+			By("Creating Service 2 with lb-1 annotation")
+			svc2Port := int32(serverPort + 1)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips2, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNameIPv4)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips2)).NotTo(BeZero())
+			svc2IP := *ips2[0]
+			Expect(svc2IP).NotTo(Equal(sharedIP), "Service 2 should have a different IP on lb-1")
+			svc2OldLB := getAzureInternalLoadBalancerFromPrivateIP(tc, &svc2IP, tc.GetResourceGroup())
+			svc2OldFIPID := getFIPIDForPrivateIP(svc2OldLB, svc2IP)
+			utils.Logf("Service 2 exposed with internal IP %s on lb-1, FIP: %s", svc2IP, svc2OldFIPID)
+
+			By("Service 2 adds azure-load-balancer-ipv4 annotation pointing to Service 1's IP, expecting blocked")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2 = updateServiceLBIPs(svc2, true, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Verifying Service 1 is still working")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+			By("Service 2 removes IP annotation instead, keeping LB annotation")
+			beforeIPRemove := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for successful reconcile after removing IP annotation")
+			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected EnsuredLoadBalancer event after removing IP annotation")
+
+			By("Verifying Service 2 stays on its original LB with its original IP")
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
+			err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
+
+			By("Verifying Service 1 is unaffected")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+			By("Service 2 adds back IP annotation, expecting conflict again")
+			beforeIPReAdd := time.Now()
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2 = updateServiceLBIPs(svc2, true, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeIPReAdd, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected conflict warning after re-adding IP annotation")
+
+			By("Service 2 removes LB annotation to resolve conflict")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
+
+			By("Verifying primary FIP has rules for all services")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Both services should share IP on the primary LB")
+
+			By("Verifying Service 2's old FIP has no rules for its port")
+			err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
+		})
+
+		It("should clean up stale rules when last secondary moves after primary deleted with user-assigned PIP", func() {
+			clusterName := os.Getenv("CLUSTER_NAME")
+
+			By("Creating user-assigned PIP")
+			pipName := "orphan-cleanup-test-pip"
+			pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
+			Expect(err).NotTo(HaveOccurred())
+			sharedIP := ptr.Deref(pip.Properties.IPAddress, "")
+			Expect(sharedIP).NotTo(BeEmpty())
+			defer func() {
+				utils.Logf("Cleaning up PIP %s", pipName)
+				err := utils.DeletePIPWithRetry(tc, pipName, "")
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			By("Creating Service 1 (primary) with user-assigned PIP")
+			svc1Port := int32(serverPort)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			svc1 = updateServicePIPNames(tc.IPFamily, svc1, []string{pipName})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred())
+			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			svc1LB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
+			svc1LBName := ptr.Deref(svc1LB.Name, "")
+			utils.Logf("Service 1 exposed with user-assigned PIP %s on %s, FIP: %s", sharedIP, svc1LBName, svc1FIPID)
+
+			By("Creating Service 2 (secondary) sharing Service 1's PIP via IP annotation")
+			svc2Port := int32(serverPort + 1)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying both services have rules on the shared FIP")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP")
+
+			By("Deleting Service 1")
+			err = utils.DeleteService(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying FIP still has Service 2's rules but not Service 1's")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "FIP should retain Service 2's rules after Service 1 deletion")
+
+			targetLBAnnotation := "lb-1"
+			if svc1LBName == "lb-1" {
+				targetLBAnnotation = clusterName
+			}
+			By(fmt.Sprintf("Service 2 adds LB annotation %q, expecting blocked", targetLBAnnotation))
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Service 2 removes IP annotation to resolve conflict")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			svc2NewIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Service 2 should get a new IP on the cluster LB")
+			utils.Logf("Service 2 now on cluster LB with IP %s", svc2NewIP)
+
+			By("Verifying old FIP is removed")
+			err = verifyFIPRemoved(tc, svc1FIPID)
+			Expect(err).NotTo(HaveOccurred(), "FIP should be removed after last service moved away")
+
+			By("Verifying user-assigned PIP is not removed")
+			userPIP, err := tc.GetPublicIPFromAddress(tc.GetResourceGroup(), &sharedIP)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userPIP).NotTo(BeNil(), "User-assigned PIP should still exist")
+		})
+
+		It("should clean up stale rules when last secondary moves after primary deleted with managed PIP", func() {
+			clusterName := os.Getenv("CLUSTER_NAME")
+
+			By("Creating Service 1 (primary) on lb-1 with managed PIP")
+			svc1Port := int32(serverPort)
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
+			}, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips1)).NotTo(BeZero())
+			sharedIP := *ips1[0]
+			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
+			utils.Logf("Service 1 exposed with managed PIP %s on lb-1, FIP: %s", sharedIP, svc1FIPID)
+
+			By("Creating Service 2 (secondary) sharing Service 1's IP via IP annotation")
+			svc2Port := int32(serverPort + 1)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying both services have rules on the shared FIP")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP")
+
+			By("Deleting Service 1")
+			err = utils.DeleteService(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying FIP still has Service 2's rules but not Service 1's")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "FIP should retain Service 2's rules after Service 1 deletion")
+
+			By(fmt.Sprintf("Service 2 adds LB annotation %q, expecting blocked", clusterName))
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = clusterName
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Service 2 removes IP annotation to resolve conflict")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			svc2NewIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Service 2 should get a new IP on the cluster LB")
+			utils.Logf("Service 2 now on cluster LB with IP %s", svc2NewIP)
+
+			By("Verifying old FIP is removed")
+			err = verifyFIPRemoved(tc, svc1FIPID)
+			Expect(err).NotTo(HaveOccurred(), "FIP should be removed after last service moved away")
+
+			By("Verifying lb-1 is deleted since it has no remaining FIPs")
+			_, lbErr := tc.GetLoadBalancer(tc.GetResourceGroup(), "lb-1")
+			Expect(lbErr).To(HaveOccurred(), "lb-1 should be deleted after all FIPs are removed")
+			Expect(strings.Contains(lbErr.Error(), "NotFound")).To(BeTrue(), "Expected NotFound error for lb-1")
+
+			By("Verifying managed PIP is removed")
+			managedPIP, err := tc.GetPublicIPFromAddress(tc.GetResourceGroup(), &sharedIP)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managedPIP).To(BeNil(), "Managed PIP should be deleted after last service moved away")
+		})
+
+		It("should block service sharing IP on LB not in eligible set", func() {
+			By("Creating Service 1 with label matching lb-2's ServiceLabelSelector")
+			svc1Port := int32(serverPort)
+			svc1Labels := map[string]string{
+				"app": testServiceName,
+				"a":   "b",
+			}
+			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, svc1Labels, ns.Name, []v1.ServicePort{{
+				Port:       svc1Port,
+				TargetPort: intstr.FromInt(int(svc1Port)),
+			}})
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ips1)).NotTo(BeZero())
+			svc1IP := *ips1[0]
+			svc1LB := getAzureLoadBalancerFromPIP(tc, &svc1IP, tc.GetResourceGroup(), tc.GetResourceGroup())
+			Expect(ptr.Deref(svc1LB.Name, "")).To(Equal("lb-2"), "Service 1 with label a=b should land on lb-2")
+			svc1FIPID := getPIPFrontendConfigurationID(tc, svc1IP, tc.GetResourceGroup(), true)
+			utils.Logf("Service 1 exposed with IP %s on lb-2, FIP: %s", svc1IP, svc1FIPID)
+
+			By("Creating Service 2 without label a=b, pointing to Service 1's IP")
+			svc2Port := int32(serverPort + 1)
+			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: svc1IP,
+			}, labels, ns.Name, []v1.ServicePort{{
+				Port:       svc2Port,
+				TargetPort: intstr.FromInt(int(svc2Port)),
+			}})
+			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			By("Verifying Service 2 is blocked with not-in-eligible-set error")
+			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", "not in the eligible set", time.Time{}, eventTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+			By("Resolving by adding label a=b to Service 2")
+			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc2.Labels["a"] = "b"
+			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying Service 2 is now exposed with Service 1's IP")
+			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc1IP})
+			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after adding label")
+
+			By("Verifying FIP has rules for both services")
+			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+			Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP on lb-2")
+		})
+	})
 })
 
 // getDeploymentPodsNodeNames returns the node names of the pods in the deployment created in BeforeEach.
@@ -299,6 +1702,159 @@ func getLBsFromPublicIPs(tc *utils.AzureTestClient, pips []*string) sets.Set[str
 	return lbNames
 }
 
+// verifyFIPRemoved checks that the specified frontend IP configuration no longer exists on the LB.
+// Returns nil if the FIP is gone (or the entire LB is gone). Returns an error if the FIP still exists.
+func verifyFIPRemoved(tc *utils.AzureTestClient, fipID string) error {
+	if fipID == "" {
+		return fmt.Errorf("empty FIP ID")
+	}
+
+	match := lbNameRE.FindStringSubmatch(fipID)
+	if len(match) != 2 {
+		return fmt.Errorf("could not parse LB name from FIP ID: %s", fipID)
+	}
+	lbName := match[1]
+
+	lb, err := tc.GetLoadBalancer(tc.GetResourceGroup(), lbName)
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			utils.Logf("LB %s not found, FIP %s is removed", lbName, fipID)
+			return nil
+		}
+		return fmt.Errorf("failed to get load balancer %s: %w", lbName, err)
+	}
+
+	if lb.Properties != nil && lb.Properties.FrontendIPConfigurations != nil {
+		for _, fip := range lb.Properties.FrontendIPConfigurations {
+			if strings.EqualFold(ptr.Deref(fip.ID, ""), fipID) {
+				var ruleIDs []string
+				if fip.Properties != nil {
+					for _, r := range fip.Properties.LoadBalancingRules {
+						ruleIDs = append(ruleIDs, ptr.Deref(r.ID, "<unknown>"))
+					}
+				}
+				return fmt.Errorf("FIP %s still exists on LB %s with rules %v", fipID, lbName, ruleIDs)
+			}
+		}
+	}
+
+	utils.Logf("FIP %s has been removed from LB %s", fipID, lbName)
+	return nil
+}
+
+// getFIPRulePorts returns all ports that have load balancing rules for the given FIP and protocol.
+// Returns (ports, lbExists, error). If lbExists is false, the LB doesn't exist (ports will be empty).
+func getFIPRulePorts(tc *utils.AzureTestClient, fipID string, protocol string) (sets.Set[int32], bool, error) {
+	if fipID == "" {
+		return nil, false, fmt.Errorf("empty FIP ID")
+	}
+
+	// Extract LB name from FIP ID.
+	match := lbNameRE.FindStringSubmatch(fipID)
+	if len(match) != 2 {
+		return nil, false, fmt.Errorf("could not parse LB name from FIP ID: %s", fipID)
+	}
+	lbName := match[1]
+
+	lb, err := tc.GetLoadBalancer(tc.GetResourceGroup(), lbName)
+	if err != nil {
+		errStr := err.Error()
+		if strings.Contains(errStr, "NotFound") {
+			return sets.New[int32](), false, nil
+		}
+		return nil, false, fmt.Errorf("failed to get load balancer %s: %w", lbName, err)
+	}
+
+	// Find all rules that reference the target FIP ID with matching protocol.
+	ports := sets.New[int32]()
+	if lb.Properties != nil && lb.Properties.LoadBalancingRules != nil {
+		for _, rule := range lb.Properties.LoadBalancingRules {
+			if rule.Properties == nil || rule.Properties.FrontendIPConfiguration == nil {
+				continue
+			}
+			ruleFIPID := ptr.Deref(rule.Properties.FrontendIPConfiguration.ID, "")
+			if !strings.EqualFold(ruleFIPID, fipID) {
+				continue
+			}
+
+			rulePort := ptr.Deref(rule.Properties.FrontendPort, 0)
+			ruleProtocol := string(ptr.Deref(rule.Properties.Protocol, ""))
+
+			if strings.EqualFold(ruleProtocol, protocol) {
+				utils.Logf("Found rule %q for port %d/%s on FIP", ptr.Deref(rule.Name, ""), rulePort, ruleProtocol)
+				ports.Insert(rulePort)
+			}
+		}
+	}
+
+	return ports, true, nil
+}
+
+// verifyFIPHasRulesForPorts checks that the specified frontend IP config has rules for exactly all expected ports.
+func verifyFIPHasRulesForPorts(tc *utils.AzureTestClient, fipID string, expectedPorts sets.Set[int32], protocol string) error {
+	utils.Logf("Verifying FIP ID %q has rules for ports %v", fipID, expectedPorts.UnsortedList())
+
+	actualPorts, lbExists, err := getFIPRulePorts(tc, fipID, protocol)
+	if err != nil {
+		return err
+	}
+	if !lbExists {
+		return fmt.Errorf("load balancer for FIP %q does not exist", fipID)
+	}
+
+	// Check for exact match.
+	missingPorts := expectedPorts.Difference(actualPorts)
+	extraPorts := actualPorts.Difference(expectedPorts)
+
+	if missingPorts.Len() > 0 || extraPorts.Len() > 0 {
+		return fmt.Errorf("FIP %q port mismatch: missing=%v, extra=%v, expected=%v, actual=%v",
+			fipID, missingPorts.UnsortedList(), extraPorts.UnsortedList(),
+			expectedPorts.UnsortedList(), actualPorts.UnsortedList())
+	}
+
+	utils.Logf("FIP %q has exactly the expected rules for ports %v", fipID, expectedPorts.UnsortedList())
+	return nil
+}
+
+// verifyFIPHasNoRulesForPorts checks that the specified frontend IP config has no rules for the specified ports.
+// If the LB does not exist, that counts as success (no rules).
+func verifyFIPHasNoRulesForPorts(tc *utils.AzureTestClient, fipID string, absentPorts sets.Set[int32], protocol string) error {
+	utils.Logf("Verifying FIP ID %q has NO rules for ports %v", fipID, absentPorts.UnsortedList())
+
+	actualPorts, lbExists, err := getFIPRulePorts(tc, fipID, protocol)
+	if err != nil {
+		return err
+	}
+	if !lbExists {
+		utils.Logf("LB for FIP %q not found, treating as no rules", fipID)
+		return nil
+	}
+
+	// Check no intersection.
+	foundPorts := absentPorts.Intersection(actualPorts)
+	if foundPorts.Len() > 0 {
+		return fmt.Errorf("FIP %q still has rules for ports %v", fipID, foundPorts.UnsortedList())
+	}
+
+	utils.Logf("FIP %q has no rules for ports %v (as expected)", fipID, absentPorts.UnsortedList())
+	return nil
+}
+
+// getFIPIDForPrivateIP finds the frontend IP configuration ID for a given private IP.
+func getFIPIDForPrivateIP(lb *armnetwork.LoadBalancer, privateIP string) string {
+	if lb.Properties == nil || lb.Properties.FrontendIPConfigurations == nil {
+		return ""
+	}
+	for _, fip := range lb.Properties.FrontendIPConfigurations {
+		if fip.Properties != nil && fip.Properties.PrivateIPAddress != nil {
+			if *fip.Properties.PrivateIPAddress == privateIP {
+				return ptr.Deref(fip.ID, "")
+			}
+		}
+	}
+	return ""
+}
+
 func waitLBCountEqualTo(tc *utils.AzureTestClient, interval, timeout time.Duration, expectedCount int, svcIPs []*string) (sets.Set[string], error) {
 	var lbNames sets.Set[string]
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
@@ -310,4 +1866,94 @@ func waitLBCountEqualTo(tc *utils.AzureTestClient, interval, timeout time.Durati
 		return true, nil
 	})
 	return lbNames, err
+}
+
+// waitForServiceEventAfter waits for an event of the given type on the service with the expected Reason
+// that occurred after the specified time and contains the expected message substring.
+func waitForServiceEventAfter(
+	cs clientset.Interface,
+	ns, serviceName string,
+	eventType string,
+	expectedReason string,
+	messageSubstring string,
+	after time.Time,
+	timeout time.Duration,
+) error {
+	return wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		events, err := cs.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Service,type=%s", serviceName, eventType),
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events.Items {
+			if event.Reason != expectedReason {
+				continue
+			}
+			if messageSubstring != "" && !strings.Contains(event.Message, messageSubstring) {
+				continue
+			}
+			eventTime := event.LastTimestamp.Time
+			if eventTime.After(after) {
+				utils.Logf("Found %s event for service %s after %v: Reason=%s, LastTimestamp=%v, Message=%s",
+					eventType, serviceName, after.Format(time.RFC3339), event.Reason, eventTime.Format(time.RFC3339), event.Message)
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+// waitForServiceNormalEventAfter waits for a Normal event on the service with the expected Reason
+// that occurred after the specified time and contains the expected message substring.
+func waitForServiceNormalEventAfter(
+	cs clientset.Interface,
+	ns, serviceName string,
+	expectedReason string,
+	messageSubstring string,
+	after time.Time,
+	timeout time.Duration,
+) error {
+	return waitForServiceEventAfter(cs, ns, serviceName, "Normal", expectedReason, messageSubstring, after, timeout)
+}
+
+// waitForServiceWarningEventAfter waits for a Warning event on the service with the expected Reason
+// that occurred after the specified time and contains the expected message substring.
+func waitForServiceWarningEventAfter(
+	cs clientset.Interface,
+	ns, serviceName string,
+	expectedReason string,
+	messageSubstring string,
+	after time.Time,
+	timeout time.Duration,
+) error {
+	return waitForServiceEventAfter(cs, ns, serviceName, "Warning", expectedReason, messageSubstring, after, timeout)
+}
+
+// waitForServiceIPChange waits for a service to get a different IP than the oldIP.
+func waitForServiceIPChange(cs clientset.Interface, ns, serviceName, oldIP string, timeout time.Duration) (string, error) {
+	var newIP string
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		service, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
+		if err != nil {
+			utils.Logf("Error getting service %s: %v", serviceName, err)
+			return false, nil
+		}
+		if len(service.Status.LoadBalancer.Ingress) == 0 {
+			utils.Logf("Service %s has no IP yet, waiting...", serviceName)
+			return false, nil
+		}
+		currentIP := service.Status.LoadBalancer.Ingress[0].IP
+		if currentIP != oldIP {
+			utils.Logf("Service %s IP changed from %s to %s", serviceName, oldIP, currentIP)
+			newIP = currentIP
+			return true, nil
+		}
+		utils.Logf("Service %s still has old IP %s, waiting for change...", serviceName, oldIP)
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("timeout waiting for service %s IP to change from %s: %w", serviceName, oldIP, err)
+	}
+	return newIP, nil
 }

--- a/tests/e2e/network/multiple_standard_lb.go
+++ b/tests/e2e/network/multiple_standard_lb.go
@@ -236,234 +236,105 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should place all external services sharing a user-assigned public IP on the same load balancer", func() {
-		By("Creating a user-assigned public IP")
-		ipName := fmt.Sprintf("%s-shared-pip-%s", basename, ns.Name[:8])
-		pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), defaultPublicIPAddress(ipName, false))
-		Expect(err).NotTo(HaveOccurred())
-		targetIP := ptr.Deref(pip.Properties.IPAddress, "")
-		utils.Logf("Created user-assigned PIP with address %s", targetIP)
-		defer func() {
-			By("Cleaning up PIP")
-			err = utils.DeletePIPWithRetry(tc, ipName, "")
-			Expect(err).NotTo(HaveOccurred())
-		}()
+	DescribeTable("should place all services sharing an IP on the same load balancer",
+		func(mode string) {
+			isInternal := mode == "internal"
+			useUserPIP := mode == "external-user-pip"
 
-		var firstFIPID string
-		serviceCount := 2
-		serviceNames := []string{}
-		servicePorts := sets.New[int32]()
+			var svcAnnotations map[string]string
+			if isInternal {
+				svcAnnotations = serviceAnnotationLoadBalancerInternalTrue
+			}
 
-		for i := range serviceCount {
-			serviceLabels := labels
-			deploymentName := testDeploymentName
-			tcpPort := int32(serverPort + i)
-			servicePorts.Insert(tcpPort)
+			var sharedIP string
+			if useUserPIP {
+				By("Creating a user-assigned public IP")
+				ipName := fmt.Sprintf("%s-shared-pip-%s", basename, ns.Name[:8])
+				pip, err := utils.WaitCreatePIP(tc, ipName, tc.GetResourceGroup(), defaultPublicIPAddress(ipName, false))
+				Expect(err).NotTo(HaveOccurred())
+				sharedIP = ptr.Deref(pip.Properties.IPAddress, "")
+				utils.Logf("Created user-assigned PIP with address %s", sharedIP)
+				defer func() {
+					By("Cleaning up PIP")
+					err = utils.DeletePIPWithRetry(tc, ipName, "")
+					Expect(err).NotTo(HaveOccurred())
+				}()
+			}
 
-			if i != 0 {
-				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
-				utils.Logf("Creating deployment %q", deploymentName)
-				serviceLabels = map[string]string{
-					"app": deploymentName,
+			var firstFIPID string
+			serviceCount := 2
+			servicePorts := sets.New[int32]()
+
+			for i := range serviceCount {
+				serviceLabels := labels
+				deploymentName := testDeploymentName
+				tcpPort := int32(serverPort + i)
+				servicePorts.Insert(tcpPort)
+
+				if i != 0 {
+					deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
+					utils.Logf("Creating deployment %q", deploymentName)
+					serviceLabels = map[string]string{
+						"app": deploymentName,
+					}
+					tcpPortPtr := tcpPort
+					extraDeployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPortPtr, nil)
+					_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), extraDeployment, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					defer func(name string) {
+						err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
+						Expect(err).NotTo(HaveOccurred())
+					}(deploymentName)
 				}
-				tcpPortPtr := tcpPort
-				extraDeployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPortPtr, nil)
-				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), extraDeployment, metav1.CreateOptions{})
+
+				serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
+				servicePort := []v1.ServicePort{{
+					Port:       tcpPort,
+					TargetPort: intstr.FromInt(int(tcpPort)),
+				}}
+				service := utils.CreateLoadBalancerServiceManifest(serviceName, svcAnnotations, serviceLabels, ns.Name, servicePort)
+				if sharedIP != "" {
+					service = updateServiceLBIPs(service, isInternal, []*string{&sharedIP})
+					utils.Logf("Creating Service %q with shared IP %s", serviceName, sharedIP)
+				} else {
+					utils.Logf("Creating Service %q (will get new IP)", serviceName)
+				}
+				_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				defer func(name string) {
-					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
+					err = utils.DeleteService(cs, ns.Name, name)
 					Expect(err).NotTo(HaveOccurred())
-				}(deploymentName)
-			}
+				}(serviceName)
 
-			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
-			serviceNames = append(serviceNames, serviceName)
-			utils.Logf("Creating Service %q with shared IP %s", serviceName, targetIP)
-
-			servicePort := []v1.ServicePort{{
-				Port:       tcpPort,
-				TargetPort: intstr.FromInt(int(tcpPort)),
-			}}
-			service := utils.CreateLoadBalancerServiceManifest(serviceName, nil, serviceLabels, ns.Name, servicePort)
-			service = updateServiceLBIPs(service, false, []*string{&targetIP})
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func(name string) {
-				err = utils.DeleteService(cs, ns.Name, name)
-				Expect(err).NotTo(HaveOccurred())
-			}(serviceName)
-
-			_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []*string{&targetIP})
-			Expect(err).NotTo(HaveOccurred())
-			utils.Logf("Service %q is exposed with IP %s", serviceName, targetIP)
-
-			// Log FIP state after each service.
-			fipID := getPIPFrontendConfigurationID(tc, targetIP, tc.GetResourceGroup(), true)
-			utils.Logf("After service %d: IP %s has FIP ID %q", i, targetIP, fipID)
-			if i == 0 {
-				firstFIPID = fipID
-			}
-		}
-
-		By("Verifying first FIP has all services' rules")
-		err = verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
-		Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all services sharing the IP")
-	})
-
-	It("should place all external services sharing a managed public IP on the same load balancer", func() {
-		var firstFIPID string
-		var sharedIP string
-		serviceCount := 2
-		serviceNames := []string{}
-		servicePorts := sets.New[int32]()
-
-		for i := range serviceCount {
-			serviceLabels := labels
-			deploymentName := testDeploymentName
-			tcpPort := int32(serverPort + i)
-			servicePorts.Insert(tcpPort)
-
-			if i != 0 {
-				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
-				utils.Logf("Creating deployment %q", deploymentName)
-				serviceLabels = map[string]string{
-					"app": deploymentName,
+				var targetIPs []*string
+				if sharedIP != "" {
+					targetIPs = []*string{&sharedIP}
 				}
-				tcpPortPtr := tcpPort
-				extraDeployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPortPtr, nil)
-				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), extraDeployment, metav1.CreateOptions{})
+				ips, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, targetIPs)
 				Expect(err).NotTo(HaveOccurred())
-				defer func(name string) {
-					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}(deploymentName)
-			}
-
-			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
-			serviceNames = append(serviceNames, serviceName)
-
-			servicePort := []v1.ServicePort{{
-				Port:       tcpPort,
-				TargetPort: intstr.FromInt(int(tcpPort)),
-			}}
-			service := utils.CreateLoadBalancerServiceManifest(serviceName, nil, serviceLabels, ns.Name, servicePort)
-			if sharedIP != "" {
-				service = updateServiceLBIPs(service, false, []*string{&sharedIP})
-				utils.Logf("Creating Service %q with shared managed IP %s", serviceName, sharedIP)
-			} else {
-				utils.Logf("Creating Service %q (will get managed IP)", serviceName)
-			}
-
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func(name string) {
-				err = utils.DeleteService(cs, ns.Name, name)
-				Expect(err).NotTo(HaveOccurred())
-			}(serviceName)
-
-			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, serviceName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips)).NotTo(BeZero())
-
-			// Record shared IP on first service.
-			if i == 0 {
-				sharedIP = *ips[0]
-				utils.Logf("First service got managed IP: %s", sharedIP)
-			}
-
-			// Log FIP state after each service.
-			fipID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			utils.Logf("After service %d: IP %s has FIP ID %q", i, sharedIP, fipID)
-			if i == 0 {
-				firstFIPID = fipID
-			}
-		}
-
-		By("Verifying first FIP has all services' rules")
-		err := verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
-		Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all services sharing the IP")
-	})
-
-	It("should place all internal services sharing a private IP on the same load balancer", func() {
-		var firstFIPID string
-		var sharedIP string
-		serviceCount := 2
-		serviceNames := []string{}
-		servicePorts := sets.New[int32]()
-
-		for i := range serviceCount {
-			serviceLabels := labels
-			deploymentName := testDeploymentName
-			tcpPort := int32(serverPort + i)
-			servicePorts.Insert(tcpPort)
-
-			if i != 0 {
-				deploymentName = fmt.Sprintf("%s-%d", testDeploymentName, i)
-				utils.Logf("Creating deployment %q", deploymentName)
-				serviceLabels = map[string]string{
-					"app": deploymentName,
+				Expect(len(ips)).NotTo(BeZero())
+				if sharedIP == "" {
+					sharedIP = *ips[0]
 				}
-				tcpPortPtr := tcpPort
-				extraDeployment := createDeploymentManifest(deploymentName, serviceLabels, &tcpPortPtr, nil)
-				_, err := cs.AppsV1().Deployments(ns.Name).Create(context.TODO(), extraDeployment, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				defer func(name string) {
-					err := cs.AppsV1().Deployments(ns.Name).Delete(context.TODO(), name, metav1.DeleteOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}(deploymentName)
+
+				fipID, lbName := getFIPIDAndLBName(tc, sharedIP, isInternal)
+				utils.Logf("After service %d: IP %s on LB %s, FIP: %s", i, sharedIP, lbName, fipID)
+				if i == 0 {
+					firstFIPID = fipID
+				}
 			}
 
-			serviceName := fmt.Sprintf("%s-%d", testServiceName, i)
-			serviceNames = append(serviceNames, serviceName)
-
-			servicePort := []v1.ServicePort{{
-				Port:       tcpPort,
-				TargetPort: intstr.FromInt(int(tcpPort)),
-			}}
-			service := utils.CreateLoadBalancerServiceManifest(serviceName, serviceAnnotationLoadBalancerInternalTrue, serviceLabels, ns.Name, servicePort)
-			if sharedIP != "" {
-				service = updateServiceLBIPs(service, true, []*string{&sharedIP})
-				utils.Logf("Creating internal Service %q with shared IP %s", serviceName, sharedIP)
-			} else {
-				utils.Logf("Creating internal Service %q (will get new IP)", serviceName)
-			}
-
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func(name string) {
-				err = utils.DeleteService(cs, ns.Name, name)
-				Expect(err).NotTo(HaveOccurred())
-			}(serviceName)
-
-			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, serviceName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips)).NotTo(BeZero())
-
-			// Record shared IP on first service.
-			if i == 0 {
-				sharedIP = *ips[0]
-				utils.Logf("First internal service got IP: %s", sharedIP)
-			}
-
-			// Log FIP state after each service.
-			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
-			fipID := getFIPIDForPrivateIP(lb, sharedIP)
-			utils.Logf("After service %d: IP %s has FIP ID %q", i, sharedIP, fipID)
-			if i == 0 {
-				firstFIPID = fipID
-			}
-		}
-
-		By("Verifying first FIP has all internal services' rules")
-		err := verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
-		Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all internal services sharing the IP")
-	})
+			By("Verifying first FIP has all services' rules")
+			err := verifyFIPHasRulesForPorts(tc, firstFIPID, servicePorts, "TCP")
+			Expect(err).NotTo(HaveOccurred(), "First FIP should have rules for all services sharing the IP")
+		},
+		Entry("external with user-assigned PIP", "external-user-pip"),
+		Entry("external with managed PIP", "external-managed"),
+		Entry("internal", "internal"),
+	)
 
 	Describe("LB Placement Conflicts", func() {
 		const (
-			eventTimeout    = 30 * time.Second
-			ipChangeTimeout = 150 * time.Second
-
 			svcNamePrimary = "svc-primary"
 			svcNameLBIP    = "svc-lbip"
 			svcNamePIPName = "svc-pipname"
@@ -472,1106 +343,581 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 			msgConflictingLBConfig = "conflicting load balancer configuration"
 		)
 
-		It("should block external services with conflicting IP and LB config for user-assigned PIP", func() {
-			By("Creating user-assigned PIP")
-			pipName := "conflict-test-pip"
-			pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
-			Expect(err).NotTo(HaveOccurred())
-			sharedIP := ptr.Deref(pip.Properties.IPAddress, "")
-			Expect(sharedIP).NotTo(BeEmpty())
-			defer func() {
-				utils.Logf("Cleaning up PIP %s", pipName)
-				err := utils.DeletePIPWithRetry(tc, pipName, "")
+		DescribeTable("should block services with conflicting IP and LB config",
+			func(mode string) {
+				isInternal := mode == "internal"
+				useUserPIP := mode == "external-user-pip"
+
+				var svcAnnotations map[string]string
+				if isInternal {
+					svcAnnotations = serviceAnnotationLoadBalancerInternalTrue
+				}
+
+				var sharedIP, pipName string
+				if useUserPIP {
+					By("Creating user-assigned PIP")
+					pipName = "conflict-test-pip"
+					pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
+					Expect(err).NotTo(HaveOccurred())
+					sharedIP = ptr.Deref(pip.Properties.IPAddress, "")
+					Expect(sharedIP).NotTo(BeEmpty())
+					defer func() {
+						utils.Logf("Cleaning up PIP %s", pipName)
+						err := utils.DeletePIPWithRetry(tc, pipName, "")
+						Expect(err).NotTo(HaveOccurred())
+					}()
+				}
+
+				By("Creating primary service")
+				primaryPort := int32(serverPort)
+				primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       primaryPort,
+					TargetPort: intstr.FromInt(int(primaryPort)),
+				}})
+				if sharedIP != "" {
+					primaryService = updateServiceLBIPs(primaryService, false, []*string{&sharedIP})
+				}
+				_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
-			By("Creating primary service with azure-load-balancer-ipv4 annotation")
-			primaryPort := int32(serverPort)
-			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       primaryPort,
-				TargetPort: intstr.FromInt(int(primaryPort)),
-			}})
-			primaryService = updateServiceLBIPs(primaryService, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				if sharedIP == "" {
+					ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(ips)).NotTo(BeZero())
+					sharedIP = *ips[0]
+				} else {
+					_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				primaryFIPID, primaryLBName := getFIPIDAndLBName(tc, sharedIP, isInternal)
+				utils.Logf("Primary service exposed with IP %s on LB %s, FIP: %s", sharedIP, primaryLBName, primaryFIPID)
+
+				type conflictSvc struct {
+					name string
+					port int32
+					svc  *v1.Service
+				}
+				nextPort := int32(serverPort + 1)
+
+				svcLBIPPort := nextPort
+				nextPort++
+				svcLBIP := utils.CreateLoadBalancerServiceManifest(svcNameLBIP, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svcLBIPPort,
+					TargetPort: intstr.FromInt(int(svcLBIPPort)),
+				}})
+				svcLBIP.Spec.LoadBalancerIP = sharedIP
+				svcLBIP.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+
+				svcIPv4Port := nextPort
+				nextPort++
+				svcIPv4 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svcIPv4Port,
+					TargetPort: intstr.FromInt(int(svcIPv4Port)),
+				}})
+				svcIPv4 = updateServiceLBIPs(svcIPv4, isInternal, []*string{&sharedIP})
+				svcIPv4.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+
+				conflicts := []conflictSvc{
+					{name: svcNameLBIP, port: svcLBIPPort, svc: svcLBIP},
+					{name: svcNameIPv4, port: svcIPv4Port, svc: svcIPv4},
+				}
+
+				if useUserPIP {
+					svcPIPPort := nextPort
+					nextPort++
+					svcPIP := utils.CreateLoadBalancerServiceManifest(svcNamePIPName, nil, labels, ns.Name, []v1.ServicePort{{
+						Port:       svcPIPPort,
+						TargetPort: intstr.FromInt(int(svcPIPPort)),
+					}})
+					svcPIP = updateServicePIPNames(tc.IPFamily, svcPIP, []string{pipName})
+					svcPIP.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+					conflicts = append(conflicts, conflictSvc{name: svcNamePIPName, port: svcPIPPort, svc: svcPIP})
+				}
+
+				for _, c := range conflicts {
+					By(fmt.Sprintf("Creating %s with conflicting config, expecting blocked", c.name))
+					_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), c.svc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					defer func(name string) {
+						err := utils.DeleteService(cs, ns.Name, name)
+						Expect(err).NotTo(HaveOccurred())
+					}(c.name)
+
+					err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, c.name, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{})
+					Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+c.name)
+				}
+
+				By("Verifying primary service is still working")
+				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
+
+				allPorts := sets.New(primaryPort)
+				for _, c := range conflicts {
+					By(fmt.Sprintf("Resolving %s by removing LB config annotation", c.name))
+					svc, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), c.name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					delete(svc.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+					_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					_, err = utils.WaitServiceExposure(cs, ns.Name, c.name, []*string{&sharedIP})
+					Expect(err).NotTo(HaveOccurred(), c.name+" should be exposed after removing LB config")
+					allPorts.Insert(c.port)
+				}
+
+				By("Verifying primary FIP has rules for all services")
+				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, allPorts, "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
+
+				By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
+				targetLBAnnotation := "lb-1"
+				if primaryLBName == "lb-1" || primaryLBName == "lb-1-internal" {
+					targetLBAnnotation = os.Getenv("CLUSTER_NAME")
+				}
+				beforeUpdate := time.Now()
+				svcIPv4, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred())
-			primaryFIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			utils.Logf("Primary service exposed on FIP: %s", primaryFIPID)
-
-			By("Creating service with spec.loadBalancerIP and LB config, expecting blocked")
-			svc1Port := int32(serverPort + 1)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNameLBIP, map[string]string{
-				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
-			}, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			svc1.Spec.LoadBalancerIP = sharedIP
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameLBIP)
+				svcIPv4.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svcIPv4, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeUpdate)
+				Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
 
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameLBIP, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameLBIP)
-
-			By("Creating service with azure-pip-name and LB config, expecting blocked")
-			svc2Port := int32(serverPort + 2)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNamePIPName, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			svc2 = updateServicePIPNames(tc.IPFamily, svc2, []string{pipName})
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePIPName)
+				By("Removing IP annotation from " + svcNameIPv4 + " to resolve conflict")
+				beforeIPRemove := time.Now()
+				svcIPv4, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNamePIPName, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNamePIPName)
-
-			By("Creating service with azure-load-balancer-ipv4 and LB config, expecting blocked")
-			svc3Port := int32(serverPort + 3)
-			svc3 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc3Port,
-				TargetPort: intstr.FromInt(int(svc3Port)),
-			}})
-			svc3 = updateServiceLBIPs(svc3, false, []*string{&sharedIP})
-			svc3.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc3, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				delete(svcIPv4.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+				delete(svcIPv4.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[true])
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svcIPv4, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
 
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+				if isInternal {
+					By("Expecting PrivateIPAddressIsAllocated failure for internal service")
+					err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", "PrivateIPAddressIsAllocated", beforeIPRemove)
+					Expect(err).NotTo(HaveOccurred(), "Internal service should fail to move because the private IP is still allocated on the old LB")
 
-			By("Verifying primary service is still working")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
+					By("Re-adding IP annotation and removing LB annotation to resolve")
+					beforeResolve := time.Now()
+					svcIPv4, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					svcIPv4.Annotations[consts.ServiceAnnotationLoadBalancerIPDualStack[false]] = sharedIP
+					delete(svcIPv4.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+					_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svcIPv4, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
 
-			By("Resolving " + svcNameIPv4 + " by removing LB config annotation")
-			svc3, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc3.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc3, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
+					err = utils.WaitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeResolve)
+					Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be reconciled after re-adding IP and removing LB annotation")
 
-			By("Resolving " + svcNamePIPName + " by removing LB config annotation")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePIPName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePIPName, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNamePIPName+" should be exposed after removing LB config")
+					By("Verifying primary FIP still has rules for all services")
+					err = verifyFIPHasRulesForPorts(tc, primaryFIPID, allPorts, "TCP")
+					Expect(err).NotTo(HaveOccurred(), "Primary FIP should still have rules for all services sharing the IP")
+				} else {
+					By("Waiting for " + svcNameIPv4 + " to get a new IP on " + targetLBAnnotation)
+					newIP, err := utils.WaitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP)
+					Expect(err).NotTo(HaveOccurred())
+					newFIPID := getPIPFrontendConfigurationID(tc, newIP, tc.GetResourceGroup(), true)
+					utils.Logf("%s moved to new IP %s on FIP: %s", svcNameIPv4, newIP, newFIPID)
 
-			By("Resolving " + svcNameLBIP + " by removing LB config annotation")
-			svc1, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameLBIP, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc1.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc1, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameLBIP, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameLBIP+" should be exposed after removing LB config")
+					By("Verifying primary FIP no longer has " + svcNameIPv4 + "'s rules")
+					remainingPorts := allPorts.Difference(sets.New(svcIPv4Port))
+					err = verifyFIPHasRulesForPorts(tc, primaryFIPID, remainingPorts, "TCP")
+					Expect(err).NotTo(HaveOccurred(), "Primary FIP should only have remaining services' rules")
 
-			By("Verifying primary FIP has rules for all services")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port, svc3Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
+					By("Verifying " + svcNameIPv4 + " has rules on the new FIP")
+					err = verifyFIPHasRulesForPorts(tc, newFIPID, sets.New(svcIPv4Port), "TCP")
+					Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should have its rule on the new FIP")
+				}
+			},
+			Entry("external with user-assigned PIP", "external-user-pip"),
+			Entry("external with managed PIP", "external-managed"),
+			Entry("internal", "internal"),
+		)
 
-			By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
-			primaryLB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
-			primaryLBName := ptr.Deref(primaryLB.Name, "")
-			targetLBAnnotation := "lb-1"
-			if primaryLBName == "lb-1" {
-				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
-			}
-			beforeUpdate := time.Now()
-			svc3, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc3.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc3, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeUpdate, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+		DescribeTable("should block primary service from moving LB when there is IP sharing",
+			func(isInternal bool) {
+				clusterName := os.Getenv("CLUSTER_NAME")
 
-			By("Removing IP annotation from " + svcNameIPv4 + " to resolve conflict and move to " + targetLBAnnotation)
-			svc3, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc3.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			delete(svc3.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[true])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc3, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
+				var svcAnnotations map[string]string
+				if isInternal {
+					svcAnnotations = serviceAnnotationLoadBalancerInternalTrue
+				}
 
-			By("Waiting for " + svcNameIPv4 + " to get a new IP on " + targetLBAnnotation)
-			newIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
-			Expect(err).NotTo(HaveOccurred())
-			newFIPID := getPIPFrontendConfigurationID(tc, newIP, tc.GetResourceGroup(), true)
-			utils.Logf("%s moved to new IP %s on FIP: %s", svcNameIPv4, newIP, newFIPID)
-
-			By("Verifying primary FIP no longer has " + svcNameIPv4 + "'s rules")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary FIP should only have remaining services' rules")
-
-			By("Verifying " + svcNameIPv4 + " has rules on the new FIP")
-			err = verifyFIPHasRulesForPorts(tc, newFIPID, sets.New(svc3Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should have its rule on the new FIP")
-		})
-
-		It("should block external services with conflicting IP and LB config for managed PIP", func() {
-			By("Creating primary service that gets a managed PIP")
-			primaryPort := int32(serverPort)
-			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       primaryPort,
-				TargetPort: intstr.FromInt(int(primaryPort)),
-			}})
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				By("Creating primary service on cluster LB")
+				primaryPort := int32(serverPort)
+				primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       primaryPort,
+					TargetPort: intstr.FromInt(int(primaryPort)),
+				}})
+				primaryService.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = clusterName
+				_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
-			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips)).NotTo(BeZero())
-			sharedIP := *ips[0]
-			primaryFIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			utils.Logf("Primary service exposed with managed IP %s on FIP: %s", sharedIP, primaryFIPID)
-
-			By("Creating service with spec.loadBalancerIP and LB config, expecting blocked")
-			svc1Port := int32(serverPort + 1)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNameLBIP, map[string]string{
-				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
-			}, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			svc1.Spec.LoadBalancerIP = sharedIP
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameLBIP)
+				ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				Expect(len(ips)).NotTo(BeZero())
+				sharedIP := *ips[0]
 
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameLBIP, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameLBIP)
+				primaryFIPID, primaryLBName := getFIPIDAndLBName(tc, sharedIP, isInternal)
+				utils.Logf("Primary service exposed with IP %s on LB %s, FIP: %s", sharedIP, primaryLBName, primaryFIPID)
 
-			By("Creating service with azure-load-balancer-ipv4 and LB config, expecting blocked")
-			svc2Port := int32(serverPort + 2)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				By("Creating secondary service sharing the IP")
+				secondaryPort := int32(serverPort + 1)
+				secondaryService := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       secondaryPort,
+					TargetPort: intstr.FromInt(int(secondaryPort)),
+				}})
+				secondaryService = updateServiceLBIPs(secondaryService, isInternal, []*string{&sharedIP})
+				_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), secondaryService, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Verifying primary service is still working")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
-
-			By("Resolving " + svcNameIPv4 + " by removing LB config annotation")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
-
-			By("Resolving " + svcNameLBIP + " by removing LB config annotation")
-			svc1, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameLBIP, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc1.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc1, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameLBIP, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameLBIP+" should be exposed after removing LB config")
-
-			By("Verifying primary FIP has rules for all services")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
-
-			By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
-			primaryLB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
-			primaryLBName := ptr.Deref(primaryLB.Name, "")
-			targetLBAnnotation := "lb-1"
-			if primaryLBName == "lb-1" {
-				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
-			}
-			beforeUpdate := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeUpdate, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Removing IP annotation from " + svcNameIPv4 + " to resolve conflict and move to " + targetLBAnnotation)
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[true])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for " + svcNameIPv4 + " to get a new IP on " + targetLBAnnotation)
-			newIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
-			Expect(err).NotTo(HaveOccurred())
-			newFIPID := getPIPFrontendConfigurationID(tc, newIP, tc.GetResourceGroup(), true)
-			utils.Logf("%s moved to new IP %s on FIP: %s", svcNameIPv4, newIP, newFIPID)
-
-			By("Verifying primary FIP no longer has " + svcNameIPv4 + "'s rules")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary FIP should only have remaining services' rules")
-
-			By("Verifying " + svcNameIPv4 + " has rules on the new FIP")
-			err = verifyFIPHasRulesForPorts(tc, newFIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should have its rule on the new FIP")
-		})
-
-		It("should block internal services with conflicting IP and LB config", func() {
-			By("Creating primary internal service")
-			primaryPort := int32(serverPort)
-			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
-				Port:       primaryPort,
-				TargetPort: intstr.FromInt(int(primaryPort)),
-			}})
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
 				Expect(err).NotTo(HaveOccurred())
-			}()
 
-			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips)).NotTo(BeZero())
-			sharedIP := *ips[0]
-			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
-			primaryFIPID := getFIPIDForPrivateIP(lb, sharedIP)
-			utils.Logf("Primary internal service exposed with IP %s on FIP: %s", sharedIP, primaryFIPID)
-
-			By("Creating service with spec.loadBalancerIP and LB config, expecting blocked")
-			svc1Port := int32(serverPort + 1)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNameLBIP, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			svc1.Spec.LoadBalancerIP = sharedIP
-			svc1.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameLBIP)
+				By("Verifying both services share the same FIP")
+				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
 				Expect(err).NotTo(HaveOccurred())
-			}()
 
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameLBIP, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameLBIP)
-
-			By("Creating service with azure-load-balancer-ipv4 and LB config, expecting blocked")
-			svc2Port := int32(serverPort + 2)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			svc2 = updateServiceLBIPs(svc2, true, []*string{&sharedIP})
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				By("Primary service changes LB annotation to lb-1, expecting blocked")
+				beforeUpdate := time.Now()
+				primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Verifying primary service is still working")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary service should still have its rule")
-
-			By("Resolving " + svcNameIPv4 + " by removing LB config annotation")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
-
-			By("Resolving " + svcNameLBIP + " by removing LB config annotation")
-			svc1, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameLBIP, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc1.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc1, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameLBIP, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameLBIP+" should be exposed after removing LB config")
-
-			By("Verifying primary FIP has rules for all services")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary FIP should have rules for all services sharing the IP")
-
-			By("Adding LB annotation to " + svcNameIPv4 + " while it still shares IP, expecting blocked")
-			primaryLB := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
-			primaryLBName := ptr.Deref(primaryLB.Name, "")
-			targetLBAnnotation := "lb-1"
-			if primaryLBName == "lb-1-internal" {
-				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
-			}
-			beforeUpdate := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeUpdate, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Removing IP annotation from " + svcNameIPv4 + ", expecting failure because the old private IP is still allocated")
-			beforeIPRemove := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[true])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Expecting SyncLoadBalancerFailed with PrivateIPAddressIsAllocated since internal services cannot release the old private IP")
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", "PrivateIPAddressIsAllocated", beforeIPRemove, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Internal service should fail to move because the private IP is still allocated on the old LB")
-
-			By("Re-adding IP annotation and removing LB annotation to resolve conflict")
-			beforeResolve := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerIPDualStack[false]] = sharedIP
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeResolve, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be reconciled after re-adding IP and removing LB annotation")
-
-			By("Verifying primary FIP still has rules for all services")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Primary FIP should still have rules for all services sharing the IP")
-		})
-
-		It("should block external primary service from moving LB when there is IP sharing", func() {
-			By("Creating primary service that gets a managed PIP")
-			primaryPort := int32(serverPort)
-			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       primaryPort,
-				TargetPort: intstr.FromInt(int(primaryPort)),
-			}})
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				primaryService.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
 
-			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips)).NotTo(BeZero())
-			sharedIP := *ips[0]
-			primaryFIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			primaryLB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
-			primaryLBName := ptr.Deref(primaryLB.Name, "")
-			utils.Logf("Primary service exposed with managed IP %s on LB %s, FIP: %s", sharedIP, primaryLBName, primaryFIPID)
+				err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svcNamePrimary, "SyncLoadBalancerFailed", "cannot migrate", beforeUpdate)
+				Expect(err).NotTo(HaveOccurred(), "Expected warning event for primary service trying to move")
 
-			By("Creating secondary service sharing the IP with azure-load-balancer-ipv4")
-			secondaryPort := int32(serverPort + 1)
-			secondaryService := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       secondaryPort,
-				TargetPort: intstr.FromInt(int(secondaryPort)),
-			}})
-			secondaryService = updateServiceLBIPs(secondaryService, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), secondaryService, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				By("Verifying both services still share IP on original LB")
+				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Services should still share IP on original LB")
+
+				By("Primary service removes LB annotation")
+				primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying both services share the same FIP")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred())
-
-			targetLBAnnotation := "lb-1"
-			if primaryLBName == "lb-1" {
-				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
-			}
-			By(fmt.Sprintf("Primary service adds LB annotation pointing to %s, expecting blocked", targetLBAnnotation))
-			beforeUpdate := time.Now()
-			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			if primaryService.Annotations == nil {
-				primaryService.Annotations = map[string]string{}
-			}
-			primaryService.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNamePrimary, "SyncLoadBalancerFailed", "cannot migrate", beforeUpdate, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected warning event for primary service trying to move")
-
-			By("Verifying both services still share IP on original LB")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Services should still share IP on original LB")
-
-			By("Primary service removes LB annotation")
-			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(primaryService.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying primary FIP still has rules for all services after removing LB annotation")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Services should still share IP after removing LB annotation")
-		})
-
-		It("should block internal primary service from moving LB when there is IP sharing", func() {
-			By("Creating primary internal service")
-			primaryPort := int32(serverPort)
-			primaryService := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
-				Port:       primaryPort,
-				TargetPort: intstr.FromInt(int(primaryPort)),
-			}})
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), primaryService, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				delete(primaryService.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
 
-			ips, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips)).NotTo(BeZero())
-			sharedIP := *ips[0]
-			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
-			primaryFIPID := getFIPIDForPrivateIP(lb, sharedIP)
-			primaryLBName := ptr.Deref(lb.Name, "")
-			utils.Logf("Primary internal service exposed with IP %s on LB %s, FIP: %s", sharedIP, primaryLBName, primaryFIPID)
+				By("Verifying primary FIP still has rules for all services after removing LB annotation")
+				err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Services should still share IP after removing LB annotation")
+			},
+			Entry("external", false),
+			Entry("internal", true),
+		)
 
-			By("Creating secondary service sharing the IP with azure-load-balancer-ipv4")
-			secondaryPort := int32(serverPort + 1)
-			secondaryService := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
-				Port:       secondaryPort,
-				TargetPort: intstr.FromInt(int(secondaryPort)),
-			}})
-			secondaryService = updateServiceLBIPs(secondaryService, true, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), secondaryService, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+		DescribeTable("should allow service with no prior IP sharing to share IP",
+			func(mode string) {
+				isInternal := mode == "internal"
+				useUserPIP := mode == "external-user-pip"
+				clusterName := os.Getenv("CLUSTER_NAME")
+
+				var svcAnnotations map[string]string
+				if isInternal {
+					svcAnnotations = serviceAnnotationLoadBalancerInternalTrue
+				}
+
+				var sharedIP string
+				var pipName string
+				if useUserPIP {
+					By("Creating user-assigned PIP")
+					pipName = "cross-lb-test-pip"
+					pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
+					Expect(err).NotTo(HaveOccurred())
+					sharedIP = ptr.Deref(pip.Properties.IPAddress, "")
+					Expect(sharedIP).NotTo(BeEmpty())
+					defer func() {
+						utils.Logf("Cleaning up PIP %s", pipName)
+						err := utils.DeletePIPWithRetry(tc, pipName, "")
+						Expect(err).NotTo(HaveOccurred())
+					}()
+				}
+
+				By("Creating Service 1")
+				svc1Port := int32(serverPort)
+				svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svc1Port,
+					TargetPort: intstr.FromInt(int(svc1Port)),
+				}})
+				if useUserPIP {
+					svc1 = updateServicePIPNames(tc.IPFamily, svc1, []string{pipName})
+				} else {
+					svc1.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = clusterName
+				}
+				_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred())
+				if useUserPIP {
+					_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(ips1)).NotTo(BeZero())
+					sharedIP = *ips1[0]
+				}
 
-			By("Verifying both services share the same FIP")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred())
+				svc1FIPID, svc1LBName := getFIPIDAndLBName(tc, sharedIP, isInternal)
+				utils.Logf("Service 1 exposed with IP %s on LB %s, FIP: %s", sharedIP, svc1LBName, svc1FIPID)
 
-			targetLBAnnotation := "lb-1"
-			if primaryLBName == "lb-1-internal" {
-				targetLBAnnotation = os.Getenv("CLUSTER_NAME")
-			}
-			By(fmt.Sprintf("Primary service adds LB annotation pointing to %s, expecting blocked", targetLBAnnotation))
-			beforeUpdate := time.Now()
-			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			if primaryService.Annotations == nil {
-				primaryService.Annotations = map[string]string{}
-			}
-			primaryService.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
+				svc2LBAnnotation := "lb-1"
+				if svc1LBName == "lb-1" || svc1LBName == "lb-1-internal" {
+					svc2LBAnnotation = clusterName
+				}
 
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNamePrimary, "SyncLoadBalancerFailed", "cannot migrate", beforeUpdate, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected warning event for primary service trying to move")
-
-			By("Verifying both services still share IP on original internal LB")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Services should still share IP on original LB")
-
-			By("Primary service removes LB annotation")
-			primaryService, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNamePrimary, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(primaryService.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), primaryService, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying primary FIP still has rules for all services after removing LB annotation")
-			err = verifyFIPHasRulesForPorts(tc, primaryFIPID, sets.New(primaryPort, secondaryPort), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Services should still share IP after removing LB annotation")
-		})
-
-		It("should allow external service with no prior IP sharing to share user-assigned PIP", func() {
-			By("Creating user-assigned PIP")
-			pipName := "cross-lb-test-pip"
-			pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
-			Expect(err).NotTo(HaveOccurred())
-			sharedIP := ptr.Deref(pip.Properties.IPAddress, "")
-			Expect(sharedIP).NotTo(BeEmpty())
-			defer func() {
-				utils.Logf("Cleaning up PIP %s", pipName)
-				err := utils.DeletePIPWithRetry(tc, pipName, "")
+				By(fmt.Sprintf("Creating Service 2 with LB annotation pointing to %s", svc2LBAnnotation))
+				svc2Port := int32(serverPort + 1)
+				svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svc2Port,
+					TargetPort: intstr.FromInt(int(svc2Port)),
+				}})
+				svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = svc2LBAnnotation
+				_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
-			By("Creating Service 1 with user-assigned PIP")
-			svc1Port := int32(serverPort)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			svc1 = updateServicePIPNames(tc.IPFamily, svc1, []string{pipName})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				ips2, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNameIPv4)
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				Expect(len(ips2)).NotTo(BeZero())
+				svc2IP := *ips2[0]
+				Expect(svc2IP).NotTo(Equal(sharedIP), "Service 2 should have a different IP on "+svc2LBAnnotation)
 
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred())
-			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			svc1LB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
-			svc1LBName := ptr.Deref(svc1LB.Name, "")
-			utils.Logf("Service 1 exposed with user-assigned PIP %s on LB %s, FIP: %s", sharedIP, svc1LBName, svc1FIPID)
+				svc2OldFIPID, svc2OldLBName := getFIPIDAndLBName(tc, svc2IP, isInternal)
+				utils.Logf("Service 2 exposed with IP %s on LB %s, FIP: %s", svc2IP, svc2OldLBName, svc2OldFIPID)
 
-			svc2LBAnnotation := "lb-1"
-			if svc1LBName == "lb-1" {
-				svc2LBAnnotation = os.Getenv("CLUSTER_NAME")
-			}
-			By(fmt.Sprintf("Creating Service 2 with LB annotation pointing to %s", svc2LBAnnotation))
-			svc2Port := int32(serverPort + 1)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, map[string]string{
-				consts.ServiceAnnotationLoadBalancerConfigurations: svc2LBAnnotation,
-			}, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				By("Service 2 adds IP annotation pointing to Service 1's IP, expecting blocked")
+				svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			ips2, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNameIPv4)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips2)).NotTo(BeZero())
-			svc2IP := *ips2[0]
-			Expect(svc2IP).NotTo(Equal(sharedIP), "Service 2 should have a different IP on "+svc2LBAnnotation)
-			svc2OldFIPID := getPIPFrontendConfigurationID(tc, svc2IP, tc.GetResourceGroup(), true)
-			utils.Logf("Service 2 exposed with IP %s on %s, FIP: %s", svc2IP, svc2LBAnnotation, svc2OldFIPID)
-
-			By("Service 2 adds azure-load-balancer-ipv4 pointing to Service 1's IP, expecting blocked")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Verifying Service 1 is still working")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
-
-			By("Service 2 removes IP annotation instead, keeping LB annotation")
-			beforeIPRemove := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for successful reconcile after removing IP annotation")
-			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected EnsuredLoadBalancer event after removing IP annotation")
-
-			By("Verifying Service 2 stays on its original LB with its original IP")
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
-			err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
-
-			By("Verifying Service 1 is unaffected")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
-
-			By("Service 2 adds back IP annotation, expecting conflict again")
-			beforeIPReAdd := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeIPReAdd, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected conflict warning after re-adding IP annotation")
-
-			By("Service 2 removes LB annotation to resolve conflict")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
-
-			By("Verifying primary FIP has rules for all services")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Both services should share the user-assigned PIP on the primary LB")
-
-			By("Verifying Service 2's old FIP has no rules for its port")
-			err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
-		})
-
-		It("should allow external service with no prior IP sharing to share managed PIP", func() {
-			clusterName := os.Getenv("CLUSTER_NAME")
-
-			By("Creating Service 1 with cluster LB annotation")
-			svc1Port := int32(serverPort)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, map[string]string{
-				consts.ServiceAnnotationLoadBalancerConfigurations: clusterName,
-			}, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				svc2 = updateServiceLBIPs(svc2, isInternal, []*string{&sharedIP})
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
 
-			ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips1)).NotTo(BeZero())
-			sharedIP := *ips1[0]
-			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			utils.Logf("Service 1 exposed with IP %s on cluster LB FIP: %s", sharedIP, svc1FIPID)
+				err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{})
+				Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
 
-			By("Creating Service 2 with lb-1 annotation")
-			svc2Port := int32(serverPort + 1)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, map[string]string{
-				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
-			}, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				By("Verifying Service 1 is still working")
+				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+				By("Service 2 removes IP annotation instead, keeping LB annotation")
+				beforeIPRemove := time.Now()
+				svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			ips2, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNameIPv4)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips2)).NotTo(BeZero())
-			svc2IP := *ips2[0]
-			Expect(svc2IP).NotTo(Equal(sharedIP), "Service 2 should have a different IP on lb-1")
-			svc2OldFIPID := getPIPFrontendConfigurationID(tc, svc2IP, tc.GetResourceGroup(), true)
-			utils.Logf("Service 2 exposed with IP %s on lb-1, FIP: %s", svc2IP, svc2OldFIPID)
-
-			By("Service 2 adds azure-load-balancer-ipv4 annotation pointing to Service 1's IP, expecting blocked")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Verifying Service 1 is still working")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
-
-			By("Service 2 removes IP annotation instead, keeping LB annotation")
-			beforeIPRemove := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for successful reconcile after removing IP annotation")
-			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected EnsuredLoadBalancer event after removing IP annotation")
-
-			By("Verifying Service 2 stays on its original LB with its original IP")
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
-			err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
-
-			By("Verifying Service 1 is unaffected")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
-
-			By("Service 2 adds back IP annotation, expecting conflict again")
-			beforeIPReAdd := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeIPReAdd, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected conflict warning after re-adding IP annotation")
-
-			By("Service 2 removes LB annotation to resolve conflict")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
-
-			By("Verifying primary FIP has rules for all services")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Both services should share IP on the primary LB")
-
-			By("Verifying Service 2's old FIP has no rules for its port")
-			err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
-		})
-
-		It("should allow internal service with no prior IP sharing to share IP", func() {
-			clusterName := os.Getenv("CLUSTER_NAME")
-
-			By("Creating Service 1 with cluster LB annotation")
-			svc1Port := int32(serverPort)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			svc1.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = clusterName
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
 
-			ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips1)).NotTo(BeZero())
-			sharedIP := *ips1[0]
-			lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &sharedIP, tc.GetResourceGroup())
-			svc1FIPID := getFIPIDForPrivateIP(lb, sharedIP)
-			utils.Logf("Service 1 exposed with internal IP %s on cluster LB FIP: %s", sharedIP, svc1FIPID)
+				By("Waiting for successful reconcile after removing IP annotation")
+				err = utils.WaitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove)
+				Expect(err).NotTo(HaveOccurred(), "Expected EnsuredLoadBalancer event after removing IP annotation")
 
-			By("Creating Service 2 with lb-1 annotation")
-			svc2Port := int32(serverPort + 1)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, serviceAnnotationLoadBalancerInternalTrue, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				By("Verifying Service 2 stays on its original LB with its original IP")
+				_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
+				Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
+				err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
+
+				By("Verifying Service 1 is unaffected")
+				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
+
+				By("Service 2 adds back IP annotation, expecting conflict again")
+				beforeIPReAdd := time.Now()
+				svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			ips2, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNameIPv4)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips2)).NotTo(BeZero())
-			svc2IP := *ips2[0]
-			Expect(svc2IP).NotTo(Equal(sharedIP), "Service 2 should have a different IP on lb-1")
-			svc2OldLB := getAzureInternalLoadBalancerFromPrivateIP(tc, &svc2IP, tc.GetResourceGroup())
-			svc2OldFIPID := getFIPIDForPrivateIP(svc2OldLB, svc2IP)
-			utils.Logf("Service 2 exposed with internal IP %s on lb-1, FIP: %s", svc2IP, svc2OldFIPID)
-
-			By("Service 2 adds azure-load-balancer-ipv4 annotation pointing to Service 1's IP, expecting blocked")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2 = updateServiceLBIPs(svc2, true, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Verifying Service 1 is still working")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
-
-			By("Service 2 removes IP annotation instead, keeping LB annotation")
-			beforeIPRemove := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for successful reconcile after removing IP annotation")
-			err = waitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected EnsuredLoadBalancer event after removing IP annotation")
-
-			By("Verifying Service 2 stays on its original LB with its original IP")
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&svc2IP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should stay on its original LB after removing IP annotation")
-			err = verifyFIPHasRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 2 should still have its rule on its original FIP")
-
-			By("Verifying Service 1 is unaffected")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 1 should still have its rule")
-
-			By("Service 2 adds back IP annotation, expecting conflict again")
-			beforeIPReAdd := time.Now()
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2 = updateServiceLBIPs(svc2, true, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeIPReAdd, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected conflict warning after re-adding IP annotation")
-
-			By("Service 2 removes LB annotation to resolve conflict")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
-
-			By("Verifying primary FIP has rules for all services")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Both services should share IP on the primary LB")
-
-			By("Verifying Service 2's old FIP has no rules for its port")
-			err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
-		})
-
-		It("should clean up stale rules when last secondary moves after primary deleted with user-assigned PIP", func() {
-			clusterName := os.Getenv("CLUSTER_NAME")
-
-			By("Creating user-assigned PIP")
-			pipName := "orphan-cleanup-test-pip"
-			pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
-			Expect(err).NotTo(HaveOccurred())
-			sharedIP := ptr.Deref(pip.Properties.IPAddress, "")
-			Expect(sharedIP).NotTo(BeEmpty())
-			defer func() {
-				utils.Logf("Cleaning up PIP %s", pipName)
-				err := utils.DeletePIPWithRetry(tc, pipName, "")
+				svc2 = updateServiceLBIPs(svc2, isInternal, []*string{&sharedIP})
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, beforeIPReAdd)
+				Expect(err).NotTo(HaveOccurred(), "Expected conflict warning after re-adding IP annotation")
 
-			By("Creating Service 1 (primary) with user-assigned PIP")
-			svc1Port := int32(serverPort)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			svc1 = updateServicePIPNames(tc.IPFamily, svc1, []string{pipName})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred())
-			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			svc1LB := getAzureLoadBalancerFromPIP(tc, &sharedIP, tc.GetResourceGroup(), tc.GetResourceGroup())
-			svc1LBName := ptr.Deref(svc1LB.Name, "")
-			utils.Logf("Service 1 exposed with user-assigned PIP %s on %s, FIP: %s", sharedIP, svc1LBName, svc1FIPID)
-
-			By("Creating Service 2 (secondary) sharing Service 1's PIP via IP annotation")
-			svc2Port := int32(serverPort + 1)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				By("Service 2 removes LB annotation to resolve conflict")
+				svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
-
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying both services have rules on the shared FIP")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP")
-
-			By("Deleting Service 1")
-			err = utils.DeleteService(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying FIP still has Service 2's rules but not Service 1's")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "FIP should retain Service 2's rules after Service 1 deletion")
-
-			targetLBAnnotation := "lb-1"
-			if svc1LBName == "lb-1" {
-				targetLBAnnotation = clusterName
-			}
-			By(fmt.Sprintf("Service 2 adds LB annotation %q, expecting blocked", targetLBAnnotation))
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
-
-			By("Service 2 removes IP annotation to resolve conflict")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			svc2NewIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Service 2 should get a new IP on the cluster LB")
-			utils.Logf("Service 2 now on cluster LB with IP %s", svc2NewIP)
-
-			By("Verifying old FIP is removed")
-			err = verifyFIPRemoved(tc, svc1FIPID)
-			Expect(err).NotTo(HaveOccurred(), "FIP should be removed after last service moved away")
-
-			By("Verifying user-assigned PIP is not removed")
-			userPIP, err := tc.GetPublicIPFromAddress(tc.GetResourceGroup(), &sharedIP)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(userPIP).NotTo(BeNil(), "User-assigned PIP should still exist")
-		})
-
-		It("should clean up stale rules when last secondary moves after primary deleted with managed PIP", func() {
-			clusterName := os.Getenv("CLUSTER_NAME")
-
-			By("Creating Service 1 (primary) on lb-1 with managed PIP")
-			svc1Port := int32(serverPort)
-			svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, map[string]string{
-				consts.ServiceAnnotationLoadBalancerConfigurations: "lb-1",
-			}, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc1Port,
-				TargetPort: intstr.FromInt(int(svc1Port)),
-			}})
-			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ips1)).NotTo(BeZero())
-			sharedIP := *ips1[0]
-			svc1FIPID := getPIPFrontendConfigurationID(tc, sharedIP, tc.GetResourceGroup(), true)
-			utils.Logf("Service 1 exposed with managed PIP %s on lb-1, FIP: %s", sharedIP, svc1FIPID)
-
-			By("Creating Service 2 (secondary) sharing Service 1's IP via IP annotation")
-			svc2Port := int32(serverPort + 1)
-			svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, nil, labels, ns.Name, []v1.ServicePort{{
-				Port:       svc2Port,
-				TargetPort: intstr.FromInt(int(svc2Port)),
-			}})
-			svc2 = updateServiceLBIPs(svc2, false, []*string{&sharedIP})
-			_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+				delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-			}()
+				_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+				Expect(err).NotTo(HaveOccurred(), svcNameIPv4+" should be exposed after removing LB config")
 
-			_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
-			Expect(err).NotTo(HaveOccurred())
+				By("Verifying primary FIP has rules for all services")
+				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Both services should share IP on the primary LB")
 
-			By("Verifying both services have rules on the shared FIP")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP")
+				By("Verifying Service 2's old FIP has no rules for its port")
+				err = verifyFIPHasNoRulesForPorts(tc, svc2OldFIPID, sets.New(svc2Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Service 2's old FIP should have no rules after moving")
+			},
+			Entry("external with user-assigned PIP", "external-user-pip"),
+			Entry("external with managed PIP", "external-managed"),
+			Entry("internal", "internal"),
+		)
 
-			By("Deleting Service 1")
-			err = utils.DeleteService(cs, ns.Name, svcNamePrimary)
-			Expect(err).NotTo(HaveOccurred())
+		DescribeTable("should clean up stale rules when last secondary moves after primary deleted",
+			func(mode string) {
+				isInternal := mode == "internal"
+				useUserPIP := mode == "external-user-pip"
+				clusterName := os.Getenv("CLUSTER_NAME")
 
-			By("Verifying FIP still has Service 2's rules but not Service 1's")
-			err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc2Port), "TCP")
-			Expect(err).NotTo(HaveOccurred(), "FIP should retain Service 2's rules after Service 1 deletion")
+				var svcAnnotations map[string]string
+				if isInternal {
+					svcAnnotations = serviceAnnotationLoadBalancerInternalTrue
+				}
 
-			By(fmt.Sprintf("Service 2 adds LB annotation %q, expecting blocked", clusterName))
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = clusterName
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
+				var sharedIP, pipName string
+				if useUserPIP {
+					By("Creating user-assigned PIP")
+					pipName = "orphan-cleanup-test-pip"
+					pip, err := utils.WaitCreatePIP(tc, pipName, tc.GetResourceGroup(), defaultPublicIPAddress(pipName, false))
+					Expect(err).NotTo(HaveOccurred())
+					sharedIP = ptr.Deref(pip.Properties.IPAddress, "")
+					Expect(sharedIP).NotTo(BeEmpty())
+					defer func() {
+						utils.Logf("Cleaning up PIP %s", pipName)
+						err := utils.DeletePIPWithRetry(tc, pipName, "")
+						Expect(err).NotTo(HaveOccurred())
+					}()
+				}
 
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{}, eventTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+				By("Creating Service 1 (primary)")
+				svc1Port := int32(serverPort)
+				svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svc1Port,
+					TargetPort: intstr.FromInt(int(svc1Port)),
+				}})
+				if useUserPIP {
+					svc1 = updateServicePIPNames(tc.IPFamily, svc1, []string{pipName})
+				} else {
+					svc1.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+				}
+				_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
-			By("Service 2 removes IP annotation to resolve conflict")
-			svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
-			_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
+				if sharedIP == "" {
+					ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(ips1)).NotTo(BeZero())
+					sharedIP = *ips1[0]
+				} else {
+					_, err = utils.WaitServiceExposure(cs, ns.Name, svcNamePrimary, []*string{&sharedIP})
+					Expect(err).NotTo(HaveOccurred())
+				}
 
-			svc2NewIP, err := waitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP, ipChangeTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Service 2 should get a new IP on the cluster LB")
-			utils.Logf("Service 2 now on cluster LB with IP %s", svc2NewIP)
+				svc1FIPID, svc1LBName := getFIPIDAndLBName(tc, sharedIP, isInternal)
+				utils.Logf("Service 1 exposed with IP %s on %s, FIP: %s", sharedIP, svc1LBName, svc1FIPID)
 
-			By("Verifying old FIP is removed")
-			err = verifyFIPRemoved(tc, svc1FIPID)
-			Expect(err).NotTo(HaveOccurred(), "FIP should be removed after last service moved away")
+				By("Creating Service 2 (secondary) sharing Service 1's IP via IP annotation")
+				svc2Port := int32(serverPort + 1)
+				svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, svcAnnotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svc2Port,
+					TargetPort: intstr.FromInt(int(svc2Port)),
+				}})
+				svc2 = updateServiceLBIPs(svc2, isInternal, []*string{&sharedIP})
+				_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+					Expect(err).NotTo(HaveOccurred())
+				}()
 
-			By("Verifying lb-1 is deleted since it has no remaining FIPs")
-			_, lbErr := tc.GetLoadBalancer(tc.GetResourceGroup(), "lb-1")
-			Expect(lbErr).To(HaveOccurred(), "lb-1 should be deleted after all FIPs are removed")
-			Expect(strings.Contains(lbErr.Error(), "NotFound")).To(BeTrue(), "Expected NotFound error for lb-1")
+				_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+				Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying managed PIP is removed")
-			managedPIP, err := tc.GetPublicIPFromAddress(tc.GetResourceGroup(), &sharedIP)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(managedPIP).To(BeNil(), "Managed PIP should be deleted after last service moved away")
-		})
+				By("Verifying both services have rules on the shared FIP")
+				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP")
+
+				By("Deleting Service 1")
+				err = utils.DeleteService(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying FIP still has Service 2's rules but not Service 1's")
+				err = verifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc2Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "FIP should retain Service 2's rules after Service 1 deletion")
+
+				targetLBAnnotation := "lb-1"
+				if svc1LBName == "lb-1" || svc1LBName == "lb-1-internal" {
+					targetLBAnnotation = clusterName
+				}
+				By(fmt.Sprintf("Service 2 adds LB annotation %q, expecting blocked", targetLBAnnotation))
+				svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				svc2.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = targetLBAnnotation
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", msgConflictingLBConfig, time.Time{})
+				Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
+
+				By("Service 2 removes IP annotation to resolve conflict")
+				beforeIPRemove := time.Now()
+				svc2, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), svcNameIPv4, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				delete(svc2.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), svc2, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				if isInternal {
+					err = utils.WaitForServiceNormalEventAfter(cs, ns.Name, svcNameIPv4, "EnsuredLoadBalancer", "", beforeIPRemove)
+					Expect(err).NotTo(HaveOccurred(), "Service 2 should be reconciled on "+targetLBAnnotation)
+				} else {
+					svc2NewIP, err := utils.WaitForServiceIPChange(cs, ns.Name, svcNameIPv4, sharedIP)
+					Expect(err).NotTo(HaveOccurred(), "Service 2 should get a new IP on "+targetLBAnnotation)
+					utils.Logf("Service 2 now on %s with IP %s", targetLBAnnotation, svc2NewIP)
+				}
+
+				By("Verifying old FIP is removed")
+				err = verifyFIPRemoved(tc, svc1FIPID)
+				Expect(err).NotTo(HaveOccurred(), "FIP should be removed after last service moved away")
+
+				if useUserPIP {
+					By("Verifying user-assigned PIP is not removed")
+					userPIP, err := tc.GetPublicIPFromAddress(tc.GetResourceGroup(), &sharedIP)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(userPIP).NotTo(BeNil(), "User-assigned PIP should still exist")
+				} else {
+					By("Verifying LB is deleted since it has no remaining FIPs")
+					_, lbErr := tc.GetLoadBalancer(tc.GetResourceGroup(), svc1LBName)
+					Expect(lbErr).To(HaveOccurred(), svc1LBName+" should be deleted after all FIPs are removed")
+					Expect(strings.Contains(lbErr.Error(), "NotFound")).To(BeTrue(), "Expected NotFound error for "+svc1LBName)
+
+					if !isInternal {
+						By("Verifying managed PIP is removed")
+						managedPIP, err := tc.GetPublicIPFromAddress(tc.GetResourceGroup(), &sharedIP)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(managedPIP).To(BeNil(), "Managed PIP should be deleted after last service moved away")
+					}
+				}
+			},
+			Entry("with user-assigned PIP", "external-user-pip"),
+			Entry("with managed PIP", "external-managed"),
+			Entry("internal", "internal"),
+		)
 
 		It("should block service sharing IP on LB not in eligible set", func() {
 			By("Creating Service 1 with label matching lb-2's ServiceLabelSelector")
@@ -1616,7 +962,7 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 			}()
 
 			By("Verifying Service 2 is blocked with not-in-eligible-set error")
-			err = waitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", "not in the eligible set", time.Time{}, eventTimeout)
+			err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svcNameIPv4, "SyncLoadBalancerFailed", "not in the eligible set", time.Time{})
 			Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+svcNameIPv4)
 
 			By("Resolving by adding label a=b to Service 2")
@@ -1855,6 +1201,16 @@ func getFIPIDForPrivateIP(lb *armnetwork.LoadBalancer, privateIP string) string 
 	return ""
 }
 
+func getFIPIDAndLBName(tc *utils.AzureTestClient, ip string, isInternal bool) (fipID, lbName string) {
+	if isInternal {
+		lb := getAzureInternalLoadBalancerFromPrivateIP(tc, &ip, tc.GetResourceGroup())
+		return getFIPIDForPrivateIP(lb, ip), ptr.Deref(lb.Name, "")
+	}
+	fipID = getPIPFrontendConfigurationID(tc, ip, tc.GetResourceGroup(), true)
+	lb := getAzureLoadBalancerFromPIP(tc, &ip, tc.GetResourceGroup(), tc.GetResourceGroup())
+	return fipID, ptr.Deref(lb.Name, "")
+}
+
 func waitLBCountEqualTo(tc *utils.AzureTestClient, interval, timeout time.Duration, expectedCount int, svcIPs []*string) (sets.Set[string], error) {
 	var lbNames sets.Set[string]
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
@@ -1866,94 +1222,4 @@ func waitLBCountEqualTo(tc *utils.AzureTestClient, interval, timeout time.Durati
 		return true, nil
 	})
 	return lbNames, err
-}
-
-// waitForServiceEventAfter waits for an event of the given type on the service with the expected Reason
-// that occurred after the specified time and contains the expected message substring.
-func waitForServiceEventAfter(
-	cs clientset.Interface,
-	ns, serviceName string,
-	eventType string,
-	expectedReason string,
-	messageSubstring string,
-	after time.Time,
-	timeout time.Duration,
-) error {
-	return wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		events, err := cs.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
-			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Service,type=%s", serviceName, eventType),
-		})
-		if err != nil {
-			return false, err
-		}
-		for _, event := range events.Items {
-			if event.Reason != expectedReason {
-				continue
-			}
-			if messageSubstring != "" && !strings.Contains(event.Message, messageSubstring) {
-				continue
-			}
-			eventTime := event.LastTimestamp.Time
-			if eventTime.After(after) {
-				utils.Logf("Found %s event for service %s after %v: Reason=%s, LastTimestamp=%v, Message=%s",
-					eventType, serviceName, after.Format(time.RFC3339), event.Reason, eventTime.Format(time.RFC3339), event.Message)
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-}
-
-// waitForServiceNormalEventAfter waits for a Normal event on the service with the expected Reason
-// that occurred after the specified time and contains the expected message substring.
-func waitForServiceNormalEventAfter(
-	cs clientset.Interface,
-	ns, serviceName string,
-	expectedReason string,
-	messageSubstring string,
-	after time.Time,
-	timeout time.Duration,
-) error {
-	return waitForServiceEventAfter(cs, ns, serviceName, "Normal", expectedReason, messageSubstring, after, timeout)
-}
-
-// waitForServiceWarningEventAfter waits for a Warning event on the service with the expected Reason
-// that occurred after the specified time and contains the expected message substring.
-func waitForServiceWarningEventAfter(
-	cs clientset.Interface,
-	ns, serviceName string,
-	expectedReason string,
-	messageSubstring string,
-	after time.Time,
-	timeout time.Duration,
-) error {
-	return waitForServiceEventAfter(cs, ns, serviceName, "Warning", expectedReason, messageSubstring, after, timeout)
-}
-
-// waitForServiceIPChange waits for a service to get a different IP than the oldIP.
-func waitForServiceIPChange(cs clientset.Interface, ns, serviceName, oldIP string, timeout time.Duration) (string, error) {
-	var newIP string
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		service, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
-		if err != nil {
-			utils.Logf("Error getting service %s: %v", serviceName, err)
-			return false, nil
-		}
-		if len(service.Status.LoadBalancer.Ingress) == 0 {
-			utils.Logf("Service %s has no IP yet, waiting...", serviceName)
-			return false, nil
-		}
-		currentIP := service.Status.LoadBalancer.Ingress[0].IP
-		if currentIP != oldIP {
-			utils.Logf("Service %s IP changed from %s to %s", serviceName, oldIP, currentIP)
-			newIP = currentIP
-			return true, nil
-		}
-		utils.Logf("Service %s still has old IP %s, waiting for change...", serviceName, oldIP)
-		return false, nil
-	})
-	if err != nil {
-		return "", fmt.Errorf("timeout waiting for service %s IP to change from %s: %w", serviceName, oldIP, err)
-	}
-	return newIP, nil
 }

--- a/tests/e2e/utils/loadbalancer_utils.go
+++ b/tests/e2e/utils/loadbalancer_utils.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+)
+
+var lbNameRE = regexp.MustCompile(`^/subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Network/loadBalancers/(.+)/frontendIPConfigurations(?:.*)`)
+
+// GetFIPIDForPrivateIP finds the frontend IP configuration ID for a given private IP.
+func GetFIPIDForPrivateIP(lb *armnetwork.LoadBalancer, privateIP string) string {
+	if lb.Properties == nil || lb.Properties.FrontendIPConfigurations == nil {
+		return ""
+	}
+	for _, fip := range lb.Properties.FrontendIPConfigurations {
+		if fip.Properties != nil && fip.Properties.PrivateIPAddress != nil {
+			if *fip.Properties.PrivateIPAddress == privateIP {
+				return ptr.Deref(fip.ID, "")
+			}
+		}
+	}
+	return ""
+}
+
+// VerifyFIPRemoved checks that the specified frontend IP configuration no longer exists on the LB.
+// Returns nil if the FIP is gone (or the entire LB is gone). Returns an error if the FIP still exists.
+func VerifyFIPRemoved(tc *AzureTestClient, fipID string) error {
+	if fipID == "" {
+		return fmt.Errorf("empty FIP ID")
+	}
+
+	match := lbNameRE.FindStringSubmatch(fipID)
+	if len(match) != 2 {
+		return fmt.Errorf("could not parse LB name from FIP ID: %s", fipID)
+	}
+	lbName := match[1]
+
+	lb, err := tc.GetLoadBalancer(tc.GetResourceGroup(), lbName)
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			Logf("LB %s not found, FIP %s is removed", lbName, fipID)
+			return nil
+		}
+		return fmt.Errorf("failed to get load balancer %s: %w", lbName, err)
+	}
+
+	if lb.Properties != nil && lb.Properties.FrontendIPConfigurations != nil {
+		for _, fip := range lb.Properties.FrontendIPConfigurations {
+			if strings.EqualFold(ptr.Deref(fip.ID, ""), fipID) {
+				var ruleIDs []string
+				if fip.Properties != nil {
+					for _, r := range fip.Properties.LoadBalancingRules {
+						ruleIDs = append(ruleIDs, ptr.Deref(r.ID, "<unknown>"))
+					}
+				}
+				return fmt.Errorf("FIP %s still exists on LB %s with rules %v", fipID, lbName, ruleIDs)
+			}
+		}
+	}
+
+	Logf("FIP %s has been removed from LB %s", fipID, lbName)
+	return nil
+}
+
+// GetFIPRulePorts returns all ports that have load balancing rules for the given FIP and protocol.
+// Returns (ports, lbExists, error). If lbExists is false, the LB doesn't exist (ports will be empty).
+func GetFIPRulePorts(tc *AzureTestClient, fipID string, protocol string) (sets.Set[int32], bool, error) {
+	if fipID == "" {
+		return nil, false, fmt.Errorf("empty FIP ID")
+	}
+
+	match := lbNameRE.FindStringSubmatch(fipID)
+	if len(match) != 2 {
+		return nil, false, fmt.Errorf("could not parse LB name from FIP ID: %s", fipID)
+	}
+	lbName := match[1]
+
+	lb, err := tc.GetLoadBalancer(tc.GetResourceGroup(), lbName)
+	if err != nil {
+		errStr := err.Error()
+		if strings.Contains(errStr, "NotFound") {
+			return sets.New[int32](), false, nil
+		}
+		return nil, false, fmt.Errorf("failed to get load balancer %s: %w", lbName, err)
+	}
+
+	// Find all rules that reference the target FIP ID with matching protocol.
+	ports := sets.New[int32]()
+	if lb.Properties != nil && lb.Properties.LoadBalancingRules != nil {
+		for _, rule := range lb.Properties.LoadBalancingRules {
+			if rule.Properties == nil || rule.Properties.FrontendIPConfiguration == nil {
+				continue
+			}
+			ruleFIPID := ptr.Deref(rule.Properties.FrontendIPConfiguration.ID, "")
+			if !strings.EqualFold(ruleFIPID, fipID) {
+				continue
+			}
+
+			rulePort := ptr.Deref(rule.Properties.FrontendPort, 0)
+			ruleProtocol := string(ptr.Deref(rule.Properties.Protocol, ""))
+
+			if strings.EqualFold(ruleProtocol, protocol) {
+				Logf("Found rule %q for port %d/%s on FIP", ptr.Deref(rule.Name, ""), rulePort, ruleProtocol)
+				ports.Insert(rulePort)
+			}
+		}
+	}
+
+	return ports, true, nil
+}
+
+// VerifyFIPHasRulesForPorts checks that the specified frontend IP config has rules for exactly all expected ports.
+func VerifyFIPHasRulesForPorts(tc *AzureTestClient, fipID string, expectedPorts sets.Set[int32], protocol string) error {
+	Logf("Verifying FIP ID %q has rules for ports %v", fipID, expectedPorts.UnsortedList())
+
+	actualPorts, lbExists, err := GetFIPRulePorts(tc, fipID, protocol)
+	if err != nil {
+		return err
+	}
+	if !lbExists {
+		return fmt.Errorf("load balancer for FIP %q does not exist", fipID)
+	}
+
+	missingPorts := expectedPorts.Difference(actualPorts)
+	extraPorts := actualPorts.Difference(expectedPorts)
+
+	if missingPorts.Len() > 0 || extraPorts.Len() > 0 {
+		return fmt.Errorf("FIP %q port mismatch: missing=%v, extra=%v, expected=%v, actual=%v",
+			fipID, missingPorts.UnsortedList(), extraPorts.UnsortedList(),
+			expectedPorts.UnsortedList(), actualPorts.UnsortedList())
+	}
+
+	Logf("FIP %q has exactly the expected rules for ports %v", fipID, expectedPorts.UnsortedList())
+	return nil
+}
+
+// VerifyFIPHasNoRulesForPorts checks that the specified frontend IP config has no rules for the specified ports.
+// If the LB does not exist, that counts as success (no rules).
+func VerifyFIPHasNoRulesForPorts(tc *AzureTestClient, fipID string, absentPorts sets.Set[int32], protocol string) error {
+	Logf("Verifying FIP ID %q has NO rules for ports %v", fipID, absentPorts.UnsortedList())
+
+	actualPorts, lbExists, err := GetFIPRulePorts(tc, fipID, protocol)
+	if err != nil {
+		return err
+	}
+	if !lbExists {
+		Logf("LB for FIP %q not found, treating as no rules", fipID)
+		return nil
+	}
+
+	foundPorts := absentPorts.Intersection(actualPorts)
+	if foundPorts.Len() > 0 {
+		return fmt.Errorf("FIP %q still has rules for ports %v", fipID, foundPorts.UnsortedList())
+	}
+
+	Logf("FIP %q has no rules for ports %v (as expected)", fipID, absentPorts.UnsortedList())
+	return nil
+}

--- a/tests/e2e/utils/service_utils.go
+++ b/tests/e2e/utils/service_utils.go
@@ -249,3 +249,90 @@ func extractSuffix() string {
 func IsInternalEndpoint(ip string) bool {
 	return strings.HasPrefix(ip, "10.")
 }
+
+// WaitForServiceEventAfter waits for an event of the given type on the service with the expected Reason
+// that occurred after the specified time and contains the expected message substring.
+func WaitForServiceEventAfter(
+	cs clientset.Interface,
+	ns, serviceName string,
+	eventType string,
+	expectedReason string,
+	messageSubstring string,
+	after time.Time,
+) error {
+	return wait.PollUntilContextTimeout(context.Background(), 10*time.Second, serviceTimeout, true, func(ctx context.Context) (bool, error) {
+		events, err := cs.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Service,type=%s", serviceName, eventType),
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events.Items {
+			if event.Reason != expectedReason {
+				continue
+			}
+			if messageSubstring != "" && !strings.Contains(event.Message, messageSubstring) {
+				continue
+			}
+			eventTime := event.LastTimestamp.Time
+			if eventTime.After(after) {
+				Logf("Found %s event for service %s after %v: Reason=%s, LastTimestamp=%v, Message=%s",
+					eventType, serviceName, after.Format(time.RFC3339), event.Reason, eventTime.Format(time.RFC3339), event.Message)
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+// WaitForServiceNormalEventAfter waits for a Normal event on the service with the expected Reason
+// that occurred after the specified time and contains the expected message substring.
+func WaitForServiceNormalEventAfter(
+	cs clientset.Interface,
+	ns, serviceName string,
+	expectedReason string,
+	messageSubstring string,
+	after time.Time,
+) error {
+	return WaitForServiceEventAfter(cs, ns, serviceName, "Normal", expectedReason, messageSubstring, after)
+}
+
+// WaitForServiceWarningEventAfter waits for a Warning event on the service with the expected Reason
+// that occurred after the specified time and contains the expected message substring.
+func WaitForServiceWarningEventAfter(
+	cs clientset.Interface,
+	ns, serviceName string,
+	expectedReason string,
+	messageSubstring string,
+	after time.Time,
+) error {
+	return WaitForServiceEventAfter(cs, ns, serviceName, "Warning", expectedReason, messageSubstring, after)
+}
+
+// WaitForServiceIPChange waits for a service to get a different IP than the oldIP.
+func WaitForServiceIPChange(cs clientset.Interface, ns, serviceName, oldIP string) (string, error) {
+	var newIP string
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, serviceTimeout, true, func(ctx context.Context) (bool, error) {
+		service, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
+		if err != nil {
+			Logf("Error getting service %s: %v", serviceName, err)
+			return false, nil
+		}
+		if len(service.Status.LoadBalancer.Ingress) == 0 {
+			Logf("Service %s has no IP yet, waiting...", serviceName)
+			return false, nil
+		}
+		currentIP := service.Status.LoadBalancer.Ingress[0].IP
+		if currentIP != oldIP {
+			Logf("Service %s IP changed from %s to %s", serviceName, oldIP, currentIP)
+			newIP = currentIP
+			return true, nil
+		}
+		Logf("Service %s still has old IP %s, waiting for change...", serviceName, oldIP)
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("timeout waiting for service %s IP to change from %s: %w", serviceName, oldIP, err)
+	}
+	return newIP, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In multi-SLB mode, when Service B shares an IP with existing Service A, `getAzureLoadBalancerName` picks the LB with the fewest rules instead of the LB where the IP resides. This triggers migration logic that accidentally removes Service A's frontend IP configuration. This fixes that by picking the LB where the IP resides.

Additional fixes:
- Block LB migration when it would remove a frontend IP shared with other services.
- Block conflicting LB config annotation when the service also specifies an IP.
- Block IP specification pointing to an ineligible LB.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9867

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix(multi-slb): support IP sharing across multiple services

When a service specifies an IP address that already exists on a load balancer, the service is now placed on that load balancer instead of picking one with the fewest rules, provided the service is eligible for that load balancer. The load balancer configuration annotation cannot be combined with an IP specification. Migration to a different load balancer is blocked if the frontend IP is still referenced by other resources.

Switching internal/external issues (10050 and 10117) will be fixed in another change.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
