### PR TITLE
docs: document Dependabot rebase handling

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -234,6 +234,8 @@ Check these docs when working in the relevant area. These docs should be updated
 Shared reusable skills live under `.agents/skills/` and are the only repo-tracked
 skill source.
 
+- Before changing shared skills, read [.agents/skills/authoring.md](skills/authoring.md)
+  and follow its authoring and pull request guidance.
 - Do not commit `.codex/`, `.claude/`, `.github/skills`, or other local
   agent-specific skill folders.
 - Shared skills are intended to be consumed directly from `.agents/skills/` by

--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -228,14 +228,13 @@ Check these docs when working in the relevant area. These docs should be updated
 | Topic | Doc | When to check |
 |-------|-----|---------------|
 | ETag & cache invalidation | [.agents/references/etag-cache.md](references/etag-cache.md) | Modifying Azure resource create/update/delete operations, or changing cache logic |
+| Shared skill authoring | [.agents/skills/authoring.md](skills/authoring.md) | Changing shared skills under `.agents/skills/`, or creating PRs with shared-skill changes |
 
 ## Shared Skills
 
 Shared reusable skills live under `.agents/skills/` and are the only repo-tracked
 skill source.
 
-- Before changing shared skills, read [.agents/skills/authoring.md](skills/authoring.md)
-  and follow its authoring and pull request guidance.
 - Do not commit `.codex/`, `.claude/`, `.github/skills`, or other local
   agent-specific skill folders.
 - Shared skills are intended to be consumed directly from `.agents/skills/` by

--- a/.agents/skills/authoring.md
+++ b/.agents/skills/authoring.md
@@ -36,6 +36,8 @@ agents that support the shared `.agents` convention.
 5. Update [`README.md`](README.md) so the shared skill catalog stays current.
 6. Verify any bundled scripts or examples still point at `.agents/skills/`
    paths when they refer to other shared skills.
+7. When creating a pull request with shared-skill changes, link it to the
+   agent-first workflow issue with `Related: #10054`.
 
 ## Design Guidance
 

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -115,11 +115,23 @@ Discuss these with the user before changing code or CI policy:
 - `dependency-review`, vulnerability, or license failures where the resolution
   may require accepting risk, excluding a finding, or changing the dependency
   version
+- The PR is labeled `needs-rebase` or `mergeable` reports `CONFLICTING`
 
-For these cases, collect the failing job names, the smallest representative log
-snippets, current dependency versions, and a proposed narrow fix. Ask before
-changing linter policy, broadening a dependency bump, or editing generated
-Dependabot PR metadata.
+For dependency, toolchain, and policy failures, collect the failing job names,
+the smallest representative log snippets, current dependency versions, and a
+proposed narrow fix. Ask before changing linter policy, broadening a dependency
+bump, or editing generated Dependabot PR metadata.
+
+If the PR still needs a rebase after other common blockers have been fixed,
+ask Dependabot to rebase the branch instead of manually rewriting the generated
+PR branch:
+
+```bash
+gh pr comment <pr> --body "@dependabot rebase"
+```
+
+Do this after local fixes and pushes are complete so Dependabot rebases the
+latest branch state.
 
 ## PR Update Rules
 
@@ -129,6 +141,8 @@ Dependabot PR metadata.
 - Push only the current task's files.
 - Use `/lgtm` after a successful module-sync push when the PR is otherwise ready
   for review.
+- If the PR needs rebase after other blockers are resolved, comment
+  `@dependabot rebase` rather than manually force-pushing a rebase.
 - Use `/retest` only for failures already classified as transient or safe to
   rerun.
 - Report pending jobs and any residual risk clearly instead of claiming the PR


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates shared agent-skill guidance to:

- document `needs-rebase` / `CONFLICTING` as a common Dependabot blocker in `unblock-dependabot-pr`
- instruct agents to ask Dependabot to rebase with `@dependabot rebase` after other blockers are fixed
- tell agents to read `.agents/skills/authoring.md` before changing shared skills
- record in shared-skill authoring guidance that PRs with skill changes should link to the agent-first workflow issue

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

Docs-only shared skill guidance update.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
