### PR TITLE
chore: remove deprecated rand.Seed

### DIFF
--- a/cmd/acr-credential-provider/main.go
+++ b/cmd/acr-credential-provider/main.go
@@ -22,10 +22,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/signal"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/logs"
@@ -37,7 +35,6 @@ import (
 
 func main() {
 	logger := log.Background().WithName("main")
-	rand.Seed(time.Now().UnixNano())
 
 	var (
 		RegistryMirrorStr string

--- a/cmd/cloud-controller-manager/controller-manager.go
+++ b/cmd/cloud-controller-manager/controller-manager.go
@@ -20,9 +20,7 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugins
 
@@ -32,7 +30,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano()) // FIXME: should use crypto/rand for better randomness
 	defer log.Flush()
 
 	command := app.NewCloudControllerManagerCommand()

--- a/cmd/cloud-node-manager/node-manager.go
+++ b/cmd/cloud-node-manager/node-manager.go
@@ -20,9 +20,7 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo" // load all the prometheus client-go plugins
@@ -32,8 +30,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	command := app.NewCloudNodeManagerCommand()
 
 	logs.InitLogs()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the deprecated top-level `rand.Seed` call from cloud-controller-manager and node-manager startup.

The project builds with a modern Go version, where the global `math/rand` generator is already auto-seeded, so the explicit `rand.Seed(...)` call is no longer needed.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

This is a cleanup-only change and does not change runtime behavior.
`rand.Float64()` is still used for resync jitter and continues to work as expected without an explicit seed.

#### Does this PR introduce a user-facing change?

```release-note
NONE