### PR TITLE
fix(multi-slb): deduplicate IP addresses in backend pool update

### DIFF
--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -714,10 +714,10 @@ func (az *Cloud) addNodeIPAddressesToBackendPool(backendPool *armnetwork.Backend
 					IPAddress: ptr.To(ipAddress),
 				},
 			})
+			backendPool.Properties.LoadBalancerBackendAddresses = addresses
 			changed = true
 		}
 	}
-	backendPool.Properties.LoadBalancerBackendAddresses = addresses
 	return changed
 }
 

--- a/pkg/provider/azure_loadbalancer_backendpool_test.go
+++ b/pkg/provider/azure_loadbalancer_backendpool_test.go
@@ -905,6 +905,58 @@ func TestRemoveNodeIPAddressFromBackendPool(t *testing.T) {
 		})
 	}
 }
+func TestAddNodeIPAddressesToBackendPoolDeduplicates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range []struct {
+		name            string
+		existingIPs     []string
+		inputIPs        []string
+		expectedIPs     []string
+		expectedChanged bool
+	}{
+		{
+			name:            "with duplicate IPs on empty pool",
+			existingIPs:     nil,
+			inputIPs:        []string{"10.0.0.1", "10.0.0.1", "10.0.0.2"},
+			expectedIPs:     []string{"10.0.0.1", "10.0.0.2"},
+			expectedChanged: true,
+		},
+		{
+			name:            "with duplicate IPs and pre-existing addresses",
+			existingIPs:     []string{"10.0.0.1"},
+			inputIPs:        []string{"10.0.0.2", "10.0.0.2", "10.0.0.1"},
+			expectedIPs:     []string{"10.0.0.1", "10.0.0.2"},
+			expectedChanged: true,
+		},
+		{
+			name:            "with all duplicate IPs already in pool",
+			existingIPs:     []string{"10.0.0.1", "10.0.0.2"},
+			inputIPs:        []string{"10.0.0.1", "10.0.0.1", "10.0.0.2"},
+			expectedIPs:     []string{"10.0.0.1", "10.0.0.2"},
+			expectedChanged: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := GetTestCloud(ctrl)
+			cloud.nodePrivateIPToNodeNameMap = map[string]string{
+				"10.0.0.1": "node1",
+				"10.0.0.2": "node2",
+			}
+
+			bp := buildTestLoadBalancerBackendPoolWithIPs("test-pool", tc.existingIPs)
+			changed := cloud.addNodeIPAddressesToBackendPool(bp, tc.inputIPs)
+			assert.Equal(t, tc.expectedChanged, changed)
+
+			var actualIPs []string
+			for _, addr := range bp.Properties.LoadBalancerBackendAddresses {
+				actualIPs = append(actualIPs, ptr.Deref(addr.Properties.IPAddress, ""))
+			}
+			assert.Equal(t, tc.expectedIPs, actualIPs)
+		})
+	}
+}
 
 func TestGetBackendPrivateIPsNodeIPConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -373,22 +373,24 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 				}
 				lbName, ipFamily := si.lbName, si.ipFamily
 
-				var previousIPs, currentIPs, previousNodeNames, currentNodeNames []string
+				var previousIPs, currentIPs []string
+				previousNodeNameSet := utilsets.NewString()
+				currentNodeNameSet := utilsets.NewString()
 				if previousES != nil {
 					for _, ep := range previousES.Endpoints {
-						previousNodeNames = append(previousNodeNames, ptr.Deref(ep.NodeName, ""))
+						previousNodeNameSet.Insert(ptr.Deref(ep.NodeName, ""))
 					}
 				}
 				if newES != nil {
 					for _, ep := range newES.Endpoints {
-						currentNodeNames = append(currentNodeNames, ptr.Deref(ep.NodeName, ""))
+						currentNodeNameSet.Insert(ptr.Deref(ep.NodeName, ""))
 					}
 				}
-				for _, previousNodeName := range previousNodeNames {
+				for _, previousNodeName := range previousNodeNameSet.UnsortedList() {
 					nodeIPsSet := az.nodePrivateIPs[strings.ToLower(previousNodeName)]
 					previousIPs = append(previousIPs, nodeIPsSet.UnsortedList()...)
 				}
-				for _, currentNodeName := range currentNodeNames {
+				for _, currentNodeName := range currentNodeNameSet.UnsortedList() {
 					nodeIPsSet := az.nodePrivateIPs[strings.ToLower(currentNodeName)]
 					currentIPs = append(currentIPs, nodeIPsSet.UnsortedList()...)
 				}

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -163,6 +163,53 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
 		},
+		{
+			name: "add operation deduplicates IPs in empty pool",
+			operations: []batchOperation{
+				getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.1", "10.0.0.2"}),
+			},
+			existingBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
+			},
+			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+			expectedBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+		},
+		{
+			name: "remove-then-add deduplicates IPs",
+			operations: []batchOperation{
+				getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+				getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.1", "10.0.0.2", "10.0.0.2"}),
+			},
+			existingBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+			expectedBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+		},
+		{
+			name: "add-then-remove deduplicates IPs and removes target",
+			operations: []batchOperation{
+				getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.1", "10.0.0.2", "10.0.0.2", "10.0.0.3", "10.0.0.3"}),
+				getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.2"}),
+			},
+			existingBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.3"}),
+			},
+			expectedBackendPools: []*armnetwork.BackendAddressPool{
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.3"}),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -569,6 +616,78 @@ func TestEndpointSlicesInformer(t *testing.T) {
 			close(stopChan)
 			cancel()
 			wg.Wait()
+		})
+	}
+}
+
+func TestEndpointSlicesInformerDeduplicatesNodeIPs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range []struct {
+		name        string
+		existingEPS *discovery_v1.EndpointSlice
+		updatedEPS  *discovery_v1.EndpointSlice
+		expectedOps []*loadBalancerBackendPoolUpdateOperation
+	}{
+		{
+			name:        "multiple endpoints on same node produces unique IPs",
+			existingEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1"),
+			updatedEPS:  getTestEndpointSlice("eps1", "test", "svc1", "node2", "node2", "node2"),
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				getRemoveIPsFromBackendPoolOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.1"}),
+				getAddIPsToBackendPoolOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.2"}),
+			},
+		},
+		{
+			name:        "unchanged node set with different endpoint counts is a no-op",
+			existingEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1", "node1"),
+			updatedEPS:  getTestEndpointSlice("eps1", "test", "svc1", "node1", "node1", "node1"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := GetTestCloud(ctrl)
+			cloud.localServiceNameToServiceInfoMap = sync.Map{}
+			cloud.localServiceNameToServiceInfoMap.Store("test/svc1", newServiceInfo(consts.IPVersionIPv4String, "lb1"))
+			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
+			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+			}
+			cloud.nodePrivateIPs = map[string]*utilsets.IgnoreCaseSet{
+				"node1": utilsets.NewString("10.0.0.1"),
+				"node2": utilsets.NewString("10.0.0.2"),
+			}
+
+			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+			// Create updater without starting run() so we can inspect queued operations.
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Hour)
+			cloud.backendPoolUpdater = u
+
+			cloud.setUpEndpointSlicesInformer(informerFactory)
+			stopChan := make(chan struct{})
+			informerFactory.Start(stopChan)
+			defer close(stopChan)
+
+			// Allow informer to initialize.
+			time.Sleep(100 * time.Millisecond)
+
+			_, err := client.DiscoveryV1().EndpointSlices("test").Update(context.Background(), tc.updatedEPS, metav1.UpdateOptions{})
+			assert.NoError(t, err)
+
+			// Allow the async UpdateFunc to fire and enqueue operations.
+			time.Sleep(500 * time.Millisecond)
+
+			ops := u.drainOperations()
+			var actual []*loadBalancerBackendPoolUpdateOperation
+			for _, op := range ops {
+				actual = append(actual, op.(*loadBalancerBackendPoolUpdateOperation))
+			}
+			assert.Equal(t, tc.expectedOps, actual)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The EndpointSlice `UpdateFunc` handler collects node names without deduplication, producing duplicate IPs in backend pool Add operations. Additionally, `addNodeIPAddressesToBackendPool` doesn't detect duplicates within a single call because newly appended entries aren't visible to `hasIPAddressInBackendPool` until the function returns. These cause `DuplicateResourceName` error on ARM when multiple endpoints share a node during rapid scaling.

This PR deduplicates at both EndpointSlice `UpdateFunc` handler and `addNodeIPAddressesToBackendPool`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10307

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix(multi-slb): deduplicate IP addresses in local service backend pool updates to prevent DuplicateResourceName errors during EndpointSlice churn
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
