### PR TITLE
[release-1.32] feat: support config-gated in-place mutation of FirstPartyUsage IP tags

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1206,6 +1206,14 @@ func (az *Cloud) ensurePublicIPExists(ctx context.Context, service *v1.Service, 
 			}
 		}
 
+		if !isUserAssignedPIP {
+			if ipTagDirty, ipTagErr := az.ensurePIPIPTagged(service, pip); ipTagErr != nil {
+				return nil, fmt.Errorf("ensurePublicIPExists for service(%s): %w", serviceName, ipTagErr)
+			} else if ipTagDirty {
+				changed = true
+			}
+		}
+
 		// return if pip exist and dns label is the same
 		if strings.EqualFold(getDomainNameLabel(pip), domainNameLabel) {
 			if existingServiceName := getServiceFromPIPDNSTags(pip.Tags); existingServiceName != "" && strings.EqualFold(existingServiceName, serviceName) {
@@ -1501,8 +1509,12 @@ func getIPTagMap(ipTagString string) map[string]string {
 func sortIPTags(ipTags *[]*armnetwork.IPTag) {
 	if ipTags != nil {
 		sort.Slice(*ipTags, func(i, j int) bool {
-			return ptr.Deref((*ipTags)[i].IPTagType, "") < ptr.Deref((*ipTags)[j].IPTagType, "") ||
-				ptr.Deref((*ipTags)[i].Tag, "") < ptr.Deref((*ipTags)[j].Tag, "")
+			leftType := ptr.Deref((*ipTags)[i].IPTagType, "")
+			rightType := ptr.Deref((*ipTags)[j].IPTagType, "")
+			if leftType != rightType {
+				return leftType < rightType
+			}
+			return ptr.Deref((*ipTags)[i].Tag, "") < ptr.Deref((*ipTags)[j].Tag, "")
 		})
 	}
 }
@@ -3297,26 +3309,17 @@ func (az *Cloud) shouldUpdateLoadBalancer(ctx context.Context, clusterName strin
 }
 
 // Determine if we should release existing owned public IPs
-// FIXME: This function is a bit of a mess, and could use some refactoring.
 func shouldReleaseExistingOwnedPublicIP(
 	existingPip *armnetwork.PublicIPAddress,
 	serviceReferences []string,
 	lbShouldExist, lbIsInternal, isUserAssignedPIP bool,
 	desiredPipName string,
 	ipTagRequest serviceIPTagRequest,
+	enableIPTagMutation bool,
 ) bool {
 	// skip deleting user created pip
 	if isUserAssignedPIP {
 		return false
-	}
-
-	// Latch some variables for readability purposes.
-	pipName := *existingPip.Name
-
-	// Assume the current IP Tags are empty by default unless properties specify otherwise.
-	currentIPTags := []*armnetwork.IPTag{}
-	if existingPip.Properties != nil {
-		currentIPTags = existingPip.Properties.IPTags
 	}
 
 	// Check whether the public IP is being referenced by other service.
@@ -3331,6 +3334,12 @@ func shouldReleaseExistingOwnedPublicIP(
 		return false
 	}
 
+	// Assume the current IP Tags are empty by default unless properties specify otherwise.
+	currentIPTags := []*armnetwork.IPTag{}
+	if existingPip.Properties != nil {
+		currentIPTags = existingPip.Properties.IPTags
+	}
+
 	// Release the ip under the following criteria -
 	// #1 - If we don't actually want a load balancer,
 	return !lbShouldExist ||
@@ -3339,9 +3348,11 @@ func shouldReleaseExistingOwnedPublicIP(
 		// #3 - If the name of this public ip does not match the desired name,
 		// NOTICE: For IPv6 Service created with CCM v1.27.1, the created PIP has IPv6 suffix.
 		// We need to recreate such PIP and current logic to delete needs no change.
-		(pipName != desiredPipName) ||
-		// #4 If the service annotations have specified the ip tags that the public ip must have, but they do not match the ip tags of the existing instance
-		(ipTagRequest.IPTagsRequestedByAnnotation && !areIPTagsEquivalent(currentIPTags, ipTagRequest.IPTags))
+		(ptr.Deref(existingPip.Name, "") != desiredPipName) ||
+		// #4 - When in-place mutation is disabled, IP tag mismatch triggers delete-and-recreate
+		(!enableIPTagMutation &&
+			ipTagRequest.IPTagsRequestedByAnnotation &&
+			!areIPTagsEquivalent(currentIPTags, ipTagRequest.IPTags))
 }
 
 // ensurePIPTagged ensures the public IP of the service is tagged as configured
@@ -3386,6 +3397,35 @@ func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAd
 	pip.Tags = tags
 
 	return changed
+}
+
+// ensurePIPIPTagged ensures the PIP has the IP tags specified by the service annotation.
+// When EnableIPTagMutationForExistingPublicIP is false or the annotation is absent,
+// existing IP tags are preserved. When enabled, the annotation becomes the source of
+// truth for the full IP tag set. Azure NRP decides which mutations are accepted on
+// an existing PIP.
+// Returns true if pip.Properties.IPTags was modified and the caller must persist
+// the change via an in-place update; false if no change is needed.
+func (az *Cloud) ensurePIPIPTagged(service *v1.Service, pip *armnetwork.PublicIPAddress) (bool, error) {
+	if !az.EnableIPTagMutationForExistingPublicIP {
+		return false, nil
+	}
+
+	ipTagRequest := getServiceIPTagRequestForPublicIP(service)
+	if !ipTagRequest.IPTagsRequestedByAnnotation {
+		return false, nil
+	}
+
+	if pip.Properties == nil {
+		return false, nil
+	}
+
+	if areIPTagsEquivalent(pip.Properties.IPTags, ipTagRequest.IPTags) {
+		return false, nil
+	}
+
+	pip.Properties.IPTags = ipTagRequest.IPTags
+	return true, nil
 }
 
 // reconcilePublicIPs reconciles the PublicIP resources similar to how the LB is reconciled.
@@ -3451,7 +3491,6 @@ func (az *Cloud) reconcilePublicIP(ctx context.Context, pips []*armnetwork.Publi
 	logger := klog.FromContext(ctx).WithName("reconcilePublicIP")
 	isInternal := requiresInternalLoadBalancer(service)
 	serviceName := getServiceName(service)
-	serviceIPTagRequest := getServiceIPTagRequestForPublicIP(service)
 	pipResourceGroup := az.getPublicIPAddressResourceGroup(service)
 
 	var (
@@ -3474,6 +3513,8 @@ func (az *Cloud) reconcilePublicIP(ctx context.Context, pips []*armnetwork.Publi
 			return nil, err
 		}
 	}
+
+	serviceIPTagRequest := getServiceIPTagRequestForPublicIP(service)
 
 	discoveredDesiredPublicIP, pipsToBeDeleted, deletedDesiredPublicIP, pipsToBeUpdated, err := az.getPublicIPUpdates(
 		clusterName, service, pips, wantLb, isInternal, desiredPipName, serviceName, serviceIPTagRequest, shouldPIPExisted, isIPv6)
@@ -3512,7 +3553,6 @@ func (az *Cloud) reconcilePublicIP(ctx context.Context, pips []*armnetwork.Publi
 	if errs != nil {
 		return nil, utilerrors.Flatten(errs)
 	}
-
 	if !isInternal && wantLb {
 		// Confirm desired public ip resource exists
 		var pip *armnetwork.PublicIPAddress
@@ -3585,7 +3625,8 @@ func (az *Cloud) getPublicIPUpdates(
 					dirtyPIP = true
 				}
 			}
-			if shouldReleaseExistingOwnedPublicIP(pip, serviceReferences, wantLb, isInternal, isUserAssignedPIP, desiredPipName, serviceIPTagRequest) {
+			shouldRelease := shouldReleaseExistingOwnedPublicIP(pip, serviceReferences, wantLb, isInternal, isUserAssignedPIP, desiredPipName, serviceIPTagRequest, az.EnableIPTagMutationForExistingPublicIP)
+			if shouldRelease {
 				// Then, release the public ip
 				pipsToBeDeleted = append(pipsToBeDeleted, pip)
 
@@ -3598,6 +3639,15 @@ func (az *Cloud) getPublicIPUpdates(
 
 				// If the pip is going to be deleted, we do not need to update it
 				toBeDeleted = true
+			}
+
+			// Only mutate IP tags on PIPs that are being kept (not deleted).
+			if !toBeDeleted && !isUserAssignedPIP {
+				if ipTagDirty, ipTagErr := az.ensurePIPIPTagged(service, pip); ipTagErr != nil {
+					return false, nil, false, nil, ipTagErr
+				} else if ipTagDirty {
+					dirtyPIP = true
+				}
 			}
 
 			// Update tags of PIP only instead of deleting it.

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1274,87 +1274,64 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 		desc                  string
 		desiredPipName        string
 		existingPip           armnetwork.PublicIPAddress
-		ipTagRequest          serviceIPTagRequest
 		lbShouldExist         bool
 		lbIsInternal          bool
 		isUserAssignedPIP     bool
 		serviceReferences     []string
+		ipTagRequest          serviceIPTagRequest
+		enableIPTagMutation   bool
 		expectedShouldRelease bool
 	}{
 		{
-			desc:           "Everything matches, no release",
-			existingPip:    existingPipWithTag,
-			lbShouldExist:  true,
-			lbIsInternal:   false,
-			desiredPipName: *existingPipWithTag.Name,
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
-			},
+			desc:                  "Everything matches, no release",
+			existingPip:           existingPipWithTag,
+			lbShouldExist:         true,
+			lbIsInternal:          false,
+			desiredPipName:        *existingPipWithTag.Name,
 			expectedShouldRelease: false,
 		},
 		{
-			desc:           "nil tags (none-specified by annotation, some are present on object), no release",
-			existingPip:    existingPipWithTag,
-			lbShouldExist:  true,
-			lbIsInternal:   false,
-			desiredPipName: *existingPipWithTag.Name,
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: false,
-				IPTags:                      nil,
-			},
+			desc:                  "nil tags (none-specified by annotation, some are present on object), no release",
+			existingPip:           existingPipWithTag,
+			lbShouldExist:         true,
+			lbIsInternal:          false,
+			desiredPipName:        *existingPipWithTag.Name,
 			expectedShouldRelease: false,
 		},
 		{
-			desc:           "existing public ip with no format properties (unit test only?), tags required by annotation, expect release",
-			existingPip:    existingPipWithNoPublicIPAddressFormatProperties,
-			lbShouldExist:  true,
-			lbIsInternal:   false,
-			desiredPipName: *existingPipWithTag.Name,
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
-			},
+			desc:                  "existing public ip with no format properties should not be released for IP tag changes",
+			existingPip:           existingPipWithNoPublicIPAddressFormatProperties,
+			lbShouldExist:         true,
+			lbIsInternal:          false,
+			desiredPipName:        *existingPipWithTag.Name,
+			expectedShouldRelease: false,
+		},
+		{
+			desc:                  "LB no longer desired, expect release",
+			existingPip:           existingPipWithTag,
+			lbShouldExist:         false,
+			lbIsInternal:          false,
+			desiredPipName:        *existingPipWithTag.Name,
 			expectedShouldRelease: true,
 		},
 		{
-			desc:           "LB no longer desired, expect release",
-			existingPip:    existingPipWithTag,
-			lbShouldExist:  false,
-			lbIsInternal:   false,
-			desiredPipName: *existingPipWithTag.Name,
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
-			},
+			desc:                  "LB now internal, expect release",
+			existingPip:           existingPipWithTag,
+			lbShouldExist:         true,
+			lbIsInternal:          true,
+			desiredPipName:        *existingPipWithTag.Name,
 			expectedShouldRelease: true,
 		},
 		{
-			desc:           "LB now internal, expect release",
-			existingPip:    existingPipWithTag,
-			lbShouldExist:  true,
-			lbIsInternal:   true,
-			desiredPipName: *existingPipWithTag.Name,
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
-			},
+			desc:                  "Alternate desired name, expect release",
+			existingPip:           existingPipWithTag,
+			lbShouldExist:         true,
+			lbIsInternal:          false,
+			desiredPipName:        "otherName",
 			expectedShouldRelease: true,
 		},
 		{
-			desc:           "Alternate desired name, expect release",
-			existingPip:    existingPipWithTag,
-			lbShouldExist:  true,
-			lbIsInternal:   false,
-			desiredPipName: "otherName",
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
-			},
-			expectedShouldRelease: true,
-		},
-		{
-			desc:           "mismatching, expect release",
+			desc:           "IP tag mismatch with mutation enabled should NOT trigger release",
 			existingPip:    existingPipWithTag,
 			lbShouldExist:  true,
 			lbIsInternal:   false,
@@ -1362,44 +1339,44 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
 				IPTags: []*armnetwork.IPTag{
-					{
-						IPTagType: ptr.To("tag2"),
-						Tag:       ptr.To("tag2value"),
-					},
+					{IPTagType: ptr.To("tag2"), Tag: ptr.To("tag2value")},
 				},
 			},
+			enableIPTagMutation:   true,
+			expectedShouldRelease: false,
+		},
+		{
+			desc:           "IP tag mismatch with mutation disabled should trigger release",
+			existingPip:    existingPipWithTag,
+			lbShouldExist:  true,
+			lbIsInternal:   false,
+			desiredPipName: *existingPipWithTag.Name,
+			ipTagRequest: serviceIPTagRequest{
+				IPTagsRequestedByAnnotation: true,
+				IPTags: []*armnetwork.IPTag{
+					{IPTagType: ptr.To("tag2"), Tag: ptr.To("tag2value")},
+				},
+			},
+			enableIPTagMutation:   false,
 			expectedShouldRelease: true,
 		},
 		{
 			// This test is for IPv6 PIP created with CCM v1.27.1 and CCM gets upgraded.
 			// Such PIP should be recreated.
-			desc:           "matching except PIP name (with IPv6 suffix), expect release",
-			existingPip:    existingPipWithTagIPv6Suffix,
-			lbShouldExist:  true,
-			lbIsInternal:   false,
-			desiredPipName: *existingPipWithTag.Name,
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags: []*armnetwork.IPTag{
-					{
-						IPTagType: ptr.To("tag1"),
-						Tag:       ptr.To("tag1value"),
-					},
-				},
-			},
+			desc:                  "matching except PIP name (with IPv6 suffix), expect release",
+			existingPip:           existingPipWithTagIPv6Suffix,
+			lbShouldExist:         true,
+			lbIsInternal:          false,
+			desiredPipName:        *existingPipWithTag.Name,
 			expectedShouldRelease: true,
 		},
 		{
-			desc:              "should delete orphaned managed public IP",
-			existingPip:       existingPipWithTag,
-			lbShouldExist:     false,
-			lbIsInternal:      false,
-			desiredPipName:    *existingPipWithTag.Name,
-			serviceReferences: []string{},
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
-			},
+			desc:                  "should delete orphaned managed public IP",
+			existingPip:           existingPipWithTag,
+			lbShouldExist:         false,
+			lbIsInternal:          false,
+			desiredPipName:        *existingPipWithTag.Name,
+			serviceReferences:     []string{},
 			expectedShouldRelease: true,
 		},
 		{
@@ -1409,10 +1386,6 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbIsInternal:      false,
 			desiredPipName:    *existingPipWithTag.Name,
 			serviceReferences: []string{"svc1"},
-			ipTagRequest: serviceIPTagRequest{
-				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
-			},
 		},
 		{
 			desc:              "should not delete orphaned unmanaged public IP",
@@ -1421,18 +1394,30 @@ func TestShouldReleaseExistingOwnedPublicIP(t *testing.T) {
 			lbIsInternal:      false,
 			desiredPipName:    *existingPipWithTag.Name,
 			serviceReferences: []string{},
+			isUserAssignedPIP: true,
+		},
+		{
+			desc:              "shared PIP with multiple refs + IP tag mismatch + mutation disabled should NOT release",
+			existingPip:       existingPipWithTag,
+			lbShouldExist:     true,
+			lbIsInternal:      false,
+			desiredPipName:    *existingPipWithTag.Name,
+			serviceReferences: []string{"svc1", "svc2"},
 			ipTagRequest: serviceIPTagRequest{
 				IPTagsRequestedByAnnotation: true,
-				IPTags:                      existingPipWithTag.Properties.IPTags,
+				IPTags: []*armnetwork.IPTag{
+					{IPTagType: ptr.To("tag2"), Tag: ptr.To("tag2value")},
+				},
 			},
-			isUserAssignedPIP: true,
+			enableIPTagMutation:   false,
+			expectedShouldRelease: false,
 		},
 	}
 
 	for _, c := range tests {
 		t.Run(c.desc, func(t *testing.T) {
 			existingPip := c.existingPip
-			actualShouldRelease := shouldReleaseExistingOwnedPublicIP(&existingPip, c.serviceReferences, c.lbShouldExist, c.lbIsInternal, c.isUserAssignedPIP, c.desiredPipName, c.ipTagRequest)
+			actualShouldRelease := shouldReleaseExistingOwnedPublicIP(&existingPip, c.serviceReferences, c.lbShouldExist, c.lbIsInternal, c.isUserAssignedPIP, c.desiredPipName, c.ipTagRequest, c.enableIPTagMutation)
 			assert.Equal(t, c.expectedShouldRelease, actualShouldRelease)
 		})
 	}
@@ -1766,6 +1751,30 @@ func TestAreIpTagsEquivalent(t *testing.T) {
 				{
 					IPTagType: ptr.To("tag1"),
 					Tag:       ptr.To("tag1value"),
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "cross-ordered tags should be treated as equal after lexicographic sort",
+			input1: []*armnetwork.IPTag{
+				{
+					IPTagType: ptr.To("B"),
+					Tag:       ptr.To("A"),
+				},
+				{
+					IPTagType: ptr.To("A"),
+					Tag:       ptr.To("B"),
+				},
+			},
+			input2: []*armnetwork.IPTag{
+				{
+					IPTagType: ptr.To("A"),
+					Tag:       ptr.To("B"),
+				},
+				{
+					IPTagType: ptr.To("B"),
+					Tag:       ptr.To("A"),
 				},
 			},
 			expected: true,
@@ -4628,11 +4637,14 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 		annotations                 map[string]string
 		existingPIPs                []*armnetwork.PublicIPAddress
 		wantLb                      bool
+		enableIPTagMutation         bool
+		createOrUpdateErr           error
 		expectedIDs                 []string
 		expectedPIPs                []*armnetwork.PublicIPAddress // len(expectedPIPs) <= 2
 		expectedError               bool
 		expectedCreateOrUpdateCount int
 		expectedDeleteCount         int
+		expectedDeleteCalls         map[string]int
 		expectedClientGet           *func(client *mock_publicipaddressclient.MockInterface)
 	}{
 		{
@@ -4863,12 +4875,13 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			expectedDeleteCount:         2,
 		},
 		{
-			desc:   "shall delete unwanted pips and existing pips, when the existing pips IP do not match",
-			wantLb: true,
+			desc:                "shall delete unwanted pips and update IP tags on existing pips in-place",
+			wantLb:              true,
+			enableIPTagMutation: true,
 			annotations: map[string]string{
 				consts.ServiceAnnotationPIPNameDualStack[false]: "testPIP",
 				consts.ServiceAnnotationPIPNameDualStack[true]:  "testPIP-IPv6",
-				consts.ServiceAnnotationIPTagsForPublicIP:       "tag1=tag1value",
+				consts.ServiceAnnotationIPTagsForPublicIP:       "FirstPartyUsage=/NonProd",
 			},
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
@@ -4897,8 +4910,9 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testPIP"),
 					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
-						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
-						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+						IPAddress:                ptr.To("1.2.3.4"),
 					},
 				},
 				{
@@ -4920,10 +4934,11 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
 						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+						IPAddress:                ptr.To("1.2.3.4"),
 						IPTags: []*armnetwork.IPTag{
 							{
-								IPTagType: ptr.To("tag1"),
-								Tag:       ptr.To("tag1value"),
+								IPTagType: ptr.To("FirstPartyUsage"),
+								Tag:       ptr.To("/NonProd"),
 							},
 						},
 					},
@@ -4935,10 +4950,11 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
 						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						IPAddress:                ptr.To("fd00::eef0"),
 						IPTags: []*armnetwork.IPTag{
 							{
-								IPTagType: ptr.To("tag1"),
-								Tag:       ptr.To("tag1value"),
+								IPTagType: ptr.To("FirstPartyUsage"),
+								Tag:       ptr.To("/NonProd"),
 							},
 						},
 					},
@@ -4946,6 +4962,12 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			},
 			expectedCreateOrUpdateCount: 2,
 			expectedDeleteCount:         2,
+			expectedDeleteCalls: map[string]int{
+				"testPIP":      0,
+				"testPIP-IPv6": 0,
+				"pip1":         1,
+				"pip2":         1,
+			},
 		},
 		{
 			desc:   "shall preserve existing pips, when the existing pips IP tags do match",
@@ -5151,6 +5173,151 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			expectedDeleteCount:         0,
 			expectedClientGet:           &getPIPAddMissingOne,
 		},
+		{
+			desc:                "mutation enabled + FirstPartyUsage mismatch should update in-place without delete",
+			wantLb:              true,
+			enableIPTagMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/Unprivileged",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("testCluster-atest1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("FirstPartyUsage"), Tag: ptr.To("/NonProd")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("testCluster-atest1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:                ptr.To("fd00::eef0"),
+						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("FirstPartyUsage"), Tag: ptr.To("/NonProd")},
+						},
+					},
+				},
+			},
+			expectedPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("testCluster-atest1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("FirstPartyUsage"), Tag: ptr.To("/Unprivileged")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("testCluster-atest1-IPv6"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:                ptr.To("fd00::eef0"),
+						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("FirstPartyUsage"), Tag: ptr.To("/Unprivileged")},
+						},
+					},
+				},
+			},
+			expectedCreateOrUpdateCount: 2,
+			expectedDeleteCount:         0,
+		},
+		{
+			desc:                "mutation disabled + IP tag mismatch should delete and recreate",
+			wantLb:              true,
+			enableIPTagMutation: false,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/Unprivileged",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("testCluster-atest1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("FirstPartyUsage"), Tag: ptr.To("/NonProd")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("testCluster-atest1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:                ptr.To("fd00::eef0"),
+						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("FirstPartyUsage"), Tag: ptr.To("/NonProd")},
+						},
+					},
+				},
+			},
+			expectedIDs: []string{
+				"/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1",
+				"/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1-IPv6",
+			},
+			expectedCreateOrUpdateCount: 2,
+			expectedDeleteCount:         0,
+			expectedDeleteCalls: map[string]int{
+				"testCluster-atest1":      1,
+				"testCluster-atest1-IPv6": 1,
+			},
+			expectedClientGet: &deleteUnwantedPIPsAndCreateANewOneclientGet,
+		},
+		{
+			desc:                "mutation enabled + non-FirstPartyUsage (RoutingPreference) mismatch should return Azure error after attempted PUT",
+			wantLb:              true,
+			enableIPTagMutation: true,
+			createOrUpdateErr:   errors.New("azure rejected iptags mutation"),
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "RoutingPreference=Invalid",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("testCluster-atest1"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:              ptr.To("1.2.3.4"),
+						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv4),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("RoutingPreference"), Tag: ptr.To("Internet")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("testCluster-atest1-IPv6"),
+					ID:   ptr.To("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/testCluster-atest1-IPv6"),
+					Tags: map[string]*string{consts.ServiceTagKey: ptr.To("default/test1")},
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress:                ptr.To("fd00::eef0"),
+						PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+						IPTags: []*armnetwork.IPTag{
+							{IPTagType: ptr.To("RoutingPreference"), Tag: ptr.To("Internet")},
+						},
+					},
+				},
+			},
+			expectedError:               true,
+			expectedCreateOrUpdateCount: 1,
+			expectedDeleteCount:         0,
+		},
 	}
 
 	for _, test := range testCases {
@@ -5159,10 +5326,13 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 			defer ctrl.Finish()
 
 			deletedPips := make(map[string]bool)
+			deleteCallTracker := make(map[string]int)
 			savedPips := make(map[string]*armnetwork.PublicIPAddress)
 			createOrUpdateCount := 0
+			primingExistingPIPs := true
 			var m sync.Mutex
 			az := GetTestCloud(ctrl)
+			az.EnableIPTagMutationForExistingPublicIP = test.enableIPTagMutation
 			mockPIPsClient := az.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
 			creator := mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", gomock.Any(), gomock.Any()).AnyTimes()
 			creator.DoAndReturn(func(_ context.Context, _ string, publicIPAddressName string, parameters armnetwork.PublicIPAddress) (result *armnetwork.PublicIPAddress, rerr error) {
@@ -5171,7 +5341,10 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				savedPips[publicIPAddressName] = &parameters
 				createOrUpdateCount++
 				m.Unlock()
-				return nil, nil
+				if primingExistingPIPs {
+					return nil, nil
+				}
+				return nil, test.createOrUpdateErr
 			})
 
 			if test.expectedClientGet != nil {
@@ -5197,6 +5370,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				deleter := mockPIPsClient.EXPECT().Delete(gomock.Any(), "rg", *pip.Name).Return(nil).AnyTimes()
 				deleter.Do(func(_ context.Context, _ string, publicIPAddressName string) error {
 					m.Lock()
+					deleteCallTracker[publicIPAddressName]++
 					deletedPips[publicIPAddressName] = true
 					m.Unlock()
 					return nil
@@ -5208,6 +5382,7 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				// Clear create or update count to prepare for main execution
 				createOrUpdateCount = 0
 			}
+			primingExistingPIPs = false
 			lister := mockPIPsClient.EXPECT().List(gomock.Any(), "rg").AnyTimes()
 			lister.DoAndReturn(func(_ context.Context, _ string) (result []*armnetwork.PublicIPAddress, rerr error) {
 				m.Lock()
@@ -5280,6 +5455,9 @@ func TestReconcilePublicIPsCommon(t *testing.T) {
 				}
 			}
 			assert.Equal(t, test.expectedDeleteCount, deletedCount)
+			for pipName, expectedCount := range test.expectedDeleteCalls {
+				assert.Equal(t, expectedCount, deleteCallTracker[pipName], "delete call count for %q", pipName)
+			}
 		})
 	}
 
@@ -5396,7 +5574,10 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 		foundDNSLabelAnnotation bool
 		isIPv6                  bool
 		useSLB                  bool
+		enableIPTagMutation     bool
 		shouldPutPIP            bool
+		assertPutPIPCalled      bool
+		putErr                  error
 		expectedError           bool
 	}{
 		{
@@ -5638,6 +5819,58 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			shouldPutPIP: true,
 		},
 		{
+			desc:                "shall update IP tags in place even when DNS label already matches",
+			pipName:             "pip1",
+			inputDNSLabel:       "test",
+			enableIPTagMutation: true,
+			existingPIPs: []*armnetwork.PublicIPAddress{{
+				Name: ptr.To("pip1"),
+				Tags: map[string]*string{
+					consts.ServiceUsingDNSKey: ptr.To("default/test1"),
+					consts.ServiceTagKey:      ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					DNSSettings: &armnetwork.PublicIPAddressDNSSettings{
+						DomainNameLabel: ptr.To("test"),
+					},
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+					IPTags: []*armnetwork.IPTag{
+						{
+							IPTagType: ptr.To("FirstPartyUsage"),
+							Tag:       ptr.To("/NonProd"),
+						},
+					},
+				},
+			}},
+			expectedPIP: &armnetwork.PublicIPAddress{
+				Name: ptr.To("pip1"),
+				ID:   ptr.To(expectedPIPID),
+				Tags: map[string]*string{
+					consts.ServiceUsingDNSKey: ptr.To("default/test1"),
+					consts.ServiceTagKey:      ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					DNSSettings: &armnetwork.PublicIPAddressDNSSettings{
+						DomainNameLabel: ptr.To("test"),
+					},
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+					IPTags: []*armnetwork.IPTag{
+						{
+							IPTagType: ptr.To("FirstPartyUsage"),
+							Tag:       ptr.To("/Unprivileged"),
+						},
+					},
+				},
+			},
+			additionalAnnotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/Unprivileged",
+			},
+			shouldPutPIP:       true,
+			assertPutPIPCalled: true,
+		},
+		{
 			desc:                    "shall report an conflict error if the DNS label is conflicted",
 			pipName:                 "pip1",
 			inputDNSLabel:           "test",
@@ -5800,6 +6033,51 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 				consts.ServiceAnnotationAzurePIPTags: "a=c",
 			},
 		},
+		{
+			desc:                "mutation enabled + FirstPartyUsage mismatch should update PIP in-place",
+			pipName:             "pip1",
+			enableIPTagMutation: true,
+			existingPIPs: []*armnetwork.PublicIPAddress{{
+				Name: ptr.To("pip1"),
+				Tags: map[string]*string{
+					consts.ServiceTagKey: ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{
+						{IPTagType: ptr.To("FirstPartyUsage"), Tag: ptr.To("/NonProd")},
+					},
+				},
+			}},
+			additionalAnnotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/Unprivileged",
+			},
+			shouldPutPIP:       true,
+			assertPutPIPCalled: true,
+			expectedID:         expectedPIPID,
+		},
+		{
+			desc:                "mutation enabled + non-FirstPartyUsage (RoutingPreference) mismatch should return Azure error after attempted PUT",
+			pipName:             "pip1",
+			enableIPTagMutation: true,
+			existingPIPs: []*armnetwork.PublicIPAddress{{
+				Name: ptr.To("pip1"),
+				Tags: map[string]*string{
+					consts.ServiceTagKey: ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{
+						{IPTagType: ptr.To("RoutingPreference"), Tag: ptr.To("Internet")},
+					},
+				},
+			}},
+			additionalAnnotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "RoutingPreference=Invalid",
+			},
+			shouldPutPIP:       true,
+			assertPutPIPCalled: true,
+			putErr:             errors.New("azure rejected iptags mutation"),
+			expectedError:      true,
+		},
 	}
 
 	for _, test := range testCases {
@@ -5808,18 +6086,21 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			if test.useSLB {
 				az.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			}
+			az.EnableIPTagMutationForExistingPublicIP = test.enableIPTagMutation
 
 			service := getTestService("test1", v1.ProtocolTCP, nil, test.isIPv6, 80)
 			service.ObjectMeta.Annotations = test.additionalAnnotations
 			mockPIPsClient := az.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
+			createOrUpdateCount := 0
 			if test.shouldPutPIP {
 				mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ string, parameters armnetwork.PublicIPAddress) (*armnetwork.PublicIPAddress, error) {
+					createOrUpdateCount++
 					if len(test.existingPIPs) != 0 {
 						test.existingPIPs[0] = &parameters
 					} else {
 						test.existingPIPs = append(test.existingPIPs, &parameters)
 					}
-					return nil, nil
+					return nil, test.putErr
 				}).AnyTimes()
 			}
 			mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", test.pipName, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ string, _ *string) (*armnetwork.PublicIPAddress, error) {
@@ -5854,6 +6135,9 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 
 			pip, err := az.ensurePublicIPExists(context.TODO(), &service, test.pipName, test.inputDNSLabel, "", false, test.foundDNSLabelAnnotation, test.isIPv6)
 			assert.Equal(t, test.expectedError, err != nil, "unexpectedly encountered (or not) error: %v", err)
+			if test.assertPutPIPCalled {
+				assert.Greater(t, createOrUpdateCount, 0)
+			}
 			if test.expectedID != "" {
 				assert.Equal(t, test.expectedID, ptr.Deref(pip.ID, ""))
 			} else {
@@ -6665,6 +6949,196 @@ func TestEnsurePIPTagged(t *testing.T) {
 		assert.True(t, changed)
 		assert.Equal(t, expectedPIP, pip)
 	})
+}
+
+func TestEnsurePIPIPTagged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	newIPTag := func(tagType, tag string) *armnetwork.IPTag {
+		return &armnetwork.IPTag{
+			IPTagType: ptr.To(tagType),
+			Tag:       ptr.To(tag),
+		}
+	}
+
+	tests := []struct {
+		desc            string
+		enableMutation  bool
+		annotations     map[string]string
+		inputPIP        armnetwork.PublicIPAddress
+		expectedChanged bool
+		expectedIPTags  []*armnetwork.IPTag
+	}{
+		{
+			desc:           "mutation disabled should be no-op",
+			enableMutation: false,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/Unprivileged",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+				},
+			},
+			expectedChanged: false,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+		},
+		{
+			desc:            "mutation enabled annotation absent should be no-op",
+			enableMutation:  true,
+			annotations:     map[string]string{},
+			inputPIP:        armnetwork.PublicIPAddress{Properties: &armnetwork.PublicIPAddressPropertiesFormat{}},
+			expectedChanged: false,
+			expectedIPTags:  nil,
+		},
+		{
+			desc:           "mutation enabled FirstPartyUsage tags match should be no-op",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/NonProd",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+				},
+			},
+			expectedChanged: false,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+		},
+		{
+			desc:           "mutation enabled FirstPartyUsage tags mismatch should update",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/Unprivileged",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+				},
+			},
+			expectedChanged: true,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/Unprivileged")},
+		},
+		{
+			desc:           "mutation enabled non-FirstPartyUsage drop should pass through",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/NonProd",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{newIPTag("RoutingPreference", "Internet")},
+				},
+			},
+			expectedChanged: true,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+		},
+		{
+			desc:           "mutation enabled empty annotation clears FirstPartyUsage tags",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+				},
+			},
+			expectedChanged: true,
+			expectedIPTags:  []*armnetwork.IPTag{},
+		},
+		{
+			desc:           "mutation enabled nil Properties should be no-op",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/NonProd",
+			},
+			inputPIP:        armnetwork.PublicIPAddress{},
+			expectedChanged: false,
+			expectedIPTags:  nil,
+		},
+		{
+			desc:           "mutation enabled non-FirstPartyUsage value change should pass through",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "RoutingPreference=Microsoft",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{newIPTag("RoutingPreference", "Internet")},
+				},
+			},
+			expectedChanged: true,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("RoutingPreference", "Microsoft")},
+		},
+		{
+			desc:           "mutation enabled new non-FirstPartyUsage tag should pass through",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "RoutingPreference=Internet",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{},
+				},
+			},
+			expectedChanged: true,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("RoutingPreference", "Internet")},
+		},
+		{
+			desc:           "mutation enabled equivalent non-FirstPartyUsage tags should be no-op",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "RoutingPreference=Internet",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{newIPTag("RoutingPreference", "Internet")},
+				},
+			},
+			expectedChanged: false,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("RoutingPreference", "Internet")},
+		},
+		{
+			desc:           "mutation enabled new FirstPartyUsage tag should update",
+			enableMutation: true,
+			annotations: map[string]string{
+				consts.ServiceAnnotationIPTagsForPublicIP: "FirstPartyUsage=/NonProd",
+			},
+			inputPIP: armnetwork.PublicIPAddress{
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					IPTags: []*armnetwork.IPTag{},
+				},
+			},
+			expectedChanged: true,
+			expectedIPTags:  []*armnetwork.IPTag{newIPTag("FirstPartyUsage", "/NonProd")},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			cloud := GetTestCloud(ctrl)
+			cloud.EnableIPTagMutationForExistingPublicIP = tc.enableMutation
+
+			service := v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+			}
+			pip := tc.inputPIP
+
+			changed, err := cloud.ensurePIPIPTagged(&service, &pip)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedChanged, changed)
+			if pip.Properties == nil {
+				assert.Nil(t, tc.expectedIPTags)
+				return
+			}
+			assert.Equal(t, tc.expectedIPTags, pip.Properties.IPTags)
+		})
+	}
 }
 
 func TestEnsureLoadBalancerTagged(t *testing.T) {

--- a/pkg/provider/azure_publicip_repo.go
+++ b/pkg/provider/azure_publicip_repo.go
@@ -159,7 +159,9 @@ func (az *Cloud) listPIP(ctx context.Context, pipResourceGroup string, crt azcac
 	var ret []*armnetwork.PublicIPAddress
 	pips.Range(func(_, value interface{}) bool {
 		pip := value.(*armnetwork.PublicIPAddress)
-		ret = append(ret, pip)
+		// Deep-copy so callers cannot mutate the cache via the returned slice.
+		// This mirrors getPublicIPAddress and keeps failed PUTs from poisoning the cache.
+		ret = append(ret, deepcopy.Copy(pip).(*armnetwork.PublicIPAddress))
 		return true
 	})
 	return ret, nil

--- a/pkg/provider/azure_publicip_repo_test.go
+++ b/pkg/provider/azure_publicip_repo_test.go
@@ -150,6 +150,50 @@ func TestListPIP(t *testing.T) {
 	}
 }
 
+func TestListPIPReturnsDeepCopy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	az := GetTestCloud(ctrl)
+	original := &armnetwork.PublicIPAddress{
+		Name: ptr.To("pip1"),
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			IPTags: []*armnetwork.IPTag{
+				{
+					IPTagType: ptr.To("FirstPartyUsage"),
+					Tag:       ptr.To("/NonProd"),
+				},
+			},
+		},
+	}
+
+	pipCache := &sync.Map{}
+	pipCache.Store(ptr.Deref(original.Name, ""), original)
+	az.pipCache.Set(az.ResourceGroup, pipCache)
+
+	first, err := az.listPIP(context.TODO(), az.ResourceGroup, azcache.CacheReadTypeDefault)
+	assert.NoError(t, err)
+	if assert.Len(t, first, 1) {
+		first[0].Properties.IPTags = []*armnetwork.IPTag{
+			{
+				IPTagType: ptr.To("FirstPartyUsage"),
+				Tag:       ptr.To("/Unprivileged"),
+			},
+		}
+	}
+
+	second, err := az.listPIP(context.TODO(), az.ResourceGroup, azcache.CacheReadTypeDefault)
+	assert.NoError(t, err)
+	if assert.Len(t, second, 1) && assert.NotNil(t, second[0].Properties) {
+		assert.Equal(t, []*armnetwork.IPTag{
+			{
+				IPTagType: ptr.To("FirstPartyUsage"),
+				Tag:       ptr.To("/NonProd"),
+			},
+		}, second[0].Properties.IPTags)
+	}
+}
+
 func TestGetPublicIPAddress(t *testing.T) {
 
 	tests := []struct {

--- a/pkg/provider/config/azure.go
+++ b/pkg/provider/config/azure.go
@@ -145,6 +145,13 @@ type Config struct {
 	// node IPs, which will introduce service downtime. The downtime increases with the number of nodes in the backend pool.
 	EnableMigrateToIPBasedBackendPoolAPI bool `json:"enableMigrateToIPBasedBackendPoolAPI" yaml:"enableMigrateToIPBasedBackendPoolAPI"`
 
+	// EnableIPTagMutationForExistingPublicIP enables in-place mutation of
+	// FirstPartyUsage IP tags on existing public IPs. When enabled, only
+	// FirstPartyUsage-type IP tags can be updated in-place; attempting to
+	// change other IP tag types (e.g. RoutingPreference) on an existing PIP
+	// produces a reconciliation error.
+	EnableIPTagMutationForExistingPublicIP bool `json:"enableIPTagMutationForExistingPublicIP,omitempty" yaml:"enableIPTagMutationForExistingPublicIP,omitempty"`
+
 	// MultipleStandardLoadBalancerConfigurations stores the properties regarding multiple standard load balancers.
 	// It will be ignored if LoadBalancerBackendPoolConfigurationType is nodeIPConfiguration.
 	// If the length is not 0, it is assumed the multiple standard load balancers mode is on. In this case,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Cherry-picks #10133 onto `release-1.32`.

Source PR: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/10133
Source commit: `92f918810247707d39933b8628259dc061fdcec8`

This adds the config flag `enableIPTagMutationForExistingPublicIP` so `FirstPartyUsage` IP tags can be mutated in-place on existing Public IPs, avoiding unnecessary delete/recreate behavior when `service.beta.kubernetes.io/azure-pip-ip-tags` changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9125

#### Special notes for your reviewer:
Validated with:

`go test -v ./pkg/provider/...`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support config-gated in-place mutation of FirstPartyUsage IP tags on existing public IPs via `enableIPTagMutationForExistingPublicIP` config flag, avoiding unnecessary IP address changes and service disruption when the `service.beta.kubernetes.io/azure-pip-ip-tags` annotation changes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/assign nilo19
