### PR TITLE
[release-1.35] docs: document Dependabot rebase handling

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -228,6 +228,7 @@ Check these docs when working in the relevant area. These docs should be updated
 | Topic | Doc | When to check |
 |-------|-----|---------------|
 | ETag & cache invalidation | [.agents/references/etag-cache.md](references/etag-cache.md) | Modifying Azure resource create/update/delete operations, or changing cache logic |
+| Shared skill authoring | [.agents/skills/authoring.md](skills/authoring.md) | Changing shared skills under `.agents/skills/`, or creating PRs with shared-skill changes |
 
 ## Shared Skills
 

--- a/.agents/skills/authoring.md
+++ b/.agents/skills/authoring.md
@@ -36,6 +36,8 @@ agents that support the shared `.agents` convention.
 5. Update [`README.md`](README.md) so the shared skill catalog stays current.
 6. Verify any bundled scripts or examples still point at `.agents/skills/`
    paths when they refer to other shared skills.
+7. When creating a pull request with shared-skill changes, link it to the
+   agent-first workflow issue with `Related: #10054`.
 
 ## Design Guidance
 

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -115,11 +115,23 @@ Discuss these with the user before changing code or CI policy:
 - `dependency-review`, vulnerability, or license failures where the resolution
   may require accepting risk, excluding a finding, or changing the dependency
   version
+- The PR is labeled `needs-rebase` or `mergeable` reports `CONFLICTING`
 
-For these cases, collect the failing job names, the smallest representative log
-snippets, current dependency versions, and a proposed narrow fix. Ask before
-changing linter policy, broadening a dependency bump, or editing generated
-Dependabot PR metadata.
+For dependency, toolchain, and policy failures, collect the failing job names,
+the smallest representative log snippets, current dependency versions, and a
+proposed narrow fix. Ask before changing linter policy, broadening a dependency
+bump, or editing generated Dependabot PR metadata.
+
+If the PR still needs a rebase after other common blockers have been fixed,
+ask Dependabot to rebase the branch instead of manually rewriting the generated
+PR branch:
+
+```bash
+gh pr comment <pr> --body "@dependabot rebase"
+```
+
+Do this after local fixes and pushes are complete so Dependabot rebases the
+latest branch state.
 
 ## PR Update Rules
 
@@ -129,6 +141,8 @@ Dependabot PR metadata.
 - Push only the current task's files.
 - Use `/lgtm` after a successful module-sync push when the PR is otherwise ready
   for review.
+- If the PR needs rebase after other blockers are resolved, comment
+  `@dependabot rebase` rather than manually force-pushing a rebase.
 - Use `/retest` only for failures already classified as transient or safe to
   rerun.
 - Report pending jobs and any residual risk clearly instead of claiming the PR


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Cherry-picks #10369 onto `release-1.35`.

Source PR: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/10369
Source commit: `11093ba5c96a7b79ccda8d6225b2ea49e8b23be0`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/assign nilo19
