### PR TITLE
Allow destination prefixes for disabled-floating-IP NSG rules

### DIFF
--- a/internal/testutil/fixture/kubernetes.go
+++ b/internal/testutil/fixture/kubernetes.go
@@ -96,6 +96,11 @@ func (f *KubernetesServiceFixture) WithAllowedIPRanges(parts ...string) *Kuberne
 	return f
 }
 
+func (f *KubernetesServiceFixture) WithAllowedDestinationIPRanges(parts ...string) *KubernetesServiceFixture {
+	f.svc.Annotations[consts.ServiceAnnotationAllowedDestinationIPRanges] = strings.Join(parts, ",")
+	return f
+}
+
 func (f *KubernetesServiceFixture) WithAllowedServiceTags(parts ...string) *KubernetesServiceFixture {
 	f.svc.Annotations[consts.ServiceAnnotationAllowedServiceTags] = strings.Join(parts, ",")
 	return f

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -287,6 +287,11 @@ const (
 	// It is compatible with both IPv4 and IPV6 CIDR formats.
 	ServiceAnnotationAllowedIPRanges = "service.beta.kubernetes.io/azure-allowed-ip-ranges"
 
+	// ServiceAnnotationAllowedDestinationIPRanges is the annotation used on the service
+	// to specify a list of allowed destination IP Ranges separated by comma.
+	// It is compatible with both IPv4 and IPV6 CIDR formats.
+	ServiceAnnotationAllowedDestinationIPRanges = "service.beta.kubernetes.io/azure-allowed-destination-ip-ranges"
+
 	// ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges  denies all traffic to the load balancer except those
 	// within the service.Spec.LoadBalancerSourceRanges. Ref: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/374.
 	ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges = "service.beta.kubernetes.io/azure-deny-all-except-load-balancer-source-ranges"

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3479,21 +3479,74 @@ func (az *Cloud) reconcileSecurityGroup(
 		dstIPv6Addresses = append(dstIPv6Addresses, lbIPv6Addresses...)
 	}
 
+	var (
+		desiredDstIPv4Prefixes                    = loadbalancer.AddressPrefixes(dstIPv4Addresses)
+		desiredDstIPv6Prefixes                    = loadbalancer.AddressPrefixes(dstIPv6Addresses)
+		desiredIncludesDefaultBackendDestinations = disableFloatingIP
+		staleDstIPv4Prefixes                      []string
+		staleDstIPv6Prefixes                      []string
+	)
+	if disableFloatingIP && len(accessControl.AllowedDestinationIPRanges) > 0 {
+		allowedDestinationIPv4Prefixes := loadbalancer.AggregatedIPRangePrefixes(accessControl.AllowedDestinationIPv4Ranges())
+		allowedDestinationIPv6Prefixes := loadbalancer.AggregatedIPRangePrefixes(accessControl.AllowedDestinationIPv6Ranges())
+		backendIPv4Prefixes := loadbalancer.AddressPrefixes(backendIPv4Addresses)
+		backendIPv6Prefixes := loadbalancer.AddressPrefixes(backendIPv6Addresses)
+		desiredIncludesDefaultBackendDestinations = false
+
+		desiredDstIPv4Prefixes = loadbalancer.AddressPrefixes(additionalIPv4Addresses)
+		if len(allowedDestinationIPv4Prefixes) > 0 {
+			desiredDstIPv4Prefixes = append(desiredDstIPv4Prefixes, allowedDestinationIPv4Prefixes...)
+			staleDstIPv4Prefixes = backendIPv4Prefixes
+		} else {
+			desiredDstIPv4Prefixes = append(desiredDstIPv4Prefixes, backendIPv4Prefixes...)
+			desiredIncludesDefaultBackendDestinations = desiredIncludesDefaultBackendDestinations || len(backendIPv4Prefixes) > 0
+		}
+
+		desiredDstIPv6Prefixes = loadbalancer.AddressPrefixes(additionalIPv6Addresses)
+		if len(allowedDestinationIPv6Prefixes) > 0 {
+			desiredDstIPv6Prefixes = append(desiredDstIPv6Prefixes, allowedDestinationIPv6Prefixes...)
+			staleDstIPv6Prefixes = backendIPv6Prefixes
+		} else {
+			desiredDstIPv6Prefixes = append(desiredDstIPv6Prefixes, backendIPv6Prefixes...)
+			desiredIncludesDefaultBackendDestinations = desiredIncludesDefaultBackendDestinations || len(backendIPv6Prefixes) > 0
+		}
+	}
+
 	{
-		retainPortRanges, err := az.listSharedIPPortMapping(ctx, service, append(dstIPv4Addresses, dstIPv6Addresses...))
+		// Include default disable-floating-IP services when the desired destination set
+		// still contains backend node IPs, including per-family fallback cases.
+		retainPortRanges, err := az.listSharedIPPortMapping(
+			ctx,
+			service,
+			append(desiredDstIPv4Prefixes, desiredDstIPv6Prefixes...),
+			desiredIncludesDefaultBackendDestinations,
+		)
 		if err != nil {
 			logger.Error(err, "Failed to list retain port ranges")
 			return nil, err
 		}
 
-		if err := accessControl.CleanSecurityGroup(dstIPv4Addresses, dstIPv6Addresses, retainPortRanges); err != nil {
+		if err := accessControl.CleanSecurityGroupPrefixes(desiredDstIPv4Prefixes, desiredDstIPv6Prefixes, retainPortRanges); err != nil {
 			logger.Error(err, "Failed to clean security group")
 			return nil, err
 		}
 	}
 
+	if len(staleDstIPv4Prefixes) > 0 || len(staleDstIPv6Prefixes) > 0 {
+		retainPortRanges, err := az.listSharedIPPortMapping(ctx, service, append(staleDstIPv4Prefixes, staleDstIPv6Prefixes...), true)
+		if err != nil {
+			logger.Error(err, "Failed to list retain port ranges")
+			return nil, err
+		}
+
+		if err := accessControl.CleanSecurityGroupPrefixes(staleDstIPv4Prefixes, staleDstIPv6Prefixes, retainPortRanges); err != nil {
+			logger.Error(err, "Failed to clean stale backend security group destinations")
+			return nil, err
+		}
+	}
+
 	if wantLb {
-		err := accessControl.PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses)
+		err := accessControl.PatchSecurityGroupPrefixes(desiredDstIPv4Prefixes, desiredDstIPv6Prefixes)
 		if err != nil {
 			logger.Error(err, "Failed to patch security group")
 			return nil, err
@@ -3502,18 +3555,17 @@ func (az *Cloud) reconcileSecurityGroup(
 
 	{
 		// Retain all destinations that are managed by cloud-provider.
-		managedDestinations, err := az.listAvailableSecurityGroupDestinations(ctx)
+		managedDestinations, err := az.listAvailableSecurityGroupDestinationPrefixes(ctx)
 		if err != nil {
 			logger.Error(err, "Failed to list available security group destinations")
 			return nil, err
 		}
 
-		managedDestinations = append(managedDestinations, lbIPAddresses...)
-		managedDestinations = append(managedDestinations, additionalIPs...)
+		managedDestinations = append(managedDestinations, loadbalancer.AddressPrefixes(lbIPAddresses)...)
+		managedDestinations = append(managedDestinations, loadbalancer.AddressPrefixes(additionalIPs)...)
 		logger.Info("Retaining security group", "managed-destinations", managedDestinations)
 
-		ipv4Addresses, ipv6Addresses := iputil.GroupAddressesByFamily(managedDestinations)
-		if err := accessControl.RetainSecurityGroup(ipv4Addresses, ipv6Addresses); err != nil {
+		if err := accessControl.RetainSecurityGroupPrefixes(managedDestinations); err != nil {
 			logger.Error(err, "Failed to retain security group")
 			return nil, err
 		}

--- a/pkg/provider/azure_loadbalancer_accesscontrol.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol.go
@@ -31,8 +31,8 @@ import (
 	fnutil "sigs.k8s.io/cloud-provider-azure/pkg/util/collectionutil"
 )
 
-func filterServicesByIngressIPs(services []*v1.Service, ips []netip.Addr) []*v1.Service {
-	targetIPs := fnutil.Map(func(ip netip.Addr) string { return ip.String() }, ips)
+func filterServicesByIngressIPPrefixes(services []*v1.Service, destinationPrefixes []string) []*v1.Service {
+	targetIPs := fnutil.IndexSet(destinationPrefixes)
 
 	return fnutil.Filter(func(svc *v1.Service) bool {
 
@@ -40,13 +40,28 @@ func filterServicesByIngressIPs(services []*v1.Service, ips []netip.Addr) []*v1.
 
 		ingressIPs = fnutil.Filter(func(ip string) bool { return ip != "" }, ingressIPs)
 
-		return len(fnutil.Intersection(ingressIPs, targetIPs)) > 0
+		return len(targetIPs.Intersection(ingressIPs)) > 0
 	}, services)
 }
 
-func filterServicesByDisableFloatingIP(services []*v1.Service) []*v1.Service {
+func filterServicesByDisableFloatingIP(
+	services []*v1.Service,
+	destinationPrefixes []string,
+	includeDefaultDestinationServices bool,
+) []*v1.Service {
+	targetPrefixes := fnutil.IndexSet(destinationPrefixes)
+
 	return fnutil.Filter(func(svc *v1.Service) bool {
-		return consts.IsK8sServiceDisableLoadBalancerFloatingIP(svc)
+		if !consts.IsK8sServiceDisableLoadBalancerFloatingIP(svc) {
+			return false
+		}
+
+		allowedDestinationIPRanges, _, _ := loadbalancer.AllowedDestinationIPRanges(svc)
+		if len(allowedDestinationIPRanges) == 0 {
+			return includeDefaultDestinationServices
+		}
+
+		return len(targetPrefixes.Intersection(loadbalancer.AggregatedIPRangePrefixes(allowedDestinationIPRanges))) > 0
 	}, services)
 }
 
@@ -56,7 +71,8 @@ func filterServicesByDisableFloatingIP(services []*v1.Service) []*v1.Service {
 func (az *Cloud) listSharedIPPortMapping(
 	ctx context.Context,
 	svc *v1.Service,
-	ingressIPs []netip.Addr,
+	destinationPrefixes []string,
+	includeDefaultDisableFloatingIPServices bool,
 ) (map[armnetwork.SecurityRuleProtocol][]int32, error) {
 	var (
 		logger = log.FromContextOrBackground(ctx).WithName("listSharedIPPortMapping")
@@ -77,10 +93,10 @@ func (az *Cloud) listSharedIPPortMapping(
 		// Filter services by ingress IPs or backend node pool IPs (when disable floating IP)
 		if consts.IsK8sServiceDisableLoadBalancerFloatingIP(svc) {
 			logger.V(5).Info("Filter service by disableFloatingIP")
-			services = filterServicesByDisableFloatingIP(services)
+			services = filterServicesByDisableFloatingIP(services, destinationPrefixes, includeDefaultDisableFloatingIPServices)
 		} else {
 			logger.V(5).Info("Filter service by external IPs")
-			services = filterServicesByIngressIPs(services, ingressIPs)
+			services = filterServicesByIngressIPPrefixes(services, destinationPrefixes)
 		}
 	}
 	logger.V(5).Info("Filtered services", "num-filtered-services", len(services))
@@ -107,7 +123,7 @@ func (az *Cloud) listSharedIPPortMapping(
 	return rv, nil
 }
 
-func (az *Cloud) listAvailableSecurityGroupDestinations(_ context.Context) ([]netip.Addr, error) {
+func (az *Cloud) listAvailableSecurityGroupDestinationPrefixes(_ context.Context) ([]string, error) {
 	services, err := az.serviceLister.List(labels.Everything())
 	if err != nil {
 		return nil, fmt.Errorf("list all services: %w", err)
@@ -118,13 +134,13 @@ func (az *Cloud) listAvailableSecurityGroupDestinations(_ context.Context) ([]ne
 		return nil, fmt.Errorf("list all nodes: %w", err)
 	}
 
-	var rv []netip.Addr
+	var rv []string
 	for _, svc := range services {
 		// Add additional public IPs
 		{
 			ips, err := loadbalancer.AdditionalPublicIPs(svc)
 			if err == nil {
-				rv = append(rv, ips...)
+				rv = append(rv, loadbalancer.AddressPrefixes(ips)...)
 			}
 		}
 
@@ -133,9 +149,14 @@ func (az *Cloud) listAvailableSecurityGroupDestinations(_ context.Context) ([]ne
 			for _, ing := range svc.Status.LoadBalancer.Ingress {
 				ip, err := netip.ParseAddr(ing.IP)
 				if err == nil {
-					rv = append(rv, ip)
+					rv = append(rv, ip.String())
 				}
 			}
+		}
+
+		if consts.IsK8sServiceDisableLoadBalancerFloatingIP(svc) {
+			destinationIPRanges, _, _ := loadbalancer.AllowedDestinationIPRanges(svc)
+			rv = append(rv, loadbalancer.AggregatedIPRangePrefixes(destinationIPRanges)...)
 		}
 	}
 
@@ -151,7 +172,7 @@ func (az *Cloud) listAvailableSecurityGroupDestinations(_ context.Context) ([]ne
 				}
 				ip, err := netip.ParseAddr(addr.Address)
 				if err == nil {
-					rv = append(rv, ip)
+					rv = append(rv, ip.String())
 				}
 			}
 		}

--- a/pkg/provider/azure_loadbalancer_accesscontrol_test.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol_test.go
@@ -428,9 +428,11 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 			defer ctrl.Finish()
 
 			{
-				kubeClient := fake.NewSimpleClientset(makeNodesByIPs(
+				runtimeObjects := []runtime.Object{&svc}
+				runtimeObjects = append(runtimeObjects, makeNodesByIPs(
 					append(azureFx.LoadBalancer().BackendPoolIPv4Addresses(), azureFx.LoadBalancer().BackendPoolIPv6Addresses()...),
 				)...)
+				kubeClient := fake.NewSimpleClientset(runtimeObjects...)
 				informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 				az.serviceLister = informerFactory.Core().V1().Services().Lister()
 				az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
@@ -493,6 +495,339 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 					azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
 					azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
 				).
+				Times(1)
+
+			_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
+			assert.NoError(t, err)
+		})
+
+		t.Run("with `service.beta.kubernetes.io/azure-allowed-destination-ip-ranges` specified", func(t *testing.T) {
+			var (
+				ctrl                    = gomock.NewController(t)
+				az                      = GetTestCloud(ctrl)
+				securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+				loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+				loadBalancer            = azureFx.LoadBalancer().Build()
+			)
+			defer ctrl.Finish()
+
+			svc := k8sFx.Service().
+				WithDisableFloatingIP().
+				WithAllowedDestinationIPRanges("10.244.0.0/24", "10.244.1.0/24", "fd00:10:244::/64").
+				Build()
+
+			{
+				runtimeObjects := []runtime.Object{&svc}
+				runtimeObjects = append(runtimeObjects, makeNodesByIPs(
+					append(azureFx.LoadBalancer().BackendPoolIPv4Addresses(), azureFx.LoadBalancer().BackendPoolIPv6Addresses()...),
+				)...)
+				kubeClient := fake.NewSimpleClientset(runtimeObjects...)
+				informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+				az.serviceLister = informerFactory.Core().V1().Services().Lister()
+				az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+				informerFactory.Start(wait.NeverStop)
+				informerFactory.WaitForCacheSync(wait.NeverStop)
+			}
+
+			serviceTags := []string{securitygroup.ServiceTagInternet}
+			staleRules := []*armnetwork.SecurityRule{
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, serviceTags, k8sFx.Service().TCPNodePorts()).
+					WithPriority(500).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+					Build(),
+
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, serviceTags, k8sFx.Service().TCPNodePorts()).
+					WithPriority(501).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+					Build(),
+
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, serviceTags, k8sFx.Service().UDPNodePorts()).
+					WithPriority(502).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+					Build(),
+
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, serviceTags, k8sFx.Service().UDPNodePorts()).
+					WithPriority(503).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+					Build(),
+			}
+			securityGroup := azureFx.SecurityGroup().WithRules(staleRules).Build()
+
+			securityGroupClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+				Return(securityGroup, nil).
+				Times(1)
+			securityGroupClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+				DoAndReturn(func(
+					_ context.Context,
+					_, _ string,
+					properties armnetwork.SecurityGroup,
+				) (*armnetwork.SecurityGroup, error) {
+					rules := []*armnetwork.SecurityRule{
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, serviceTags, k8sFx.Service().TCPNodePorts()).
+							WithPriority(500).
+							WithDestination("10.244.0.0/23").
+							Build(),
+
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, serviceTags, k8sFx.Service().TCPNodePorts()).
+							WithPriority(501).
+							WithDestination("fd00:10:244::/64").
+							Build(),
+
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, serviceTags, k8sFx.Service().UDPNodePorts()).
+							WithPriority(502).
+							WithDestination("10.244.0.0/23").
+							Build(),
+
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, serviceTags, k8sFx.Service().UDPNodePorts()).
+							WithPriority(503).
+							WithDestination("fd00:10:244::/64").
+							Build(),
+					}
+
+					testutil.ExpectExactSecurityRules(t, &properties, rules)
+					return nil, nil
+				}).Times(1)
+			loadBalancerClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+				Return(loadBalancer, nil).
+				Times(1)
+			loadBalancerBackendPool.EXPECT().
+				GetBackendPrivateIPs(gomock.Any(), ClusterName, &svc, loadBalancer).
+				Return(
+					azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+					azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
+				).
+				Times(1)
+
+			_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
+			assert.NoError(t, err)
+		})
+
+		t.Run("with partial `service.beta.kubernetes.io/azure-allowed-destination-ip-ranges` specified", func(t *testing.T) {
+			var (
+				ctrl                    = gomock.NewController(t)
+				az                      = GetTestCloud(ctrl)
+				securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+				loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+				loadBalancer            = azureFx.LoadBalancer().Build()
+			)
+			defer ctrl.Finish()
+
+			svc := k8sFx.Service().
+				WithDisableFloatingIP().
+				WithAllowedDestinationIPRanges("10.244.0.0/16").
+				Build()
+
+			{
+				runtimeObjects := []runtime.Object{&svc}
+				runtimeObjects = append(runtimeObjects, makeNodesByIPs(
+					append(azureFx.LoadBalancer().BackendPoolIPv4Addresses(), azureFx.LoadBalancer().BackendPoolIPv6Addresses()...),
+				)...)
+				kubeClient := fake.NewSimpleClientset(runtimeObjects...)
+				informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+				az.serviceLister = informerFactory.Core().V1().Services().Lister()
+				az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+				informerFactory.Start(wait.NeverStop)
+				informerFactory.WaitForCacheSync(wait.NeverStop)
+			}
+
+			serviceTags := []string{securitygroup.ServiceTagInternet}
+			staleRules := []*armnetwork.SecurityRule{
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, serviceTags, k8sFx.Service().TCPNodePorts()).
+					WithPriority(500).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+					Build(),
+
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, serviceTags, k8sFx.Service().UDPNodePorts()).
+					WithPriority(502).
+					WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+					Build(),
+			}
+			securityGroup := azureFx.SecurityGroup().WithRules(staleRules).Build()
+
+			securityGroupClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+				Return(securityGroup, nil).
+				Times(1)
+			securityGroupClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+				DoAndReturn(func(
+					_ context.Context,
+					_, _ string,
+					properties armnetwork.SecurityGroup,
+				) (*armnetwork.SecurityGroup, error) {
+					rules := []*armnetwork.SecurityRule{
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, serviceTags, k8sFx.Service().TCPNodePorts()).
+							WithPriority(500).
+							WithDestination("10.244.0.0/16").
+							Build(),
+
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, serviceTags, k8sFx.Service().TCPNodePorts()).
+							WithPriority(501).
+							WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+							Build(),
+
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, serviceTags, k8sFx.Service().UDPNodePorts()).
+							WithPriority(502).
+							WithDestination("10.244.0.0/16").
+							Build(),
+
+						azureFx.
+							AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, serviceTags, k8sFx.Service().UDPNodePorts()).
+							WithPriority(503).
+							WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+							Build(),
+					}
+
+					testutil.ExpectExactSecurityRules(t, &properties, rules)
+					return nil, nil
+				}).Times(1)
+			loadBalancerClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+				Return(loadBalancer, nil).
+				Times(1)
+			loadBalancerBackendPool.EXPECT().
+				GetBackendPrivateIPs(gomock.Any(), ClusterName, &svc, loadBalancer).
+				Return(
+					azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+					azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
+				).
+				Times(1)
+
+			_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
+			assert.NoError(t, err)
+		})
+
+		t.Run("with shared backend node destinations for disable floating IP services", func(t *testing.T) {
+			var (
+				ctrl                    = gomock.NewController(t)
+				az                      = GetTestCloud(ctrl)
+				securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+				loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+				loadBalancer            = azureFx.LoadBalancer().Build()
+			)
+			defer ctrl.Finish()
+
+			svc := k8sFx.Service().
+				WithNamespace("ns-01").
+				WithName("svc-01").
+				WithDisableFloatingIP().
+				Build()
+			svc.Spec.Ports = []v1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: v1.ProtocolTCP,
+					Port:     80,
+					NodePort: 50080,
+				},
+			}
+
+			sharedSvc := k8sFx.Service().
+				WithNamespace("ns-02").
+				WithName("svc-02").
+				WithDisableFloatingIP().
+				Build()
+			sharedSvc.Spec.Ports = []v1.ServicePort{
+				{
+					Name:     "app-1",
+					Protocol: v1.ProtocolTCP,
+					Port:     18000,
+					NodePort: 48000,
+				},
+				{
+					Name:     "app-2",
+					Protocol: v1.ProtocolTCP,
+					Port:     19000,
+					NodePort: 49000,
+				},
+			}
+
+			backendIPv4Addresses := azureFx.LoadBalancer().BackendPoolIPv4Addresses()
+			backendIPv6Addresses := azureFx.LoadBalancer().BackendPoolIPv6Addresses()
+			{
+				runtimeObjects := []runtime.Object{&svc, &sharedSvc}
+				runtimeObjects = append(runtimeObjects, makeNodesByIPs(
+					append(backendIPv4Addresses, backendIPv6Addresses...),
+				)...)
+				kubeClient := fake.NewSimpleClientset(runtimeObjects...)
+				informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+				az.serviceLister = informerFactory.Core().V1().Services().Lister()
+				az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+				informerFactory.Start(wait.NeverStop)
+				informerFactory.WaitForCacheSync(wait.NeverStop)
+			}
+
+			serviceTags := []string{securitygroup.ServiceTagInternet}
+			securityGroup := azureFx.SecurityGroup().WithRules([]*armnetwork.SecurityRule{
+				azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, serviceTags, []int32{48000, 49000, 50080}).
+					WithPriority(500).
+					WithDestination(backendIPv4Addresses...).
+					Build(),
+			}).Build()
+
+			securityGroupClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+				Return(securityGroup, nil).
+				Times(1)
+			securityGroupClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+				DoAndReturn(func(
+					_ context.Context,
+					_, _ string,
+					properties armnetwork.SecurityGroup,
+				) (*armnetwork.SecurityGroup, error) {
+					assertHasRule := func(ipFamily iputil.Family, dstPrefixes []string, dstPorts []int32) {
+						for _, rule := range properties.Properties.SecurityRules {
+							if rule.Properties == nil ||
+								rule.Properties.Protocol == nil ||
+								*rule.Properties.Protocol != armnetwork.SecurityRuleProtocolTCP ||
+								rule.Properties.Access == nil ||
+								*rule.Properties.Access != armnetwork.SecurityRuleAccessAllow {
+								continue
+							}
+
+							rulePorts, err := securitygroup.ListDestinationPortRanges(rule)
+							assert.NoError(t, err)
+							if assert.ObjectsAreEqualValues([]string{securitygroup.ServiceTagInternet}, securitygroup.ListSourcePrefixes(rule)) &&
+								assert.ObjectsAreEqualValues(dstPrefixes, securitygroup.ListDestinationPrefixes(rule)) &&
+								assert.ObjectsAreEqualValues(dstPorts, rulePorts) {
+								return
+							}
+						}
+						assert.Failf(t, "expected security rule not found", "ipFamily=%s dstPrefixes=%v dstPorts=%v", ipFamily, dstPrefixes, dstPorts)
+					}
+
+					assertHasRule(iputil.IPv4, backendIPv4Addresses, []int32{48000, 49000})
+					assertHasRule(iputil.IPv4, backendIPv4Addresses, []int32{50080})
+					assertHasRule(iputil.IPv6, backendIPv6Addresses, []int32{50080})
+					return nil, nil
+				}).Times(1)
+			loadBalancerClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+				Return(loadBalancer, nil).
+				Times(1)
+			loadBalancerBackendPool.EXPECT().
+				GetBackendPrivateIPs(gomock.Any(), ClusterName, &svc, loadBalancer).
+				Return(backendIPv4Addresses, backendIPv6Addresses).
 				Times(1)
 
 			_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
@@ -2704,4 +3039,47 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
+}
+
+func TestCloud_listAvailableSecurityGroupDestinationPrefixes(t *testing.T) {
+	var (
+		fx    = fixture.NewFixture()
+		k8sFx = fx.Kubernetes()
+		ctrl  = gomock.NewController(t)
+		az    = GetTestCloud(ctrl)
+	)
+	defer ctrl.Finish()
+
+	svc := k8sFx.Service().
+		WithDisableFloatingIP().
+		WithAllowedDestinationIPRanges("10.244.0.0/24", "10.244.1.0/24", "fd00:10:244::/64").
+		WithIngressIPs([]string{"20.0.0.4"}).
+		Build()
+	kubeClient := fake.NewSimpleClientset(
+		&svc,
+		&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-0"},
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{
+					{Type: v1.NodeInternalIP, Address: "10.0.0.4"},
+					{Type: v1.NodeExternalIP, Address: "52.0.0.4"},
+				},
+			},
+		},
+	)
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	az.serviceLister = informerFactory.Core().V1().Services().Lister()
+	az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+	informerFactory.Start(wait.NeverStop)
+	informerFactory.WaitForCacheSync(wait.NeverStop)
+
+	prefixes, err := az.listAvailableSecurityGroupDestinationPrefixes(context.Background())
+
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"20.0.0.4",
+		"10.244.0.0/23",
+		"fd00:10:244::/64",
+		"10.0.0.4",
+	}, prefixes)
 }

--- a/pkg/provider/loadbalancer/accesscontrol.go
+++ b/pkg/provider/loadbalancer/accesscontrol.go
@@ -46,6 +46,7 @@ type AccessControl struct {
 	// immutable pre-compute states.
 	SourceRanges                           []netip.Prefix
 	AllowedIPRanges                        []netip.Prefix
+	AllowedDestinationIPRanges             []netip.Prefix
 	AllowedServiceTags                     []string
 	invalidRanges                          []string
 	securityRuleDestinationPortsByProtocol map[armnetwork.SecurityRuleProtocol][]int32
@@ -95,6 +96,12 @@ func NewAccessControl(logger logr.Logger, svc *v1.Service, sg *armnetwork.Securi
 		// Backward compatibility: no error but emit a warning event.
 		eventEmitter(svc, v1.EventTypeWarning, "InvalidAllowedIPRanges", EventMessageOfInvalidAllowedIPRanges(invalidAllowedIPRanges))
 	}
+	allowedDestinationIPRanges, invalidAllowedDestinationIPRanges, err := AllowedDestinationIPRanges(svc)
+	if err != nil {
+		logger.Error(err, "Failed to parse AllowedDestinationIPRanges configuration")
+
+		eventEmitter(svc, v1.EventTypeWarning, "InvalidAllowedDestinationIPRanges", EventMessageOfInvalidAllowedDestinationIPRanges(invalidAllowedDestinationIPRanges))
+	}
 	allowedServiceTags := AllowedServiceTags(svc)
 	securityRuleDestinationPortsByProtocol, err := SecurityRuleDestinationPortsByProtocol(svc)
 	if err != nil {
@@ -121,6 +128,7 @@ func NewAccessControl(logger logr.Logger, svc *v1.Service, sg *armnetwork.Securi
 		sgHelper:                               sgHelper,
 		SourceRanges:                           sourceRanges,
 		AllowedIPRanges:                        allowedIPRanges,
+		AllowedDestinationIPRanges:             allowedDestinationIPRanges,
 		AllowedServiceTags:                     allowedServiceTags,
 		invalidRanges:                          append(invalidSourceRanges, invalidAllowedIPRanges...),
 		securityRuleDestinationPortsByProtocol: securityRuleDestinationPortsByProtocol,
@@ -194,8 +202,47 @@ func (ac *AccessControl) AllowedIPv6Ranges() []netip.Prefix {
 	return rv
 }
 
+// AllowedDestinationIPv4Ranges returns the IPv4 ranges that should be used as SecurityGroup destinations.
+func (ac *AccessControl) AllowedDestinationIPv4Ranges() []netip.Prefix {
+	var rv []netip.Prefix
+	for _, cidr := range ac.AllowedDestinationIPRanges {
+		if cidr.Addr().Is4() {
+			rv = append(rv, cidr)
+		}
+	}
+	return rv
+}
+
+// AllowedDestinationIPv6Ranges returns the IPv6 ranges that should be used as SecurityGroup destinations.
+func (ac *AccessControl) AllowedDestinationIPv6Ranges() []netip.Prefix {
+	var rv []netip.Prefix
+	for _, cidr := range ac.AllowedDestinationIPRanges {
+		if cidr.Addr().Is6() {
+			rv = append(rv, cidr)
+		}
+	}
+	return rv
+}
+
+func AddressPrefixes(addrs []netip.Addr) []string {
+	return fnutil.Map(func(addr netip.Addr) string { return addr.String() }, addrs)
+}
+
+func IPRangePrefixes(prefixes []netip.Prefix) []string {
+	return fnutil.Map(func(prefix netip.Prefix) string { return prefix.String() }, prefixes)
+}
+
+func AggregatedIPRangePrefixes(prefixes []netip.Prefix) []string {
+	return IPRangePrefixes(iputil.AggregatePrefixes(prefixes))
+}
+
 // PatchSecurityGroup checks and adds rules for the given destination IP addresses.
 func (ac *AccessControl) PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses []netip.Addr) error {
+	return ac.PatchSecurityGroupPrefixes(AddressPrefixes(dstIPv4Addresses), AddressPrefixes(dstIPv6Addresses))
+}
+
+// PatchSecurityGroupPrefixes checks and adds rules for the given destination IP prefixes.
+func (ac *AccessControl) PatchSecurityGroupPrefixes(dstIPv4Prefixes, dstIPv6Prefixes []string) error {
 	logger := ac.logger.WithName("PatchSecurityGroup")
 
 	var (
@@ -238,31 +285,31 @@ func (ac *AccessControl) PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses [
 		if !found {
 			continue
 		}
-		if len(dstIPv4Addresses) > 0 {
+		if len(dstIPv4Prefixes) > 0 {
 			for _, tag := range allowedServiceTags {
-				err := ac.sgHelper.AddRuleForAllowedServiceTag(tag, protocol, dstIPv4Addresses, dstPorts)
+				err := ac.sgHelper.AddRuleForAllowedServiceTagPrefixes(tag, protocol, iputil.IPv4, dstIPv4Prefixes, dstPorts)
 				if err != nil {
 					return fmt.Errorf("add rule for allowed service tag on IPv4: %w", err)
 				}
 			}
 
 			if len(allowedIPv4Ranges) > 0 {
-				err := ac.sgHelper.AddRuleForAllowedIPRanges(allowedIPv4Ranges, protocol, dstIPv4Addresses, dstPorts)
+				err := ac.sgHelper.AddRuleForAllowedIPRangesWithDestinationPrefixes(allowedIPv4Ranges, protocol, iputil.IPv4, dstIPv4Prefixes, dstPorts)
 				if err != nil {
 					return fmt.Errorf("add rule for allowed IP ranges on IPv4: %w", err)
 				}
 			}
 		}
-		if len(dstIPv6Addresses) > 0 {
+		if len(dstIPv6Prefixes) > 0 {
 			for _, tag := range allowedServiceTags {
-				err := ac.sgHelper.AddRuleForAllowedServiceTag(tag, protocol, dstIPv6Addresses, dstPorts)
+				err := ac.sgHelper.AddRuleForAllowedServiceTagPrefixes(tag, protocol, iputil.IPv6, dstIPv6Prefixes, dstPorts)
 				if err != nil {
 					return fmt.Errorf("add rule for allowed service tag on IPv6: %w", err)
 				}
 			}
 
 			if len(allowedIPv6Ranges) > 0 {
-				err := ac.sgHelper.AddRuleForAllowedIPRanges(allowedIPv6Ranges, protocol, dstIPv6Addresses, dstPorts)
+				err := ac.sgHelper.AddRuleForAllowedIPRangesWithDestinationPrefixes(allowedIPv6Ranges, protocol, iputil.IPv6, dstIPv6Prefixes, dstPorts)
 				if err != nil {
 					return fmt.Errorf("add rule for allowed IP ranges on IPv6: %w", err)
 				}
@@ -271,13 +318,13 @@ func (ac *AccessControl) PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses [
 	}
 
 	if ac.DenyAllExceptSourceRanges() {
-		if len(dstIPv4Addresses) > 0 {
-			if err := ac.sgHelper.AddRuleForDenyAll(dstIPv4Addresses); err != nil {
+		if len(dstIPv4Prefixes) > 0 {
+			if err := ac.sgHelper.AddRuleForDenyAllPrefixes(iputil.IPv4, dstIPv4Prefixes); err != nil {
 				return fmt.Errorf("add rule for deny all on IPv4: %w", err)
 			}
 		}
-		if len(dstIPv6Addresses) > 0 {
-			if err := ac.sgHelper.AddRuleForDenyAll(dstIPv6Addresses); err != nil {
+		if len(dstIPv6Prefixes) > 0 {
+			if err := ac.sgHelper.AddRuleForDenyAllPrefixes(iputil.IPv6, dstIPv6Prefixes); err != nil {
 				return fmt.Errorf("add rule for deny all on IPv6: %w", err)
 			}
 		}
@@ -293,15 +340,18 @@ func (ac *AccessControl) CleanSecurityGroup(
 	dstIPv4Addresses, dstIPv6Addresses []netip.Addr,
 	retainPortRanges map[armnetwork.SecurityRuleProtocol][]int32,
 ) error {
-	logger := ac.logger.WithName("CleanSecurityGroup").
-		WithValues("num-dst-ipv4-addresses", len(dstIPv4Addresses)).
-		WithValues("num-dst-ipv6-addresses", len(dstIPv6Addresses))
-	logger.V(10).Info("Start cleaning")
+	return ac.CleanSecurityGroupPrefixes(AddressPrefixes(dstIPv4Addresses), AddressPrefixes(dstIPv6Addresses), retainPortRanges)
+}
 
-	var (
-		ipv4Prefixes = fnutil.Map(func(addr netip.Addr) string { return addr.String() }, dstIPv4Addresses)
-		ipv6Prefixes = fnutil.Map(func(addr netip.Addr) string { return addr.String() }, dstIPv6Addresses)
-	)
+// CleanSecurityGroupPrefixes removes the given IP prefixes from the SecurityGroup.
+func (ac *AccessControl) CleanSecurityGroupPrefixes(
+	dstIPv4Prefixes, dstIPv6Prefixes []string,
+	retainPortRanges map[armnetwork.SecurityRuleProtocol][]int32,
+) error {
+	logger := ac.logger.WithName("CleanSecurityGroup").
+		WithValues("num-dst-ipv4-prefixes", len(dstIPv4Prefixes)).
+		WithValues("num-dst-ipv6-prefixes", len(dstIPv6Prefixes))
+	logger.V(10).Info("Start cleaning")
 
 	protocols := []armnetwork.SecurityRuleProtocol{
 		armnetwork.SecurityRuleProtocolTCP,
@@ -311,12 +361,12 @@ func (ac *AccessControl) CleanSecurityGroup(
 
 	for _, protocol := range protocols {
 		retainDstPorts := retainPortRanges[protocol]
-		if err := ac.sgHelper.RemoveDestinationFromRules(protocol, ipv4Prefixes, retainDstPorts); err != nil {
+		if err := ac.sgHelper.RemoveDestinationFromRules(protocol, dstIPv4Prefixes, retainDstPorts); err != nil {
 			logger.Error(err, "Failed to remove IPv4 destination from rules")
 			return err
 		}
 
-		if err := ac.sgHelper.RemoveDestinationFromRules(protocol, ipv6Prefixes, retainDstPorts); err != nil {
+		if err := ac.sgHelper.RemoveDestinationFromRules(protocol, dstIPv6Prefixes, retainDstPorts); err != nil {
 			logger.Error(err, "Failed to remove IPv6 destination from rules")
 			return err
 		}
@@ -328,17 +378,15 @@ func (ac *AccessControl) CleanSecurityGroup(
 
 // RetainSecurityGroup retains the given destination IP addresses from the SecurityGroup.
 func (ac *AccessControl) RetainSecurityGroup(dstIPv4Addresses, dstIPv6Addresses []netip.Addr) error {
+	return ac.RetainSecurityGroupPrefixes(append(AddressPrefixes(dstIPv4Addresses), AddressPrefixes(dstIPv6Addresses)...))
+}
+
+// RetainSecurityGroupPrefixes retains the given destination IP prefixes from the SecurityGroup.
+func (ac *AccessControl) RetainSecurityGroupPrefixes(retainedPrefixes []string) error {
 	logger := ac.logger.WithName("RetainSecurityGroup").
-		WithValues("num-dst-ipv4-addresses", len(dstIPv4Addresses)).
-		WithValues("num-dst-ipv6-addresses", len(dstIPv6Addresses))
+		WithValues("num-dst-prefixes", len(retainedPrefixes))
 	logger.V(10).Info("Start retaining")
 	defer logger.V(10).Info("Completed retaining")
-
-	var (
-		ipv4Prefixes     = fnutil.Map(func(addr netip.Addr) string { return addr.String() }, dstIPv4Addresses)
-		ipv6Prefixes     = fnutil.Map(func(addr netip.Addr) string { return addr.String() }, dstIPv6Addresses)
-		retainedPrefixes = append(ipv4Prefixes, ipv6Prefixes...)
-	)
 
 	if err := ac.sgHelper.RetainDestinationFromRules(retainedPrefixes); err != nil {
 		logger.Error(err, "Failed to retain destination from rules")

--- a/pkg/provider/loadbalancer/accesscontrol_test.go
+++ b/pkg/provider/loadbalancer/accesscontrol_test.go
@@ -184,6 +184,27 @@ func TestNewAccessControl(t *testing.T) {
 		assert.Equal(t, 1, called)
 	})
 
+	t.Run("it should emit warning event if invalid azure-allowed-destination-ip-ranges", func(t *testing.T) {
+		svc := k8sFx.Service().
+			WithAllowedDestinationIPRanges("foo", "10.0.0.0/24", "bar").
+			Build()
+
+		called := 0
+		eventEmitter := func(obj runtime.Object, eventType, reason, message string) {
+			called++
+			assert.Equal(t, &svc, obj)
+			assert.Equal(t, v1.EventTypeWarning, eventType)
+			assert.Equal(t, "InvalidAllowedDestinationIPRanges", reason)
+			assert.Equal(t, EventMessageOfInvalidAllowedDestinationIPRanges([]string{"foo", "bar"}), message)
+		}
+
+		ac, err := NewAccessControl(log.Noop(), &svc, sg, WithEventEmitter(eventEmitter))
+		assert.NoError(t, err)
+		assert.True(t, ac.IsAllowFromInternet())
+		assert.False(t, ac.DenyAllExceptSourceRanges())
+		assert.Equal(t, 1, called)
+	})
+
 	t.Run("it should emit warning event if using spec.LoadBalancerSourceRanges and azure-allowed-service-tags", func(t *testing.T) {
 		svc := k8sFx.Service().
 			WithLoadBalancerSourceRanges("20.0.0.1/32").

--- a/pkg/provider/loadbalancer/configuration.go
+++ b/pkg/provider/loadbalancer/configuration.go
@@ -93,6 +93,40 @@ func AllowedIPRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
 	return validRanges, invalidRanges, nil
 }
 
+// AllowedDestinationIPRanges returns the allowed destination IP ranges configured by user through AKS custom annotations:
+// service.beta.kubernetes.io/azure-allowed-destination-ip-ranges.
+func AllowedDestinationIPRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
+	const (
+		Sep = ","
+		Key = consts.ServiceAnnotationAllowedDestinationIPRanges
+	)
+	var (
+		errs          []error
+		validRanges   []netip.Prefix
+		invalidRanges []string
+	)
+
+	value, found := svc.Annotations[Key]
+	if !found {
+		return nil, nil, nil
+	}
+
+	for _, p := range strings.Split(strings.TrimSpace(value), Sep) {
+		p = strings.TrimSpace(p)
+		prefix, err := iputil.ParsePrefix(p)
+		if err != nil {
+			errs = append(errs, err)
+			invalidRanges = append(invalidRanges, p)
+		} else {
+			validRanges = append(validRanges, prefix)
+		}
+	}
+	if len(errs) > 0 {
+		return validRanges, invalidRanges, NewErrAnnotationValue(Key, value, errors.Join(errs...))
+	}
+	return validRanges, invalidRanges, nil
+}
+
 // SourceRanges returns the allowed IP ranges configured by user through `spec.LoadBalancerSourceRanges`.
 func SourceRanges(svc *v1.Service) ([]netip.Prefix, []string, error) {
 	var (

--- a/pkg/provider/loadbalancer/configuration_test.go
+++ b/pkg/provider/loadbalancer/configuration_test.go
@@ -223,6 +223,60 @@ func TestAllowedIPRanges(t *testing.T) {
 	})
 }
 
+func TestAllowedDestinationIPRanges(t *testing.T) {
+	t.Run("no annotation", func(t *testing.T) {
+		actual, invalid, err := AllowedDestinationIPRanges(&v1.Service{
+			Spec: v1.ServiceSpec{
+				Type: v1.ServiceTypeLoadBalancer,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, actual)
+		assert.Empty(t, invalid)
+	})
+
+	t.Run("with multiple destination ranges", func(t *testing.T) {
+		actual, invalid, err := AllowedDestinationIPRanges(&v1.Service{
+			Spec: v1.ServiceSpec{
+				Type: v1.ServiceTypeLoadBalancer,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					consts.ServiceAnnotationAllowedDestinationIPRanges: " 10.10.0.0/24, 2001:db8::/64 ",
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, []netip.Prefix{
+			netip.MustParsePrefix("10.10.0.0/24"),
+			netip.MustParsePrefix("2001:db8::/64"),
+		}, actual)
+		assert.Empty(t, invalid)
+	})
+
+	t.Run("with invalid destination ranges", func(t *testing.T) {
+		actual, invalid, err := AllowedDestinationIPRanges(&v1.Service{
+			Spec: v1.ServiceSpec{
+				Type: v1.ServiceTypeLoadBalancer,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					consts.ServiceAnnotationAllowedDestinationIPRanges: "foobar,10.0.0.0/24,10.0.0.1/24",
+				},
+			},
+		})
+		assert.Error(t, err)
+
+		var e *ErrAnnotationValue
+		assert.ErrorAs(t, err, &e)
+		assert.Equal(t, []netip.Prefix{netip.MustParsePrefix("10.0.0.0/24")}, actual)
+		assert.Equal(t, []string{"foobar", "10.0.0.1/24"}, invalid)
+	})
+}
+
 func TestSourceRanges(t *testing.T) {
 	t.Run("not specified in spec", func(t *testing.T) {
 		actual, invalid, err := SourceRanges(&v1.Service{

--- a/pkg/provider/loadbalancer/k8sevent.go
+++ b/pkg/provider/loadbalancer/k8sevent.go
@@ -42,6 +42,13 @@ func EventMessageOfInvalidAllowedIPRanges(allowedIPRanges []string) string {
 	)
 }
 
+func EventMessageOfInvalidAllowedDestinationIPRanges(allowedDestinationIPRanges []string) string {
+	return fmt.Sprintf("Found invalid %s %q, ignoring invalid entries.",
+		consts.ServiceAnnotationAllowedDestinationIPRanges,
+		allowedDestinationIPRanges,
+	)
+}
+
 func EventMessageOfConflictLoadBalancerSourceRangesAndAllowedIPRanges() string {
 	return fmt.Sprintf(
 		"Please use annotation %s instead of spec.loadBalancerSourceRanges while using %s annotation at the same time.",

--- a/pkg/provider/securitygroup/securitygroup.go
+++ b/pkg/provider/securitygroup/securitygroup.go
@@ -214,10 +214,25 @@ func (helper *RuleHelper) AddRuleForAllowedServiceTag(
 	}
 
 	var (
-		ipFamily    = iputil.FamilyOfAddr(dstAddresses[0])
-		srcPrefixes = []string{serviceTag}
-		dstPrefixes = fnutil.Map(func(ip netip.Addr) string { return ip.String() }, dstAddresses)
+		ipFamily = iputil.FamilyOfAddr(dstAddresses[0])
 	)
+
+	return helper.AddRuleForAllowedServiceTagPrefixes(serviceTag, protocol, ipFamily, fnutil.Map(func(ip netip.Addr) string { return ip.String() }, dstAddresses), dstPorts)
+}
+
+// AddRuleForAllowedServiceTagPrefixes adds a rule for traffic from a certain service tag to destination prefixes.
+func (helper *RuleHelper) AddRuleForAllowedServiceTagPrefixes(
+	serviceTag string,
+	protocol armnetwork.SecurityRuleProtocol,
+	ipFamily iputil.Family,
+	dstPrefixes []string,
+	dstPorts []int32,
+) error {
+	if err := validateDestinationPrefixFamilies(ipFamily, dstPrefixes); err != nil {
+		return err
+	}
+
+	srcPrefixes := []string{serviceTag}
 
 	helper.logger.V(4).Info("Patching a rule for allowed service tag", "ip-family", ipFamily)
 
@@ -242,10 +257,37 @@ func (helper *RuleHelper) AddRuleForAllowedIPRanges(
 	}
 
 	var (
-		ipFamily    = iputil.FamilyOfAddr(ipRanges[0].Addr())
-		srcPrefixes = fnutil.Map(func(ip netip.Prefix) string { return ip.String() }, ipRanges)
-		dstPrefixes = fnutil.Map(func(ip netip.Addr) string { return ip.String() }, dstAddresses)
+		ipFamily = iputil.FamilyOfAddr(ipRanges[0].Addr())
 	)
+
+	return helper.AddRuleForAllowedIPRangesWithDestinationPrefixes(
+		ipRanges,
+		protocol,
+		ipFamily,
+		fnutil.Map(func(ip netip.Addr) string { return ip.String() }, dstAddresses),
+		dstPorts,
+	)
+}
+
+// AddRuleForAllowedIPRangesWithDestinationPrefixes adds a rule for traffic from certain IP ranges to destination prefixes.
+func (helper *RuleHelper) AddRuleForAllowedIPRangesWithDestinationPrefixes(
+	ipRanges []netip.Prefix,
+	protocol armnetwork.SecurityRuleProtocol,
+	ipFamily iputil.Family,
+	dstPrefixes []string,
+	dstPorts []int32,
+) error {
+	if !iputil.ArePrefixesFromSameFamily(ipRanges) {
+		return ErrSecurityRuleSourceAddressesNotFromSameIPFamily
+	}
+	if err := validateDestinationPrefixFamilies(ipFamily, dstPrefixes); err != nil {
+		return err
+	}
+	if iputil.FamilyOfAddr(ipRanges[0].Addr()) != ipFamily {
+		return ErrSecurityRuleSourceAndDestinationNotFromSameIPFamily
+	}
+
+	srcPrefixes := fnutil.Map(func(ip netip.Prefix) string { return ip.String() }, ipRanges)
 
 	helper.logger.V(4).Info("Patching a rule for allowed IP ranges", "ip-family", ipFamily)
 
@@ -263,8 +305,18 @@ func (helper *RuleHelper) AddRuleForDenyAll(dstAddresses []netip.Addr) error {
 
 	var (
 		ipFamily = iputil.FamilyOfAddr(dstAddresses[0])
-		ruleName = GenerateDenyAllSecurityRuleName(ipFamily)
 	)
+
+	return helper.AddRuleForDenyAllPrefixes(ipFamily, fnutil.Map(func(ip netip.Addr) string { return ip.String() }, dstAddresses))
+}
+
+// AddRuleForDenyAllPrefixes adds a rule to deny all traffic from the given destination prefixes.
+func (helper *RuleHelper) AddRuleForDenyAllPrefixes(ipFamily iputil.Family, dstPrefixes []string) error {
+	if err := validateDestinationPrefixFamilies(ipFamily, dstPrefixes); err != nil {
+		return err
+	}
+
+	ruleName := GenerateDenyAllSecurityRuleName(ipFamily)
 
 	helper.logger.V(4).Info("Patching a rule for deny all", "ip-family", ipFamily)
 
@@ -282,8 +334,7 @@ func (helper *RuleHelper) AddRuleForDenyAll(dstAddresses []netip.Addr) error {
 	}
 	{
 		// Destination
-		addresses := fnutil.Map(func(ip netip.Addr) string { return ip.String() }, dstAddresses)
-		addresses = append(addresses, ListDestinationPrefixes(rule)...)
+		addresses := append(dstPrefixes, ListDestinationPrefixes(rule)...)
 		SetDestinationPrefixes(rule, addresses)
 		SetAsteriskDestinationPortRange(rule)
 	}
@@ -399,13 +450,49 @@ func (helper *RuleHelper) removeDestinationFromRule(rule *armnetwork.SecurityRul
 	}
 
 	// There are additional ports are expected, need to create a new rule for them.
-	addr, err := netip.ParseAddr(prefixes[0])
+	ipFamily, err := destinationPrefixFamily(prefixes[0])
 	if err != nil {
-		logger.Error(err, "Failed to parse dst IP address", "dst-ip", prefixes[0])
-		return fmt.Errorf("parse prefix as IP address %q: %w", prefixes[0], err)
+		logger.Error(err, "Failed to parse dst prefix", "dst-prefix", prefixes[0])
+		return fmt.Errorf("parse destination prefix %q: %w", prefixes[0], err)
 	}
-	ipFamily := iputil.FamilyOfAddr(addr)
 	return helper.addAllowRule(*rule.Properties.Protocol, ipFamily, ListSourcePrefixes(rule), prefixes, expectedPorts)
+}
+
+func destinationPrefixFamily(prefix string) (iputil.Family, error) {
+	if addr, err := netip.ParseAddr(prefix); err == nil {
+		return iputil.FamilyOfAddr(addr), nil
+	}
+	ipPrefix, err := netip.ParsePrefix(prefix)
+	if err != nil {
+		return "", err
+	}
+	return iputil.FamilyOfAddr(ipPrefix.Addr()), nil
+}
+
+func validateDestinationPrefixFamilies(ipFamily iputil.Family, dstPrefixes []string) error {
+	if len(dstPrefixes) == 0 {
+		return nil
+	}
+
+	family, err := destinationPrefixFamily(dstPrefixes[0])
+	if err != nil {
+		return fmt.Errorf("parse destination prefix %q: %w", dstPrefixes[0], err)
+	}
+	if family != ipFamily {
+		return ErrSecurityRuleSourceAndDestinationNotFromSameIPFamily
+	}
+
+	for _, prefix := range dstPrefixes[1:] {
+		family, err := destinationPrefixFamily(prefix)
+		if err != nil {
+			return fmt.Errorf("parse destination prefix %q: %w", prefix, err)
+		}
+		if family != ipFamily {
+			return ErrSecurityRuleDestinationAddressesNotFromSameIPFamily
+		}
+	}
+
+	return nil
 }
 
 // SecurityGroup returns the underlying SecurityGroup object and a bool indicating whether any changes were made to the RuleHelper.

--- a/pkg/provider/securitygroup/securitygroup_test.go
+++ b/pkg/provider/securitygroup/securitygroup_test.go
@@ -131,6 +131,34 @@ func TestSecurityGroupHelper_AddRuleForAllowedIPRanges(t *testing.T) {
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, ErrSecurityRuleSourceAndDestinationNotFromSameIPFamily)
 		})
+		t.Run("when destination prefixes are not from the same IP family", func(t *testing.T) {
+			var (
+				sg     = fx.Azure().SecurityGroup().Build()
+				helper = ExpectNewSecurityGroupHelper(t, sg)
+
+				protocol    = armnetwork.SecurityRuleProtocolTCP
+				srcIPRanges = fx.RandomIPv4Prefixes(2)
+				dstPrefixes = []string{"10.0.0.0/24", "fd00::/64"}
+				dstPorts    = []int32{80, 443}
+			)
+			err := helper.AddRuleForAllowedIPRangesWithDestinationPrefixes(srcIPRanges, protocol, iputil.IPv4, dstPrefixes, dstPorts)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrSecurityRuleDestinationAddressesNotFromSameIPFamily)
+		})
+		t.Run("when source IP ranges and destination prefixes are not from the same IP family", func(t *testing.T) {
+			var (
+				sg     = fx.Azure().SecurityGroup().Build()
+				helper = ExpectNewSecurityGroupHelper(t, sg)
+
+				protocol    = armnetwork.SecurityRuleProtocolTCP
+				srcIPRanges = fx.RandomIPv4Prefixes(2)
+				dstPrefixes = []string{"fd00::/64"}
+				dstPorts    = []int32{80, 443}
+			)
+			err := helper.AddRuleForAllowedIPRangesWithDestinationPrefixes(srcIPRanges, protocol, iputil.IPv4, dstPrefixes, dstPorts)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrSecurityRuleSourceAndDestinationNotFromSameIPFamily)
+		})
 	})
 
 	t.Run("when no rule exists, it should add one", func(t *testing.T) {
@@ -463,6 +491,32 @@ func TestSecurityGroupHelper_AddRuleForAllowedServiceTag(t *testing.T) {
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, ErrSecurityRuleDestinationAddressesNotFromSameIPFamily)
 		})
+		t.Run("when destination prefixes are not from the same IP family", func(t *testing.T) {
+			var (
+				sg     = fx.Azure().SecurityGroup().Build()
+				helper = ExpectNewSecurityGroupHelper(t, sg)
+
+				protocol   = armnetwork.SecurityRuleProtocolTCP
+				serviceTag = "AzureCloud"
+				dstPorts   = []int32{80, 443}
+			)
+			err := helper.AddRuleForAllowedServiceTagPrefixes(serviceTag, protocol, iputil.IPv4, []string{"10.0.0.0/24", "fd00::/64"}, dstPorts)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrSecurityRuleDestinationAddressesNotFromSameIPFamily)
+		})
+		t.Run("when destination prefixes do not match the declared IP family", func(t *testing.T) {
+			var (
+				sg     = fx.Azure().SecurityGroup().Build()
+				helper = ExpectNewSecurityGroupHelper(t, sg)
+
+				protocol   = armnetwork.SecurityRuleProtocolTCP
+				serviceTag = "AzureCloud"
+				dstPorts   = []int32{80, 443}
+			)
+			err := helper.AddRuleForAllowedServiceTagPrefixes(serviceTag, protocol, iputil.IPv4, []string{"fd00::/64"}, dstPorts)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrSecurityRuleSourceAndDestinationNotFromSameIPFamily)
+		})
 	})
 
 	t.Run("when no rule exists, it should add one", func(t *testing.T) {
@@ -792,6 +846,24 @@ func TestSecurityGroupHelper_AddRuleForDenyAll(t *testing.T) {
 			err := helper.AddRuleForDenyAll(dstAddresses)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, ErrSecurityRuleDestinationAddressesNotFromSameIPFamily)
+		})
+		t.Run("when destination prefixes are not from the same IP family", func(t *testing.T) {
+			var (
+				sg     = fx.Azure().SecurityGroup().Build()
+				helper = ExpectNewSecurityGroupHelper(t, sg)
+			)
+			err := helper.AddRuleForDenyAllPrefixes(iputil.IPv4, []string{"10.0.0.0/24", "fd00::/64"})
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrSecurityRuleDestinationAddressesNotFromSameIPFamily)
+		})
+		t.Run("when destination prefixes do not match the declared IP family", func(t *testing.T) {
+			var (
+				sg     = fx.Azure().SecurityGroup().Build()
+				helper = ExpectNewSecurityGroupHelper(t, sg)
+			)
+			err := helper.AddRuleForDenyAllPrefixes(iputil.IPv4, []string{"fd00::/64"})
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, ErrSecurityRuleSourceAndDestinationNotFromSameIPFamily)
 		})
 	})
 

--- a/pkg/trace/attributes/svc.go
+++ b/pkg/trace/attributes/svc.go
@@ -35,6 +35,7 @@ func FeatureOfService(svc *v1.Service) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.Bool("annotations.allowed_service_tags", hasAnnotation(consts.ServiceAnnotationAllowedServiceTags)),
 		attribute.Bool("annotations.allowed_ip_ranges", hasAnnotation(consts.ServiceAnnotationAllowedIPRanges)),
+		attribute.Bool("annotations.allowed_destination_ip_ranges", hasAnnotation(consts.ServiceAnnotationAllowedDestinationIPRanges)),
 		attribute.Bool("annotations.internal_load_balancer", hasAnnotation(consts.ServiceAnnotationLoadBalancerInternal)),
 		attribute.Bool("annotations.load_balancer_source_ranges", hasAnnotation(v1.AnnotationLoadBalancerSourceRangesKey)),
 		attribute.Bool("annotations.additional_public_ips", hasAnnotation(consts.ServiceAnnotationAdditionalPublicIPs)),


### PR DESCRIPTION
## What this PR does

This PR proposes Option B from the discussion in #10083: keep cloud-provider-azure responsible for NSG rule management, but allow operators to explicitly provide the destination CIDR prefixes used for LoadBalancer NSG rules when floating IP is disabled.

The issue is that Services using `service.beta.kubernetes.io/azure-disable-load-balancer-floating-ip: "true"` currently generate NSG destinations from backend node IPs. On large clusters, that can cause ACP-managed NSG rules to grow with the number of backend nodes even when the practical destination scope is a smaller set of worker-pool subnet prefixes.

## How the solution works

This adds a new Service annotation:

```yaml
service.beta.kubernetes.io/azure-allowed-destination-ip-ranges: "10.244.0.0/16,fd00:10:244::/64"
```

When the Service also has floating IP disabled, ACP uses these destination prefixes for the relevant IP family instead of enumerating backend node IPs. The behavior is intentionally scoped:

- The annotation only applies to disabled-floating-IP Services.
- IPv4 and IPv6 are handled independently; if only one family is specified, the other family keeps the existing backend-node destination behavior.
- Additional public IP destinations remain additive.
- Invalid destination entries produce a warning event and are ignored, but they do not affect source allow/deny behavior.
- ACP still owns rule creation, cleanup, shared-port retention, and global destination retention.

This keeps the mitigation in the ACP-managed rule lifecycle rather than requiring operators to fully opt out and hand-manage replacement NSG rules.

## Why this shape

This is meant to be a narrow scalability escape hatch, not a general-purpose IP blocking or network policy feature. Operators that know the relevant worker-pool destination prefixes can avoid per-node destination expansion while ACP continues to manage ports, priorities, source controls, stale-rule cleanup, and multi-Service retention.

It is also complementary to the smaller opt-out proposal: the opt-out is a break-glass fallback, while this PR is the managed option that should be easier to operate safely if maintainers agree with the annotation surface.