### PR TITLE
Add service opt-out for load balancer NSG rules

### DIFF
--- a/internal/testutil/fixture/kubernetes.go
+++ b/internal/testutil/fixture/kubernetes.go
@@ -106,6 +106,11 @@ func (f *KubernetesServiceFixture) WithDisableFloatingIP() *KubernetesServiceFix
 	return f
 }
 
+func (f *KubernetesServiceFixture) WithDisableLoadBalancerSecurityGroupRules() *KubernetesServiceFixture {
+	f.svc.Annotations[consts.ServiceAnnotationDisableLoadBalancerSecurityGroupRules] = "true"
+	return f
+}
+
 func (f *KubernetesServiceFixture) WithLoadBalancerSourceRanges(parts ...string) *KubernetesServiceFixture {
 	f.svc.Spec.LoadBalancerSourceRanges = parts
 	return f

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -325,6 +325,10 @@ const (
 	// If omitted, the default value is false
 	ServiceAnnotationDisableLoadBalancerFloatingIP = "service.beta.kubernetes.io/azure-disable-load-balancer-floating-ip"
 
+	// ServiceAnnotationDisableLoadBalancerSecurityGroupRules is the annotation used on the service to disable cloud-provider-managed load balancer security group rules.
+	// If omitted, the default value is false.
+	ServiceAnnotationDisableLoadBalancerSecurityGroupRules = "service.beta.kubernetes.io/azure-disable-load-balancer-security-group-rules"
+
 	// ServiceAnnotationAdditionalPublicIPs sets the additional Public IPs (split by comma) besides the service's Public IP configured on LoadBalancer.
 	// These additional Public IPs would be consumed by kube-proxy to configure the iptables rules on each node. Note they would not be configured
 	// automatically on Azure LoadBalancer. Instead, they need to be configured manually (e.g. on Azure cross-region LoadBalancer by another operator).

--- a/pkg/consts/helpers.go
+++ b/pkg/consts/helpers.go
@@ -40,6 +40,11 @@ func IsK8sServiceDisableLoadBalancerFloatingIP(service *v1.Service) bool {
 	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationDisableLoadBalancerFloatingIP, TrueAnnotationValue)
 }
 
+// IsK8sServiceDisableLoadBalancerSecurityGroupRules returns if cloud-provider-managed load balancer security group rules are disabled in kubernetes service annotations.
+func IsK8sServiceDisableLoadBalancerSecurityGroupRules(service *v1.Service) bool {
+	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationDisableLoadBalancerSecurityGroupRules, TrueAnnotationValue)
+}
+
 // GetHealthProbeConfigOfPortFromK8sSvcAnnotation get health probe configuration for port
 func GetHealthProbeConfigOfPortFromK8sSvcAnnotation(annotations map[string]string, port int32, key HealthProbeParams, validators ...BusinessValidator) (*string, error) {
 	return GetAttributeValueInSvcAnnotation(annotations, BuildHealthProbeAnnotationKeyForPort(port, key), validators...)

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3492,7 +3492,7 @@ func (az *Cloud) reconcileSecurityGroup(
 		}
 	}
 
-	if wantLb {
+	if wantLb && !consts.IsK8sServiceDisableLoadBalancerSecurityGroupRules(service) {
 		err := accessControl.PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses)
 		if err != nil {
 			logger.Error(err, "Failed to patch security group")

--- a/pkg/provider/azure_loadbalancer_accesscontrol.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol.go
@@ -46,7 +46,8 @@ func filterServicesByIngressIPs(services []*v1.Service, ips []netip.Addr) []*v1.
 
 func filterServicesByDisableFloatingIP(services []*v1.Service) []*v1.Service {
 	return fnutil.Filter(func(svc *v1.Service) bool {
-		return consts.IsK8sServiceDisableLoadBalancerFloatingIP(svc)
+		return consts.IsK8sServiceDisableLoadBalancerFloatingIP(svc) &&
+			!consts.IsK8sServiceDisableLoadBalancerSecurityGroupRules(svc)
 	}, services)
 }
 

--- a/pkg/provider/azure_loadbalancer_accesscontrol_test.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -481,6 +482,92 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					}
 
 					testutil.ExpectExactSecurityRules(t, &properties, rules)
+					return nil, nil
+				}).Times(1)
+			loadBalancerClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+				Return(loadBalancer, nil).
+				Times(1)
+			loadBalancerBackendPool.EXPECT().
+				GetBackendPrivateIPs(gomock.Any(), ClusterName, &svc, loadBalancer).
+				Return(
+					azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+					azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
+				).
+				Times(1)
+
+			_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
+			assert.NoError(t, err)
+		})
+
+		t.Run("with `service.beta.kubernetes.io/azure-disable-load-balancer-security-group-rules` specified", func(t *testing.T) {
+			var (
+				ctrl                    = gomock.NewController(t)
+				az                      = GetTestCloud(ctrl)
+				securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+				loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+				loadBalancer            = azureFx.LoadBalancer().Build()
+			)
+			defer ctrl.Finish()
+
+			svc := k8sFx.Service().
+				WithDisableFloatingIP().
+				WithDisableLoadBalancerSecurityGroupRules().
+				Build()
+
+			{
+				kubeClient := fake.NewSimpleClientset(makeNodesByIPs(
+					append(azureFx.LoadBalancer().BackendPoolIPv4Addresses(), azureFx.LoadBalancer().BackendPoolIPv6Addresses()...),
+				)...)
+				informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+				az.serviceLister = informerFactory.Core().V1().Services().Lister()
+				az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+				informerFactory.Start(wait.NeverStop)
+				informerFactory.WaitForCacheSync(wait.NeverStop)
+			}
+
+			serviceTags := []string{securitygroup.ServiceTagInternet}
+			noiseRules := azureFx.NoiseSecurityRules()
+			rules := append(testutil.CloneInJSON(noiseRules),
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, serviceTags, k8sFx.Service().TCPNodePorts()).
+					WithPriority(500).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+					Build(),
+
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, serviceTags, k8sFx.Service().TCPNodePorts()).
+					WithPriority(501).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+					Build(),
+
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, serviceTags, k8sFx.Service().UDPNodePorts()).
+					WithPriority(502).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+					Build(),
+
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, serviceTags, k8sFx.Service().UDPNodePorts()).
+					WithPriority(503).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+					Build(),
+			)
+			securityGroup := azureFx.SecurityGroup().WithRules(rules).Build()
+
+			securityGroupClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+				Return(securityGroup, nil).
+				Times(1)
+			securityGroupClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+				DoAndReturn(func(
+					_ context.Context,
+					_, _ string,
+					properties armnetwork.SecurityGroup,
+				) (*armnetwork.SecurityGroup, error) {
+					testutil.ExpectExactSecurityRules(t, &properties, noiseRules)
 					return nil, nil
 				}).Times(1)
 			loadBalancerClient.EXPECT().
@@ -2704,4 +2791,75 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
+}
+
+func TestCloud_listSharedIPPortMapping_excludesServicesWithDisabledSecurityGroupRules(t *testing.T) {
+	var (
+		fx    = fixture.NewFixture()
+		k8sFx = fx.Kubernetes()
+		ctx   = log.NewContext(context.Background(), log.Noop())
+		ctrl  = gomock.NewController(t)
+		az    = GetTestCloud(ctrl)
+	)
+	defer ctrl.Finish()
+
+	svc := k8sFx.Service().
+		WithName("current").
+		WithDisableFloatingIP().
+		Build()
+
+	retainedSvc := k8sFx.Service().
+		WithName("retained").
+		WithDisableFloatingIP().
+		Build()
+	retainedSvc.Spec.Ports = []v1.ServicePort{
+		{
+			Name:     "tcp",
+			Protocol: v1.ProtocolTCP,
+			Port:     8080,
+			NodePort: 31080,
+		},
+		{
+			Name:     "udp",
+			Protocol: v1.ProtocolUDP,
+			Port:     5353,
+			NodePort: 31553,
+		},
+	}
+
+	optedOutSvc := k8sFx.Service().
+		WithName("opted-out").
+		WithDisableFloatingIP().
+		WithDisableLoadBalancerSecurityGroupRules().
+		Build()
+	optedOutSvc.Spec.Ports = []v1.ServicePort{
+		{
+			Name:     "tcp",
+			Protocol: v1.ProtocolTCP,
+			Port:     8081,
+			NodePort: 32081,
+		},
+		{
+			Name:     "udp",
+			Protocol: v1.ProtocolUDP,
+			Port:     5354,
+			NodePort: 32554,
+		},
+	}
+
+	{
+		kubeClient := fake.NewSimpleClientset(&svc, &retainedSvc, &optedOutSvc)
+		informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+		az.serviceLister = informerFactory.Core().V1().Services().Lister()
+		informerFactory.Start(wait.NeverStop)
+		informerFactory.WaitForCacheSync(wait.NeverStop)
+	}
+
+	retainPortRanges, err := az.listSharedIPPortMapping(ctx, &svc, []netip.Addr{netip.MustParseAddr("10.0.0.4")})
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[armnetwork.SecurityRuleProtocol][]int32{
+		armnetwork.SecurityRuleProtocolTCP: []int32{31080},
+		armnetwork.SecurityRuleProtocolUDP: []int32{31553},
+	}, retainPortRanges)
 }


### PR DESCRIPTION
Refs kubernetes-sigs/cloud-provider-azure#10083.

This PR implements the first, minimal option from the issue discussion: a per-Service break-glass annotation that lets operators opt out of cloud-provider-managed LoadBalancer NSG rule creation for Services where those rules need to be managed externally.

The new annotation is intentionally narrow in scope. When it is set, cloud-provider-azure still computes the Service's NSG destinations and cleans stale ACP-managed rules for that Service, but it does not recreate the managed allow/deny rules. Load balancer rules, frontend IPs, backend pool membership, probes, and backend selection are unchanged.

This is not intended to be the preferred long-term UX for the destination-prefix scaling problem described in the issue. It is one of the proposed options, and provides a small, explicit escape hatch while preserving ACP cleanup behavior. A follow-up option can still explore allowing operators to provide destination prefixes while keeping ACP as the NSG rule owner.

Operators using this annotation are responsible for ensuring equivalent NSG access is provided outside ACP-managed rules. Manual rules should stay outside ACP's managed rule naming and priority conventions.