### PR TITLE
[release-1.35] fix(multi-slb): support switching internal/external when IP sharing across multiple services

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -819,6 +819,8 @@ func (az *Cloud) getServiceLoadBalancer(
 
 	// check if the service already has a load balancer
 	var shouldChangeLB bool
+	// This loop iterates backward so that removing existingLBs[i] inside
+	// removeServiceFromLB does not cause the loop to skip items.
 	for i := len(existingLBs) - 1; i >= 0; i-- {
 		existingLB := existingLBs[i]
 
@@ -826,6 +828,28 @@ func (az *Cloud) getServiceLoadBalancer(
 			defaultLB = existingLB
 		}
 		if isInternalLoadBalancer(existingLB) != isInternal {
+			// External<->internal LB cleanup (multi-SLB only): after switching a service
+			// between external and internal, the opposite LB may still have stale
+			// rules/probes from this service. Clean them up here during the wantLb=true
+			// reconcile so that the subsequent wantLb=false reconcile finds nothing to
+			// remove and won't incorrectly evict the service from ActiveServices.
+			if wantLb && az.UseMultipleStandardLoadBalancers() &&
+				az.lbHasServiceOwnedResources(existingLB, service) {
+
+				existingLBs, deletedPLS, err = az.removeServiceFromLB(ctx, existingLB, existingLBs, clusterName, service, nodes, nil)
+				if err != nil {
+					return nil, nil, nil, nil, false, false, fmt.Errorf("remove stale service resources from opposite-type load balancer %q for service %q: %w",
+						ptr.Deref(existingLB.Name, ""), getServiceName(service), err)
+				}
+				if deletedPLS {
+					return nil, nil, nil, nil, false, true, nil
+				}
+				logger.V(2).Info("Removed stale service resources from opposite-type load balancer",
+					"service", service.Name,
+					"oldLB", ptr.Deref(existingLB.Name, ""),
+					"targetLB", defaultLBName,
+				)
+			}
 			continue
 		}
 
@@ -844,7 +868,7 @@ func (az *Cloud) getServiceLoadBalancer(
 				az.shouldChangeLoadBalancer(service, ptr.Deref(existingLB.Name, ""), clusterName, defaultLBName) &&
 				az.lbHasServiceOwnedResources(existingLB, service) {
 
-				deletedLBName, deletedPLS, err := az.removeStaleServiceLBResources(ctx, existingLB, existingLBs, clusterName, service)
+				existingLBs, deletedPLS, err = az.removeServiceFromLB(ctx, existingLB, existingLBs, clusterName, service, nodes, nil)
 				if err != nil {
 					return nil, nil, nil, nil, false, false, fmt.Errorf("remove stale service resources from load balancer %q for service %q: %w",
 						ptr.Deref(existingLB.Name, ""), getServiceName(service), err)
@@ -857,32 +881,6 @@ func (az *Cloud) getServiceLoadBalancer(
 					"oldLB", ptr.Deref(existingLB.Name, ""),
 					"targetLB", defaultLBName,
 				)
-
-				if deletedLBName != "" {
-					removeLBFromList(&existingLBs, deletedLBName)
-				}
-
-				az.reconcileMultipleStandardLoadBalancerConfigurationStatus(
-					false,
-					getServiceName(service),
-					ptr.Deref(existingLB.Name, ""),
-				)
-
-				// Same backend pool cleanup as the normal LB migration path below.
-				if isLocalService(service) {
-					svcName := getServiceName(service)
-					if az.backendPoolUpdater != nil {
-						az.backendPoolUpdater.removeOperation(svcName)
-					}
-					if deletedLBName == "" {
-						newLBs, err := az.cleanupLocalServiceBackendPool(ctx, service, nodes, existingLBs, clusterName)
-						if err != nil {
-							return nil, nil, nil, nil, false, false, fmt.Errorf("clean up backend pool for local service %q on load balancer %q: %w",
-								getServiceName(service), ptr.Deref(existingLB.Name, ""), err)
-						}
-						existingLBs = newLBs
-					}
-				}
 			}
 			continue
 		}
@@ -896,10 +894,6 @@ func (az *Cloud) getServiceLoadBalancer(
 
 		// select another load balancer instead of returning
 		// the current one if the change is needed
-		var (
-			deletedLBName string
-			err           error
-		)
 		if wantLb && az.shouldChangeLoadBalancer(service, ptr.Deref(existingLB.Name, ""), clusterName, defaultLBName) {
 			// Block migration if the frontend IP is unsafe to delete
 			// (shared with other services, or referenced by outbound/NAT rules).
@@ -924,42 +918,19 @@ func (az *Cloud) getServiceLoadBalancer(
 			for _, fipConfig := range fipConfigs {
 				fipConfigNames = append(fipConfigNames, ptr.Deref(fipConfig.Name, ""))
 			}
-			deletedLBName, deletedPLS, err = az.removeFrontendIPConfigurationFromLoadBalancer(ctx, existingLB, existingLBs, fipConfigs, clusterName, service)
+			existingLBs, deletedPLS, err = az.removeServiceFromLB(ctx, existingLB, existingLBs, clusterName, service, nodes, fipConfigs)
 			if err != nil {
-				logger.Error(err, "failed to remove frontend IP configurations from load balancer", "service", service.Name, "clusterName", clusterName, "wantLb", wantLb, "fipConfigNames", fipConfigNames)
-				return nil, nil, nil, nil, false, false, err
+				return nil, nil, nil, nil, false, false, fmt.Errorf("remove service %q from load balancer %q (frontend IPs %v): %w",
+					getServiceName(service), ptr.Deref(existingLB.Name, ""), fipConfigNames, err)
 			}
 			if deletedPLS {
 				return nil, nil, nil, nil, false, true, nil
 			}
-			if deletedLBName != "" {
-				removeLBFromList(&existingLBs, deletedLBName)
-			}
-			az.reconcileMultipleStandardLoadBalancerConfigurationStatus(
-				false,
-				getServiceName(service),
-				ptr.Deref(existingLB.Name, ""),
+			logger.V(2).Info("Removed service from load balancer",
+				"service", service.Name,
+				"oldLB", ptr.Deref(existingLB.Name, ""),
+				"targetLB", defaultLBName,
 			)
-
-			if isLocalService(service) && az.UseMultipleStandardLoadBalancers() {
-				// No need for the endpoint slice informer to update the backend pool
-				// for the service because the main loop will delete the old backend pool
-				// and create a new one in the new load balancer.
-				svcName := getServiceName(service)
-				if az.backendPoolUpdater != nil {
-					az.backendPoolUpdater.removeOperation(svcName)
-				}
-
-				// Remove backend pools on the previous load balancer for the local service
-				if deletedLBName == "" {
-					newLBs, err := az.cleanupLocalServiceBackendPool(ctx, service, nodes, existingLBs, clusterName)
-					if err != nil {
-						logger.Error(err, "failed to cleanup backend pool for local service", "service", service.Name, "clusterName", clusterName, "wantLb", wantLb)
-						return nil, nil, nil, nil, false, false, err
-					}
-					existingLBs = newLBs
-				}
-			}
 
 			if isPinnedIPMultiSLB {
 				continue
@@ -2663,6 +2634,69 @@ func (az *Cloud) removeStaleServiceLBResources(
 		)
 	}
 	return "", false, nil
+}
+
+// removeServiceFromLB removes the service resources from the given LB. If
+// fipConfigs is provided, it removes the specified frontend IP configurations;
+// otherwise it removes the service's stale rules, probes, and orphaned frontend
+// IPs. It then updates the multi-SLB ActiveServices tracking, LB list, and
+// local-service backend pools.
+// Only existingLB may be removed from existingLBs. All other entries must be preserved.
+func (az *Cloud) removeServiceFromLB(
+	ctx context.Context,
+	existingLB *armnetwork.LoadBalancer,
+	existingLBs []*armnetwork.LoadBalancer,
+	clusterName string,
+	service *v1.Service,
+	nodes []*v1.Node,
+	fipConfigs []*armnetwork.FrontendIPConfiguration,
+) ([]*armnetwork.LoadBalancer, bool /* deletedPLS */, error) {
+	var deletedLBName string
+	var deletedPLS bool
+	var err error
+
+	if len(fipConfigs) > 0 {
+		deletedLBName, deletedPLS, err = az.removeFrontendIPConfigurationFromLoadBalancer(ctx, existingLB, existingLBs, fipConfigs, clusterName, service)
+	} else {
+		deletedLBName, deletedPLS, err = az.removeStaleServiceLBResources(ctx, existingLB, existingLBs, clusterName, service)
+	}
+	if err != nil {
+		return existingLBs, false, err
+	}
+	if deletedPLS {
+		return existingLBs, true, nil
+	}
+
+	if deletedLBName != "" {
+		removeLBFromList(&existingLBs, deletedLBName)
+	}
+
+	az.reconcileMultipleStandardLoadBalancerConfigurationStatus(
+		false,
+		getServiceName(service),
+		ptr.Deref(existingLB.Name, ""),
+	)
+
+	if isLocalService(service) && az.UseMultipleStandardLoadBalancers() {
+		// No need for the endpoint slice informer to update the backend pool
+		// for the service because the main loop will delete the old backend pool
+		// and create a new one in the new load balancer.
+		svcName := getServiceName(service)
+		if az.backendPoolUpdater != nil {
+			az.backendPoolUpdater.removeOperation(svcName)
+		}
+		// Remove backend pools on the previous load balancer for the local service
+		if deletedLBName == "" {
+			newLBs, err := az.cleanupLocalServiceBackendPool(ctx, service, nodes, existingLBs, clusterName)
+			if err != nil {
+				return existingLBs, false, fmt.Errorf("clean up backend pool for local service %q on load balancer %q: %w",
+					getServiceName(service), ptr.Deref(existingLB.Name, ""), err)
+			}
+			existingLBs = newLBs
+		}
+	}
+
+	return existingLBs, false, nil
 }
 
 func (az *Cloud) reconcileMultipleStandardLoadBalancerConfigurationStatus(wantLb bool, svcName, lbName string) {
@@ -4372,6 +4406,7 @@ func (az *Cloud) getAzureLoadBalancerName(
 		lbIPs := getServiceLoadBalancerIPs(service)
 		pipNames := getServicePIPNames(service)
 		pinsIP := len(lbIPs) > 0 || len(pipNames) > 0
+		annotatedLBs := consts.GetLoadBalancerConfigurationsNames(service)
 
 		// Only block when creating resources (wantLb=true).
 		// Cleanup operations (wantLb=false) don't need this constraint.
@@ -4380,7 +4415,6 @@ func (az *Cloud) getAzureLoadBalancerName(
 			// When specifying an IP, the LB is determined by where the IP resides.
 			// Specifying a different LB is contradictory. This early check also
 			// avoids unnecessary PIP lookups on every reconcile.
-			annotatedLBs := consts.GetLoadBalancerConfigurationsNames(service)
 			logger.V(5).Info("checking LB and IP config", "service", service.Name, "annotatedLBs", annotatedLBs, "lbIPs", lbIPs, "pipNames", pipNames, "pinsIP", pinsIP)
 			if len(annotatedLBs) > 0 && pinsIP {
 				return "", fmt.Errorf(
@@ -4401,6 +4435,14 @@ func (az *Cloud) getAzureLoadBalancerName(
 		}
 
 		currentLBName := az.getServiceCurrentLoadBalancerName(service)
+
+		// If a service does not pin a specific IP, has no LB annotation, and its primary frontend IP already exists
+		// on a same-kind (internal/external) LB, use that LB.
+		if wantLb && !pinsIP && len(annotatedLBs) == 0 {
+			if fipLBName := az.getLoadBalancerNameByFrontendIPName(ctx, service, existingLBs, isInternal); fipLBName != "" {
+				currentLBName = fipLBName
+			}
+		}
 
 		// If service specifies an IP, find which LB has that IP. The service should use the LB where the IP resides.
 		// This also detects secondary services sharing an IP with a primary service already on an LB.
@@ -4434,6 +4476,36 @@ func (az *Cloud) getAzureLoadBalancerName(
 	return lbNamePrefix, nil
 }
 
+// getLoadBalancerNameByFrontendIPName finds which LB config owns the primary
+// frontend IP for a service, using the same name-prefix check as
+// serviceOwnsFrontendIP. Only LBs matching isInternal are checked.
+// Returns the base config name (without "-internal" suffix) or "" if not found.
+func (az *Cloud) getLoadBalancerNameByFrontendIPName(
+	ctx context.Context,
+	service *v1.Service,
+	existingLBs []*armnetwork.LoadBalancer,
+	isInternal bool,
+) string {
+	logger := log.FromContextOrBackground(ctx).WithName("getLoadBalancerNameByFrontendIPName")
+	baseName := az.GetLoadBalancerName(ctx, "", service)
+	for _, lb := range existingLBs {
+		if isInternalLoadBalancer(lb) != isInternal {
+			continue
+		}
+		if lb.Properties == nil || lb.Properties.FrontendIPConfigurations == nil {
+			continue
+		}
+		for _, fip := range lb.Properties.FrontendIPConfigurations {
+			if strings.HasPrefix(ptr.Deref(fip.Name, ""), baseName) {
+				lbName := trimSuffixIgnoreCase(ptr.Deref(lb.Name, ""), consts.InternalLoadBalancerNameSuffix)
+				logger.V(4).Info("Found LB by frontend IP name prefix", "service", service.Name, "fipNamePrefix", baseName, "lbName", lbName)
+				return lbName
+			}
+		}
+	}
+	return ""
+}
+
 // getLoadBalancerNameByPrivateIP finds the LB by scanning frontend IPs for a matching private address.
 func (az *Cloud) getLoadBalancerNameByPrivateIP(
 	ctx context.Context,
@@ -4459,7 +4531,7 @@ func (az *Cloud) getLoadBalancerNameByPrivateIP(
 			}
 			for _, ip := range loadBalancerIPs {
 				if ip != "" && strings.EqualFold(*fip.Properties.PrivateIPAddress, ip) {
-					logger.V(2).Info("Found LB from frontend IP by private IP", "service", service.Name, "privateIP", ip, "lbName", ptr.Deref(lb.Name, ""))
+					logger.V(4).Info("Found LB from frontend IP by private IP", "service", service.Name, "privateIP", ip, "lbName", ptr.Deref(lb.Name, ""))
 					return trimSuffixIgnoreCase(ptr.Deref(lb.Name, ""), consts.InternalLoadBalancerNameSuffix)
 				}
 			}
@@ -4488,7 +4560,7 @@ func (az *Cloud) getLoadBalancerNameByPublicIP(
 			return "", fmt.Errorf("find public IP by address %q: %w", ip, err)
 		}
 		if lbName := az.getLoadBalancerNameFromPIP(pip, clusterName); lbName != "" {
-			logger.V(2).Info("Found LB from PIP by IP", "service", service.Name, "pip", ptr.Deref(pip.Name, ""), "lbName", lbName)
+			logger.V(4).Info("Found LB from PIP by IP", "service", service.Name, "pip", ptr.Deref(pip.Name, ""), "lbName", lbName)
 			return lbName, nil
 		}
 	}
@@ -4503,7 +4575,7 @@ func (az *Cloud) getLoadBalancerNameByPublicIP(
 			return "", fmt.Errorf("find public IP by name %q: %w", pipName, err)
 		}
 		if lbName := az.getLoadBalancerNameFromPIP(pip, clusterName); lbName != "" {
-			logger.V(2).Info("Found LB from PIP by name", "service", service.Name, "pip", pipName, "lbName", lbName)
+			logger.V(4).Info("Found LB from PIP by name", "service", service.Name, "pip", pipName, "lbName", lbName)
 			return lbName, nil
 		}
 	}

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -1791,19 +1791,22 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 	defer ctrl.Finish()
 
 	for _, tc := range []struct {
-		description     string
-		existingLBs     []*armnetwork.LoadBalancer
-		refreshedLBs    []*armnetwork.LoadBalancer
-		existingPIPs    []*armnetwork.PublicIPAddress
-		service         v1.Service
-		local           bool
-		multiSLBConfigs []config.MultipleStandardLoadBalancerConfiguration
-		expectedLB      *armnetwork.LoadBalancer
-		expectedLBs     []*armnetwork.LoadBalancer
-		expectedError   error
+		description      string
+		existingLBs      []*armnetwork.LoadBalancer
+		refreshedLBs     []*armnetwork.LoadBalancer
+		existingPIPs     []*armnetwork.PublicIPAddress
+		service          v1.Service
+		local            bool
+		multiSLBConfigs  []config.MultipleStandardLoadBalancerConfiguration
+		expectedLB       *armnetwork.LoadBalancer
+		expectedLBs      []*armnetwork.LoadBalancer
+		expectedError    error
+		expectedDeleteLB string
+		expectedDeleteBP struct{ LBName, PoolName string }
 	}{
 		{
-			description: "should return the existing lb if the service is moved to the lb",
+			description:      "should return the existing lb if the service is moved to the lb",
+			expectedDeleteLB: "lb1-internal",
 			existingLBs: []*armnetwork.LoadBalancer{
 				{
 					Name: ptr.To("lb1-internal"),
@@ -1821,29 +1824,44 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 				},
 				{
 					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
 				},
 			},
-			service: getInternalTestService("test1"),
+			service: getTestServiceWithAnnotation("test1", map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:       consts.TrueAnnotationValue,
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			}, false),
 			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
 				{
 					Name: "lb1",
-				},
-				{
-					Name: "lb2",
 					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
 						ActiveServices: utilsets.NewString("default/test1"),
 					},
 				},
+				{
+					Name: "lb2",
+				},
 			},
 			expectedLB: &armnetwork.LoadBalancer{
 				Name: ptr.To("lb2-internal"),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+				},
 			},
 			expectedLBs: []*armnetwork.LoadBalancer{
-				{Name: ptr.To("lb2-internal")},
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
+				},
 			},
 		},
 		{
-			description: "remove backend pool when a local service changes its load balancer",
+			description:      "remove backend pool when a local service changes its load balancer",
+			expectedDeleteBP: struct{ LBName, PoolName string }{"lb1", "default-test1"},
 			existingLBs: []*armnetwork.LoadBalancer{
 				{
 					Name: ptr.To("lb1"),
@@ -1903,17 +1921,19 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 					},
 				},
 			},
-			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
-			local:   true,
+			service: getTestServiceWithAnnotation("test1", map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			}, false, 80),
+			local: true,
 			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
 				{
 					Name: "lb1",
-				},
-				{
-					Name: "lb2",
 					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
 						ActiveServices: utilsets.NewString("default/test1"),
 					},
+				},
+				{
+					Name: "lb2",
 				},
 			},
 			expectedLB: &armnetwork.LoadBalancer{
@@ -1950,7 +1970,8 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 			},
 		},
 		{
-			description: "remove backend pool when a local secondary service changes its load balancer",
+			description:      "remove backend pool when a local secondary service changes its load balancer",
+			expectedDeleteBP: struct{ LBName, PoolName string }{"lb1", "default-test1"},
 			existingLBs: []*armnetwork.LoadBalancer{
 				{
 					Name: ptr.To("lb1"),
@@ -2118,6 +2139,134 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-other")},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "remove backend pool when a local service switches to opposite-type load balancer",
+			expectedDeleteBP: struct{ LBName, PoolName string }{"lb1", "default-test1"},
+			local:            true,
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("atest1-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+							{Name: ptr.To("atest1-TCP-81")},
+						},
+						BackendAddressPools: []*armnetwork.BackendAddressPool{
+							{Name: ptr.To("kubernetes")},
+							{Name: ptr.To("default-test1")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+						BackendAddressPools: []*armnetwork.BackendAddressPool{
+							{Name: ptr.To("kubernetes")},
+						},
+					},
+				},
+			},
+			service: getInternalTestService("test1", 81),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb1-internal"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+						BackendAddressPools: []*armnetwork.BackendAddressPool{
+							{Name: ptr.To("kubernetes")},
 						},
 					},
 				},
@@ -2873,7 +3022,8 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 			// When isPinnedIPMultiSLB is true and the source LB is deleted
 			// during migration (its only FIP removed), removeLBFromList shrinks existingLBs
 			// while the for-range loop still iterates with the original length leads to index panic.
-			description: "internal: pinned IP migration deletes source LB without panic",
+			description:      "internal: pinned IP migration deletes source LB without panic",
+			expectedDeleteLB: "lb1-internal",
 			existingLBs: []*armnetwork.LoadBalancer{
 				{
 					Name: ptr.To("lb1-internal"),
@@ -2959,6 +3109,1170 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:      "external: migration deletes source LB when only secondary service remains on it",
+			expectedDeleteLB: "lb1",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("atest1-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("atest1-TCP-81")},
+						},
+					},
+				},
+			},
+			service: getTestServiceWithAnnotation("test1", map[string]string{
+				consts.ServiceAnnotationLoadBalancerConfigurations: "lb2",
+			}, false, 81),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb2"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{},
+		},
+		{
+			description: "switch external to internal: clean stale rules from old LB when secondary service stays on same LB config",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("atest1-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+							{Name: ptr.To("atest1-TCP-81")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+			service: getInternalTestService("test1", 81),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb1-internal"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "switch internal to external: clean stale rules from old LB when secondary service stays on same LB config",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("atest1-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+							{Name: ptr.To("atest1-TCP-81")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+			service: getTestService("test1", v1.ProtocolTCP, nil, false, 81),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb1"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "switch external to internal: clean stale rules from old LB when secondary service moves to different LB config",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("atest1-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+							{Name: ptr.To("atest1-TCP-81")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+			service: func() v1.Service {
+				svc := getInternalTestService("test1", 81)
+				svc.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb2"
+				return svc
+			}(),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb2-internal"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip-primary")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "switch internal to external: clean stale rules from old LB when secondary service moves to different LB config",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+							{
+								Name: ptr.To("atest1-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+							{Name: ptr.To("atest1-TCP-81")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+			service: func() v1.Service {
+				svc := getTestService("test1", v1.ProtocolTCP, nil, false, 81)
+				svc.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb2"
+				return svc
+			}(),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name:     ptr.To("lb2"),
+				Location: ptr.To("westus"),
+				SKU: &armnetwork.LoadBalancerSKU{
+					Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard),
+				},
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("aprimary"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("aprimary-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/aprimary"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("aprimary-TCP-80")},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "switch back to external: primary service finds original shared FIP on same LB",
+			expectedDeleteLB: "lb1-internal",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("atest1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("atest1-TCP-80")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip-test1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+					},
+				},
+			},
+			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name: ptr.To("lb1"),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name: ptr.To("atest1"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+							},
+						},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To("asecondary-TCP-81"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{
+									ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To("asecondary-TCP-81")},
+					},
+				},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "switch back to internal: primary service finds original shared FIP on same LB",
+			expectedDeleteLB: "lb1",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("atest1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("atest1-TCP-80")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+			service: getInternalTestService("test1", 80),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name: ptr.To("lb1-internal"),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name: ptr.To("atest1"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								PrivateIPAddress: ptr.To("10.0.0.1"),
+							},
+						},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To("asecondary-TCP-81"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{
+									ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To("asecondary-TCP-81")},
+					},
+				},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "switch back to external: primary service finds original shared FIP on different LB",
+			expectedDeleteLB: "lb2-internal",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("atest1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("atest1-TCP-80")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip-test1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+					},
+				},
+			},
+			service: getTestService("test1", v1.ProtocolTCP, nil, false, 80),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name: ptr.To("lb1"),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name: ptr.To("atest1"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+							},
+						},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To("asecondary-TCP-81"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{
+									ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To("asecondary-TCP-81")},
+					},
+				},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:      "switch back to internal: primary service finds original shared FIP on different LB",
+			expectedDeleteLB: "lb2",
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb2"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip-test1")},
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("atest1-TCP-80"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("atest1-TCP-80")},
+						},
+					},
+				},
+			},
+			refreshedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+			service: getInternalTestService("test1", 80),
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test1"),
+					},
+				},
+			},
+			expectedLB: &armnetwork.LoadBalancer{
+				Name: ptr.To("lb1-internal"),
+				Properties: &armnetwork.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+						{
+							Name: ptr.To("atest1"),
+							ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+							Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+								PrivateIPAddress: ptr.To("10.0.0.1"),
+							},
+						},
+					},
+					LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+						{
+							Name: ptr.To("asecondary-TCP-81"),
+							Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+								FrontendIPConfiguration: &armnetwork.SubResource{
+									ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								},
+							},
+						},
+					},
+					Probes: []*armnetwork.Probe{
+						{Name: ptr.To("asecondary-TCP-81")},
+					},
+				},
+			},
+			expectedLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("atest1"),
+								ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.1"),
+								},
+							},
+						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{
+								Name: ptr.To("asecondary-TCP-81"),
+								Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+									FrontendIPConfiguration: &armnetwork.SubResource{
+										ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1-internal/frontendIPConfigurations/atest1"),
+									},
+								},
+							},
+						},
+						Probes: []*armnetwork.Probe{
+							{Name: ptr.To("asecondary-TCP-81")},
+						},
+					},
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
@@ -2966,15 +4280,19 @@ func TestGetServiceLoadBalancerMultiSLB(t *testing.T) {
 			cloud.LoadBalancerSKU = "Standard"
 			cloud.MultipleStandardLoadBalancerConfigurations = tc.multiSLBConfigs
 			lbClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
-			lbClient.EXPECT().Delete(gomock.Any(), gomock.Any(), "lb1-internal").MaxTimes(1)
+			if tc.expectedDeleteLB != "" {
+				lbClient.EXPECT().Delete(gomock.Any(), gomock.Any(), tc.expectedDeleteLB).Times(1)
+			}
 			bpClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
-			bpClient.EXPECT().Delete(gomock.Any(), gomock.Any(), "lb1", "default-test1").Return(nil).MaxTimes(1)
+			if tc.expectedDeleteBP.LBName != "" {
+				bpClient.EXPECT().Delete(gomock.Any(), gomock.Any(), tc.expectedDeleteBP.LBName, tc.expectedDeleteBP.PoolName).Return(nil).Times(1)
+			}
 			lbClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.refreshedLBs, nil).MaxTimes(1)
 			lbClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).MaxTimes(1)
 
 			if tc.expectedError == nil {
 				mockPLSRepo := cloud.plsRepo.(*privatelinkservice.MockRepository)
-				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil)
+				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&armnetwork.PrivateLinkService{ID: to.Ptr(consts.PrivateLinkServiceNotExistID)}, nil).MaxTimes(1)
 			}
 
 			mockPIPClient := cloud.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
@@ -9834,6 +11152,144 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 			),
 		},
 		{
+			description:   "multi-slb external: existing service on lb1 shares IP with service on lb2",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "1.2.3.4",
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{
+				{
+					Name: ptr.To("pip1"),
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pip1"),
+					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+						IPAddress: ptr.To("1.2.3.4"),
+						IPConfiguration: &armnetwork.IPConfiguration{
+							ID: ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb2/frontendIPConfigurations/fip1"),
+						},
+					},
+				},
+			},
+			expected: "lb2",
+		},
+		{
+			description:   "multi-slb external: primary FIP on external LB determines placement when service does not specify IP",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{Name: ptr.To("lb1")},
+				{
+					Name: ptr.To("lb2"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+			},
+			expected: "lb2",
+		},
+		{
+			description:   "multi-slb external: primary FIP on internal LB is ignored when service does not specify IP",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+			},
+			expected: "lb1",
+		},
+		{
+			description:   "multi-slb external: prefer lb1 with existing primary FIP over ActiveServices on lb2 when both eligible",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+				{Name: ptr.To("lb2")},
+			},
+			expected: "lb1",
+		},
+		{
+			description:   "multi-slb external: primary FIP on ineligible LB is ignored",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationSpec: config.MultipleStandardLoadBalancerConfigurationSpec{
+						AllowServicePlacement: ptr.To(false),
+					},
+				},
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
+				},
+				{
+					Name: ptr.To("lb2"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+			},
+			expected: "lb1",
+		},
+		{
 			description:   "multi-slb internal: IP annotation returns lb2-internal where IP resides",
 			vmSet:         primary,
 			useStandardLB: true,
@@ -10033,6 +11489,165 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 					`check or adjust the load balancer eligibility configuration ` +
 					`(ServiceLabelSelector, ServiceNamespaceSelector, or AllowServicePlacement)`,
 			),
+		},
+		{
+			description:   "multi-slb internal: existing service on lb1-internal shares IP with service on lb2-internal",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal:           "true",
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{
+								Name: ptr.To("fip1"),
+								Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+									PrivateIPAddress: ptr.To("10.0.0.5"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "lb2-internal",
+		},
+		{
+			description:   "multi-slb internal: primary FIP on internal LB determines placement when service does not specify IP",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{Name: ptr.To("lb1-internal")},
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+			},
+			expected: "lb2-internal",
+		},
+		{
+			description:   "multi-slb internal: primary FIP on external LB is ignored when service does not specify IP",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "lb1",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+			},
+			expected: "lb1-internal",
+		},
+		{
+			description:   "multi-slb internal: prefer lb1-internal with existing primary FIP over ActiveServices on lb2 when both eligible",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+						ActiveServices: utilsets.NewString("default/test"),
+					},
+				},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+				{Name: ptr.To("lb2-internal")},
+			},
+			expected: "lb1-internal",
+		},
+		{
+			description:   "multi-slb internal: primary FIP on ineligible LB is ignored",
+			vmSet:         primary,
+			useStandardLB: true,
+			isInternal:    true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{
+					Name: "lb2",
+					MultipleStandardLoadBalancerConfigurationSpec: config.MultipleStandardLoadBalancerConfigurationSpec{
+						AllowServicePlacement: ptr.To(false),
+					},
+				},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+			},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
+				},
+				{
+					Name: ptr.To("lb2-internal"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{Name: ptr.To("atest")},
+						},
+					},
+				},
+			},
+			expected: "lb1-internal",
 		},
 		{
 			// Service is originally internal on lb2.
@@ -12211,6 +13826,329 @@ func TestRemoveStaleServiceLBResources(t *testing.T) {
 					probeNames = append(probeNames, *probe.Name)
 				}
 				assert.Equal(t, tc.expectedProbeNames, probeNames)
+			}
+		})
+	}
+}
+
+func TestRemoveServiceFromLB(t *testing.T) {
+	const (
+		fipName = "atest1"
+		fipID   = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb1/frontendIPConfigurations/atest1"
+	)
+
+	// sharedLB: FIP kept alive by another service's rule. After removing test1's
+	// rule, the FIP still has aprimary's rule so the LB is updated, not deleted.
+	sharedLB := func() *armnetwork.LoadBalancer {
+		return &armnetwork.LoadBalancer{
+			Name: ptr.To("lb1"),
+			Properties: &armnetwork.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+					{
+						Name: ptr.To(fipName),
+						ID:   ptr.To(fipID),
+						Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip1")},
+						},
+					},
+				},
+				LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+					{
+						Name: ptr.To("aprimary-TCP-80"),
+						Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+						},
+					},
+					{
+						Name: ptr.To("atest1-TCP-81"),
+						Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+						},
+					},
+				},
+				Probes: []*armnetwork.Probe{
+					{Name: ptr.To("aprimary-TCP-80")},
+					{Name: ptr.To("atest1-TCP-81")},
+				},
+			},
+		}
+	}
+
+	// soloLB: only test1's FIP/rule. After removal, the FIP is orphaned
+	// and the LB is deleted entirely.
+	soloLB := func() *armnetwork.LoadBalancer {
+		return &armnetwork.LoadBalancer{
+			Name: ptr.To("lb1"),
+			Properties: &armnetwork.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+					{
+						Name: ptr.To(fipName),
+						ID:   ptr.To(fipID),
+						Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+							PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip1")},
+						},
+					},
+				},
+				LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+					{
+						Name: ptr.To("atest1-TCP-80"),
+						Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+							FrontendIPConfiguration: &armnetwork.SubResource{ID: ptr.To(fipID)},
+						},
+					},
+				},
+				Probes: []*armnetwork.Probe{
+					{Name: ptr.To("atest1-TCP-80")},
+				},
+			},
+		}
+	}
+
+	fipsToRemove := []*armnetwork.FrontendIPConfiguration{
+		{
+			Name: ptr.To(fipName),
+			ID:   ptr.To(fipID),
+			Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &armnetwork.PublicIPAddress{ID: ptr.To("pip1")},
+			},
+		},
+	}
+
+	lb0 := &armnetwork.LoadBalancer{
+		Name:       ptr.To("lb0"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+	}
+	lb2 := &armnetwork.LoadBalancer{
+		Name:       ptr.To("lb2"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{},
+	}
+
+	multiSLBConfig := func() []config.MultipleStandardLoadBalancerConfiguration {
+		return []config.MultipleStandardLoadBalancerConfiguration{
+			{Name: ptr.Deref(lb0.Name, "")},
+			{
+				Name: "lb1",
+				MultipleStandardLoadBalancerConfigurationStatus: config.MultipleStandardLoadBalancerConfigurationStatus{
+					ActiveServices: utilsets.NewString("default/test1", "default/other"),
+				},
+			},
+			{Name: ptr.Deref(lb2.Name, "")},
+		}
+	}
+
+	for _, tc := range []struct {
+		description string
+		existingLB  *armnetwork.LoadBalancer
+		fipConfigs  []*armnetwork.FrontendIPConfiguration
+		multiSLB    []config.MultipleStandardLoadBalancerConfiguration
+		local       bool
+		plsExists   bool
+
+		expectDeleteLBName         string
+		expectDeleteLBErr          error
+		expectCreateOrUpdateLBName string
+		expectCreateOrUpdateErr    error
+		expectDeleteBPOnLB         string
+		expectDeleteBPName         string
+		expectDeleteBPErr          error
+
+		expectedLBNames     []string
+		expectedDeletedPLS  bool
+		expectedErrContains string
+	}{
+		{
+			description:                "should remove stale rules and probes and update the LB when fipConfigs is nil",
+			existingLB:                 sharedLB(),
+			multiSLB:                   multiSLBConfig(),
+			expectCreateOrUpdateLBName: "lb1",
+			expectedLBNames:            []string{"lb0", "lb1", "lb2"},
+		},
+		{
+			description:        "should remove the frontend IP and delete the LB when fipConfigs is provided",
+			existingLB:         soloLB(),
+			fipConfigs:         fipsToRemove,
+			multiSLB:           multiSLBConfig(),
+			expectDeleteLBName: "lb1",
+			expectedLBNames:    []string{"lb0", "lb2"},
+		},
+		{
+			description:                "should return error when CreateOrUpdate fails on stale resource path",
+			existingLB:                 sharedLB(),
+			multiSLB:                   multiSLBConfig(),
+			expectCreateOrUpdateLBName: "lb1",
+			expectCreateOrUpdateErr:    errors.New("api error"),
+			expectedLBNames:            []string{"lb0", "lb1", "lb2"},
+			expectedErrContains:        "api error",
+		},
+		{
+			description:         "should return error when Delete fails on frontend IP removal path",
+			existingLB:          soloLB(),
+			fipConfigs:          fipsToRemove,
+			multiSLB:            multiSLBConfig(),
+			expectDeleteLBName:  "lb1",
+			expectDeleteLBErr:   errors.New("delete failed"),
+			expectedLBNames:     []string{"lb0", "lb1", "lb2"},
+			expectedErrContains: "delete failed",
+		},
+		{
+			description:                "should wrap error from backend pool cleanup for local service",
+			existingLB:                 sharedLB(),
+			local:                      true,
+			multiSLB:                   multiSLBConfig(),
+			expectCreateOrUpdateLBName: "lb1",
+			expectDeleteBPOnLB:         "lb1",
+			expectDeleteBPName:         "default-test1",
+			expectDeleteBPErr:          errors.New("bp error"),
+			expectedLBNames:            []string{"lb0", "lb1", "lb2"},
+			expectedErrContains:        "clean up backend pool for local service",
+		},
+		{
+			description:        "should return deletedPLS when PLS exists on stale resource path",
+			existingLB:         soloLB(),
+			multiSLB:           multiSLBConfig(),
+			plsExists:          true,
+			expectedLBNames:    []string{"lb0", "lb1", "lb2"},
+			expectedDeletedPLS: true,
+		},
+		{
+			description:        "should return deletedPLS when PLS exists on frontend IP removal path",
+			existingLB:         soloLB(),
+			fipConfigs:         fipsToRemove,
+			multiSLB:           multiSLBConfig(),
+			plsExists:          true,
+			expectedLBNames:    []string{"lb0", "lb1", "lb2"},
+			expectedDeletedPLS: true,
+		},
+		{
+			description:                "should not clean up backend pool for local service on single SLB",
+			existingLB:                 sharedLB(),
+			local:                      true,
+			expectCreateOrUpdateLBName: "lb1",
+			expectedLBNames:            []string{"lb1"},
+		},
+		{
+			description:                "should not clean up backend pool for non-local service on multi-SLB",
+			existingLB:                 sharedLB(),
+			multiSLB:                   multiSLBConfig(),
+			expectCreateOrUpdateLBName: "lb1",
+			expectedLBNames:            []string{"lb0", "lb1", "lb2"},
+		},
+		{
+			description:                "should clean up backend pool for local service when LB is not deleted",
+			existingLB:                 sharedLB(),
+			local:                      true,
+			multiSLB:                   multiSLBConfig(),
+			expectCreateOrUpdateLBName: "lb1",
+			expectDeleteBPOnLB:         "lb1",
+			expectDeleteBPName:         "default-test1",
+			expectedLBNames:            []string{"lb0", "lb1", "lb2"},
+		},
+		{
+			description:        "should skip backend pool cleanup for local service when LB is deleted",
+			existingLB:         soloLB(),
+			fipConfigs:         fipsToRemove,
+			local:              true,
+			multiSLB:           multiSLBConfig(),
+			expectDeleteLBName: "lb1",
+			expectedLBNames:    []string{"lb0", "lb2"},
+		},
+	} {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			cloud := GetTestCloud(ctrl)
+			cloud.LoadBalancerSKU = "Standard"
+
+			if tc.local {
+				tc.existingLB.Properties.BackendAddressPools = []*armnetwork.BackendAddressPool{
+					{Name: ptr.To("kubernetes")},
+					{Name: ptr.To("default-test1")},
+				}
+			}
+
+			isMultiSLB := len(tc.multiSLB) > 0
+			var existingLBs []*armnetwork.LoadBalancer
+			if isMultiSLB {
+				cloud.MultipleStandardLoadBalancerConfigurations = tc.multiSLB
+				existingLBs = []*armnetwork.LoadBalancer{lb0, tc.existingLB, lb2}
+			} else {
+				existingLBs = []*armnetwork.LoadBalancer{tc.existingLB}
+			}
+
+			lbClient := cloud.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+			if tc.expectDeleteLBName != "" {
+				lbClient.EXPECT().Delete(gomock.Any(), gomock.Any(), tc.expectDeleteLBName).Return(tc.expectDeleteLBErr).Times(1)
+			}
+			if tc.expectCreateOrUpdateLBName != "" {
+				lbClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), tc.expectCreateOrUpdateLBName, gomock.Any()).Return(nil, tc.expectCreateOrUpdateErr).Times(1)
+			}
+
+			bpClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+			if tc.expectDeleteBPOnLB != "" {
+				bpClient.EXPECT().Delete(gomock.Any(), gomock.Any(), tc.expectDeleteBPOnLB, tc.expectDeleteBPName).Return(tc.expectDeleteBPErr).Times(1)
+			}
+			// List is called by cleanupLocalServiceBackendPool via ListManagedLBs when
+			// local + multi-SLB + LB not deleted.
+			if tc.local && isMultiSLB && tc.expectDeleteLBName == "" && tc.expectedErrContains == "" {
+				lbClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(existingLBs, nil).Times(1)
+			}
+
+			mockPLSRepo := cloud.plsRepo.(*privatelinkservice.MockRepository)
+			if tc.plsExists {
+				realPLS := &armnetwork.PrivateLinkService{
+					ID:   ptr.To("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/privateLinkServices/pls1"),
+					Name: ptr.To("pls1"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{
+							{ID: ptr.To(fipID)},
+						},
+					},
+				}
+				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(realPLS, nil).Times(1)
+				mockPLSRepo.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			} else {
+				notExistPLS := &armnetwork.PrivateLinkService{ID: ptr.To(consts.PrivateLinkServiceNotExistID)}
+				mockPLSRepo.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(notExistPLS, nil).MaxTimes(1)
+			}
+
+			svc := getTestService("test1", v1.ProtocolTCP, nil, false, 81)
+			if tc.local {
+				svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
+			}
+
+			lbs, deletedPLS, err := cloud.removeServiceFromLB(
+				context.TODO(), tc.existingLB, existingLBs, testClusterName, &svc, []*v1.Node{}, tc.fipConfigs,
+			)
+
+			// Assert error.
+			if tc.expectedErrContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrContains)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Assert deletedPLS.
+			assert.Equal(t, tc.expectedDeletedPLS, deletedPLS)
+
+			// Assert LB list names and order.
+			var gotNames []string
+			for _, lb := range lbs {
+				gotNames = append(gotNames, ptr.Deref(lb.Name, ""))
+			}
+			assert.Equal(t, tc.expectedLBNames, gotNames)
+
+			// Assert ActiveServices on all successful non-PLS cases.
+			if tc.expectedErrContains == "" && !tc.expectedDeletedPLS && isMultiSLB {
+				for _, cfg := range cloud.MultipleStandardLoadBalancerConfigurations {
+					if cfg.Name == "lb1" {
+						assert.False(t, cfg.ActiveServices.Has("default/test1"),
+							"test1 should be removed from ActiveServices")
+						assert.True(t, cfg.ActiveServices.Has("default/other"),
+							"other services should be preserved in ActiveServices")
+					}
+				}
 			}
 		})
 	}

--- a/tests/e2e/network/multiple_standard_lb.go
+++ b/tests/e2e/network/multiple_standard_lb.go
@@ -917,6 +917,204 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelMultiSLB), fun
 			Entry("internal", "internal"),
 		)
 
+		DescribeTable("should clean up rules and preserve LB placement when a service sharing IP switches between internal and external",
+			func(startInternal, moveToDifferentLB, switchPrimary bool) {
+				clusterName := os.Getenv("CLUSTER_NAME")
+
+				By("Creating Service 1 (primary)")
+				svc1Port := int32(serverPort)
+				svc1Annotations := map[string]string{}
+				if startInternal {
+					svc1Annotations[consts.ServiceAnnotationLoadBalancerInternal] = "true"
+				}
+				if moveToDifferentLB {
+					svc1Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = clusterName
+				}
+				svc1 := utils.CreateLoadBalancerServiceManifest(svcNamePrimary, svc1Annotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svc1Port,
+					TargetPort: intstr.FromInt(int(svc1Port)),
+				}})
+				_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc1, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNamePrimary)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+
+				ips1, err := utils.WaitServiceExposureAndGetIPs(cs, ns.Name, svcNamePrimary)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(ips1)).NotTo(BeZero())
+				sharedIP := *ips1[0]
+
+				svc1FIPID, svc1LBName := getFIPIDAndLBName(tc, sharedIP, startInternal)
+				utils.Logf("Service 1 exposed with IP %s on LB %s, FIP: %s", sharedIP, svc1LBName, svc1FIPID)
+
+				By("Creating Service 2 (secondary) sharing Service 1's IP via IP annotation")
+				svc2Port := int32(serverPort + 1)
+				var svc2Annotations map[string]string
+				if startInternal {
+					svc2Annotations = serviceAnnotationLoadBalancerInternalTrue
+				}
+				svc2 := utils.CreateLoadBalancerServiceManifest(svcNameIPv4, svc2Annotations, labels, ns.Name, []v1.ServicePort{{
+					Port:       svc2Port,
+					TargetPort: intstr.FromInt(int(svc2Port)),
+				}})
+				svc2 = updateServiceLBIPs(svc2, startInternal, []*string{&sharedIP})
+				_, err = cs.CoreV1().Services(ns.Name).Create(context.TODO(), svc2, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					err := utils.DeleteService(cs, ns.Name, svcNameIPv4)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+
+				_, err = utils.WaitServiceExposure(cs, ns.Name, svcNameIPv4, []*string{&sharedIP})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying both services have rules on the shared FIP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP")
+
+				switchTo := "internal"
+				if startInternal {
+					switchTo = "external"
+				}
+				switchSvcRole := "secondary"
+				switchSvcName := svcNameIPv4
+				if switchPrimary {
+					switchSvcRole = "primary"
+					switchSvcName = svcNamePrimary
+				}
+				switchSvcPort := svc2Port
+				if switchPrimary {
+					switchSvcPort = svc1Port
+				}
+				remainingPort := svc1Port
+				if switchPrimary {
+					remainingPort = svc2Port
+				}
+
+				targetLB := ""
+				if moveToDifferentLB {
+					targetLB = " and moves to lb-1"
+				}
+				By(fmt.Sprintf("%s service switches to %s%s", switchSvcRole, switchTo, targetLB))
+				switchSvc, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), switchSvcName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				if switchSvc.Annotations == nil {
+					switchSvc.Annotations = map[string]string{}
+				}
+				if startInternal {
+					delete(switchSvc.Annotations, consts.ServiceAnnotationLoadBalancerInternal)
+				} else {
+					switchSvc.Annotations[consts.ServiceAnnotationLoadBalancerInternal] = "true"
+				}
+				if moveToDifferentLB {
+					switchSvc.Annotations[consts.ServiceAnnotationLoadBalancerConfigurations] = "lb-1"
+				}
+				delete(switchSvc.Annotations, consts.ServiceAnnotationLoadBalancerIPDualStack[false])
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), switchSvc, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				newIP, err := utils.WaitForServiceIPChange(cs, ns.Name, switchSvcName, sharedIP)
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("%s service should get a new %s IP", switchSvcRole, switchTo))
+
+				By(fmt.Sprintf("Verifying %s service is on the correct %s LB", switchSvcRole, switchTo))
+				switchedToInternal := switchTo == "internal"
+				newFIPID, newLBName := getFIPIDAndLBName(tc, newIP, switchedToInternal)
+				utils.Logf("%s service now on LB %s with IP %s, FIP: %s", switchSvcRole, newLBName, newIP, newFIPID)
+				Expect(newFIPID).NotTo(BeEmpty(), switchSvcRole+" service should have a FIP on the new LB")
+
+				var expectedLBAfterSwitch string
+				if moveToDifferentLB {
+					expectedLBAfterSwitch = "lb-1"
+					if switchedToInternal {
+						expectedLBAfterSwitch += consts.InternalLoadBalancerNameSuffix
+					}
+				} else {
+					if switchedToInternal {
+						expectedLBAfterSwitch = svc1LBName + consts.InternalLoadBalancerNameSuffix
+					} else {
+						expectedLBAfterSwitch = strings.TrimSuffix(svc1LBName, consts.InternalLoadBalancerNameSuffix)
+					}
+				}
+				Expect(newLBName).To(Equal(expectedLBAfterSwitch), fmt.Sprintf("%s service should be on LB %s", switchSvcRole, expectedLBAfterSwitch))
+
+				err = utils.VerifyFIPHasRulesForPorts(tc, newFIPID, sets.New(switchSvcPort), "TCP")
+				Expect(err).NotTo(HaveOccurred(), switchSvcRole+" service should have rules on its new FIP")
+
+				By("Verifying old FIP only has the remaining service's rules")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(remainingPort), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Switched service's rules should be cleaned from the old FIP")
+
+				By(fmt.Sprintf("Triggering reconcile and verifying %s service stays on LB %s", switchSvcRole, newLBName))
+				beforeReconcile := time.Now().Add(-1 * time.Second)
+				addDummyAnnotationWithServiceName(cs, ns.Name, switchSvcName)
+				err = utils.WaitForServiceNormalEventAfter(cs, ns.Name, switchSvcName, "EnsuredLoadBalancer", "", beforeReconcile)
+				Expect(err).NotTo(HaveOccurred(), "Reconcile should succeed after dummy annotation")
+				reconFIPID, reconLBName := getFIPIDAndLBName(tc, newIP, switchedToInternal)
+				Expect(reconLBName).To(Equal(newLBName), switchSvcRole+" service should stay on the same LB after reconcile")
+				Expect(reconFIPID).To(Equal(newFIPID), switchSvcRole+" service should keep the same FIP after reconcile")
+
+				switchBack := "external"
+				if startInternal {
+					switchBack = "internal"
+				}
+				By(fmt.Sprintf("%s service switches back to %s", switchSvcRole, switchBack))
+				switchSvc, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), switchSvcName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				if switchSvc.Annotations == nil {
+					switchSvc.Annotations = map[string]string{}
+				}
+				if startInternal {
+					switchSvc.Annotations[consts.ServiceAnnotationLoadBalancerInternal] = "true"
+				} else {
+					delete(switchSvc.Annotations, consts.ServiceAnnotationLoadBalancerInternal)
+				}
+				if moveToDifferentLB {
+					delete(switchSvc.Annotations, consts.ServiceAnnotationLoadBalancerConfigurations)
+				}
+				if !switchPrimary {
+					switchSvc = updateServiceLBIPs(switchSvc, startInternal, []*string{&sharedIP})
+				}
+				_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), switchSvc, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = utils.WaitServiceExposure(cs, ns.Name, switchSvcName, []*string{&sharedIP})
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("%s service should get back shared IP %s", switchSvcRole, sharedIP))
+
+				By("Verifying service is back on the original LB")
+				switchBackFIPID, switchBackLBName := getFIPIDAndLBName(tc, sharedIP, startInternal)
+				utils.Logf("%s service back on LB %s with IP %s, FIP: %s", switchSvcRole, switchBackLBName, sharedIP, switchBackFIPID)
+				Expect(switchBackLBName).To(Equal(svc1LBName), switchSvcRole+" service should be back on the original LB")
+				Expect(switchBackFIPID).To(Equal(svc1FIPID), "Should be back on the original FIP")
+
+				By("Verifying both services' rules are back on the shared FIP")
+				err = utils.VerifyFIPHasRulesForPorts(tc, svc1FIPID, sets.New(svc1Port, svc2Port), "TCP")
+				Expect(err).NotTo(HaveOccurred(), "Both services should share the FIP again after switch back")
+
+				By(fmt.Sprintf("Verifying rules are cleaned from LB %s after switch back", expectedLBAfterSwitch))
+				err = utils.VerifyFIPHasNoRulesForPorts(tc, newFIPID, sets.New(switchSvcPort), "TCP")
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Switched service's rules should be cleaned from LB %s after switch back", expectedLBAfterSwitch))
+
+				By(fmt.Sprintf("Triggering reconcile and verifying %s service stays on LB %s after switch back", switchSvcRole, svc1LBName))
+				beforeReconcile2 := time.Now().Add(-1 * time.Second)
+				addDummyAnnotationWithServiceName(cs, ns.Name, switchSvcName)
+				err = utils.WaitForServiceNormalEventAfter(cs, ns.Name, switchSvcName, "EnsuredLoadBalancer", "", beforeReconcile2)
+				Expect(err).NotTo(HaveOccurred(), "Reconcile should succeed after switch back")
+				finalFIPID, finalLBName := getFIPIDAndLBName(tc, sharedIP, startInternal)
+				Expect(finalLBName).To(Equal(svc1LBName), switchSvcRole+" service should stay on original LB after reconcile")
+				Expect(finalFIPID).To(Equal(svc1FIPID), switchSvcRole+" service should keep original FIP after reconcile")
+			},
+			Entry("secondary: external to internal same LB", false, false, false),
+			Entry("secondary: external to internal different LB", false, true, false),
+			Entry("secondary: internal to external same LB", true, false, false),
+			Entry("secondary: internal to external different LB", true, true, false),
+			Entry("primary: external to internal same LB", false, false, true),
+			Entry("primary: external to internal different LB", false, true, true),
+			Entry("primary: internal to external same LB", true, false, true),
+			Entry("primary: internal to external different LB", true, true, true),
+		)
+
 		It("should block service sharing IP on LB not in eligible set", func() {
 			By("Creating Service 1 with label matching lb-2's ServiceLabelSelector")
 			svc1Port := int32(serverPort)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Cherry-picks #10211 onto `release-1.35`.

Source PR: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/10211
Source commit: `2c581b2a6df142525f15ea55c645176edf0e9eb9`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix(multi-slb): support switching internal/external when IP sharing across multiple services

Correctly clean up stale rules and probes when services sharing a frontend IP switch between external and internal in multi-SLB mode.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/assign Liunardy
