### PR TITLE
feat: support separate resource group for private DNS zone

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -495,10 +495,10 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
 				if err := az.createVNetLink(ctx, vNetLinkName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
+					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in privateDNSResourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
+				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in privateDNSResourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 	}

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -494,7 +494,7 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		}
 		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				if err := az.createVNetLink(ctx, vNetLinkName, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+				if err := az.createVNetLink(ctx, vNetLinkName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
 					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
@@ -733,8 +733,8 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.StorageType == StorageTypeBlob {
 			dnsZoneGroupName = dnsZoneGroupName + blobNameSuffix
 		}
-		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
-			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, privateDNSResourceGroup, err)
+		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), privateEndpointResourceGroup(%s), privateDNSZoneResourceGroup(%s): %w", privateEndpointName, vnetName, vnetResourceGroup, privateDNSResourceGroup, err)
 		}
 	}
 
@@ -819,9 +819,9 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGro
 	return nil
 }
 
-func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetResourceGroup, vnetName, privateDNSZoneName string) error {
+func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createVNetLink")
-	logger.V(2).Info("Creating virtual network link", "vNetLinkName", vNetLinkName, "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating virtual network link", "vNetLinkName", vNetLinkName, "privateDNSZone", privateDNSZoneName, "vnetResourceGroup", vnetResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 	clientFactory := az.NetworkClientFactory
 	if clientFactory == nil {
 		// multi-tenant support
@@ -837,20 +837,20 @@ func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetRes
 			VirtualNetwork:      &privatedns.SubResource{ID: &vnetID},
 			RegistrationEnabled: ptr.To(false)},
 	}
-	_, err := vnetLinkClient.CreateOrUpdate(ctx, vnetResourceGroup, privateDNSZoneName, vNetLinkName, parameters)
+	_, err := vnetLinkClient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName, parameters)
 	return err
 }
 
-func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, vnetName, privateDNSZoneName string) error {
+func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGroupName, privateEndpointName, privateEndpointResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZoneGroup")
-	logger.V(2).Info("Creating private DNS zone group", "dnsZoneGroup", dnsZoneGroupName, "privateEndpoint", privateEndpointName, "vnetName", vnetName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating private DNS zone group", "dnsZoneGroup", dnsZoneGroupName, "privateEndpoint", privateEndpointName, "vnetName", vnetName, "privateEndpointResourceGroup", privateEndpointResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 	privateDNSZoneGroup := &armnetwork.PrivateDNSZoneGroup{
 		Properties: &armnetwork.PrivateDNSZoneGroupPropertiesFormat{
 			PrivateDNSZoneConfigs: []*armnetwork.PrivateDNSZoneConfig{
 				{
 					Name: &privateDNSZoneName,
 					Properties: &armnetwork.PrivateDNSZonePropertiesFormat{
-						PrivateDNSZoneID: to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s", az.SubscriptionID, vnetResourceGroup, privateDNSZoneName)),
+						PrivateDNSZoneID: to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s", az.SubscriptionID, privateDNSResourceGroup, privateDNSZoneName)),
 					},
 				},
 			},
@@ -861,7 +861,7 @@ func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGro
 		clientFactory = az.ComputeClientFactory
 	}
 	privatednsgroupClient := clientFactory.GetPrivateDNSZoneGroupClient()
-	_, err := privatednsgroupClient.CreateOrUpdate(ctx, vnetResourceGroup, privateEndpointName, dnsZoneGroupName, *privateDNSZoneGroup)
+	_, err := privatednsgroupClient.CreateOrUpdate(ctx, privateEndpointResourceGroup, privateEndpointName, dnsZoneGroupName, *privateDNSZoneGroup)
 	return err
 }
 

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -100,6 +100,8 @@ type AccountOptions struct {
 	SourceAccountName string
 	// default is "privatelink"
 	PrivateDNSZoneName string
+	// resource group for private DNS zone, default is vnetResourceGroup
+	PrivateDNSZoneResourceGroup string
 	// default is vnetName + "-vnetlink"
 	VNetLinkName        string
 	PublicNetworkAccess string
@@ -461,17 +463,24 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		}
 	}
 
+	// Use a separate resource group for private DNS zone if specified,
+	// otherwise default to vnetResourceGroup for backward compatibility.
+	privateDnsResourceGroup := vnetResourceGroup
+	if accountOptions.PrivateDNSZoneResourceGroup != "" {
+		privateDnsResourceGroup = accountOptions.PrivateDNSZoneResourceGroup
+	}
+
 	if ptr.Deref(accountOptions.CreatePrivateEndpoint, false) {
 		clientFactory := az.NetworkClientFactory
 		if clientFactory == nil {
 			// multi-tenant support
 			clientFactory = az.ComputeClientFactory
 		}
-		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, vnetResourceGroup, privateDNSZoneName); err != nil {
+		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, privateDnsResourceGroup, privateDNSZoneName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				// Create DNS zone first, this could make sure driver has write permission on vnetResourceGroup
-				if err := az.createPrivateDNSZone(ctx, vnetResourceGroup, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create private DNS zone(%s) in resourceGroup(%s): %w", privateDNSZoneName, vnetResourceGroup, err)
+				// Create DNS zone first, this could make sure driver has write permission on privateDnsResourceGroup
+				if err := az.createPrivateDNSZone(ctx, privateDnsResourceGroup, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create private DNS zone(%s) in resourceGroup(%s): %w", privateDNSZoneName, privateDnsResourceGroup, err)
 				}
 			} else {
 				return "", "", fmt.Errorf("get private dns zone %s returned with %v", privateDNSZoneName, err.Error())
@@ -483,13 +492,13 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.VNetLinkName != "" {
 			vNetLinkName = accountOptions.VNetLinkName
 		}
-		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, vnetResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
+		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, privateDnsResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				if err := az.createVNetLink(ctx, vNetLinkName, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, vnetResourceGroup, err)
+				if err := az.createVNetLink(ctx, vNetLinkName, privateDnsResourceGroup, vnetName, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDnsResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, vnetResourceGroup, err)
+				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, privateDnsResourceGroup, err)
 			}
 		}
 	}
@@ -724,8 +733,8 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.StorageType == StorageTypeBlob {
 			dnsZoneGroupName = dnsZoneGroupName + blobNameSuffix
 		}
-		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
-			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, vnetResourceGroup, err)
+		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, privateDnsResourceGroup, vnetName, privateDNSZoneName); err != nil {
+			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, privateDnsResourceGroup, err)
 		}
 	}
 

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -483,7 +483,7 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 					return "", "", fmt.Errorf("create private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get private dns zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
+				return "", "", fmt.Errorf("get private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -465,9 +465,9 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 
 	// Use a separate resource group for private DNS zone if specified,
 	// otherwise default to vnetResourceGroup for backward compatibility.
-	privateDnsResourceGroup := vnetResourceGroup
+	privateDNSResourceGroup := vnetResourceGroup
 	if accountOptions.PrivateDNSZoneResourceGroup != "" {
-		privateDnsResourceGroup = accountOptions.PrivateDNSZoneResourceGroup
+		privateDNSResourceGroup = accountOptions.PrivateDNSZoneResourceGroup
 	}
 
 	if ptr.Deref(accountOptions.CreatePrivateEndpoint, false) {
@@ -476,11 +476,11 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 			// multi-tenant support
 			clientFactory = az.ComputeClientFactory
 		}
-		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, privateDnsResourceGroup, privateDNSZoneName); err != nil {
+		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				// Create DNS zone first, this could make sure driver has write permission on privateDnsResourceGroup
-				if err := az.createPrivateDNSZone(ctx, privateDnsResourceGroup, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create private DNS zone(%s) in resourceGroup(%s): %w", privateDNSZoneName, privateDnsResourceGroup, err)
+				// Create DNS zone first, this could make sure driver has write permission on privateDNSResourceGroup
+				if err := az.createPrivateDNSZone(ctx, privateDNSResourceGroup, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create private DNS zone(%s) in resourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
 				return "", "", fmt.Errorf("get private dns zone %s returned with %v", privateDNSZoneName, err.Error())
@@ -492,13 +492,13 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.VNetLinkName != "" {
 			vNetLinkName = accountOptions.VNetLinkName
 		}
-		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, privateDnsResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
+		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				if err := az.createVNetLink(ctx, vNetLinkName, privateDnsResourceGroup, vnetName, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDnsResourceGroup, err)
+				if err := az.createVNetLink(ctx, vNetLinkName, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, privateDnsResourceGroup, err)
+				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 	}
@@ -733,8 +733,8 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.StorageType == StorageTypeBlob {
 			dnsZoneGroupName = dnsZoneGroupName + blobNameSuffix
 		}
-		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, privateDnsResourceGroup, vnetName, privateDNSZoneName); err != nil {
-			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, privateDnsResourceGroup, err)
+		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, privateDNSResourceGroup, err)
 		}
 	}
 

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -799,7 +799,7 @@ func (az *AccountRepo) createPrivateEndpoint(ctx context.Context, accountName st
 
 func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, privateDNSResourceGroup, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZone")
-	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "ResourceGroup", privateDNSResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
+	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "resourceGroup", privateDNSResourceGroup)
 	location := LocationGlobal
 	privateDNSZone := privatedns.PrivateZone{Location: &location}
 	clientFactory := az.NetworkClientFactory
@@ -811,7 +811,7 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, privateDNSResou
 
 	if _, err := privatednsclient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
 		if strings.Contains(err.Error(), "exists already") {
-			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "ResourceGroup", privateDNSResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
+			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "resourceGroup", privateDNSResourceGroup)
 			return nil
 		}
 		return err

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -480,7 +480,7 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
 				// Create DNS zone first, this could make sure driver has write permission on privateDNSResourceGroup
 				if err := az.createPrivateDNSZone(ctx, privateDNSResourceGroup, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create private DNS zone(%s) in resourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
+					return "", "", fmt.Errorf("create private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
 				return "", "", fmt.Errorf("get private dns zone %s returned with %v", privateDNSZoneName, err.Error())
@@ -797,9 +797,9 @@ func (az *AccountRepo) createPrivateEndpoint(ctx context.Context, accountName st
 	return err
 }
 
-func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGroup, privateDNSZoneName string) error {
+func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, privateDNSResourceGroup, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZone")
-	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "privateDNSResourceGroup", privateDNSResourceGroup)
 	location := LocationGlobal
 	privateDNSZone := privatedns.PrivateZone{Location: &location}
 	clientFactory := az.NetworkClientFactory
@@ -809,9 +809,9 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGro
 	}
 	privatednsclient := clientFactory.GetPrivateZoneClient()
 
-	if _, err := privatednsclient.CreateOrUpdate(ctx, vnetResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
+	if _, err := privatednsclient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
 		if strings.Contains(err.Error(), "exists already") {
-			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "privateDNSResourceGroup", privateDNSResourceGroup)
 			return nil
 		}
 		return err

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -483,7 +483,7 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 					return "", "", fmt.Errorf("create private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get private dns zone %s returned with %v", privateDNSZoneName, err.Error())
+				return "", "", fmt.Errorf("get private dns zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 
@@ -799,7 +799,7 @@ func (az *AccountRepo) createPrivateEndpoint(ctx context.Context, accountName st
 
 func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, privateDNSResourceGroup, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZone")
-	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "privateDNSResourceGroup", privateDNSResourceGroup)
+	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "ResourceGroup", privateDNSResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 	location := LocationGlobal
 	privateDNSZone := privatedns.PrivateZone{Location: &location}
 	clientFactory := az.NetworkClientFactory
@@ -811,7 +811,7 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, privateDNSResou
 
 	if _, err := privatednsclient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
 		if strings.Contains(err.Error(), "exists already") {
-			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "privateDNSResourceGroup", privateDNSResourceGroup)
+			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "ResourceGroup", privateDNSResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 			return nil
 		}
 		return err

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -414,6 +414,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 		name                            string
 		createAccount                   bool
 		createPrivateEndpoint           *bool
+		privateDNSZoneResourceGroup     string
 		vNetLinkName                    string
 		publicNetworkAccess             string
 		SubnetPropertiesFormatNil       bool
@@ -458,6 +459,19 @@ func TestEnsureStorageAccount(t *testing.T) {
 			setAccountOptions:               true,
 			requireInfrastructureEncryption: ptr.To(true),
 			keyVaultURL:                     ptr.To("keyVaultURL"),
+			resourceGroup:                   "rg",
+			accessTier:                      "AccessTierHot",
+			accountName:                     "",
+			expectedErr:                     "",
+		},
+		{
+			name:                            "[Success] EnsureStorageAccount with createPrivateEndpoint and separate privateDNSZoneResourceGroup",
+			createAccount:                   true,
+			createPrivateEndpoint:           ptr.To(true),
+			privateDNSZoneResourceGroup:     "dns-rg",
+			mockStorageAccountsClient:       true,
+			setAccountOptions:               true,
+			requireInfrastructureEncryption: ptr.To(true),
 			resourceGroup:                   "rg",
 			accessTier:                      "AccessTierHot",
 			accountName:                     "",
@@ -548,21 +562,27 @@ func TestEnsureStorageAccount(t *testing.T) {
 					createOrUpdateCall.Times(1)
 				}
 
+				// DNS operations use privateDNSZoneResourceGroup when set, otherwise vnetResourceGroup
+				dnsRG := vnetResourceGroup
+				if test.privateDNSZoneResourceGroup != "" {
+					dnsRG = test.privateDNSZoneResourceGroup
+				}
+
 				mockPrivateDNSClient := mock_privatezoneclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateZoneClient().Return(mockPrivateDNSClient).AnyTimes()
-				mockPrivateDNSClient.EXPECT().Get(gomock.Any(), vnetResourceGroup, gomock.Any()).Return(&privatedns.PrivateZone{}, errors.New("ResourceNotFound")).Times(1)
-				mockPrivateDNSClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockPrivateDNSClient.EXPECT().Get(gomock.Any(), dnsRG, gomock.Any()).Return(&privatedns.PrivateZone{}, errors.New("ResourceNotFound")).Times(1)
+				mockPrivateDNSClient.EXPECT().CreateOrUpdate(gomock.Any(), dnsRG, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 
 				mockPrivateDNSZoneGroup := mock_privatednszonegroupclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateDNSZoneGroupClient().Return(mockPrivateDNSZoneGroup).AnyTimes()
-				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), dnsRG, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 				mockPrivateEndpointClient := mock_privateendpointclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateEndpointClient().Return(mockPrivateEndpointClient).AnyTimes()
 				mockPrivateEndpointClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 				mockVirtualNetworkLinksClient := mock_virtualnetworklinkclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetVirtualNetworkLinkClient().Return(mockVirtualNetworkLinksClient).AnyTimes()
-				mockVirtualNetworkLinksClient.EXPECT().Get(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(&privatedns.VirtualNetworkLink{}, errors.New("ResourceNotFound")).Times(1)
-				mockVirtualNetworkLinksClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockVirtualNetworkLinksClient.EXPECT().Get(gomock.Any(), dnsRG, gomock.Any(), gomock.Any()).Return(&privatedns.VirtualNetworkLink{}, errors.New("ResourceNotFound")).Times(1)
+				mockVirtualNetworkLinksClient.EXPECT().CreateOrUpdate(gomock.Any(), dnsRG, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			}
 
 			if test.sourceAccountName != "" {
@@ -574,6 +594,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 				testAccountOptions = &AccountOptions{
 					ResourceGroup:                   test.resourceGroup,
 					CreatePrivateEndpoint:           test.createPrivateEndpoint,
+					PrivateDNSZoneResourceGroup:     test.privateDNSZoneResourceGroup,
 					VNetLinkName:                    test.vNetLinkName,
 					PublicNetworkAccess:             test.publicNetworkAccess,
 					Name:                            test.accountName,

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -575,7 +575,17 @@ func TestEnsureStorageAccount(t *testing.T) {
 
 				mockPrivateDNSZoneGroup := mock_privatednszonegroupclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateDNSZoneGroupClient().Return(mockPrivateDNSZoneGroup).AnyTimes()
-				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Cond(func(x any) bool {
+					group, ok := x.(armnetwork.PrivateDNSZoneGroup)
+					if !ok {
+						return false
+					}
+					if group.Properties == nil || len(group.Properties.PrivateDNSZoneConfigs) == 0 {
+						return false
+					}
+					zoneID := *group.Properties.PrivateDNSZoneConfigs[0].Properties.PrivateDNSZoneID
+					return strings.Contains(zoneID, "/resourceGroups/"+dnsRG+"/")
+				})).Return(nil, nil).Times(1)
 				mockPrivateEndpointClient := mock_privateendpointclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateEndpointClient().Return(mockPrivateEndpointClient).AnyTimes()
 				mockPrivateEndpointClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -575,7 +575,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 
 				mockPrivateDNSZoneGroup := mock_privatednszonegroupclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateDNSZoneGroupClient().Return(mockPrivateDNSZoneGroup).AnyTimes()
-				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), dnsRG, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 				mockPrivateEndpointClient := mock_privateendpointclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateEndpointClient().Return(mockPrivateEndpointClient).AnyTimes()
 				mockPrivateEndpointClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it
Adds `PrivateDNSZoneResourceGroup` field to `AccountOptions` to allow specifying a separate resource group for Private DNS zone operations, independent of the VNet resource group used for private endpoint creation.

## Which issue(s) this PR fixes
Ref: kubernetes-sigs/azurefile-csi-driver#2845

## Problem
When using `networkEndpointType: privateEndpoint`, the CSI driver creates Private DNS zones in the same resource group as the VNet (`vnetResourceGroup`). Enterprise environments with centralized Private DNS zone management need these in a separate, dedicated resource group.

## Solution
- Add `PrivateDNSZoneResourceGroup` to `AccountOptions` struct
- When set, all DNS zone operations (create/get Private DNS zone, VNet link, DNS zone group) use this resource group
- When not set, defaults to `vnetResourceGroup` — fully backward compatible

## How to consume
CSI drivers (azurefile, azuredisk) can pass the new field via StorageClass parameters:
```yaml
parameters:
  networkEndpointType: privateEndpoint
  privateDnsResourceGroup: "rg-centralized-dns"
```
