### PR TITLE
[release-1.34] feat: support podman as container CLI with auto-detection

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -58,6 +58,8 @@ jobs:
           make build-ccm-image
           make build-node-image-linux-amd64
           cd health-probe-proxy && make build-health-probe-proxy-image && cd ..
+        env:
+          CONTAINER_CLI: docker
 
       - name: Run Trivy scanner CCM
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master

--- a/.pipelines/ccm-image.yml
+++ b/.pipelines/ccm-image.yml
@@ -4,7 +4,8 @@ steps:
       version: '1.21.5'
   - bash: |
       git show --stat
-      echo $REGISTRY_PASSWORD | docker login $REGISTRY_URL -u $REGISTRY_USERNAME --password-stdin
+      CONTAINER_CLI="${CONTAINER_CLI:-$(which podman 2>/dev/null || echo docker)}"
+      echo $REGISTRY_PASSWORD | $CONTAINER_CLI login $REGISTRY_URL -u $REGISTRY_USERNAME --password-stdin
       export IMAGE_REGISTRY=$REGISTRY_URL
       USER="cloudtest"
       if [[ -n "${RELEASE_PIPELINE:-}" ]]; then

--- a/.pipelines/cnm-image.yml
+++ b/.pipelines/cnm-image.yml
@@ -4,7 +4,8 @@ steps:
       version: '1.21.5'
   - bash: |
       git show --stat
-      echo $REGISTRY_PASSWORD | docker login $REGISTRY_URL -u $REGISTRY_USERNAME --password-stdin
+      CONTAINER_CLI="${CONTAINER_CLI:-$(which podman 2>/dev/null || echo docker)}"
+      echo $REGISTRY_PASSWORD | $CONTAINER_CLI login $REGISTRY_URL -u $REGISTRY_USERNAME --password-stdin
       export IMAGE_REGISTRY=$REGISTRY_URL
       USER="cloudtest"
       if [[ -n "${RELEASE_PIPELINE:-}" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), $(foreach osversion, 
 ARCH ?= amd64
 # OS Version for the Windows images: 1809, 2004, 20H2, ltsc2022
 WINDOWS_OSVERSION ?= 1809
-# The output type for `docker buildx build` could either be docker (local), or registry.
+# The output type for the container build command could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 
 BASE.windows := mcr.microsoft.com/windows/nanoserver
@@ -52,18 +52,30 @@ IMAGE_REGISTRY ?= local
 K8S_VERSION ?= v1.18.0-rc.1
 HYPERKUBE_IMAGE ?= gcrio.azureedge.net/google_containers/hyperkube-amd64:$(K8S_VERSION)
 
-# `docker buildx` and `docker manifest` requires enabling DOCKER_CLI_EXPERIMENTAL for docker version < 1.20
-export DOCKER_CLI_EXPERIMENTAL=enabled
-
 ifndef TAG
 	IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)
 else
 	IMAGE_TAG ?= $(TAG)
 endif
 
-DOCKER_CLI_EXPERIMENTAL := enabled
+# Container CLI: uses podman if available, otherwise docker
+CONTAINER_CLI ?= $(shell which podman 2>/dev/null || echo "docker")
+MANIFEST_AMEND_FLAG ?= --amend
 
-DOCKER_BUILDX ?= docker buildx
+ifeq ($(notdir $(CONTAINER_CLI)),podman)
+CONTAINER_BUILDX ?= $(CONTAINER_CLI)
+BUILDX_EXTRA_FLAGS ?=
+OUTPUT_FLAG ?=
+MANIFEST_PURGE_FLAG ?= --rm
+MANIFEST_PUSH_FORMAT ?= --format v2s2
+else
+CONTAINER_BUILDX ?= $(CONTAINER_CLI) buildx
+BUILDX_EXTRA_FLAGS ?= --provenance=false --sbom=false
+OUTPUT_FLAG ?= --output=type=$(OUTPUT_TYPE)
+MANIFEST_PURGE_FLAG ?= --purge
+MANIFEST_PUSH_FORMAT ?=
+export DOCKER_CLI_EXPERIMENTAL=enabled
+endif
 
 # cloud controller manager image
 ifeq ($(ARCH), amd64)
@@ -133,17 +145,22 @@ $(BIN_DIR)/azure-acr-credential-provider.exe: $(PKG_CONFIG) $(wildcard cmd/acr-c
 ## --------------------------------------
 .PHONY: buildx-setup
 buildx-setup:
-	$(DOCKER_BUILDX) inspect img-builder > /dev/null 2>&1 || $(DOCKER_BUILDX) create --name img-builder --use
+ifeq ($(notdir $(CONTAINER_CLI)),podman)
+	# podman build handles multi-platform natively; ensure qemu-user-static is registered
+	$(CONTAINER_CLI) run --rm --privileged tonistiigi/binfmt --install all
+else
+	$(CONTAINER_BUILDX) inspect img-builder > /dev/null 2>&1 || $(CONTAINER_BUILDX) create --name img-builder --use
 	# enable qemu for arm64 build
 	# https://github.com/docker/buildx/issues/464#issuecomment-741507760
-	docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
-	docker run --rm --privileged tonistiigi/binfmt --install all
+	$(CONTAINER_CLI) run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
+	$(CONTAINER_CLI) run --rm --privileged tonistiigi/binfmt --install all
+endif
 
 .PHONY: build-ccm-image
 build-ccm-image: buildx-setup ## Build controller-manager image.
-	$(DOCKER_BUILDX) build \
+	$(CONTAINER_BUILDX) build \
 		--pull \
-		--output=type=$(OUTPUT_TYPE) \
+		$(OUTPUT_FLAG) \
 		--platform linux/$(ARCH) \
 		--build-arg ENABLE_GIT_COMMAND="$(ENABLE_GIT_COMMAND)" \
 		--build-arg GOEXPERIMENT="$(GOEXPERIMENT)" \
@@ -151,14 +168,13 @@ build-ccm-image: buildx-setup ## Build controller-manager image.
 		--build-arg VERSION="$(VERSION)" \
 		--file Dockerfile \
 		--tag $(CONTROLLER_MANAGER_IMAGE) . \
-		--provenance=false \
-		--sbom=false
+		$(BUILDX_EXTRA_FLAGS)
 
 .PHONY: build-node-image-linux
 build-node-image-linux: buildx-setup ## Build node-manager image.
-	$(DOCKER_BUILDX) build \
+	$(CONTAINER_BUILDX) build \
 		--pull \
-		--output=type=$(OUTPUT_TYPE) \
+		$(OUTPUT_FLAG) \
 		--platform linux/$(ARCH) \
 		--build-arg ENABLE_GIT_COMMAND="$(ENABLE_GIT_COMMAND)" \
 		--build-arg GOEXPERIMENT="$(GOEXPERIMENT)" \
@@ -166,56 +182,63 @@ build-node-image-linux: buildx-setup ## Build node-manager image.
 		--build-arg VERSION="$(VERSION)" \
 		--file cloud-node-manager.Dockerfile \
 		--tag $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) . \
-		--provenance=false \
-		--sbom=false
+		$(BUILDX_EXTRA_FLAGS)
 
 .PHONY: build-node-image-windows
 build-node-image-windows: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ## Build node-manager image for Windows.
-	$(DOCKER_BUILDX) build --pull \
-		--output=type=$(OUTPUT_TYPE) \
+	$(CONTAINER_BUILDX) build --pull \
+		$(OUTPUT_FLAG) \
 		--platform windows/$(ARCH) \
 		-t $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH) \
 		--build-arg OSVERSION=$(WINDOWS_OSVERSION) \
 		--build-arg ARCH=$(ARCH) \
 		-f cloud-node-manager-windows.Dockerfile . \
-		--provenance=false \
-		--sbom=false
+		$(BUILDX_EXTRA_FLAGS)
 
 .PHONY: build-node-image-windows-hpc
 build-node-image-windows-hpc: buildx-setup $(BIN_DIR)/azure-cloud-node-manager.exe ## Build node-manager image for Windows.
-	$(DOCKER_BUILDX) build --pull \
-		--output=type=$(OUTPUT_TYPE) \
+	$(CONTAINER_BUILDX) build --pull \
+		$(OUTPUT_FLAG) \
 		--platform windows/$(ARCH) \
 		-t $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH) \
 		--build-arg ARCH=$(ARCH) \
 		-f cloud-node-manager-windows-hpc.Dockerfile . \
-		--provenance=false \
-		--sbom=false
+		$(BUILDX_EXTRA_FLAGS)
 
 .PHONY: build-ccm-e2e-test-image
 build-ccm-e2e-test-image: ## Build e2e test image.
-	docker build -t $(CCM_E2E_TEST_IMAGE) -f ./e2e.Dockerfile .
+	$(CONTAINER_CLI) build -t $(CCM_E2E_TEST_IMAGE) -f ./e2e.Dockerfile .
 
 .PHONY: push-ccm-image
 push-ccm-image: ## Push controller-manager image.
-	docker push $(CONTROLLER_MANAGER_IMAGE)
+	$(CONTAINER_CLI) push $(CONTROLLER_MANAGER_IMAGE)
 
 .PHONY: push-node-image-linux
 push-node-image-linux: ## Push node-manager image for Linux.
-	docker push $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
+	@RETRY_COUNT=0; \
+	MAX_RETRIES=3; \
+	until $(CONTAINER_CLI) push $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) || [ $$RETRY_COUNT -ge $$MAX_RETRIES ]; do \
+		RETRY_COUNT=$$((RETRY_COUNT+1)); \
+		echo "Retrying to push image $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH), attempt #$$RETRY_COUNT"; \
+		sleep 30; \
+	done; \
+	if [ $$? -ne 0 ]; then \
+		echo "image push failed after $$MAX_RETRIES attempts. Aborting."; \
+		exit 1; \
+	fi; \
 
 push-node-image-linux-push-name-%:
 	$(MAKE) ARCH=$* push-node-image-linux-push-name
 
 .PHONY: push-node-image-linux-push-name
  push-node-image-linux-push-name:
-	docker tag $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_IMAGE)
-	docker push $(NODE_MANAGER_IMAGE)
+	$(CONTAINER_CLI) tag $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_IMAGE)
+	$(CONTAINER_CLI) push $(NODE_MANAGER_IMAGE)
 
 .PHONY: release-ccm-e2e-test-image
 release-ccm-e2e-test-image: ## Build and release e2e test image.
-	docker build -t $(CCM_E2E_TEST_RELEASE_IMAGE) -f ./e2e.Dockerfile .
-	docker push $(CCM_E2E_TEST_RELEASE_IMAGE)
+	$(CONTAINER_CLI) build -t $(CCM_E2E_TEST_RELEASE_IMAGE) -f ./e2e.Dockerfile .
+	$(CONTAINER_CLI) push $(CCM_E2E_TEST_RELEASE_IMAGE)
 
 hyperkube:  ## Build hyperkube image.
 ifneq ($(K8S_BRANCH), )
@@ -244,31 +267,31 @@ push: push-multi-arch-controller-manager-image push-multi-arch-node-manager-imag
 .PHONY: push-multi-arch-controller-manager-image ## Push multi-arch controller-manager image
 push-multi-arch-controller-manager-image: push-all-ccm-images ## Create and push a manifest list containing all the Linux ccm images.
 	## Linux amd64 ccm image name has no amd64
-	docker tag $(CONTROLLER_MANAGER_FULL_IMAGE_NAME):$(IMAGE_TAG) $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-amd64:$(IMAGE_TAG)
-	docker push $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-amd64:$(IMAGE_TAG)
+	$(CONTAINER_CLI) tag $(CONTROLLER_MANAGER_FULL_IMAGE_NAME):$(IMAGE_TAG) $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-amd64:$(IMAGE_TAG)
+	$(CONTAINER_CLI) push $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-amd64:$(IMAGE_TAG)
 
-	docker manifest create --amend $(CONTROLLER_MANAGER_IMAGE) $(ALL_CONTROLLER_MANAGER_IMAGES)
+	$(CONTAINER_CLI) manifest create $(MANIFEST_AMEND_FLAG) $(CONTROLLER_MANAGER_IMAGE) $(ALL_CONTROLLER_MANAGER_IMAGES)
 	for arch in $(ALL_ARCH.linux); do \
-		docker manifest annotate --os linux --arch $${arch} $(CONTROLLER_MANAGER_IMAGE) $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-$${arch}:$(IMAGE_TAG); \
+		$(CONTAINER_CLI) manifest annotate --os linux --arch $${arch} $(CONTROLLER_MANAGER_IMAGE) $(CONTROLLER_MANAGER_FULL_IMAGE_NAME)-$${arch}:$(IMAGE_TAG); \
 	done
-	docker manifest push --purge $(CONTROLLER_MANAGER_IMAGE)
+	$(CONTAINER_CLI) manifest push $(MANIFEST_PUSH_FORMAT) $(MANIFEST_PURGE_FLAG) $(CONTROLLER_MANAGER_IMAGE)
 
-.PHONY: push-multi-arch-node-manager-image ## Push multi-arch node-manager image
-push-multi-arch-node-manager-image: push-all-node-images ## Create and push a manifest list containing all the Windows and Linux images.
-	docker manifest create --amend $(NODE_MANAGER_IMAGE) $(ALL_NODE_MANAGER_IMAGES)
+.PHONY: push-multi-arch-node-manager-image
+push-multi-arch-node-manager-image: push-all-node-images ## Push multi-arch node-manager image
+	$(CONTAINER_CLI) manifest create $(MANIFEST_AMEND_FLAG) $(NODE_MANAGER_IMAGE) $(ALL_NODE_MANAGER_IMAGES)
 	for arch in $(ALL_ARCH.linux); do \
-		docker manifest annotate --os linux --arch $${arch} $(NODE_MANAGER_IMAGE)  $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$${arch}; \
+		$(CONTAINER_CLI) manifest annotate --os linux --arch $${arch} $(NODE_MANAGER_IMAGE)  $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$${arch}; \
 	done
 	# For Windows images, we also need to include the "os.version" in the manifest list, so the Windows node can pull the proper image it needs.
 	# we use awk to also trim the quotes around the OS version string.
 	set -x; \
 	for windowsarch in $(ALL_ARCH.windows); do \
 		for osversion in $(ALL_OSVERSIONS.windows); do \
-			full_version=`docker manifest inspect ${BASE.windows}:$${osversion} | jq -r '.manifests[0].platform["os.version"]'`; \
-			docker manifest annotate --os windows --arch $${windowsarch} --os-version $${full_version} $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$${osversion}-$${windowsarch}; \
+			full_version=`$(CONTAINER_CLI) manifest inspect ${BASE.windows}:$${osversion} | jq -r '.manifests[0].platform["os.version"]'`; \
+			$(CONTAINER_CLI) manifest annotate --os windows --arch $${windowsarch} --os-version $${full_version} $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$${osversion}-$${windowsarch}; \
 		done; \
 	done
-	docker manifest push --purge $(NODE_MANAGER_IMAGE)
+	$(CONTAINER_CLI) manifest push $(MANIFEST_PUSH_FORMAT) $(MANIFEST_PURGE_FLAG) $(NODE_MANAGER_IMAGE)
 
 .PHONY: push-all-node-images ## Push node-manager image for os and archs.
 push-all-node-images: push-all-node-images-linux push-all-node-images-windows
@@ -289,10 +312,20 @@ push-node-image-linux-%:
 	$(MAKE) ARCH=$* push-node-image-linux
 
 push-node-image-windows-%:
+ifeq ($(notdir $(CONTAINER_CLI)),podman)
+	$(MAKE) WINDOWS_OSVERSION=$(call word-hyphen,$*,1) ARCH=$(call word-hyphen,$*,2) build-node-image-windows
+	$(CONTAINER_CLI) push $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(call word-hyphen,$*,1)-$(call word-hyphen,$*,2)
+else
 	$(MAKE) WINDOWS_OSVERSION=$(call word-hyphen,$*,1) ARCH=$(call word-hyphen,$*,2) OUTPUT_TYPE=registry build-node-image-windows
+endif
 
 push-node-image-windows-hpc-%:
+ifeq ($(notdir $(CONTAINER_CLI)),podman)
+	$(MAKE) ARCH=$(call word-hyphen,$*,1) build-node-image-windows-hpc
+	$(CONTAINER_CLI) push $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(call word-hyphen,$*,1)
+else
 	$(MAKE) ARCH=$(call word-hyphen,$*,1) OUTPUT_TYPE=registry build-node-image-windows-hpc
+endif
 
 .PHONY: build-all-node-images ## Build node-manager image for all OS and archs.
 build-all-node-images: build-all-node-images-linux build-all-node-images-windows
@@ -330,19 +363,19 @@ manifest-node-manager-image-windows-hpc-%:
 .PHONY: manifest-node-manager-image-windows
 manifest-node-manager-image-windows:
 	set -x
-	docker manifest create --amend $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH)
-	docker manifest annotate --os linux --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
-	full_version=`docker manifest inspect ${BASE.windows}:$(WINDOWS_OSVERSION) | jq -r '.manifests[0].platform["os.version"]'`; \
-	docker manifest annotate --os windows --arch $(ARCH) --os-version $${full_version} $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH)
-	docker manifest push --purge $(NODE_MANAGER_IMAGE)
+	$(CONTAINER_CLI) manifest create $(MANIFEST_AMEND_FLAG) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH)
+	$(CONTAINER_CLI) manifest annotate --os linux --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
+	full_version=`$(CONTAINER_CLI) manifest inspect ${BASE.windows}:$(WINDOWS_OSVERSION) | jq -r '.manifests[0].platform["os.version"]'`; \
+	$(CONTAINER_CLI) manifest annotate --os windows --arch $(ARCH) --os-version $${full_version} $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-$(WINDOWS_OSVERSION)-$(ARCH)
+	$(CONTAINER_CLI) manifest push $(MANIFEST_PUSH_FORMAT) $(MANIFEST_PURGE_FLAG) $(NODE_MANAGER_IMAGE)
 
 .PHONY: manifest-node-manager-images-windows-hpc
 manifest-node-manager-image-windows-hpc:
 	set -x
-	docker manifest create --amend $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH)
-	docker manifest annotate --os linux --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
-	docker manifest annotate --os windows --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH)
-	docker manifest push --purge $(NODE_MANAGER_IMAGE)
+	$(CONTAINER_CLI) manifest create $(MANIFEST_AMEND_FLAG) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH)
+	$(CONTAINER_CLI) manifest annotate --os linux --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_LINUX_FULL_IMAGE_PREFIX)-$(ARCH)
+	$(CONTAINER_CLI) manifest annotate --os windows --arch $(ARCH) $(NODE_MANAGER_IMAGE) $(NODE_MANAGER_WINDOWS_FULL_IMAGE_PREFIX)-hpc-$(ARCH)
+	$(CONTAINER_CLI) manifest push $(MANIFEST_PUSH_FORMAT) $(MANIFEST_PURGE_FLAG) $(NODE_MANAGER_IMAGE)
 
 ## --------------------------------------
 ##@ Tests

--- a/health-probe-proxy/Makefile
+++ b/health-probe-proxy/Makefile
@@ -19,7 +19,7 @@ BIN_DIR=bin
 ARCH ?= amd64
 # OS Version for the Windows images: 1809, 2004, 20H2, ltsc2022
 WINDOWS_OSVERSION ?= 1809
-# The output type for `docker buildx build` could either be docker (local), or registry.
+# The output type for the container build command could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 
 IMAGE_REGISTRY ?= local
@@ -27,7 +27,18 @@ IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)
 HEALTH_PROBE_PROXY_IMAGE=$(IMAGE_REGISTRY)/health-probe-proxy:$(IMAGE_TAG)
 HEALTH_PROBE_PROXY_WIN_IMAGE=$(IMAGE_REGISTRY)/health-probe-proxy-windows:$(IMAGE_TAG)
 
-DOCKER_BUILDX ?= docker buildx
+CONTAINER_CLI ?= $(shell which podman 2>/dev/null || echo "docker")
+
+ifeq ($(notdir $(CONTAINER_CLI)),podman)
+CONTAINER_BUILDX ?= $(CONTAINER_CLI)
+BUILDX_EXTRA_FLAGS ?=
+OUTPUT_FLAG ?=
+else
+CONTAINER_BUILDX ?= $(CONTAINER_CLI) buildx
+BUILDX_EXTRA_FLAGS ?= --provenance=false --sbom=false
+OUTPUT_FLAG ?= --output=type=$(OUTPUT_TYPE)
+export DOCKER_CLI_EXPERIMENTAL=enabled
+endif
 
 $(BIN_DIR)/health-probe-proxy: ## Build binary for health-probe-proxy.
 	CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o $(BIN_DIR)/health-probe-proxy .
@@ -36,32 +47,35 @@ $(BIN_DIR)/health-probe-proxy.exe: ## Build binary for health-probe-proxy.
 	CGO_ENABLED=0 GOOS=windows GOARCH=${ARCH} go build -a -o $(BIN_DIR)/health-probe-proxy.exe .
 
 buildx-setup:
-	$(DOCKER_BUILDX) inspect img-builder > /dev/null 2>&1 || $(DOCKER_BUILDX) create --name img-builder --use
+ifeq ($(notdir $(CONTAINER_CLI)),podman)
+	# podman build handles multi-platform natively; ensure qemu-user-static is registered
+	$(CONTAINER_CLI) run --rm --privileged tonistiigi/binfmt --install all
+else
+	$(CONTAINER_BUILDX) inspect img-builder > /dev/null 2>&1 || $(CONTAINER_BUILDX) create --name img-builder --use
 	# enable qemu for arm64 build
 	# https://github.com/docker/buildx/issues/464#issuecomment-741507760
-	docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
-	docker run --rm --privileged tonistiigi/binfmt --install all
+	$(CONTAINER_CLI) run --privileged --rm tonistiigi/binfmt --uninstall qemu-aarch64
+	$(CONTAINER_CLI) run --rm --privileged tonistiigi/binfmt --install all
+endif
 
 .PHONY: build-health-probe-proxy-image
 build-health-probe-proxy-image: buildx-setup  $(BIN_DIR)/health-probe-proxy ## Build health-probe-proxy image for Linux.
-	$(DOCKER_BUILDX) build --pull \
-		--output=type=$(OUTPUT_TYPE) \
+	$(CONTAINER_BUILDX) build --pull \
+		$(OUTPUT_FLAG) \
 		--platform linux/$(ARCH) \
 		-t $(HEALTH_PROBE_PROXY_IMAGE) \
 		--build-arg OS=linux \
 		--build-arg ARCH=$(ARCH) \
 		-f Dockerfile . \
-		--provenance=false \
-		--sbom=false
+		$(BUILDX_EXTRA_FLAGS)
 
 .PHONY: build-health-probe-proxy-image-windows
 build-health-probe-proxy-image-windows: buildx-setup $(BIN_DIR)/health-probe-proxy.exe ## Build health-probe-proxy image for Windows.
-	$(DOCKER_BUILDX) build --pull \
-		--output=type=$(OUTPUT_TYPE) \
+	$(CONTAINER_BUILDX) build --pull \
+		$(OUTPUT_FLAG) \
 		--platform windows/$(ARCH) \
 		-t $(HEALTH_PROBE_PROXY_WIN_IMAGE) \
 		--build-arg OSVERSION=$(WINDOWS_OSVERSION) \
 		--build-arg ARCH=$(ARCH) \
 		-f windows.Dockerfile . \
-		--provenance=false \
-		--sbom=false
+		$(BUILDX_EXTRA_FLAGS)

--- a/kubetest2-aks/Makefile
+++ b/kubetest2-aks/Makefile
@@ -25,7 +25,7 @@ INSTALL_DIR?=$(GOPATH)/bin
 BINARY_NAME?=kubetest2-aks
 BINARY_PATH?=.
 # the container cli to use e.g. docker,podman
-DOCKER?=$(shell which docker || which podman || echo "docker")
+DOCKER?=$(shell which podman 2>/dev/null || which docker 2>/dev/null || echo "docker")
 export DOCKER
 # ========================= Setup Go With Gimme ================================
 # go version to use for build etc.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Cherry-picks #10108 onto `release-1.34`.

Source PR: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/10108
Source commit: `8a3aa3aefe16b5d2e41927865fb481d332898c87`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The build system now auto-detects and supports podman as the container CLI. When podman is available it is used for image build, push, and manifest operations. Set CONTAINER_CLI=docker to force docker usage.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/assign nilo19
