### PR TITLE
fix: add isSmbOAuthEnabledEqual check to storage account matching

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -159,7 +159,7 @@ func (az *AccountRepo) getStorageAccounts(ctx context.Context, storageAccountCli
 	accounts := []accountWithLocation{}
 	for _, acct := range result {
 		if acct.Name != nil && acct.Location != nil && acct.SKU != nil {
-			if !isStorageTypeEqual(acct, accountOptions) || !isAccountKindEqual(acct, accountOptions) || !isLocationEqual(acct, accountOptions) || !isLargeFileSharesPropertyEqual(acct, accountOptions) || !isTagsEqual(acct, accountOptions) || !isTaggedWithSkip(acct) || !isHnsPropertyEqual(acct, accountOptions) || !isEnableNfsV3PropertyEqual(acct, accountOptions) || !isEnableHTTPSTrafficOnlyEqual(acct, accountOptions) || !isAllowBlobPublicAccessEqual(acct, accountOptions) || !isRequireInfrastructureEncryptionEqual(acct, accountOptions) || !isAllowSharedKeyAccessEqual(acct, accountOptions) || !isAllowCrossTenantReplicationEqual(acct, accountOptions) || !isAccessTierEqual(acct, accountOptions) || !AreVNetRulesEqual(acct, accountOptions) || !isPrivateEndpointAsExpected(acct, accountOptions) {
+			if !isStorageTypeEqual(acct, accountOptions) || !isAccountKindEqual(acct, accountOptions) || !isLocationEqual(acct, accountOptions) || !isLargeFileSharesPropertyEqual(acct, accountOptions) || !isTagsEqual(acct, accountOptions) || !isTaggedWithSkip(acct) || !isHnsPropertyEqual(acct, accountOptions) || !isEnableNfsV3PropertyEqual(acct, accountOptions) || !isEnableHTTPSTrafficOnlyEqual(acct, accountOptions) || !isAllowBlobPublicAccessEqual(acct, accountOptions) || !isRequireInfrastructureEncryptionEqual(acct, accountOptions) || !isAllowSharedKeyAccessEqual(acct, accountOptions) || !isAllowCrossTenantReplicationEqual(acct, accountOptions) || !isAccessTierEqual(acct, accountOptions) || !AreVNetRulesEqual(acct, accountOptions) || !isPrivateEndpointAsExpected(acct, accountOptions) || !isSmbOAuthEnabledEqual(acct, accountOptions) {
 				continue
 			}
 
@@ -1081,6 +1081,18 @@ func isAccessTierEqual(account *armstorage.Account, accountOptions *AccountOptio
 		return true
 	}
 	return account != nil && account.Properties != nil && account.Properties.AccessTier != nil && accountOptions.AccessTier == string(*account.Properties.AccessTier)
+}
+
+func isSmbOAuthEnabledEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {
+	if accountOptions.IsSmbOAuthEnabled == nil {
+		return true
+	}
+	if account == nil || account.Properties == nil || account.Properties.AzureFilesIdentityBasedAuthentication == nil ||
+		account.Properties.AzureFilesIdentityBasedAuthentication.SmbOAuthSettings == nil ||
+		account.Properties.AzureFilesIdentityBasedAuthentication.SmbOAuthSettings.IsSmbOAuthEnabled == nil {
+		return !*accountOptions.IsSmbOAuthEnabled
+	}
+	return *account.Properties.AzureFilesIdentityBasedAuthentication.SmbOAuthSettings.IsSmbOAuthEnabled == *accountOptions.IsSmbOAuthEnabled
 }
 
 func (az *AccountRepo) isMultichannelEnabledEqual(ctx context.Context, account *armstorage.Account, accountOptions *AccountOptions) (bool, error) {

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -358,7 +358,7 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 		{
 			testCase: "IsSmbOAuthEnabled true should only match OAuth-enabled accounts",
 			testAccountOptions: &AccountOptions{
-				ResourceGroup:    "rg",
+				ResourceGroup:     "rg",
 				IsSmbOAuthEnabled: ptr.To(true),
 			},
 			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{}}},
@@ -368,7 +368,7 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 		{
 			testCase: "IsSmbOAuthEnabled true should match OAuth-enabled account",
 			testAccountOptions: &AccountOptions{
-				ResourceGroup:    "rg",
+				ResourceGroup:     "rg",
 				IsSmbOAuthEnabled: ptr.To(true),
 			},
 			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -408,8 +408,10 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 			t.Errorf("unexpected result count: got %d, expected %d", len(accountsWithLocations), len(test.expectedResult))
 		} else {
 			for i, acct := range accountsWithLocations {
-				if acct.Name != test.expectedResult[i].Name {
-					t.Errorf("unexpected account name at index %d: got %q, expected %q", i, acct.Name, test.expectedResult[i].Name)
+				if acct.Name != test.expectedResult[i].Name || acct.StorageType != test.expectedResult[i].StorageType || acct.Location != test.expectedResult[i].Location {
+					t.Errorf("unexpected account at index %d: got {Name:%q, StorageType:%q, Location:%q}, expected {Name:%q, StorageType:%q, Location:%q}",
+						i, acct.Name, acct.StorageType, acct.Location,
+						test.expectedResult[i].Name, test.expectedResult[i].StorageType, test.expectedResult[i].Location)
 				}
 			}
 		}

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -372,6 +372,7 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 				IsSmbOAuthEnabled: ptr.To(true),
 			},
 			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{
+				EnableHTTPSTrafficOnly: ptr.To(false),
 				AzureFilesIdentityBasedAuthentication: &armstorage.AzureFilesIdentityBasedAuthentication{
 					SmbOAuthSettings: &armstorage.SmbOAuthSettings{
 						IsSmbOAuthEnabled: ptr.To(true),

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -361,26 +361,37 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 				ResourceGroup:     "rg",
 				IsSmbOAuthEnabled: ptr.To(true),
 			},
-			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{}}},
-			expectedResult:     []accountWithLocation{},
-			expectedError:      nil,
+			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{
+				EnableHTTPSTrafficOnly: ptr.To(false),
+			}}},
+			expectedResult: []accountWithLocation{},
+			expectedError:  nil,
 		},
 		{
-			testCase: "IsSmbOAuthEnabled true should match OAuth-enabled account",
+			testCase: "IsSmbOAuthEnabled true should match OAuth-enabled account among mixed candidates",
 			testAccountOptions: &AccountOptions{
 				ResourceGroup:     "rg",
 				IsSmbOAuthEnabled: ptr.To(true),
 			},
-			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{
-				EnableHTTPSTrafficOnly: ptr.To(false),
-				AzureFilesIdentityBasedAuthentication: &armstorage.AzureFilesIdentityBasedAuthentication{
-					SmbOAuthSettings: &armstorage.SmbOAuthSettings{
-						IsSmbOAuthEnabled: ptr.To(true),
-					},
-				},
-			}}},
-			expectedResult:     []accountWithLocation{{Name: name, StorageType: "testSku", Location: location}},
-			expectedError:      nil,
+			testResourceGroups: func() []*armstorage.Account {
+				nonOAuthName := "nonOAuthAccount"
+				oauthName := "oauthAccount"
+				return []*armstorage.Account{
+					{Name: &nonOAuthName, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{
+						EnableHTTPSTrafficOnly: ptr.To(false),
+					}},
+					{Name: &oauthName, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{
+						EnableHTTPSTrafficOnly: ptr.To(false),
+						AzureFilesIdentityBasedAuthentication: &armstorage.AzureFilesIdentityBasedAuthentication{
+							SmbOAuthSettings: &armstorage.SmbOAuthSettings{
+								IsSmbOAuthEnabled: ptr.To(true),
+							},
+						},
+					}},
+				}
+			}(),
+			expectedResult: []accountWithLocation{{Name: "oauthAccount", StorageType: "testSku", Location: location}},
+			expectedError:  nil,
 		},
 	}
 
@@ -394,7 +405,13 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 		}
 
 		if len(accountsWithLocations) != len(test.expectedResult) {
-			t.Error("unexpected error as returned accounts slice is not empty")
+			t.Errorf("unexpected result count: got %d, expected %d", len(accountsWithLocations), len(test.expectedResult))
+		} else {
+			for i, acct := range accountsWithLocations {
+				if acct.Name != test.expectedResult[i].Name {
+					t.Errorf("unexpected account name at index %d: got %q, expected %q", i, acct.Name, test.expectedResult[i].Name)
+				}
+			}
 		}
 	}
 }

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -355,6 +355,32 @@ func TestGetStorageAccountEdgeCases(t *testing.T) {
 			expectedResult:     []accountWithLocation{},
 			expectedError:      nil,
 		},
+		{
+			testCase: "IsSmbOAuthEnabled true should only match OAuth-enabled accounts",
+			testAccountOptions: &AccountOptions{
+				ResourceGroup:    "rg",
+				IsSmbOAuthEnabled: ptr.To(true),
+			},
+			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{}}},
+			expectedResult:     []accountWithLocation{},
+			expectedError:      nil,
+		},
+		{
+			testCase: "IsSmbOAuthEnabled true should match OAuth-enabled account",
+			testAccountOptions: &AccountOptions{
+				ResourceGroup:    "rg",
+				IsSmbOAuthEnabled: ptr.To(true),
+			},
+			testResourceGroups: []*armstorage.Account{{Name: &name, Kind: to.Ptr(armstorage.Kind("kind")), Location: &location, SKU: sku, Properties: &armstorage.AccountProperties{
+				AzureFilesIdentityBasedAuthentication: &armstorage.AzureFilesIdentityBasedAuthentication{
+					SmbOAuthSettings: &armstorage.SmbOAuthSettings{
+						IsSmbOAuthEnabled: ptr.To(true),
+					},
+				},
+			}}},
+			expectedResult:     []accountWithLocation{{Name: name, StorageType: "testSku", Location: location}},
+			expectedError:      nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -1704,6 +1730,20 @@ func TestIsSmbOAuthEnabledEqual(t *testing.T) {
 			account:        &armstorage.Account{Properties: &armstorage.AccountProperties{}},
 			accountOptions: &AccountOptions{IsSmbOAuthEnabled: ptr.To(false)},
 			expectedResult: true,
+		},
+		{
+			desc: "option false, account true (OAuth-enabled account should not match non-OAuth request)",
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AzureFilesIdentityBasedAuthentication: &armstorage.AzureFilesIdentityBasedAuthentication{
+						SmbOAuthSettings: &armstorage.SmbOAuthSettings{
+							IsSmbOAuthEnabled: ptr.To(true),
+						},
+					},
+				},
+			},
+			accountOptions: &AccountOptions{IsSmbOAuthEnabled: ptr.To(false)},
+			expectedResult: false,
 		},
 	}
 

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -1652,6 +1652,69 @@ func TestIsAccessTierEqual(t *testing.T) {
 	}
 }
 
+func TestIsSmbOAuthEnabledEqual(t *testing.T) {
+	tests := []struct {
+		desc           string
+		account        *armstorage.Account
+		accountOptions *AccountOptions
+		expectedResult bool
+	}{
+		{
+			desc:           "option nil should match any account",
+			account:        &armstorage.Account{Properties: &armstorage.AccountProperties{}},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			desc: "option true, account true",
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AzureFilesIdentityBasedAuthentication: &armstorage.AzureFilesIdentityBasedAuthentication{
+						SmbOAuthSettings: &armstorage.SmbOAuthSettings{
+							IsSmbOAuthEnabled: ptr.To(true),
+						},
+					},
+				},
+			},
+			accountOptions: &AccountOptions{IsSmbOAuthEnabled: ptr.To(true)},
+			expectedResult: true,
+		},
+		{
+			desc: "option true, account false",
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AzureFilesIdentityBasedAuthentication: &armstorage.AzureFilesIdentityBasedAuthentication{
+						SmbOAuthSettings: &armstorage.SmbOAuthSettings{
+							IsSmbOAuthEnabled: ptr.To(false),
+						},
+					},
+				},
+			},
+			accountOptions: &AccountOptions{IsSmbOAuthEnabled: ptr.To(true)},
+			expectedResult: false,
+		},
+		{
+			desc:           "option true, account nil (no SmbOAuth settings)",
+			account:        &armstorage.Account{Properties: &armstorage.AccountProperties{}},
+			accountOptions: &AccountOptions{IsSmbOAuthEnabled: ptr.To(true)},
+			expectedResult: false,
+		},
+		{
+			desc:           "option false, account nil (no SmbOAuth settings)",
+			account:        &armstorage.Account{Properties: &armstorage.AccountProperties{}},
+			accountOptions: &AccountOptions{IsSmbOAuthEnabled: ptr.To(false)},
+			expectedResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			result := isSmbOAuthEnabledEqual(test.account, test.accountOptions)
+			assert.Equal(t, test.expectedResult, result)
+		})
+	}
+}
+
 func TestIsMultichannelEnabledEqual(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Add `isSmbOAuthEnabledEqual` check when searching for existing storage accounts to reuse.

Previously, `IsSmbOAuthEnabled` was not included in the account matching logic. This could cause volumes that require SmbOAuth-enabled storage accounts to incorrectly reuse non-OAuth accounts, resulting in authentication failures (e.g., `Error calling AzAuthenticatorLib: -1` from azfilesauthmanager).

### Changes:
- Added `isSmbOAuthEnabledEqual` function that compares the account's `SmbOAuthSettings.IsSmbOAuthEnabled` with the requested `AccountOptions.IsSmbOAuthEnabled`
- Added the check to the account filtering chain in `GetStorageAccesskey` / `EnsureStorageAccount`
- Added unit tests for the new function

## Which issue(s) this PR fixes:


**Release note**:
```
none
```