### PR TITLE
chore: restrict dependabot k8s updates to patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -40,6 +44,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -65,6 +73,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -90,6 +102,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -115,6 +131,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -140,6 +160,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -164,6 +188,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -188,6 +216,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -212,6 +244,10 @@ updates:
       - "lgtm"
       - "approved"
     ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:
@@ -307,7 +343,9 @@ updates:
     target-branch: "release-1.36"
     ignore:
       - dependency-name: "k8s.io/*"
-        versions: [">=0.37.0"]
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     groups:
       all:
         applies-to: version-updates
@@ -384,7 +422,9 @@ updates:
     target-branch: "release-1.35"
     ignore:
       - dependency-name: "k8s.io/*"
-        versions: [">=0.36.0"]
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     groups:
       all:
         applies-to: version-updates
@@ -461,7 +501,9 @@ updates:
     target-branch: "release-1.34"
     ignore:
       - dependency-name: "k8s.io/*"
-        versions: [">=0.35.0"]
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     groups:
       all:
         applies-to: version-updates
@@ -537,7 +579,9 @@ updates:
     target-branch: "release-1.33"
     ignore:
       - dependency-name: "k8s.io/*"
-        versions: [">=0.34.0"]
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
       - dependency-name: "go"
     groups:
       all:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Configures Dependabot to ignore `k8s.io/*` semver minor and major version updates for all Go module update entries.

This keeps Kubernetes module bumps to patch updates only, while preserving the existing patch/minor/major grouping behavior for non-`k8s.io` dependencies.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The existing release branch `k8s.io/*` version-floor ignores are replaced with the equivalent semver update-type policy so the rule does not need branch-specific threshold maintenance.

Validation:
- `ruby -ryaml -e 'data = YAML.load_file(".github/dependabot.yml"); gomod = data.fetch("updates").select { |u| u["package-ecosystem"] == "gomod" }; missing = gomod.reject { |u| Array(u["ignore"]).any? { |i| i["dependency-name"] == "k8s.io/*" && i["update-types"] == ["version-update:semver-minor", "version-update:semver-major"] } }; puts "updates=#{data.fetch("updates").length}"; puts "gomod=#{gomod.length}"; puts "missing_k8s_rule=#{missing.map { |u| u["directory"] }.join(",")}"; exit(missing.empty? ? 0 : 1)'`
- `git diff --check -- .github/dependabot.yml`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
