### PR TITLE
fix(multi-slb): serialize backendPoolUpdater with service reconcile loop

### DIFF
--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -160,13 +160,15 @@ func (updater *loadBalancerBackendPoolUpdater) removeOperation(serviceName strin
 	}
 }
 
-// drainOperations drains all pending operations from the queue, groups them
-// by loadBalancerName:backendPoolName, and returns the groups. The queue is
-// cleared before returning.
-//
-// The caller must not hold updater.lock when calling this method.
-func (updater *loadBalancerBackendPoolUpdater) drainOperations() map[string][]batchOperation {
-	logger := log.Background().WithName("loadBalancerBackendPoolUpdater.drainOperations")
+// countOperations returns the number of pending operations in the queue.
+func (updater *loadBalancerBackendPoolUpdater) countOperations() int {
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+	return len(updater.operations)
+}
+
+// drainOperations drains all pending operations from the queue and clears it.
+func (updater *loadBalancerBackendPoolUpdater) drainOperations() []batchOperation {
 	updater.lock.Lock()
 	defer updater.lock.Unlock()
 
@@ -174,9 +176,19 @@ func (updater *loadBalancerBackendPoolUpdater) drainOperations() map[string][]ba
 		return nil
 	}
 
-	// Group operations by loadBalancerName:backendPoolName
+	ops := updater.operations
+	updater.operations = make([]batchOperation, 0)
+	return ops
+}
+
+// groupOperations filters and groups operations by loadBalancerName:backendPoolName.
+// Must be called under serviceReconcileLock so that
+// localServiceNameToServiceInfoMap reads are consistent.
+func (updater *loadBalancerBackendPoolUpdater) groupOperations(ctx context.Context, ops []batchOperation) map[string][]batchOperation {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.groupOperations")
+
 	groups := make(map[string][]batchOperation)
-	for _, op := range updater.operations {
+	for _, op := range ops {
 		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
 		si, found := updater.az.getLocalServiceInfo(strings.ToLower(lbOp.serviceName))
 		if !found {
@@ -195,21 +207,7 @@ func (updater *loadBalancerBackendPoolUpdater) drainOperations() map[string][]ba
 		groups[key] = append(groups[key], op)
 	}
 
-	// Clear all jobs.
-	updater.operations = make([]batchOperation, 0)
-
 	return groups
-}
-
-// requeueOperations puts operations back into the queue so they can be
-// retried on the next tick.
-func (updater *loadBalancerBackendPoolUpdater) requeueOperations(groups map[string][]batchOperation) {
-	updater.lock.Lock()
-	defer updater.lock.Unlock()
-
-	for _, ops := range groups {
-		updater.operations = append(updater.operations, ops...)
-	}
 }
 
 // process processes all operations in the loadBalancerBackendPoolUpdater.
@@ -220,43 +218,28 @@ func (updater *loadBalancerBackendPoolUpdater) requeueOperations(groups map[stri
 func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.process")
 
-	// Drain under updater.lock first, then acquire serviceReconcileLock.
-	// The reverse order would deadlock because the main reconcile path
-	// holds serviceReconcileLock and calls addOperation, which acquires
-	// updater.lock.
-	groups := updater.drainOperations()
-	if len(groups) == 0 {
-		logger.V(4).Info("no operations to process")
-		return
-	}
-
-	// Serialize with the main service reconciliation loop.
+	// Acquire serviceReconcileLock before draining operations so that
+	// removeOperation can cancel queued operations and localServiceNameToServiceInfoMap
+	// reads in groupOperations are consistent. The lock ordering
+	// (serviceReconcileLock, azureResourceLocker, updater.lock) matches
+	// the main reconciliation loop.
 	updater.az.serviceReconcileLock.Lock()
 	defer updater.az.serviceReconcileLock.Unlock()
 
-	// Serialize across multiple CCM replicas in HA deployments.
+	if updater.countOperations() == 0 {
+		return
+	}
+
+	// Serialize with other components that may update Azure load balancer resources.
 	if updater.az.azureResourceLocker != nil {
 		if err := updater.az.azureResourceLocker.Lock(ctx); err != nil {
-			logger.Error(fmt.Errorf(
-				consts.AzureResourceLockFailedToLockErrorTemplate,
-				"loadBalancerBackendPoolUpdater.process",
-				err,
-			), "Re-queuing operations for retry")
-			updater.requeueOperations(groups)
 			return
 		}
-		defer func() {
-			if unlockErr := updater.az.azureResourceLocker.Unlock(ctx); unlockErr != nil {
-				logger.Error(fmt.Errorf(
-					consts.AzureResourceLockFailedToUnlockErrorTemplate,
-					"loadBalancerBackendPoolUpdater.process",
-					consts.AzureResourceLockLeaseNamespace,
-					consts.AzureResourceLockLeaseName,
-					unlockErr,
-				), "Could not release distributed lease lock")
-			}
-		}()
+		defer func() { _ = updater.az.azureResourceLocker.Unlock(ctx) }()
 	}
+
+	ops := updater.drainOperations()
+	groups := updater.groupOperations(ctx, ops)
 
 	for key, ops := range groups {
 		parts := strings.Split(key, ":")
@@ -270,15 +253,12 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 			updater.az.getNetworkResourceSubscriptionID(),
 			"local_service_backend_pool_updater", // source name, use a constant source name for aggregation
 		)
-		isOperationSucceeded := false
-		defer func() {
-			mc.ObserveOperationWithResult(isOperationSucceeded)
-		}()
 
 		bp, err := updater.az.NetworkClientFactory.GetBackendAddressPoolClient().Get(ctx, updater.az.ResourceGroup, lbName, poolName)
 		if err != nil {
+			mc.ObserveOperationWithResult(false)
 			updater.processError(err, operationName, ops...)
-			continue // Metric will be recorded as failure via defer
+			continue
 		}
 
 		var changed bool
@@ -301,11 +281,12 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 			logger.V(2).Info("updating backend pool", "loadBalancer", lbName, "backendPool", poolName)
 			_, err = updater.az.NetworkClientFactory.GetBackendAddressPoolClient().CreateOrUpdate(ctx, updater.az.ResourceGroup, lbName, poolName, *bp)
 			if err != nil {
+				mc.ObserveOperationWithResult(false)
 				updater.processError(err, operationName, ops...)
-				continue // Metric will be recorded as failure via defer
+				continue
 			}
 		}
-		isOperationSucceeded = true // Mark operation as successful before notifying
+		mc.ObserveOperationWithResult(true)
 		updater.notify(newBatchOperationResult(operationName, true, nil), ops...)
 	}
 }

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -160,19 +160,18 @@ func (updater *loadBalancerBackendPoolUpdater) removeOperation(serviceName strin
 	}
 }
 
-// process processes all operations in the loadBalancerBackendPoolUpdater.
-// It merges operations that have the same loadBalancerName and backendPoolName,
-// and then processes them in batches. If an operation fails, it will be retried
-// if it is retriable, otherwise all operations in the batch targeting to
-// this backend pool will fail.
-func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
-	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.process")
+// drainOperations drains all pending operations from the queue, groups them
+// by loadBalancerName:backendPoolName, and returns the groups. The queue is
+// cleared before returning.
+//
+// The caller must not hold updater.lock when calling this method.
+func (updater *loadBalancerBackendPoolUpdater) drainOperations() map[string][]batchOperation {
+	logger := log.Background().WithName("loadBalancerBackendPoolUpdater.drainOperations")
 	updater.lock.Lock()
 	defer updater.lock.Unlock()
 
 	if len(updater.operations) == 0 {
-		logger.V(4).Info("no operations to process")
-		return
+		return nil
 	}
 
 	// Group operations by loadBalancerName:backendPoolName
@@ -198,6 +197,66 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 
 	// Clear all jobs.
 	updater.operations = make([]batchOperation, 0)
+
+	return groups
+}
+
+// requeueOperations puts operations back into the queue so they can be
+// retried on the next tick.
+func (updater *loadBalancerBackendPoolUpdater) requeueOperations(groups map[string][]batchOperation) {
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+
+	for _, ops := range groups {
+		updater.operations = append(updater.operations, ops...)
+	}
+}
+
+// process processes all operations in the loadBalancerBackendPoolUpdater.
+// It merges operations that have the same loadBalancerName and backendPoolName,
+// and then processes them in batches. If an operation fails, it will be retried
+// if it is retriable, otherwise all operations in the batch targeting to
+// this backend pool will fail.
+func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.process")
+
+	// Drain under updater.lock first, then acquire serviceReconcileLock.
+	// The reverse order would deadlock because the main reconcile path
+	// holds serviceReconcileLock and calls addOperation, which acquires
+	// updater.lock.
+	groups := updater.drainOperations()
+	if len(groups) == 0 {
+		logger.V(4).Info("no operations to process")
+		return
+	}
+
+	// Serialize with the main service reconciliation loop.
+	updater.az.serviceReconcileLock.Lock()
+	defer updater.az.serviceReconcileLock.Unlock()
+
+	// Serialize across multiple CCM replicas in HA deployments.
+	if updater.az.azureResourceLocker != nil {
+		if err := updater.az.azureResourceLocker.Lock(ctx); err != nil {
+			logger.Error(fmt.Errorf(
+				consts.AzureResourceLockFailedToLockErrorTemplate,
+				"loadBalancerBackendPoolUpdater.process",
+				err,
+			), "Re-queuing operations for retry")
+			updater.requeueOperations(groups)
+			return
+		}
+		defer func() {
+			if unlockErr := updater.az.azureResourceLocker.Unlock(ctx); unlockErr != nil {
+				logger.Error(fmt.Errorf(
+					consts.AzureResourceLockFailedToUnlockErrorTemplate,
+					"loadBalancerBackendPoolUpdater.process",
+					consts.AzureResourceLockLeaseNamespace,
+					consts.AzureResourceLockLeaseName,
+					unlockErr,
+				), "Could not release distributed lease lock")
+			}
+		}()
+	}
 
 	for key, ops := range groups {
 		parts := strings.Split(key, ":")

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -33,8 +33,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discovery_v1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/backendaddresspoolclient/mock_backendaddresspoolclient"
@@ -661,4 +663,277 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 			wg.Wait()
 		})
 	}
+}
+
+func TestDrainOperations(t *testing.T) {
+	addPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	removePool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	addPool1WithExtra := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
+	addPool2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"})
+
+	testCases := []struct {
+		name           string
+		operations     []batchOperation
+		localServices  map[string]*serviceInfo
+		expectedGroups map[string][]batchOperation
+	}{
+		{
+			name:           "returns nil when queue is empty",
+			operations:     nil,
+			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
+			expectedGroups: nil,
+		},
+		{
+			name:           "groups single operation by pool key",
+			operations:     []batchOperation{addPool1},
+			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
+			expectedGroups: map[string][]batchOperation{"lb1:pool1": {addPool1}},
+		},
+		{
+			name:           "groups operations targeting same pool together",
+			operations:     []batchOperation{removePool1, addPool1WithExtra},
+			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
+			expectedGroups: map[string][]batchOperation{"lb1:pool1": {removePool1, addPool1WithExtra}},
+		},
+		{
+			name:       "groups operations targeting different pools separately",
+			operations: []batchOperation{addPool1, addPool2},
+			localServices: map[string]*serviceInfo{
+				"ns1/svc1": {lbName: "lb1"},
+				"ns1/svc2": {lbName: "lb1"},
+			},
+			expectedGroups: map[string][]batchOperation{"lb1:pool1": {addPool1}, "lb1:pool2": {addPool2}},
+		},
+		{
+			name:           "skips operations for non-local services",
+			operations:     []batchOperation{addPool1},
+			localServices:  map[string]*serviceInfo{},
+			expectedGroups: map[string][]batchOperation{},
+		},
+		{
+			name:           "skips operations targeting stale load balancer",
+			operations:     []batchOperation{addPool1},
+			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb2"}},
+			expectedGroups: map[string][]batchOperation{},
+		},
+		{
+			name:          "keeps valid operation when another is filtered",
+			operations:    []batchOperation{addPool1, addPool2},
+			localServices: map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
+			expectedGroups: map[string][]batchOperation{
+				"lb1:pool1": {addPool1},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := &Cloud{}
+			for k, v := range tc.localServices {
+				cloud.localServiceNameToServiceInfoMap.Store(k, v)
+			}
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			for _, op := range tc.operations {
+				u.addOperation(op)
+			}
+
+			groups := u.drainOperations()
+
+			if tc.expectedGroups == nil {
+				assert.Nil(t, groups)
+			} else {
+				assert.Equal(t, len(tc.expectedGroups), len(groups))
+				for key, expectedOps := range tc.expectedGroups {
+					assert.Equal(t, len(expectedOps), len(groups[key]), "group %s count", key)
+					for i, expectedOp := range expectedOps {
+						assert.Equal(t, expectedOp, groups[key][i], "group %s op %d", key, i)
+					}
+				}
+			}
+
+			u.lock.Lock()
+			assert.Equal(t, 0, len(u.operations), "queue should be cleared after drain")
+			u.lock.Unlock()
+		})
+	}
+}
+
+func TestRequeueOperationsPreservesExistingOperations(t *testing.T) {
+	u := newLoadBalancerBackendPoolUpdater(&Cloud{}, time.Second)
+
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"}))
+
+	groups := map[string][]batchOperation{
+		"lb1:pool1": {getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})},
+	}
+	u.requeueOperations(groups)
+
+	u.lock.Lock()
+	assert.Equal(t, 2, len(u.operations))
+	u.lock.Unlock()
+}
+
+func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	client := fake.NewSimpleClientset(&svc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
+	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+
+	// ARM calls should only happen after the lock is released.
+	armCalled := make(chan struct{})
+	mockBPClient.EXPECT().Get(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+	).DoAndReturn(func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+		close(armCalled)
+		return existingBP, nil
+	})
+	mockBPClient.EXPECT().CreateOrUpdate(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+		*getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1"}),
+	).Return(nil, nil)
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	// Hold serviceReconcileLock to simulate the main reconcile path.
+	cloud.serviceReconcileLock.Lock()
+
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		u.process(context.Background())
+	}()
+
+	// process() should be blocked, ARM call should not have happened yet.
+	select {
+	case <-armCalled:
+		t.Fatal("ARM call happened while serviceReconcileLock was held")
+	case <-time.After(500 * time.Millisecond):
+		// Expected: process() is blocked waiting for the lock.
+	}
+
+	// Release the lock, process() should now complete.
+	cloud.serviceReconcileLock.Unlock()
+
+	select {
+	case <-processDone:
+		// process() completed after lock was released.
+	case <-time.After(5 * time.Second):
+		t.Fatal("process() did not complete after serviceReconcileLock was released")
+	}
+}
+
+func TestLoadBalancerBackendPoolUpdaterAddOperationNotBlockedDuringProcess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	client := fake.NewSimpleClientset(&svc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	// Block the ARM Get call so process() is in the middle of ARM work.
+	armBlocked := make(chan struct{})
+	armUnblock := make(chan struct{})
+	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
+	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+	mockBPClient.EXPECT().Get(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+	).DoAndReturn(func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+		close(armBlocked)
+		<-armUnblock
+		return existingBP, nil
+	})
+	mockBPClient.EXPECT().CreateOrUpdate(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+		*getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1"}),
+	).Return(nil, nil)
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		u.process(context.Background())
+	}()
+
+	// Wait until the ARM call is in flight (updater.lock has been released).
+	select {
+	case <-armBlocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ARM call did not start")
+	}
+
+	// addOperation should not block because updater.lock is released during ARM calls.
+	addDone := make(chan struct{})
+	go func() {
+		defer close(addDone)
+		u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.2"}))
+	}()
+
+	select {
+	case <-addDone:
+		// addOperation returned without blocking.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("addOperation blocked while process() was performing ARM calls")
+	}
+
+	// Unblock the ARM call and wait for process() to finish
+	// so that mock expectations (CreateOrUpdate) are satisfied.
+	close(armUnblock)
+	select {
+	case <-processDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("process() did not complete after unblocking ARM call")
+	}
+}
+
+func TestLoadBalancerBackendPoolUpdaterRequeuesOnLeaseLockFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+	// Set up azureResourceLocker with a KubeClient that fails lease operations.
+	leaseClient := fake.NewSimpleClientset()
+	leaseClient.PrependReactor("get", "leases", func(_ clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated lease API failure")
+	})
+
+	cloud.KubeClient = leaseClient
+	cloud.azureResourceLocker = NewAzureResourceLocker(
+		cloud,
+		"test-holder",
+		"test-lease",
+		"test-namespace",
+		15,
+	)
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	// No ARM mock expectations, ARM call should not happen.
+	u.process(context.Background())
+
+	// Verify operations were re-queued.
+	u.lock.Lock()
+	assert.Equal(t, 1, len(u.operations), "Operations should have been re-queued after lease lock failure")
+	u.lock.Unlock()
 }

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -137,6 +138,30 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			name:       "not on this load balancer",
 			operations: []batchOperation{addOperationPool1},
 			changeLB:   true,
+		},
+		{
+			name:       "empty queue returns without ARM calls",
+			operations: nil,
+		},
+		{
+			name:       "removing non-existent IPs does not trigger CreateOrUpdate",
+			operations: []batchOperation{removeOperationPool1},
+			existingBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
+			},
+			expectedBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
+			},
+		},
+		{
+			name:       "adding already-present IPs does not trigger CreateOrUpdate",
+			operations: []batchOperation{addOperationPool1},
+			existingBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+			expectedBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
 		},
 	}
 
@@ -665,7 +690,132 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 	}
 }
 
+func TestCountOperations(t *testing.T) {
+	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getRemoveIPsFromBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+
+	tests := []struct {
+		name     string
+		ops      []batchOperation
+		expected int
+	}{
+		{name: "empty queue", ops: nil, expected: 0},
+		{name: "one operation", ops: []batchOperation{op1}, expected: 1},
+		{name: "two operations", ops: []batchOperation{op1, op2}, expected: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := &Cloud{}
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			for _, op := range tc.ops {
+				u.addOperation(op)
+			}
+			assert.Equal(t, tc.expected, u.countOperations())
+		})
+	}
+
+	t.Run("acquires updater lock", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(op1)
+
+		u.lock.Lock()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			u.countOperations()
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("countOperations should block while lock is held")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		u.lock.Unlock()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("countOperations did not complete after lock released")
+		}
+	})
+}
+
 func TestDrainOperations(t *testing.T) {
+	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"})
+
+	testCases := []struct {
+		name       string
+		operations []batchOperation
+		expected   []batchOperation
+	}{
+		{
+			name:     "returns nil when queue is empty",
+			expected: nil,
+		},
+		{
+			name:       "returns single operation",
+			operations: []batchOperation{op1},
+			expected:   []batchOperation{op1},
+		},
+		{
+			name:       "returns all operations in order",
+			operations: []batchOperation{op1, op2},
+			expected:   []batchOperation{op1, op2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := &Cloud{}
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			for _, op := range tc.operations {
+				u.addOperation(op)
+			}
+
+			ops := u.drainOperations()
+
+			assert.Equal(t, tc.expected, ops)
+
+			u.lock.Lock()
+			assert.Equal(t, 0, len(u.operations), "queue should be cleared after drain")
+			u.lock.Unlock()
+		})
+	}
+
+	t.Run("acquires updater lock", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(op1)
+
+		u.lock.Lock()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			u.drainOperations()
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("drainOperations returned while lock was held")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		u.lock.Unlock()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("drainOperations did not complete after lock released")
+		}
+	})
+}
+
+func TestGroupOperations(t *testing.T) {
 	addPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 	removePool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 	addPool1WithExtra := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
@@ -678,10 +828,10 @@ func TestDrainOperations(t *testing.T) {
 		expectedGroups map[string][]batchOperation
 	}{
 		{
-			name:           "returns nil when queue is empty",
+			name:           "returns empty map for nil input",
 			operations:     nil,
 			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
-			expectedGroups: nil,
+			expectedGroups: map[string][]batchOperation{},
 		},
 		{
 			name:           "groups single operation by pool key",
@@ -733,44 +883,18 @@ func TestDrainOperations(t *testing.T) {
 				cloud.localServiceNameToServiceInfoMap.Store(k, v)
 			}
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-			for _, op := range tc.operations {
-				u.addOperation(op)
-			}
 
-			groups := u.drainOperations()
+			groups := u.groupOperations(context.Background(), tc.operations)
 
-			if tc.expectedGroups == nil {
-				assert.Nil(t, groups)
-			} else {
-				assert.Equal(t, len(tc.expectedGroups), len(groups))
-				for key, expectedOps := range tc.expectedGroups {
-					assert.Equal(t, len(expectedOps), len(groups[key]), "group %s count", key)
-					for i, expectedOp := range expectedOps {
-						assert.Equal(t, expectedOp, groups[key][i], "group %s op %d", key, i)
-					}
+			assert.Equal(t, len(tc.expectedGroups), len(groups))
+			for key, expectedOps := range tc.expectedGroups {
+				assert.Equal(t, len(expectedOps), len(groups[key]), "group %s count", key)
+				for i, expectedOp := range expectedOps {
+					assert.Equal(t, expectedOp, groups[key][i], "group %s op %d", key, i)
 				}
 			}
-
-			u.lock.Lock()
-			assert.Equal(t, 0, len(u.operations), "queue should be cleared after drain")
-			u.lock.Unlock()
 		})
 	}
-}
-
-func TestRequeueOperationsPreservesExistingOperations(t *testing.T) {
-	u := newLoadBalancerBackendPoolUpdater(&Cloud{}, time.Second)
-
-	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"}))
-
-	groups := map[string][]batchOperation{
-		"lb1:pool1": {getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})},
-	}
-	u.requeueOperations(groups)
-
-	u.lock.Lock()
-	assert.Equal(t, 2, len(u.operations))
-	u.lock.Unlock()
 }
 
 func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *testing.T) {
@@ -903,7 +1027,7 @@ func TestLoadBalancerBackendPoolUpdaterAddOperationNotBlockedDuringProcess(t *te
 	}
 }
 
-func TestLoadBalancerBackendPoolUpdaterRequeuesOnLeaseLockFailure(t *testing.T) {
+func TestLoadBalancerBackendPoolUpdaterPreservesOperationsOnLeaseLockFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -932,8 +1056,163 @@ func TestLoadBalancerBackendPoolUpdaterRequeuesOnLeaseLockFailure(t *testing.T) 
 	// No ARM mock expectations, ARM call should not happen.
 	u.process(context.Background())
 
-	// Verify operations were re-queued.
 	u.lock.Lock()
-	assert.Equal(t, 1, len(u.operations), "Operations should have been re-queued after lease lock failure")
+	assert.Equal(t, 1, len(u.operations), "Operations should be preserved after lease lock failure")
+	u.lock.Unlock()
+}
+
+func TestLoadBalancerBackendPoolUpdaterCompletesOnUnlockFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	client := fake.NewSimpleClientset(&svc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	// Fail the second lease update (releaseLease), let the first (acquireLease) pass.
+	var updateCount int32
+	leaseClient := fake.NewSimpleClientset()
+	leaseClient.PrependReactor("update", "leases", func(_ clientgotesting.Action) (bool, runtime.Object, error) {
+		if atomic.AddInt32(&updateCount, 1) >= 2 {
+			return true, nil, fmt.Errorf("simulated unlock failure")
+		}
+		return false, nil, nil
+	})
+
+	cloud.KubeClient = leaseClient
+	cloud.azureResourceLocker = NewAzureResourceLocker(
+		cloud,
+		"test-holder",
+		"test-lease",
+		"test-namespace",
+		15,
+	)
+
+	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
+	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+	mockBPClient.EXPECT().Get(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+	).Return(existingBP, nil)
+	mockBPClient.EXPECT().CreateOrUpdate(
+		gomock.Any(), gomock.Any(), "lb1", "pool1",
+		*getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1"}),
+	).Return(nil, nil)
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	// ARM calls should complete despite unlock failure.
+	u.process(context.Background())
+
+	u.lock.Lock()
+	assert.Equal(t, 0, len(u.operations), "Operations should have been processed despite unlock failure")
+	u.lock.Unlock()
+}
+
+func TestLoadBalancerBackendPoolUpdaterFiltersOperationsWhenLBChangedDuringProcess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	client := fake.NewSimpleClientset(&svc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	// No ARM mock expectations. The operation targets lb1 but the service moves
+	// to lb2 while process() is blocked on serviceReconcileLock, so groupOperations
+	// filters it.
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	// Hold serviceReconcileLock to simulate the main reconcile loop running.
+	cloud.serviceReconcileLock.Lock()
+
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		u.process(context.Background())
+	}()
+
+	// process() is blocked on serviceReconcileLock. The queue has not been drained yet.
+	time.Sleep(200 * time.Millisecond)
+	u.lock.Lock()
+	assert.Equal(t, 1, len(u.operations), "queue should not be drained while process() is blocked")
+	u.lock.Unlock()
+
+	// Simulate the main reconcile loop moving svc1 from lb1 to lb2.
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb2"})
+
+	// Release the lock. process() will drain and filter the operation via groupOperations.
+	cloud.serviceReconcileLock.Unlock()
+
+	select {
+	case <-processDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("process() did not complete")
+	}
+
+	u.lock.Lock()
+	assert.Equal(t, 0, len(u.operations))
+	u.lock.Unlock()
+}
+
+func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDrain(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	client := fake.NewSimpleClientset(&svc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	// No ARM mock expectations. removeOperation cancels the operation
+	// before process() drains the queue.
+
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+	// Hold serviceReconcileLock to simulate the main reconcile loop running.
+	cloud.serviceReconcileLock.Lock()
+
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		u.process(context.Background())
+	}()
+
+	// process() is blocked on serviceReconcileLock. The queue has not been drained yet.
+	time.Sleep(200 * time.Millisecond)
+	u.lock.Lock()
+	assert.Equal(t, 1, len(u.operations), "queue should not be drained while process() is blocked")
+	u.lock.Unlock()
+
+	// Simulate the main reconcile loop calling removeOperation to cancel pending operations.
+	u.removeOperation("ns1/svc1")
+
+	// Release the lock. process() should not make ARM calls for the cancelled service.
+	cloud.serviceReconcileLock.Unlock()
+
+	select {
+	case <-processDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("process() did not complete")
+	}
+
+	u.lock.Lock()
+	assert.Equal(t, 0, len(u.operations))
 	u.lock.Unlock()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The `backendPoolUpdater.process()` performs backend pool updates without holding `serviceReconcileLock` or `azureResourceLocker`, allowing concurrent writes to the same backend pool from the updater and the main service reconciliation path.

This PR serializes the updater with the main reconciliation loop by acquiring `serviceReconcileLock` and `azureResourceLocker` in `process()` before ARM calls. The `updater.lock` is released before acquiring `serviceReconcileLock` and `azureResourceLocker` to avoid deadlock with the main path, which holds `serviceReconcileLock` and calls `addOperation()` (which acquires the `updater.lock`).

If the distributed lease lock cannot be acquired, operations are re-queued for retry on the next tick.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #9839

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: serialize backendPoolUpdater with service reconciliation to prevent concurrent backend pool writes in multi-standard-load-balancer configurations with externalTrafficPolicy: Local
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
