### PR TITLE
fix: force privatelink prefix for Private Endpoint DNS zone name

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -381,7 +381,10 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if len(accountOptions.StorageEndpointSuffix) == 0 && az.Environment != nil {
 			accountOptions.StorageEndpointSuffix = az.Environment.StorageEndpointSuffix
 		}
-		privateDNSZoneName = fmt.Sprintf(privateDNSZoneNameFmt, privateDNSZoneName, accountOptions.StorageType, accountOptions.StorageEndpointSuffix)
+		// Private Endpoint DNS resolution requires the fixed "privatelink" prefix.
+		// Azure public DNS always returns a CNAME pointing to privatelink.{service}.{suffix},
+		// so using a custom prefix would break the DNS resolution chain.
+		privateDNSZoneName = fmt.Sprintf(privateDNSZoneNameFmt, defaultPrivateDNSZoneName, accountOptions.StorageType, accountOptions.StorageEndpointSuffix)
 	}
 
 	if len(accountOptions.Tags) == 0 {


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
Forces the `privatelink` prefix when constructing the Private DNS zone name for Private Endpoint scenarios, ignoring user-specified `PrivateDNSZoneName`.

## Problem
When `CreatePrivateEndpoint` is true, the code allows users to override the DNS zone prefix via `PrivateDNSZoneName`. For example, setting it to `custom` produces `custom.file.core.windows.net`.

However, Azure public DNS **always** returns a CNAME pointing to `privatelink.{service}.{suffix}` for Private Endpoint resolution. This CNAME redirect is a fixed Azure platform behavior and cannot be changed. So a custom prefix silently breaks the DNS resolution chain:

```
mystorageaccount.file.core.windows.net
  → CNAME → mystorageaccount.privatelink.file.core.windows.net  (Azure fixed)
  → Private DNS Zone is custom.file.core.windows.net             (no match)
  → DNS resolution fails ❌
```

## Fix
When `CreatePrivateEndpoint` is true, always use `defaultPrivateDNSZoneName` ("privatelink") regardless of `PrivateDNSZoneName` setting.
