### PR TITLE
fix(e2e): dynamically set Windows OS version for credential provider tests

### DIFF
--- a/tests/e2e/auth/cred.go
+++ b/tests/e2e/auth/cred.go
@@ -141,7 +141,7 @@ var _ = Describe("Azure Credential Provider", Label(utils.TestSuiteLabelCredenti
 
 		testPull("mcr.microsoft.com/mirror/docker/library/nginx", "1.25", "linux")
 		if tc.HasWindowsNodes {
-			testPull("mcr.microsoft.com/windows/nanoserver", "ltsc2019", "windows")
+			testPull("mcr.microsoft.com/windows/nanoserver", tc.WindowsOSVersion, "windows")
 		}
 	})
 })

--- a/tests/e2e/utils/azure_test_client.go
+++ b/tests/e2e/utils/azure_test_client.go
@@ -41,6 +41,7 @@ import (
 
 var (
 	azureResourceGroupNameRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/(?:.*)`)
+	windowsServerYearRE      = regexp.MustCompile(`\b20\d{2}\b`)
 	nodeLabelLocation        = "failure-domain.beta.kubernetes.io/region"
 	defaultLocation          = "eastus2"
 )
@@ -54,6 +55,7 @@ type AzureTestClient struct {
 	azFactoryConfig *azclient.ClientFactoryConfig
 	IPFamily        IPFamily
 	HasWindowsNodes bool
+	WindowsOSVersion string
 }
 
 // CreateAzureTestClient makes a new AzureTestClient
@@ -91,9 +93,11 @@ func CreateAzureTestClient() (*AzureTestClient, error) {
 	}
 
 	hasWindowsNodes := false
+	windowsOSVersion := ""
 	for _, node := range nodes {
 		if os, ok := node.Labels["kubernetes.io/os"]; ok && os == "windows" {
 			hasWindowsNodes = true
+			windowsOSVersion = nanoserverTagFromOSImage(node.Status.NodeInfo.OSImage)
 			break
 		}
 	}
@@ -113,8 +117,9 @@ func CreateAzureTestClient() (*AzureTestClient, error) {
 		location:        location,
 		resourceGroup:   resourceGroup,
 		IPFamily:        ipFamily,
-		HasWindowsNodes: hasWindowsNodes,
-		authConfig:      authConfig,
+		HasWindowsNodes:  hasWindowsNodes,
+		WindowsOSVersion: windowsOSVersion,
+		authConfig:       authConfig,
 		azFactoryConfig: clientFactoryConfig,
 		client:          azFactory,
 	}
@@ -227,4 +232,13 @@ func getLocationFromNodeLabels(node *v1.Node) string {
 		return location
 	}
 	return defaultLocation
+}
+
+// nanoserverTagFromOSImage extracts the Windows Server year from the node's OSImage
+// (e.g. "Windows Server 2022 Datacenter") and returns the nanoserver tag (e.g. "ltsc2022").
+func nanoserverTagFromOSImage(osImage string) string {
+	if year := windowsServerYearRE.FindString(osImage); year != "" {
+		return "ltsc" + year
+	}
+	return "ltsc2022"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The ACR cache credential provider e2e test hardcoded nanoserver:ltsc2019 (https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/cloud-provider-azure-ccm-windows-capz/2056498552921657344), but the Windows nodes run Server 2022 (https://storage.googleapis.com/kubernetes-ci-logs/logs/cloud-provider-azure-ccm-windows-capz/2056498552921657344/artifacts/clusters/capz-conf-8bq851/nodes/capz-conf-28lvn/node-describe.txt). This caused ImagePullBackOff due to a platform mismatch in the manifest.
>Failed to pull image "e2eacr45ae.azurecr.io/nanoserver:ltsc2019": [rpc error: code = NotFound desc = get image config descriptor: no match for platform in manifest sha256:8cfbc152747c948cc595b081d9e351b6968737eb9ace62d2fe7a47b7c4bf5e0d: not found, failed to pull and unpack image "e2eacr45ae.azurecr.io/nanoserver:ltsc2019": failed to resolve image: failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://e2eacr45ae.azurecr.io/oauth2/token?scope=repository%3Ananoserver%3Apull&service=e2eacr45ae.azurecr.io: 401 Unauthorized

Detect the Windows Server year from node.Status.NodeInfo.OSImage and use it as the nanoserver image tag. Falls back to `ltsc2022` if the year cannot be extracted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
