### PR TITLE
ci(update-trivy-db): declare contents: read + actions: write

### DIFF
--- a/.github/workflows/update-trivy-db.yaml
+++ b/.github/workflows/update-trivy-db.yaml
@@ -7,6 +7,12 @@ on:
     - cron: '0 0 * * *'  # Run daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
 
+# Pulls the Trivy DB from GHCR (anonymous) and saves it to the GHA cache;
+# no source checkout is needed, only actions: write for the cache save.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   update-trivy-db:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` on `update-trivy-db.yaml` to the minimum scope it actually uses:
- `actions: write` for `actions/cache/save@v5` (the Trivy DB save path).
- `contents: read` is included for consistency, though the workflow has no checkout step.

The `oras pull` of `ghcr.io/aquasecurity/trivy-db:2` is anonymous (public image). Hardens against the GitHub-side write surface.

YAML validated locally with `yaml.safe_load`.