### PR TITLE
fix(multi-slb): fix race condition for backendpoolUpdater

### DIFF
--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -161,43 +161,24 @@ func (updater *loadBalancerBackendPoolUpdater) removeOperation(serviceName strin
 }
 
 // process processes all operations in the loadBalancerBackendPoolUpdater.
-// It merges operations that have the same loadBalancerName and backendPoolName,
-// and then processes them in batches. If an operation fails, it will be retried
-// if it is retriable, otherwise all operations in the batch targeting to
-// this backend pool will fail.
+// It dequeues and groups operations under the queue lock, then performs
+// ARM operations under serviceReconcileLock to serialize with the main
+// service reconciliation loop (EnsureLoadBalancer / UpdateLoadBalancer /
+// EnsureLoadBalancerDeleted). This prevents ETag conflicts (HTTP 412)
+// between concurrent LB parent PUTs and backend pool child PUTs.
 func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.process")
-	updater.lock.Lock()
-	defer updater.lock.Unlock()
 
-	if len(updater.operations) == 0 {
-		logger.V(4).Info("no operations to process")
+	// Dequeue and group operations under the queue lock.
+	groups := updater.dequeue(ctx)
+	if len(groups) == 0 {
 		return
 	}
 
-	// Group operations by loadBalancerName:backendPoolName
-	groups := make(map[string][]batchOperation)
-	for _, op := range updater.operations {
-		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
-		si, found := updater.az.getLocalServiceInfo(strings.ToLower(lbOp.serviceName))
-		if !found {
-			logger.V(4).Info("service is not a local service, skip the operation", "service", lbOp.serviceName)
-			continue
-		}
-		if !strings.EqualFold(si.lbName, lbOp.loadBalancerName) {
-			logger.V(4).Info("service is not associated with the load balancer, skip the operation",
-				"service", lbOp.serviceName,
-				"previous load balancer", lbOp.loadBalancerName,
-				"current load balancer", si.lbName)
-			continue
-		}
-
-		key := fmt.Sprintf("%s:%s", lbOp.loadBalancerName, lbOp.backendPoolName)
-		groups[key] = append(groups[key], op)
-	}
-
-	// Clear all jobs.
-	updater.operations = make([]batchOperation, 0)
+	// Acquire serviceReconcileLock so that backend pool PUTs do not
+	// overlap with LB-level PUTs in the main reconciliation loop.
+	updater.az.serviceReconcileLock.Lock()
+	defer updater.az.serviceReconcileLock.Unlock()
 
 	for key, ops := range groups {
 		parts := strings.Split(key, ":")
@@ -249,6 +230,47 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 		isOperationSucceeded = true // Mark operation as successful before notifying
 		updater.notify(newBatchOperationResult(operationName, true, nil), ops...)
 	}
+}
+
+// dequeue drains the operation queue under the queue lock and returns
+// grouped operations by loadBalancerName:backendPoolName.
+// The queue lock is released before returning so that addOperation() is not
+// blocked during ARM calls.
+func (updater *loadBalancerBackendPoolUpdater) dequeue(ctx context.Context) map[string][]batchOperation {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.dequeue")
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+
+	if len(updater.operations) == 0 {
+		logger.V(4).Info("no operations to process")
+		return nil
+	}
+
+	// Group operations by loadBalancerName:backendPoolName
+	groups := make(map[string][]batchOperation)
+	for _, op := range updater.operations {
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		si, found := updater.az.getLocalServiceInfo(strings.ToLower(lbOp.serviceName))
+		if !found {
+			logger.V(4).Info("service is not a local service, skip the operation", "service", lbOp.serviceName)
+			continue
+		}
+		if !strings.EqualFold(si.lbName, lbOp.loadBalancerName) {
+			logger.V(4).Info("service is not associated with the load balancer, skip the operation",
+				"service", lbOp.serviceName,
+				"previous load balancer", lbOp.loadBalancerName,
+				"current load balancer", si.lbName)
+			continue
+		}
+
+		key := fmt.Sprintf("%s:%s", lbOp.loadBalancerName, lbOp.backendPoolName)
+		groups[key] = append(groups[key], op)
+	}
+
+	// Clear all jobs.
+	updater.operations = make([]batchOperation, 0)
+
+	return groups
 }
 
 // processError mark the operations as retriable if the error is retriable,

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -434,6 +434,122 @@ func getTestEndpointSlice(name, namespace, svcName string, nodeNames ...string) 
 	}
 }
 
+var lockCallbackTimeout = 2 * time.Second
+
+func ensureCallbackHappens(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(lockCallbackTimeout):
+		t.Fatal("timed out waiting for callback")
+	}
+}
+
+func ensureNoCallback(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal("unexpected callback")
+	case <-time.After(lockCallbackTimeout):
+	}
+}
+
+// TestLoadBalancerBackendPoolUpdaterSerialization verifies that process()
+// acquires serviceReconcileLock before performing ARM operations, serializing
+// with the main service reconciliation loop. This prevents the ETag race on ARM calls.
+func TestLoadBalancerBackendPoolUpdaterSerialization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	client := fake.NewSimpleClientset(&svc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
+	expectedBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1"})
+
+	getCalled := make(chan struct{})
+	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+	mockBPClient.EXPECT().Get(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+	).DoAndReturn(func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+		close(getCalled)
+		return existingBP, nil
+	})
+	mockBPClient.EXPECT().CreateOrUpdate(
+		gomock.Any(), gomock.Any(), "lb1", "pool1", *expectedBP,
+	).Return(nil, nil)
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	// Simulate serviceReconcileLock (e.g., reconcileLoadBalancer in progress).
+	cloud.serviceReconcileLock.Lock()
+
+	processDone := make(chan struct{})
+	go func() {
+		u.process(context.Background())
+		close(processDone)
+	}()
+
+	// process() must NOT perform ARM calls while the lock is held.
+	ensureNoCallback(t, getCalled)
+
+	// Release lock - process() should proceed and complete.
+	cloud.serviceReconcileLock.Unlock()
+	ensureCallbackHappens(t, getCalled)
+	ensureCallbackHappens(t, processDone)
+}
+
+// TestLoadBalancerBackendPoolUpdaterDequeueUnderQueueLock verifies that the
+// queue lock is released before ARM operations, so addOperation() is not
+// blocked while process() is waiting on the Azure API.
+func TestLoadBalancerBackendPoolUpdaterDequeueUnderQueueLock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	client := fake.NewSimpleClientset(&svc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
+	expectedBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1"})
+
+	addDone := make(chan struct{})
+	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+	mockBPClient.EXPECT().Get(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+	).DoAndReturn(func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+		// While the ARM Get is in-flight, try to enqueue a new operation.
+		// If the queue lock were still held, this would deadlock.
+		go func() {
+			cloud.localServiceNameToServiceInfoMap.Store("ns1/svc2", &serviceInfo{lbName: "lb1"})
+			u := cloud.backendPoolUpdater.(*loadBalancerBackendPoolUpdater)
+			u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.3"}))
+			close(addDone)
+		}()
+		ensureCallbackHappens(t, addDone)
+		return existingBP, nil
+	})
+	mockBPClient.EXPECT().CreateOrUpdate(
+		gomock.Any(), gomock.Any(), "lb1", "pool1", *expectedBP,
+	).Return(nil, nil)
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	cloud.backendPoolUpdater = u
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	u.process(context.Background())
+}
+
 func TestEndpointSlicesInformer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In multi-SLB clusters with `ExternalTrafficPolicy: Local` the `loadBalancerBackendPoolUpdater.process()` and the main service reconciliation loop (i.e., `reconcileLoadBalancer` → `CreateOrUpdateLB`) can issue concurrent ARM calls targeting the same load balancer. 
Because these are parent PUT (LB-level) and child PUT (backend pool-level) operations.
ARM rejects the operation with HTTP 412 (ETag mismatch / PreconditionFailed) when they race.

This PR fixes the race by splitting `process()` into two phases:

Dequeue — drains the operation queue under the existing queue lock (updater.lock), then releases it.
ARM operations — performs Get/CreateOrUpdate under serviceReconcileLock, serializing with the main reconciliation loop.
This ensures that backend pool PUTs and LB PUTs never overlap, eliminating the ETag conflict. The queue lock is released before acquiring serviceReconcileLock to avoid nested locks and to keep addOperation() non-blocking during ARM calls.

#### Which issue(s) this PR fixes:
Fixes #9839

#### Special notes for your reviewer:
The core fix is in `azure_local_services.go`: `process()` is split into `dequeue()`, and ARM operations under `serviceReconcileLock`.

Two new unit tests verify the lock behavior:
`TestLoadBalancerBackendPoolUpdaterSerialization` - ARM calls are blocked while serviceReconcileLock is held.
`TestLoadBalancerBackendPoolUpdaterDequeueUnderQueueLock` - queue lock is released before ARM calls, so addOperation() for `backendPoolUpdater` is not blocked.

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```