### PR TITLE
chore: fix trivy-action version comment from master to v0.35.0

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -60,7 +60,7 @@ jobs:
           cd health-probe-proxy && make build-health-probe-proxy-image && cd ..
 
       - name: Run Trivy scanner CCM
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'local/azure-cloud-controller-manager:${{ github.sha }}'
           format: 'sarif'
@@ -76,7 +76,7 @@ jobs:
           sarif_file: 'trivy-ccm-results.sarif'
           category: azure-cloud-controller-manager-image
       - name: Run Trivy scanner CNM
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'local/azure-cloud-node-manager:${{ github.sha }}-linux-amd64'
           format: 'sarif'
@@ -92,7 +92,7 @@ jobs:
           sarif_file: 'trivy-cnm-linux-results.sarif'
           category: azure-cloud-node-manager-linux-image
       - name: Run Trivy scanner health-probe-proxy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'local/health-probe-proxy:${{ github.sha }}'
           format: 'sarif'
@@ -109,7 +109,7 @@ jobs:
           category: health-probe-proxy-linux-image
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           format: 'github'


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

The `aquasecurity/trivy-action` SHA (`57a97c7e`) is already correctly pinned, but the inline comment still says `# master`. This PR updates the comment to `# v0.35.0` to accurately reflect the pinned version.

This is a comment-only change with no functional impact, but improves clarity for future maintenance — especially given the [supply chain attack](https://github.com/aquasecurity/trivy/discussions/10425) that made mutable references a concern.

### Changes

| File | Before | After |
|------|--------|-------|
| `trivy.yaml` (4 occurrences) | `@57a97c7e... # master` | `@57a97c7e... # v0.35.0` |

### References
- Supply chain attack discussion: https://github.com/aquasecurity/trivy/discussions/10425
- Similar fix: https://github.com/kubernetes-csi/csi-release-tools/pull/295