### PR TITLE
chore: remove service.beta.kubernetes.io/azure-shared-securityrule

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -268,13 +268,6 @@ const (
 	// to specify the DNS label name for the service.
 	ServiceAnnotationDNSLabelName = "service.beta.kubernetes.io/azure-dns-label-name"
 
-	// ServiceAnnotationSharedSecurityRule is the annotation used on the service
-	// to specify that the service should be exposed using an Azure security rule
-	// that may be shared with other service, trading specificity of rules for an
-	// increase in the number of services that can be exposed. This relies on the
-	// Azure "augmented security rules" feature.
-	ServiceAnnotationSharedSecurityRule = "service.beta.kubernetes.io/azure-shared-securityrule"
-
 	// ServiceAnnotationLoadBalancerResourceGroup is the annotation used on the service
 	// to specify the resource group of load balancer objects that are not in the same resource group as the cluster.
 	ServiceAnnotationLoadBalancerResourceGroup = "service.beta.kubernetes.io/azure-load-balancer-resource-group"

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3847,14 +3847,6 @@ func (az *Cloud) getServiceLoadBalancerMode(service *v1.Service) (bool, bool, st
 	return hasMode, isAuto, mode
 }
 
-func useSharedSecurityRule(service *v1.Service) bool {
-	if l, ok := service.Annotations[consts.ServiceAnnotationSharedSecurityRule]; ok {
-		return l == consts.TrueAnnotationValue
-	}
-
-	return false
-}
-
 // serviceOwnsPublicIP checks if the service owns the pip and if the pip is user-created.
 // The pip is user-created if and only if there is no service tags.
 // The service owns the pip if:

--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -310,13 +310,8 @@ func (az *Cloud) getSecurityRuleName(service *v1.Service, port v1.ServicePort, s
 	isDualStack := isServiceDualStack(service)
 	safePrefix := strings.ReplaceAll(sourceAddrPrefix, "/", "_")
 	safePrefix = strings.ReplaceAll(safePrefix, ":", ".") // Consider IPv6 address
-	var name string
-	if useSharedSecurityRule(service) {
-		name = fmt.Sprintf("shared-%s-%d-%s", port.Protocol, port.Port, safePrefix)
-	} else {
-		rulePrefix := az.getRulePrefix(service)
-		name = fmt.Sprintf("%s-%s-%d-%s", rulePrefix, port.Protocol, port.Port, safePrefix)
-	}
+	rulePrefix := az.getRulePrefix(service)
+	name := fmt.Sprintf("%s-%s-%d-%s", rulePrefix, port.Protocol, port.Port, safePrefix)
 	return getResourceByIPFamily(name, isDualStack, isIPv6)
 }
 

--- a/pkg/provider/azure_standard_test.go
+++ b/pkg/provider/azure_standard_test.go
@@ -2006,22 +2006,6 @@ func TestGetSecurityRuleName(t *testing.T) {
 			"a257b965551374ad2b091ef3f07043ad-TCP-80-10.0.0.1_24",
 		},
 		{
-			"IPv4-shared",
-			&v1.Service{
-				ObjectMeta: meta.ObjectMeta{
-					UID:         "257b9655-5137-4ad2-b091-ef3f07043ad3",
-					Annotations: map[string]string{consts.ServiceAnnotationSharedSecurityRule: "true"},
-				},
-			},
-			v1.ServicePort{
-				Protocol: v1.ProtocolTCP,
-				Port:     80,
-			},
-			"10.0.0.1/24",
-			false,
-			"shared-TCP-80-10.0.0.1_24",
-		},
-		{
 			"IPv6",
 			&v1.Service{
 				ObjectMeta: meta.ObjectMeta{

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -1067,7 +1067,6 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 
 		annotation := map[string]string{
 			consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true",
-			consts.ServiceAnnotationSharedSecurityRule:            "true",
 		}
 
 		By("Creating BYO public IP prefixes")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the deprecated annotation service.beta.kubernetes.io/azure-shared-securityrule

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```