### PR TITLE
fix: support GOEXPERIMENT build arg in Dockerfiles for manual testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@
 FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.25.8-bookworm@sha256:0b7cc047573fe23c973a23cf9d3afebaa26b88de13d4c6a77f861db97e5d10a5 AS builder
 
 ARG ENABLE_GIT_COMMAND=true
+ARG GOEXPERIMENT
 ARG ARCH=amd64
+ENV GOEXPERIMENT=${GOEXPERIMENT}
 
 RUN if [ "$ARCH" = "arm64" ] ; then \
     apt-get update && apt-get install -y gcc-aarch64-linux-gnu ; \

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ build-ccm-image: buildx-setup ## Build controller-manager image.
 		--output=type=$(OUTPUT_TYPE) \
 		--platform linux/$(ARCH) \
 		--build-arg ENABLE_GIT_COMMAND="$(ENABLE_GIT_COMMAND)" \
+		--build-arg GOEXPERIMENT="$(GOEXPERIMENT)" \
 		--build-arg ARCH="$(ARCH)" \
 		--build-arg VERSION="$(VERSION)" \
 		--file Dockerfile \
@@ -160,6 +161,7 @@ build-node-image-linux: buildx-setup ## Build node-manager image.
 		--output=type=$(OUTPUT_TYPE) \
 		--platform linux/$(ARCH) \
 		--build-arg ENABLE_GIT_COMMAND="$(ENABLE_GIT_COMMAND)" \
+		--build-arg GOEXPERIMENT="$(GOEXPERIMENT)" \
 		--build-arg ARCH="$(ARCH)" \
 		--build-arg VERSION="$(VERSION)" \
 		--file cloud-node-manager.Dockerfile \

--- a/cloud-node-manager.Dockerfile
+++ b/cloud-node-manager.Dockerfile
@@ -17,7 +17,9 @@
 FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.25.8-bookworm@sha256:0b7cc047573fe23c973a23cf9d3afebaa26b88de13d4c6a77f861db97e5d10a5 AS builder
 
 ARG ENABLE_GIT_COMMAND=true
+ARG GOEXPERIMENT
 ARG ARCH=amd64
+ENV GOEXPERIMENT=${GOEXPERIMENT}
 
 RUN if [ "$ARCH" = "arm64" ] ; then \
     apt-get update && apt-get install -y gcc-aarch64-linux-gnu ; \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

After upgrading to Microsoft's Go 1.25.8 fork in the Dockerfiles (#9930), the cloud-controller-manager and cloud-node-manager crash on systems with FIPS mode enabled:

```
panic: opensslcrypto: FIPS mode requested (system FIPS mode) but not available: OpenSSL 3.0.17 1 Jul 2025
```

This adds a `GOEXPERIMENT` build arg to the Dockerfiles and Makefile so that developers can pass `GOEXPERIMENT=nofips` to disable the FIPS crypto backend for local/manual testing.

**Note:** This is a workaround for manual testing only and is NOT recommended for production builds. Production environments should use a runtime base image with a properly configured OpenSSL FIPS provider.

Usage:
```sh
IMAGE_REGISTRY=<registry> IMAGE_TAG=<tag> GOEXPERIMENT=nofips make build-ccm-image
IMAGE_REGISTRY=<registry> IMAGE_TAG=<tag> GOEXPERIMENT=nofips make build-cnm-image
```

#### Which issue(s) this PR fixes:

Fixes the FIPS panic introduced by the Go 1.25.8 upgrade in #9930.

#### Special notes for your reviewer:

This only adds an optional build arg — default behavior (FIPS enabled) is unchanged. The arg is only useful for environments where the runtime image lacks a FIPS-configured OpenSSL.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```