### PR TITLE
chore: enable dependabot for release-1.35

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -293,7 +293,84 @@ updates:
     directory: "/"
     open-pull-requests-limit: 1
     schedule:
-      interval: daily
+      interval: weekly
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "lgtm"
+      - "approved"
+      - "release-1.35"
+    target-branch: "release-1.35"
+    ignore:
+      - dependency-name: "k8s.io/*"
+        versions: [">=0.36.0"]
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+        - "minor"
+        - "major"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    target-branch: "release-1.35"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+      - "kind/testing"
+      - "lgtm"
+      - "approved"
+      - "release-1.35"
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+        - "minor"
+        - "major"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    target-branch: "release-1.35"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "lgtm"
+      - "approved"
+      - "release-1.35"
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+        - "minor"
+        - "major"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    open-pull-requests-limit: 1
+    schedule:
+      interval: weekly
       time: "01:00"
       timezone: "Asia/Shanghai"
     labels:
@@ -320,7 +397,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "01:00"
       timezone: "Asia/Shanghai"
     target-branch: "release-1.34"
@@ -344,7 +421,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "01:00"
       timezone: "Asia/Shanghai"
     target-branch: "release-1.34"

--- a/ai/agents.md
+++ b/ai/agents.md
@@ -186,6 +186,21 @@ logger.Error(err, "Failed to reconcile LoadBalancer")
 logger.V(4).Info("Could not fetch instance metadata", "err", err, "node", nodeName)
 ```
 
+## Pull Requests
+
+When creating a pull request, use the template at `.github/PULL_REQUEST_TEMPLATE.md`.
+The PR body must include the following sections filled in appropriately:
+
+1. **What type of PR is this?** — add a Prow `/kind` command (`/kind bug`, `/kind cleanup`,
+   `/kind feature`, `/kind documentation`, `/kind design`)
+2. **What this PR does / why we need it** — concise description of the change
+3. **Which issue(s) this PR fixes** — use `Fixes #<number>` to auto-close issues on merge
+4. **Special notes for your reviewer** — anything reviewers should pay attention to
+5. **Does this PR introduce a user-facing change?** — fill the `release-note` block;
+   write `NONE` if there is no user-facing change
+6. **Additional documentation** — link to KEPs, usage docs, or other references in the
+   `docs` block; leave empty if not applicable
+
 ## Reference Docs
 
 Check these docs when working in the relevant area. These docs should be updated once the logics have been changed.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Add Dependabot entries for `release-1.35` branch (gomod, github-actions, docker)
- Change `release-1.34` Dependabot interval from daily to weekly for consistency
- Add PR template instructions to `ai/agents.md`

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```