### PR TITLE
chore: pin release-notes cli in generate release note script to v0.21.1

### DIFF
--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -25,7 +25,10 @@ install_cli() {
      ! go version -m "$(command -v release-notes)" 2>/dev/null | \
        grep -qE "^[[:space:]]+mod[[:space:]]+k8s.io/release[[:space:]]+${RELEASE_NOTES_VERSION}([[:space:]]|$)"; then
     echo "CLI release-notes ${RELEASE_NOTES_VERSION} not found, installing..."
-    GO111MODULE=on go install "k8s.io/release/cmd/release-notes@${RELEASE_NOTES_VERSION}"
+    if ! GO111MODULE=on go install "k8s.io/release/cmd/release-notes@${RELEASE_NOTES_VERSION}"; then
+      echo "ERROR: failed to install release-notes ${RELEASE_NOTES_VERSION}" >&2
+      exit 1
+    fi
   else
     echo "CLI release-notes ${RELEASE_NOTES_VERSION} found, skip installing."
   fi

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -20,12 +20,13 @@ UPDATE_SITE=${3:-false}
 RELEASE_NOTES_VERSION=v0.21.1
 
 install_cli() {
-  export PATH="$(go env GOPATH)/bin:${PATH}"
+  GOPATH_BIN="$(go env GOPATH)/bin"
+  export PATH="${GOPATH_BIN}:${PATH}"
   if ! [[ -x "$(command -v release-notes)" ]] || \
      ! go version -m "$(command -v release-notes)" 2>/dev/null | \
        grep -qE "^[[:space:]]+mod[[:space:]]+k8s.io/release[[:space:]]+${RELEASE_NOTES_VERSION}([[:space:]]|$)"; then
     echo "CLI release-notes ${RELEASE_NOTES_VERSION} not found, installing..."
-    if ! GO111MODULE=on go install "k8s.io/release/cmd/release-notes@${RELEASE_NOTES_VERSION}"; then
+    if ! GOBIN="${GOPATH_BIN}" GO111MODULE=on go install "k8s.io/release/cmd/release-notes@${RELEASE_NOTES_VERSION}"; then
       echo "ERROR: failed to install release-notes ${RELEASE_NOTES_VERSION}" >&2
       exit 1
     fi

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -17,13 +17,17 @@ RELEASE=$1
 OUTPUT=${2:-release-notes.md}
 UPDATE_SITE=${3:-false}
 
+RELEASE_NOTES_VERSION=v0.21.1
+
 install_cli() {
   export PATH="$(go env GOPATH)/bin:${PATH}"
-  if ! [[ -x "$(command -v release-notes)" ]]; then
-    echo "CLI release-notes not found, installing..."
-    GO111MODULE=on go install k8s.io/release/cmd/release-notes@v0.21.1
+  if ! [[ -x "$(command -v release-notes)" ]] || \
+     ! go version -m "$(command -v release-notes)" 2>/dev/null | \
+       grep -qE "^[[:space:]]+mod[[:space:]]+k8s.io/release[[:space:]]+${RELEASE_NOTES_VERSION}([[:space:]]|$)"; then
+    echo "CLI release-notes ${RELEASE_NOTES_VERSION} not found, installing..."
+    GO111MODULE=on go install "k8s.io/release/cmd/release-notes@${RELEASE_NOTES_VERSION}"
   else
-    echo "CLI release-notes found, skip installing. If you want to upgrade, run 'GO111MODULE=on go install k8s.io/release/cmd/release-notes@latest'"
+    echo "CLI release-notes ${RELEASE_NOTES_VERSION} found, skip installing."
   fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
Pin the `release-notes` CLI version used by `hack/generate-release-note.sh`.

Previously the script only installed `release-notes` when the binary was not already on `PATH`, so any pre-existing version would be reused, making release note generation non-deterministic across machines and CI runners.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
