### PR TITLE
Handle NICs without VM associations gracefully

### DIFF
--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -231,6 +231,11 @@ func (bc *backendPoolTypeNodeIPConfig) ReconcileBackendPools(
 						}
 					}
 
+					if nodeName == "" {
+						logger.V(2).Info("empty nodeName, skipping ipConfID", "serviceName", serviceName, "ipConfID", ipConfID)
+						continue
+					}
+
 					// If a node is not supposed to be included in the LB, it
 					// would not be in the `nodes` slice. We need to check the nodes that
 					// have been added to the LB's backendpool, find the unwanted ones and
@@ -361,6 +366,10 @@ func (bc *backendPoolTypeNodeIPConfig) GetBackendPrivateIPs(ctx context.Context,
 					nodeName, _, err := bc.VMSet.GetNodeNameByIPConfigurationID(ctx, ipConfigID)
 					if err != nil {
 						logger.Error(err, "failed: GetNodeNameByIPConfigurationID", "service", serviceName)
+						continue
+					}
+					if nodeName == "" {
+						logger.V(2).Info("empty nodeName, skipping ipConfigID", "serviceName", serviceName, "ipConfigID", ipConfigID)
 						continue
 					}
 					privateIPsSet, ok := bc.nodePrivateIPs[strings.ToLower(nodeName)]

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1697,6 +1697,11 @@ func (ss *ScaleSet) GetNodeNameByIPConfigurationID(ctx context.Context, ipConfig
 		return "", "", err
 	}
 
+	if vmManagementType == ManagedByNoVM {
+		logger.V(2).Info("No VM attached, skipping node", "ipConfigurationID", ipConfigurationID)
+		return "", "", nil
+	}
+
 	if vmManagementType == ManagedByAvSet {
 		// vm is managed by availability set.
 		return ss.availabilitySet.GetNodeNameByIPConfigurationID(ctx, ipConfigurationID)
@@ -1961,6 +1966,10 @@ func (ss *ScaleSet) ensureBackendPoolDeleted(ctx context.Context, service *v1.Se
 
 			logger.Error(err, "Failed to GetNodeNameByIPConfigurationID", "ipConfigurationID", ipConfigurationID)
 			allErrs = append(allErrs, err)
+			continue
+		}
+		if nodeName == "" {
+			logger.V(2).Info("Empty nodeName, skipping node", "service", getServiceName(service), "ipConfigurationID", ipConfigurationID)
 			continue
 		}
 

--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -63,6 +63,7 @@ const (
 	ManagedByVmssFlex     VMManagementType = "ManagedByVmssFlex"
 	ManagedByAvSet        VMManagementType = "ManagedByAvSet"
 	ManagedByUnknownVMSet VMManagementType = "ManagedByUnknownVMSet"
+	ManagedByNoVM         VMManagementType = "ManagedByNoVM"
 )
 
 func (ss *ScaleSet) newVMSSCache() (azcache.Resource, error) {
@@ -530,6 +531,9 @@ func (ss *ScaleSet) getVMManagementTypeByIPConfigurationID(ctx context.Context, 
 	if err != nil {
 		return ManagedByUnknownVMSet, fmt.Errorf("failed to get vm name by ip config ID %s: %w", ipConfigurationID, err)
 	}
+	if vmName == "" {
+		return ManagedByNoVM, nil
+	}
 	if cachedAvSetVMs.Has(vmName) {
 		return ManagedByAvSet, nil
 	}
@@ -542,10 +546,14 @@ func (az *Cloud) GetVMNameByIPConfigurationName(ctx context.Context, nicResource
 	if rerr != nil {
 		return "", fmt.Errorf("failed to get interface of name %s: %w", nicName, rerr)
 	}
+	// Return empty when VM association is missing
 	if nic.Properties == nil || nic.Properties.VirtualMachine == nil || nic.Properties.VirtualMachine.ID == nil {
-		return "", fmt.Errorf("failed to get vm ID of nic %s", ptr.Deref(nic.Name, ""))
+		return "", nil
 	}
 	vmID := ptr.Deref(nic.Properties.VirtualMachine.ID, "")
+	if vmID == "" {
+		return "", nil
+	}
 	matches := vmIDRE.FindStringSubmatch(vmID)
 	if len(matches) != 2 {
 		return "", fmt.Errorf("invalid virtual machine ID %s", vmID)

--- a/pkg/provider/azure_vmss_cache_test.go
+++ b/pkg/provider/azure_vmss_cache_test.go
@@ -18,7 +18,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -382,11 +381,11 @@ func TestGetVMManagementTypeByIPConfigurationID(t *testing.T) {
 			expectedVMManagementType: ManagedByAvSet,
 		},
 		{
-			description:              "getVMManagementTypeByIPConfigurationID should return an error if nic.VirtualMachine.ID is empty",
+			description:              "getVMManagementTypeByIPConfigurationID should return ManagedByNoVM if nic.VirtualMachine.ID is empty",
 			ipConfigurationID:        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm3-interface/ipConfigurations/pipConfig",
 			expectedNIC:              "testvm3",
-			expectedVMManagementType: ManagedByUnknownVMSet,
-			expectedErr:              fmt.Errorf("failed to get vm name by ip config ID /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/testvm3-interface/ipConfigurations/pipConfig: %w", errors.New("failed to get vm ID of nic testvm3")),
+			expectedVMManagementType: ManagedByNoVM,
+			expectedErr:              nil,
 		},
 		{
 			description:              "getVMManagementTypeByIPConfigurationID should return an error if failed to get nic",

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -688,6 +688,7 @@ func TestGetNodeNameByIPConfigurationID(t *testing.T) {
 		expectedNodeName     string
 		expectedScaleSetName string
 		expectError          bool
+		nicWithoutVM         bool
 	}{
 		{
 			description:          "GetNodeNameByIPConfigurationID should get node's Name when the node is existing",
@@ -710,6 +711,15 @@ func TestGetNodeNameByIPConfigurationID(t *testing.T) {
 			ipConfigurationID: "invalid-configuration-id",
 			vmList:            []string{"vmssee6c2000004", "vmssee6c2000005"},
 			expectError:       true,
+		},
+		{
+			description:          "GetNodeNameByIPConfigurationID should return empty strings for NIC without VM attachment",
+			scaleSet:             "scaleset4",
+			ipConfigurationID:    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/orphaned-nic/ipConfigurations/ipconfig1",
+			vmList:               []string{"vmssee6c2000006", "vmssee6c2000007"},
+			expectedNodeName:     "",
+			expectedScaleSetName: "",
+			nicWithoutVM:         true,
 		},
 	}
 
@@ -737,6 +747,17 @@ func TestGetNodeNameByIPConfigurationID(t *testing.T) {
 					mockVMSSVMClient.EXPECT().ListVMInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedVMs, nil).AnyTimes()
 				}
 				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+
+				if test.nicWithoutVM {
+					mockNICClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
+					nicWithoutVM := &armnetwork.Interface{
+						Name: ptr.To("orphaned-nic"),
+						Properties: &armnetwork.InterfacePropertiesFormat{
+							VirtualMachine: nil,
+						},
+					}
+					mockNICClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nicWithoutVM, nil).AnyTimes()
+				}
 
 				nodeName, scalesetName, err := ss.GetNodeNameByIPConfigurationID(context.TODO(), test.ipConfigurationID)
 				if test.expectError {
@@ -3667,6 +3688,31 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:   "EnsureBackendPoolDeleted should skip IP configuration with no attached VM",
+			backendpoolID: testLBBackendpoolID0,
+			backendAddressPools: []*armnetwork.BackendAddressPool{
+				{
+					ID: ptr.To(testLBBackendpoolID0),
+					Properties: &armnetwork.BackendAddressPoolPropertiesFormat{
+						BackendIPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Name: ptr.To("ip-vmss"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0/networkInterfaces/nic"),
+							},
+							{
+								Name: ptr.To("ip-orphan"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/orphan-nic/ipConfigurations/ipconfig1"),
+							},
+						},
+					},
+				},
+				{
+					ID: ptr.To(testLBBackendpoolID1),
+				},
+			},
+			expectedVMSSVMPutTimes: 1,
+		},
 	}
 
 	for _, test := range testCases {
@@ -3698,6 +3744,14 @@ func TestEnsureBackendPoolDeleted(t *testing.T) {
 
 				mockVMsClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
 				mockVMsClient.EXPECT().List(gomock.Any(), gomock.Any()).Return([]*armcompute.VirtualMachine{}, nil).AnyTimes()
+
+				mockInterfaceClient := ss.ComputeClientFactory.GetInterfaceClient().(*mock_interfaceclient.MockInterface)
+				orphanNIC := &armnetwork.Interface{
+					Properties: &armnetwork.InterfacePropertiesFormat{
+						VirtualMachine: nil,
+					},
+				}
+				mockInterfaceClient.EXPECT().Get(gomock.Any(), "rg", "orphan-nic", nil).Return(orphanNIC, nil).AnyTimes()
 
 				updated, err := ss.EnsureBackendPoolDeleted(context.TODO(), &v1.Service{}, []string{test.backendpoolID}, testVMSSName, test.backendAddressPools, true)
 				assert.Equal(t, test.expectedErr, err != nil, test.description+errMsgSuffix)

--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -408,6 +408,11 @@ func (fs *FlexScaleSet) getNodeInformationByIPConfigurationID(ctx context.Contex
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to get vm name of ip config ID %s: %w", ipConfigurationID, err)
 	}
+	if vmName == "" {
+		// skip this node
+		logger.Info("Empty vmName, skipping node.", "ipConfigurationID", ipConfigurationID)
+		return "", "", "", nil
+	}
 
 	nodeName, err := fs.getNodeNameByVMName(ctx, vmName)
 	if err != nil {

--- a/pkg/provider/azure_vmssflex_test.go
+++ b/pkg/provider/azure_vmssflex_test.go
@@ -929,6 +929,21 @@ func TestGetNodeNameByIPConfigurationIDVmssFlex(t *testing.T) {
 			expectedVMSetName:              "",
 			expectedErr:                    fmt.Errorf("failed to get resource group and name from ip config ID /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces//ipConfigurations/pipConfig: %w", errors.New("invalid ip config ID /subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces//ipConfigurations/pipConfig")),
 		},
+		{
+			description:                    "GetNodeNameByIPConfigurationID should return empty strings when NIC has no attached VM",
+			ipConfigurationID:              "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/orphan-nic/ipConfigurations/pipConfig",
+			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
+			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
+			vmListErr:                      nil,
+			nic: func() *armnetwork.Interface {
+				nic := generateTestNic("orphan-nic", false, to.Ptr(armnetwork.ProvisioningStateSucceeded), "")
+				nic.Properties.VirtualMachine = nil
+				return nic
+			}(),
+			expectedNodeName:  "",
+			expectedVMSetName: "",
+			expectedErr:       nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Load balancer creation fails completely when any node in the cluster has a NIC that is not yet fully associated with a VM. This occurs during normal cluster operations when:
1. New node pools are scaling up - VMs take time to fully provision and associate with their NICs
2. Quota or capacity constraints - VM creation is delayed while Azure allocates resources
3. Any VM provisioning delay - Network, region capacity, or transient API issues

##### Impact:

- Load balancer services cannot be created until all VMs are fully provisioned
- Blocks application deployment that requires load balancer services
- No automatic recovery - LB creation remains blocked even after VMs finish provisioning (requires manual intervention or CCM restart)
- Affects both VMSS and VMSS Flex deployments

##### Expected Behavior: 
The load balancer should be created with currently-available nodes, and automatically add delayed nodes once their VMs are fully provisioned (on subsequent sync cycles).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The change modifies error handling behavior in several key areas:

1. **`GetVMNameByIPConfigurationName`** - Returns `("", nil)` instead of an error when a NIC has no VM association
2. **`getVMManagementTypeByIPConfigurationID`** - Returns new `ManagedByNoVM` type when vmName is empty
3. **`GetNodeNameByIPConfigurationID`** (VMSS) - Checks for `ManagedByNoVM` and returns `("", "", nil)` early
4. **`getNodeInformationByIPConfigurationID`** (Flex) - Checks for empty vmName and returns early with logging
5. **Backend pool reconciliation** - Guards against empty nodeName in two locations:
   - `ReconcileBackendPools` - skips processing
   - `GetBackendPrivateIPs` - skips IP collection
6. **`ensureBackendPoolDeleted`** - Skips nodes with empty nodeName

Added comprehensive test coverage:
- New test case in `TestGetNodeNameByIPConfigurationID` for NIC without VM
- New test case in `TestEnsureBackendPoolDeleted` for orphaned NIC in backend pool
- New test case in `TestGetNodeNameByIPConfigurationIDVmssFlex` for orphaned NIC
- Updated `TestGetVMManagementTypeByIPConfigurationID` to expect `ManagedByNoVM` instead of error

#### Does this PR introduce a user-facing change?

```release-note
Handle NICs without VM associations gracefully in VMSS and VMSS Flex code paths
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
