### PR TITLE
feat: support AllowCrossTenantReplication in AccountOptions

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -77,7 +77,7 @@ type AccountOptions struct {
 	AllowBlobPublicAccess                   *bool
 	RequireInfrastructureEncryption         *bool
 	AllowSharedKeyAccess                    *bool
-	AllowCrossTenantReplication              *bool
+	AllowCrossTenantReplication             *bool
 	IsMultichannelEnabled                   *bool
 	IsSmbOAuthEnabled                       *bool
 	KeyName                                 *string
@@ -1061,7 +1061,10 @@ func isAllowSharedKeyAccessEqual(account *armstorage.Account, accountOptions *Ac
 }
 
 func isAllowCrossTenantReplicationEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {
-	return ptr.Deref(accountOptions.AllowCrossTenantReplication, false) == ptr.Deref(account.Properties.AllowCrossTenantReplication, false)
+	if accountOptions.AllowCrossTenantReplication == nil {
+		return true
+	}
+	return *accountOptions.AllowCrossTenantReplication == ptr.Deref(account.Properties.AllowCrossTenantReplication, false)
 }
 
 func isAccessTierEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -77,6 +77,7 @@ type AccountOptions struct {
 	AllowBlobPublicAccess                   *bool
 	RequireInfrastructureEncryption         *bool
 	AllowSharedKeyAccess                    *bool
+	AllowCrossTenantReplication              *bool
 	IsMultichannelEnabled                   *bool
 	IsSmbOAuthEnabled                       *bool
 	KeyName                                 *string
@@ -156,7 +157,7 @@ func (az *AccountRepo) getStorageAccounts(ctx context.Context, storageAccountCli
 	accounts := []accountWithLocation{}
 	for _, acct := range result {
 		if acct.Name != nil && acct.Location != nil && acct.SKU != nil {
-			if !isStorageTypeEqual(acct, accountOptions) || !isAccountKindEqual(acct, accountOptions) || !isLocationEqual(acct, accountOptions) || !isLargeFileSharesPropertyEqual(acct, accountOptions) || !isTagsEqual(acct, accountOptions) || !isTaggedWithSkip(acct) || !isHnsPropertyEqual(acct, accountOptions) || !isEnableNfsV3PropertyEqual(acct, accountOptions) || !isEnableHTTPSTrafficOnlyEqual(acct, accountOptions) || !isAllowBlobPublicAccessEqual(acct, accountOptions) || !isRequireInfrastructureEncryptionEqual(acct, accountOptions) || !isAllowSharedKeyAccessEqual(acct, accountOptions) || !isAccessTierEqual(acct, accountOptions) || !AreVNetRulesEqual(acct, accountOptions) || !isPrivateEndpointAsExpected(acct, accountOptions) {
+			if !isStorageTypeEqual(acct, accountOptions) || !isAccountKindEqual(acct, accountOptions) || !isLocationEqual(acct, accountOptions) || !isLargeFileSharesPropertyEqual(acct, accountOptions) || !isTagsEqual(acct, accountOptions) || !isTaggedWithSkip(acct) || !isHnsPropertyEqual(acct, accountOptions) || !isEnableNfsV3PropertyEqual(acct, accountOptions) || !isEnableHTTPSTrafficOnlyEqual(acct, accountOptions) || !isAllowBlobPublicAccessEqual(acct, accountOptions) || !isRequireInfrastructureEncryptionEqual(acct, accountOptions) || !isAllowSharedKeyAccessEqual(acct, accountOptions) || !isAllowCrossTenantReplicationEqual(acct, accountOptions) || !isAccessTierEqual(acct, accountOptions) || !AreVNetRulesEqual(acct, accountOptions) || !isPrivateEndpointAsExpected(acct, accountOptions) {
 				continue
 			}
 
@@ -569,6 +570,10 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.AllowBlobPublicAccess != nil {
 			logger.V(2).Info("set AllowBlobPublicAccess for storage account", "AllowBlobPublicAccess", *accountOptions.AllowBlobPublicAccess, "account", accountName)
 			cp.Properties.AllowBlobPublicAccess = accountOptions.AllowBlobPublicAccess
+		}
+		if accountOptions.AllowCrossTenantReplication != nil {
+			logger.V(2).Info("set AllowCrossTenantReplication for storage account", "AllowCrossTenantReplication", *accountOptions.AllowCrossTenantReplication, "account", accountName)
+			cp.Properties.AllowCrossTenantReplication = accountOptions.AllowCrossTenantReplication
 		}
 		if accountOptions.RequireInfrastructureEncryption != nil {
 			logger.V(2).Info("set RequireInfrastructureEncryption for storage account", "RequireInfrastructureEncryption", *accountOptions.RequireInfrastructureEncryption, "account", accountName)
@@ -1053,6 +1058,10 @@ func isRequireInfrastructureEncryptionEqual(account *armstorage.Account, account
 
 func isAllowSharedKeyAccessEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {
 	return ptr.Deref(accountOptions.AllowSharedKeyAccess, true) == ptr.Deref(account.Properties.AllowSharedKeyAccess, true)
+}
+
+func isAllowCrossTenantReplicationEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {
+	return ptr.Deref(accountOptions.AllowCrossTenantReplication, false) == ptr.Deref(account.Properties.AllowCrossTenantReplication, false)
 }
 
 func isAccessTierEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -1347,14 +1347,14 @@ func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			// account true, options nil (default false) -> mismatch
+			// account true, options nil (don't care) -> match
 			account: &armstorage.Account{
 				Properties: &armstorage.AccountProperties{
 					AllowCrossTenantReplication: ptr.To(true),
 				},
 			},
 			accountOptions: &AccountOptions{},
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			// both true

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -1322,6 +1322,82 @@ func TestIsAllowSharedKeyAccessEqual(t *testing.T) {
 	}
 }
 
+func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
+	tests := []struct {
+		account        *armstorage.Account
+		accountOptions *AccountOptions
+		expectedResult bool
+	}{
+		{
+			// both nil, default false == default false
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			// account false, options nil (default false)
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(false),
+				},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			// account true, options nil (default false) -> mismatch
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(true),
+				},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: false,
+		},
+		{
+			// both true
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(true),
+				},
+			},
+			accountOptions: &AccountOptions{
+				AllowCrossTenantReplication: ptr.To(true),
+			},
+			expectedResult: true,
+		},
+		{
+			// account true, options false -> mismatch
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(true),
+				},
+			},
+			accountOptions: &AccountOptions{
+				AllowCrossTenantReplication: ptr.To(false),
+			},
+			expectedResult: false,
+		},
+		{
+			// account nil (default false), options true -> mismatch
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				AllowCrossTenantReplication: ptr.To(true),
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := isAllowCrossTenantReplicationEqual(test.account, test.accountOptions)
+		assert.Equal(t, test.expectedResult, result)
+	}
+}
+
 func TestIsRequireInfrastructureEncryptionEqual(t *testing.T) {
 	tests := []struct {
 		account        *armstorage.Account

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -1329,7 +1329,7 @@ func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
 		expectedResult bool
 	}{
 		{
-			// both nil, default false == default false
+			// options nil (don't care), always match regardless of account value
 			account: &armstorage.Account{
 				Properties: &armstorage.AccountProperties{},
 			},
@@ -1337,7 +1337,7 @@ func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			// account false, options nil (default false)
+			// options nil (don't care), match even when account is false
 			account: &armstorage.Account{
 				Properties: &armstorage.AccountProperties{
 					AllowCrossTenantReplication: ptr.To(false),
@@ -1347,7 +1347,7 @@ func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			// account true, options nil (don't care) -> match
+			// options nil (don't care), match even when account is true
 			account: &armstorage.Account{
 				Properties: &armstorage.AccountProperties{
 					AllowCrossTenantReplication: ptr.To(true),
@@ -1357,7 +1357,7 @@ func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			// both true
+			// both explicitly true
 			account: &armstorage.Account{
 				Properties: &armstorage.AccountProperties{
 					AllowCrossTenantReplication: ptr.To(true),
@@ -1369,7 +1369,7 @@ func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			// account true, options false -> mismatch
+			// options false, account true -> mismatch
 			account: &armstorage.Account{
 				Properties: &armstorage.AccountProperties{
 					AllowCrossTenantReplication: ptr.To(true),
@@ -1381,7 +1381,7 @@ func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			// account nil (default false), options true -> mismatch
+			// options true, account nil (defaults to false) -> mismatch
 			account: &armstorage.Account{
 				Properties: &armstorage.AccountProperties{},
 			},


### PR DESCRIPTION
## What
Add `AllowCrossTenantReplication` field to `AccountOptions` struct to allow CSI drivers and other consumers to control cross-tenant object replication when creating or matching storage accounts.

## Why
Users need the ability to disable cross-tenant object replication on storage accounts for security compliance. Currently `AccountOptions` has no way to pass this setting through.

## Changes
- Add `AllowCrossTenantReplication *bool` field to `AccountOptions`
- Set `cp.Properties.AllowCrossTenantReplication` during account creation when specified
- Add `isAllowCrossTenantReplicationEqual` for account matching
- Wire the new check into the account filtering logic

**Release note**:
```
feat: support AllowCrossTenantReplication in AccountOptions
```

/kind feature