### PR TITLE
[release-1.35] docs: add Dependabot minor version guard

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -43,8 +43,9 @@ level small:
 - `sync-go-modules`: unblock `go-mod-consistency` by tidying and verifying all
   tracked Go modules, then refreshing the main module's `vendor/` tree
 - `unblock-dependabot-pr`: diagnose failed Dependabot PR CI, reuse the Go module
-  sync workflow, retest Azure public-IP quota e2e flakes, add `/lgtm` when only
-  Tide is pending, and escalate dependency/toolchain blockers for discussion
+  sync workflow, close Kubernetes minor-version bumps, retest Azure public-IP
+  quota e2e flakes, add `/lgtm` when only Tide is pending, and escalate
+  dependency/toolchain blockers for discussion
 
 ## How To Use
 

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unblock-dependabot-pr
-description: Diagnose and unblock failed Dependabot pull requests in cloud-provider-azure by classifying CI failures, syncing Go modules, retesting quota-flaked e2e jobs, and updating PR status. Use when a Dependabot PR fails go-mod-consistency, pull-cloud-provider-azure-e2e jobs, or dependency/toolchain CI.
+description: Diagnose and unblock failed Dependabot pull requests in cloud-provider-azure by closing Kubernetes minor-version dependency bumps, classifying CI failures, syncing Go modules, retesting quota-flaked e2e jobs, and updating PR status. Use when a Dependabot PR fails go-mod-consistency, pull-cloud-provider-azure-e2e jobs, or dependency/toolchain CI.
 ---
 
 # Unblock Dependabot Pull Requests
@@ -18,14 +18,25 @@ Expected inputs:
 
 ## Triage First
 
-1. Inspect the current PR state before changing files:
+1. Inspect the PR metadata and changed dependencies before checking CI:
+
+```bash
+gh pr view <pr> --json number,title,headRefName,headRepositoryOwner,headRefOid,baseRefName,author,labels,mergeable
+```
+
+2. Run the [Kubernetes Minor Version Guard](#kubernetes-minor-version-guard)
+   immediately for Dependabot Go module PRs. If the guard finds a minor-version
+   change, close the PR and stop before inspecting CI, syncing modules,
+   retesting, commenting `/lgtm`, or reporting that no unblock action is needed.
+
+3. Inspect CI only after the minor version guard passes:
 
 ```bash
 gh pr view <pr> --json number,title,headRefName,headRepositoryOwner,headRefOid,baseRefName,author,labels,mergeable,statusCheckRollup
 gh pr checks <pr>
 ```
 
-2. If the local checkout is needed, fetch and check out the PR head, then check
+4. If the local checkout is needed, fetch and check out the PR head, then check
    for unrelated work:
 
 ```bash
@@ -36,11 +47,47 @@ git status --short
 Stop and report a conflict if unrelated uncommitted changes exist. Do not stage
 or overwrite unrelated files.
 
-3. Classify every failing required job. Do not treat a PR as unblocked until all
+5. Classify every failing required job. Do not treat a PR as unblocked until all
    non-pending failures have a clear action.
 
-4. If no checks are failing and the only pending status is `tide`, follow the
+6. If no checks are failing and the only pending status is `tide`, follow the
    [Only Tide Pending](#only-tide-pending) path.
+
+## Kubernetes Minor Version Guard
+
+Run this guard for every Dependabot Go module PR before inspecting CI or taking
+an unblock action. The goal is to close Kubernetes minor-version bumps early
+instead of spending automation time on checks that should not unblock the PR.
+
+Inspect the PR diff for `go.mod` changes to Kubernetes modules:
+
+```bash
+gh pr diff <pr> --patch | grep -E '^[+-][[:space:]]+(require[[:space:]]+)?(k8s\.io/[[:alnum:]_.\-/]+)[[:space:]]+v0\.[0-9]+\.[0-9]+'
+```
+
+Then apply these rules:
+
+- For a PR targeting `release-1.N`, every added `k8s.io/*` module version must
+  stay in the `v0.N.x` family.
+- For any branch, a changed `k8s.io/*` module must not move from one minor
+  family to another, such as `v0.36.x` to `v0.37.x`, unless the user explicitly
+  asks for that Kubernetes minor bump.
+- The added `k8s.io/*` module versions in one PR must not mix minor families,
+  such as some modules at `v0.36.x` and others at `v0.37.x`.
+
+If the guard finds a minor-version mismatch, comment `/close` and stop for that
+PR:
+
+```bash
+gh pr comment <pr> --body "/close"
+```
+
+Do not inspect CI, run module sync, comment `/lgtm`, post `/retest` or `/test`,
+or report the PR as requiring no action. Report the `/close` comment plus the
+mismatched module lines, the base branch, and the expected minor family.
+
+If the guard finds no `k8s.io/*` module changes, or only patch-level updates
+within the same minor family, continue with the matching workflow below.
 
 ## go-mod-consistency Failed
 
@@ -131,9 +178,6 @@ Discuss these with the user before changing code or CI policy:
   bump
 - Mixed Azure SDK major versions, such as `armcompute/v6` consumers in a PR
   that updated packages to `armcompute/v7`
-- Mixed Kubernetes module families, such as `k8s.io/api`,
-  `k8s.io/apimachinery`, and `k8s.io/client-go` moving ahead of the rest of the
-  Kubernetes dependency set
 - `dependency-review`, vulnerability, or license failures where the resolution
   may require accepting risk, excluding a finding, or changing the dependency
   version
@@ -161,6 +205,10 @@ latest branch state.
   pushed, append a concise reviewer-facing note instead of replacing the body.
 - Use specific staging commands, never `git add .`.
 - Push only the current task's files.
+- Run the Kubernetes minor version guard before inspecting CI, module sync,
+  retest comments, `/lgtm` comments, or no-action reports for Dependabot Go
+  module PRs.
+- If the Kubernetes minor version guard fails, comment `/close` and stop.
 - Use `/lgtm` after a successful module-sync push when the PR is otherwise ready
   for review.
 - Use `/lgtm` when no checks are failing, `tide` is the only pending status,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Cherry-picks #10469 onto `release-1.35`.

Source PR: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/10469
Source commit: `6530016bc9628d99b728c4b366fc82eac6a7acd7`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/assign nilo19
