### PR TITLE
test: add CALICO_VERSION substitution to linux-vmss-ci-version manifest

### DIFF
--- a/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
+++ b/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml
@@ -828,6 +828,7 @@ spec:
   namespace: tigera-operator
   releaseName: projectcalico
   repoURL: https://docs.tigera.io/calico/charts
+  version: ${CALICO_VERSION}
   valuesTemplate: |-
     installation:
       cni:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds a `version: ${CALICO_VERSION}` field to the `calico` `HelmChartProxy`
in `tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version-oot-credential-provider.yaml`
so that the Calico chart version is pinned at template-render time via
`envsubst`, instead of always resolving to the latest published chart in
`https://docs.tigera.io/calico/charts`.

Follow-up to #10268, which made the same change in the sibling
`linux-vmss-ci-no-win-oot-credential-provider.yaml` manifest. Both
manifests should follow the convention used in the upstream
[cluster-api-provider-azure `release-1.22` template](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/release-1.22/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml#L562),
where the same `${CALICO_VERSION}` substitution variable is used. Pinning
the version makes CI runs reproducible and avoids unexpected breakage when
a new Calico chart is published upstream.

CI scripts that consume this manifest must export `CALICO_VERSION` in
their environment when running `envsubst` (or equivalent). Same contract
as the upstream CAPZ template.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Single-line YAML change in a CI test manifest — no production code paths
or unit tests are affected. The new field is a top-level sibling of
`chartName`, `repoURL`, `releaseName`, and `valuesTemplate` inside the
`HelmChartProxy` `spec`, which is the schema expected by the
`addons.cluster.x-k8s.io/v1alpha1` HelmChartProxy CRD.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```