### PR TITLE
Avoid listPIP for non-public pinned LB IPs

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
+	providererrors "sigs.k8s.io/cloud-provider-azure/pkg/provider/errors"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/loadbalancer"
 	"sigs.k8s.io/cloud-provider-azure/pkg/trace"
 	"sigs.k8s.io/cloud-provider-azure/pkg/trace/attributes"
@@ -1190,11 +1191,11 @@ func (az *Cloud) determinePublicIPName(ctx context.Context, clusterName string, 
 		return pipName, false, err
 	}
 
-	// For the services with loadBalancerIP set, an existing public IP is required, primary
-	// or secondary, or a public IP not found error would be reported.
+	// For services with loadBalancerIP set, validate the IP and require an existing
+	// public IP, primary or secondary.
 	pip, err := az.findMatchedPIP(ctx, loadBalancerIP, "", pipResourceGroup)
 	if err != nil {
-		return "", false, err
+		return "", false, providererrors.NewExternalServiceLoadBalancerIPError(getServiceName(service), loadBalancerIP, err)
 	}
 
 	if pip != nil && pip.Name != nil {
@@ -4549,6 +4550,9 @@ func (az *Cloud) getLoadBalancerNameByPublicIP(
 		}
 		pip, err := az.findMatchedPIP(ctx, ip, "", pipResourceGroup)
 		if err != nil {
+			if providererrors.IsLoadBalancerIPValidationError(err) {
+				return "", fmt.Errorf("find public IP by address %q: %w", ip, providererrors.NewExternalServiceLoadBalancerIPError(getServiceName(service), ip, err))
+			}
 			return "", fmt.Errorf("find public IP by address %q: %w", ip, err)
 		}
 		if lbName := az.getLoadBalancerNameFromPIP(pip, clusterName); lbName != "" {
@@ -4889,6 +4893,9 @@ func (az *Cloud) serviceOwnsFrontendIP(ctx context.Context, fip *armnetwork.Fron
 		for _, loadBalancerIP := range loadBalancerIPs {
 			pip, err := az.findMatchedPIP(ctx, loadBalancerIP, "", pipResourceGroup)
 			if err != nil {
+				if providererrors.IsLoadBalancerIPValidationError(err) {
+					return false, isPrimaryService, nil
+				}
 				klog.Warningf("serviceOwnsFrontendIP: unexpected error when finding match public IP of the service %s with loadBalancerIP %s: %v", service.Name, loadBalancerIP, err)
 				return false, isPrimaryService, nil
 			}

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
+	providererrors "sigs.k8s.io/cloud-provider-azure/pkg/provider/errors"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/privatelinkservice"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/subnet"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/zone"
@@ -107,6 +108,14 @@ func TestExistsPip(t *testing.T) {
 			func(client *mock_publicipaddressclient.MockInterface) {
 				client.EXPECT().List(gomock.Any(), "rg").Return([]*armnetwork.PublicIPAddress{}, nil).MaxTimes(2)
 			},
+			false,
+		},
+		{
+			"IPv4 non-public LoadBalancer IP does not trigger Public IP list",
+			getTestService("service", v1.ProtocolTCP, map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+			}, false, 80),
+			func(_ *mock_publicipaddressclient.MockInterface) {},
 			false,
 		},
 		{
@@ -4792,6 +4801,7 @@ func TestDeterminePublicIPName(t *testing.T) {
 		existingPIPs    []*armnetwork.PublicIPAddress
 		expectedPIPName string
 		expectedError   bool
+		expectNoList    bool
 		isIPv6          bool
 		serviceIPv6     bool
 		annotations     map[string]string
@@ -4807,6 +4817,13 @@ func TestDeterminePublicIPName(t *testing.T) {
 			loadBalancerIP:  "1.2.3.4",
 			expectedPIPName: "",
 			expectedError:   true,
+		},
+		{
+			desc:            "determinePublicIpName shall report validation error for non-public LoadBalancer IP",
+			loadBalancerIP:  "10.0.0.5",
+			expectedPIPName: "",
+			expectedError:   true,
+			expectNoList:    true,
 		},
 		{
 			desc: "determinePublicIpName shall return loadBalancerIP in service.Spec if it's in the " +
@@ -4842,7 +4859,9 @@ func TestDeterminePublicIPName(t *testing.T) {
 			setServiceLoadBalancerIP(&service, test.loadBalancerIP)
 
 			mockPIPsClient := az.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
-			mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPIPs, nil).MaxTimes(2)
+			if !test.expectNoList {
+				mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return(test.existingPIPs, nil).MaxTimes(2)
+			}
 			mockPIPsClient.EXPECT().CreateOrUpdate(gomock.Any(), "rg", gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			for _, existingPIP := range test.existingPIPs {
 				mockPIPsClient.EXPECT().Get(gomock.Any(), "rg", *existingPIP.Name, gomock.Any()).Return(existingPIP, nil).AnyTimes()
@@ -4852,6 +4871,10 @@ func TestDeterminePublicIPName(t *testing.T) {
 			pipName, _, err := az.determinePublicIPName(context.TODO(), "testCluster", &service, test.isIPv6)
 			assert.Equal(t, test.expectedPIPName, pipName)
 			assert.Equal(t, test.expectedError, err != nil)
+			if test.expectNoList {
+				assert.ErrorIs(t, err, providererrors.ErrNonPublicLoadBalancerIP)
+				assert.Contains(t, err.Error(), `external Service "default/test1" cannot use non-public LoadBalancer IP "10.0.0.5"`)
+			}
 		})
 	}
 }
@@ -6624,7 +6647,11 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 
 			service := test.service
 			setServiceLoadBalancerIP(&service, "1.2.3.4")
-			setServiceLoadBalancerIP(&service, "fd00::eef0")
+			serviceIPv6 := "2603:1030::eef0"
+			if consts.IsK8sServiceUsingInternalLoadBalancer(&service) {
+				serviceIPv6 = "fd00::eef0"
+			}
+			setServiceLoadBalancerIP(&service, serviceIPv6)
 
 			_, err := az.NetworkClientFactory.GetPublicIPAddressClient().CreateOrUpdate(context.TODO(), "rg", "pipName", armnetwork.PublicIPAddress{
 				Name: ptr.To("pipName"),
@@ -6637,7 +6664,7 @@ func TestReconcileLoadBalancerCommon(t *testing.T) {
 			_, err = az.NetworkClientFactory.GetPublicIPAddressClient().CreateOrUpdate(context.TODO(), "rg", "pipName-IPv6", armnetwork.PublicIPAddress{
 				Name: ptr.To("pipName-IPv6"),
 				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
-					IPAddress:              ptr.To("fd00::eef0"),
+					IPAddress:              ptr.To(serviceIPv6),
 					PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv6),
 				},
 			})
@@ -11021,7 +11048,21 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: fmt.Errorf(`look up load balancer by public IP for service "test": find public IP by address "5.6.7.8": findMatchedPIPByLoadBalancerIP: cannot find public IP with IP address 5.6.7.8 in resource group rg`),
+			expectedErr: fmt.Errorf(`look up load balancer by public IP for service "test": find public IP by address "5.6.7.8": findMatchedPIPByLoadBalancerIP: cannot find public IP with IP address 5.6.7.8 in resource group rg: getExpectedPIPFromListByIPAddress: cannot find public IP with IP address 5.6.7.8`),
+		},
+		{
+			description:   "multi-slb external: non-public LoadBalancer IP returns validation error",
+			vmSet:         primary,
+			useStandardLB: true,
+			clusterName:   "azure",
+			multiSLBConfigs: []config.MultipleStandardLoadBalancerConfiguration{
+				{Name: "lb1"},
+				{Name: "lb2"},
+			},
+			serviceAnnotation: map[string]string{
+				consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+			},
+			expectedErr: fmt.Errorf(`look up load balancer by public IP for service "test": find public IP by address "10.0.0.5": external Service "default/test" cannot use non-public LoadBalancer IP "10.0.0.5"; use an internal LoadBalancer annotation or a valid Azure Public IP address`),
 		},
 		{
 			description:   "multi-slb external: PIP name not found returns error",
@@ -12256,6 +12297,25 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 			},
 		},
 		{
+			desc: "serviceOwnsFrontendIP should not list public IPs for non-public LoadBalancer IP during flipped cleanup",
+			fip: &armnetwork.FrontendIPConfiguration{
+				Name: ptr.To("auid"),
+				Properties: &armnetwork.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &armnetwork.PublicIPAddress{
+						ID: ptr.To("pip"),
+					},
+				},
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("secondary"),
+					Annotations: map[string]string{
+						consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "10.0.0.5",
+					},
+				},
+			},
+		},
+		{
 			desc: "serviceOwnsFrontendIP should detect the secondary external service",
 			existingPIPs: []*armnetwork.PublicIPAddress{
 				{
@@ -12300,7 +12360,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 					ID:   ptr.To("pip1"),
 					Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 						PublicIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv6),
-						IPAddress:              ptr.To("fd00::eef0"),
+						IPAddress:              ptr.To("2603:1030::eef0"),
 					},
 				},
 			},
@@ -12320,7 +12380,7 @@ func TestServiceOwnsFrontendIP(t *testing.T) {
 					UID: types.UID("secondary"),
 					Annotations: map[string]string{
 						consts.ServiceAnnotationLoadBalancerIPDualStack[false]: "4.3.2.1",
-						consts.ServiceAnnotationLoadBalancerIPDualStack[true]:  "fd00::eef0",
+						consts.ServiceAnnotationLoadBalancerIPDualStack[true]:  "2603:1030::eef0",
 					},
 				},
 			},

--- a/pkg/provider/azure_publicip_repo.go
+++ b/pkg/provider/azure_publicip_repo.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"regexp"
 	"strings"
 	"sync"
@@ -36,7 +37,15 @@ import (
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
+	providererrors "sigs.k8s.io/cloud-provider-azure/pkg/provider/errors"
 	"sigs.k8s.io/cloud-provider-azure/pkg/util/deepcopy"
+)
+
+var (
+	azureReservedIPPrefixes = []netip.Prefix{
+		netip.MustParsePrefix("100.64.0.0/10"),
+		netip.MustParsePrefix("168.63.129.16/32"),
+	}
 )
 
 // CreateOrUpdatePIP invokes az.NetworkClientFactory.GetPublicIPAddressClient().CreateOrUpdate with exponential backoff retry
@@ -168,9 +177,15 @@ func (az *Cloud) listPIP(ctx context.Context, pipResourceGroup string, crt azcac
 }
 
 func (az *Cloud) findMatchedPIP(ctx context.Context, loadBalancerIP, pipName, pipResourceGroup string) (pip *armnetwork.PublicIPAddress, err error) {
+	if loadBalancerIP != "" {
+		if err := validatePublicIPCandidate(loadBalancerIP); err != nil {
+			return nil, err
+		}
+	}
+
 	pips, err := az.listPIP(ctx, pipResourceGroup, azcache.CacheReadTypeDefault)
 	if err != nil {
-		return nil, fmt.Errorf("findMatchedPIPByLoadBalancerIP: failed to listPIP: %w", err)
+		return nil, fmt.Errorf("findMatchedPIP: failed to listPIP: %w", err)
 	}
 
 	if loadBalancerIP != "" {
@@ -220,11 +235,35 @@ func (az *Cloud) findMatchedPIPByLoadBalancerIP(ctx context.Context, pips []*arm
 
 		pip, err = getExpectedPIPFromListByIPAddress(pipList, loadBalancerIP)
 		if err != nil {
-			return nil, fmt.Errorf("findMatchedPIPByLoadBalancerIP: cannot find public IP with IP address %s in resource group %s", loadBalancerIP, pipResourceGroup)
+			return nil, fmt.Errorf("findMatchedPIPByLoadBalancerIP: cannot find public IP with IP address %s in resource group %s: %w", loadBalancerIP, pipResourceGroup, err)
 		}
 	}
 
 	return pip, nil
+}
+
+func validatePublicIPCandidate(ip string) error {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return providererrors.NewInvalidLoadBalancerIPError(ip)
+	}
+	addr = addr.Unmap()
+	if !addr.IsGlobalUnicast() || addr.IsPrivate() || isAzureReservedIP(addr) {
+		return providererrors.NewNonPublicLoadBalancerIPError(ip)
+	}
+	return nil
+}
+
+// isAzureReservedIP reports whether addr belongs to an Azure reserved Virtual
+// Network address range not covered by netip.Addr.IsPrivate:
+// https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq#what-address-ranges-can-i-use-in-my-virtual-networks
+func isAzureReservedIP(addr netip.Addr) bool {
+	for _, prefix := range azureReservedIPPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }
 
 func getExpectedPIPFromListByIPAddress(pips []*armnetwork.PublicIPAddress, ip string) (*armnetwork.PublicIPAddress, error) {

--- a/pkg/provider/azure_publicip_repo_test.go
+++ b/pkg/provider/azure_publicip_repo_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"sync"
 	"testing"
 
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/publicipaddressclient/mock_publicipaddressclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
+	providererrors "sigs.k8s.io/cloud-provider-azure/pkg/provider/errors"
 )
 
 func TestCreateOrUpdatePIP(t *testing.T) {
@@ -284,12 +286,13 @@ func TestFindMatchedPIP(t *testing.T) {
 			shouldRefreshCache: true,
 			loadBalancerIP:     "2.3.4.5",
 			pipName:            "pipName",
-			expectedError:      errors.New("findMatchedPIPByLoadBalancerIP: cannot find public IP with IP address 2.3.4.5 in resource group rg"),
+			expectedError: errors.New("findMatchedPIPByLoadBalancerIP: cannot find public IP with IP address 2.3.4.5 in resource group rg: " +
+				"getExpectedPIPFromListByIPAddress: cannot find public IP with IP address 2.3.4.5"),
 		},
 		{
 			description:   "should report an error if failed to list pip",
 			listError:     &azcore.ResponseError{ErrorCode: "list error"},
-			expectedError: errors.New("list error"),
+			expectedError: errors.New("findMatchedPIP: failed to listPIP"),
 		},
 		{
 			description:        "should refresh the cache if failed to search by name",
@@ -326,6 +329,129 @@ func TestFindMatchedPIP(t *testing.T) {
 			if tc.expectedError != nil {
 				assert.Contains(t, err.Error(), tc.expectedError.Error())
 			}
+		})
+	}
+}
+
+func TestFindMatchedPIPSkipsListForInvalidOrNonPublicLoadBalancerIP(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range []struct {
+		description    string
+		loadBalancerIP string
+		expectedErr    error
+	}{
+		{
+			description:    "invalid load balancer IP",
+			loadBalancerIP: "not-an-ip",
+			expectedErr:    providererrors.ErrInvalidLoadBalancerIP,
+		},
+		{
+			description:    "non-public load balancer IP",
+			loadBalancerIP: "10.0.0.5",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "RFC1918 172.16/12 load balancer IP",
+			loadBalancerIP: "172.16.0.5",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "RFC1918 192.168/16 load balancer IP",
+			loadBalancerIP: "192.168.0.5",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "IPv6 unique local address load balancer IP",
+			loadBalancerIP: "fd00::5",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "Azure shared address space load balancer IP",
+			loadBalancerIP: "100.100.0.202",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "Azure internal DNS load balancer IP",
+			loadBalancerIP: "168.63.129.16",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "IPv4-mapped RFC1918 load balancer IP",
+			loadBalancerIP: "::ffff:a00:5",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "IPv4-mapped Azure shared address space load balancer IP",
+			loadBalancerIP: "::ffff:100.100.0.202",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+		{
+			description:    "IPv4-mapped Azure internal DNS load balancer IP",
+			loadBalancerIP: "::ffff:168.63.129.16",
+			expectedErr:    providererrors.ErrNonPublicLoadBalancerIP,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			az := GetTestCloud(ctrl)
+			_, err := az.findMatchedPIP(context.TODO(), tc.loadBalancerIP, "", "rg")
+
+			assert.ErrorIs(t, err, tc.expectedErr)
+			assert.Contains(t, err.Error(), tc.loadBalancerIP)
+		})
+	}
+}
+
+func TestIsAzureReservedIP(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		ip          string
+		expected    bool
+	}{
+		{
+			description: "RFC1918 10/8",
+			ip:          "10.0.0.5",
+			expected:    false,
+		},
+		{
+			description: "RFC1918 172.16/12",
+			ip:          "172.16.0.5",
+			expected:    false,
+		},
+		{
+			description: "RFC1918 192.168/16",
+			ip:          "192.168.0.5",
+			expected:    false,
+		},
+		{
+			description: "RFC6598 shared address space",
+			ip:          "100.100.0.202",
+			expected:    true,
+		},
+		{
+			description: "Azure internal DNS",
+			ip:          "168.63.129.16",
+			expected:    true,
+		},
+		{
+			description: "public IP",
+			ip:          "1.2.3.4",
+			expected:    false,
+		},
+		{
+			description: "IPv6 unique local address",
+			ip:          "fd00::5",
+			expected:    false,
+		},
+		{
+			description: "IPv6 global unicast",
+			ip:          "2001:4860:4860::8888",
+			expected:    false,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isAzureReservedIP(netip.MustParseAddr(tc.ip)))
 		})
 	}
 }

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -193,8 +193,8 @@ func setMockPublicIP(az *Cloud, mockPIPsClient *mock_publicipaddressclient.MockI
 	if isIPv6 {
 		suffix = "-" + consts.IPVersionIPv6String
 		ipVer = to.Ptr(armnetwork.IPVersionIPv6)
-		ipAddr1 = "fd00::eef0"
-		ipAddra = "fd00::eef1"
+		ipAddr1 = "2603:1030::eef0"
+		ipAddra = "2603:1030::eef1"
 	}
 
 	a := 'a'

--- a/pkg/provider/errors/loadbalancer_ip.go
+++ b/pkg/provider/errors/loadbalancer_ip.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providererrors
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrInvalidLoadBalancerIP identifies a LoadBalancer IP that is not a valid IP address.
+	ErrInvalidLoadBalancerIP = errors.New("invalid LoadBalancer IP")
+	// ErrNonPublicLoadBalancerIP identifies a LoadBalancer IP that cannot be used as an Azure Public IP.
+	ErrNonPublicLoadBalancerIP = errors.New("non-public LoadBalancer IP")
+)
+
+type serviceLoadBalancerIPError struct {
+	msg string
+	err error
+}
+
+func (e *serviceLoadBalancerIPError) Error() string {
+	return e.msg
+}
+
+func (e *serviceLoadBalancerIPError) Unwrap() error {
+	return e.err
+}
+
+// NewInvalidLoadBalancerIPError returns an error for a syntactically invalid LoadBalancer IP.
+func NewInvalidLoadBalancerIPError(ip string) error {
+	return fmt.Errorf("%w %q", ErrInvalidLoadBalancerIP, ip)
+}
+
+// NewNonPublicLoadBalancerIPError returns an error for a LoadBalancer IP that is not a public IP candidate.
+func NewNonPublicLoadBalancerIPError(ip string) error {
+	return fmt.Errorf("%w %q", ErrNonPublicLoadBalancerIP, ip)
+}
+
+// IsLoadBalancerIPValidationError reports whether err is a known LoadBalancer IP validation error.
+func IsLoadBalancerIPValidationError(err error) bool {
+	return errors.Is(err, ErrInvalidLoadBalancerIP) || errors.Is(err, ErrNonPublicLoadBalancerIP)
+}
+
+// NewExternalServiceLoadBalancerIPError returns a clean external Service error while preserving the validation cause.
+func NewExternalServiceLoadBalancerIPError(serviceName, loadBalancerIP string, err error) error {
+	if errors.Is(err, ErrInvalidLoadBalancerIP) {
+		return &serviceLoadBalancerIPError{
+			msg: fmt.Sprintf("external Service %q has invalid LoadBalancer IP %q", serviceName, loadBalancerIP),
+			err: err,
+		}
+	}
+	if errors.Is(err, ErrNonPublicLoadBalancerIP) {
+		return &serviceLoadBalancerIPError{
+			msg: fmt.Sprintf("external Service %q cannot use non-public LoadBalancer IP %q; use an internal LoadBalancer annotation or a valid Azure Public IP address", serviceName, loadBalancerIP),
+			err: err,
+		}
+	}
+	return err
+}

--- a/pkg/provider/errors/loadbalancer_ip_test.go
+++ b/pkg/provider/errors/loadbalancer_ip_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providererrors_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	providererrors "sigs.k8s.io/cloud-provider-azure/pkg/provider/errors"
+)
+
+func TestLoadBalancerIPErrors(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		err         error
+		target      error
+		expected    string
+	}{
+		{
+			description: "invalid LoadBalancer IP",
+			err:         providererrors.NewInvalidLoadBalancerIPError("not-an-ip"),
+			target:      providererrors.ErrInvalidLoadBalancerIP,
+			expected:    `invalid LoadBalancer IP "not-an-ip"`,
+		},
+		{
+			description: "non-public LoadBalancer IP",
+			err:         providererrors.NewNonPublicLoadBalancerIPError("10.0.0.5"),
+			target:      providererrors.ErrNonPublicLoadBalancerIP,
+			expected:    `non-public LoadBalancer IP "10.0.0.5"`,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.ErrorIs(t, tc.err, tc.target)
+			assert.EqualError(t, tc.err, tc.expected)
+			assert.True(t, providererrors.IsLoadBalancerIPValidationError(tc.err))
+		})
+	}
+}
+
+func TestNewExternalServiceLoadBalancerIPError(t *testing.T) {
+	unknownErr := errors.New("unexpected")
+	for _, tc := range []struct {
+		description    string
+		loadBalancerIP string
+		err            error
+		target         error
+		expected       string
+		expectedSame   bool
+	}{
+		{
+			description:    "invalid LoadBalancer IP",
+			loadBalancerIP: "not-an-ip",
+			err:            providererrors.NewInvalidLoadBalancerIPError("not-an-ip"),
+			target:         providererrors.ErrInvalidLoadBalancerIP,
+			expected:       `external Service "default/test" has invalid LoadBalancer IP "not-an-ip"`,
+		},
+		{
+			description:    "non-public LoadBalancer IP",
+			loadBalancerIP: "10.0.0.5",
+			err:            providererrors.NewNonPublicLoadBalancerIPError("10.0.0.5"),
+			target:         providererrors.ErrNonPublicLoadBalancerIP,
+			expected:       `external Service "default/test" cannot use non-public LoadBalancer IP "10.0.0.5"; use an internal LoadBalancer annotation or a valid Azure Public IP address`,
+		},
+		{
+			description:    "unknown error",
+			loadBalancerIP: "1.2.3.4",
+			err:            unknownErr,
+			expected:       "unexpected",
+			expectedSame:   true,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			err := providererrors.NewExternalServiceLoadBalancerIPError("default/test", tc.loadBalancerIP, tc.err)
+
+			if tc.target != nil {
+				assert.ErrorIs(t, err, tc.target)
+			}
+			if tc.expectedSame {
+				assert.Same(t, unknownErr, err)
+			}
+			assert.EqualError(t, err, tc.expected)
+		})
+	}
+}

--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -224,6 +224,37 @@ var _ = Describe("Ensure LoadBalancer", Label(utils.TestSuiteLabelLB), func() {
 		}
 	})
 
+	It("should reject an external service with a non-public LoadBalancer IP", func() {
+		lbIP := "10.0.0.5"
+		isIPv6 := false
+		if tc.IPFamily == utils.IPv6 {
+			lbIP = "fd00::5"
+			isIPv6 = true
+		}
+
+		By("creating an external LoadBalancer Service with a non-public IP")
+		service := utils.CreateLoadBalancerServiceManifest(testServiceName, map[string]string{
+			consts.ServiceAnnotationLoadBalancerIPDualStack[isIPv6]: lbIP,
+		}, labels, ns.Name, ports)
+		beforeCreate := time.Now()
+		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			By("Cleaning up Service")
+			err := utils.DeleteService(cs, ns.Name, testServiceName)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		By("verifying the Service is blocked with a non-public IP validation error")
+		expectedMessage := fmt.Sprintf("cannot use non-public LoadBalancer IP %q", lbIP)
+		err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, testServiceName, "SyncLoadBalancerFailed", expectedMessage, beforeCreate)
+		Expect(err).NotTo(HaveOccurred(), "Expected SyncLoadBalancerFailed event for "+testServiceName)
+
+		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(service.Status.LoadBalancer.Ingress).To(BeEmpty())
+	})
+
 	// Public w/o IP -> Public w/ IP
 	It("should support assigning to specific IP when updating public service", func() {
 		ipNameBase := basename + "-public-none-IP" + string(uuid.NewUUID())[0:4]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR rejects invalid or non-public pinned LoadBalancer IPs before `findMatchedPIP` lists Azure Public IPs.

For external Services with a pinned LoadBalancer IP that cannot identify an Azure Public IP, the provider now returns a clear validation error instead of doing a guaranteed-miss Public IP list. The validation covers non-global-unicast addresses plus Azure-documented private/reserved VNet ranges, including RFC1918, RFC6598 `100.64.0.0/10`, Azure internal DNS `168.63.129.16/32`, and IPv6 ULA.

It also moves the pinned LoadBalancer IP validation errors into `pkg/provider/errors` so the clean user-facing Service event message can be preserved while callers can still classify the root cause with `errors.Is`.

#### Which issue(s) this PR fixes:

Partially addresses #10226

#### Special notes for your reviewer:

This intentionally does not close #10226. It addresses the non-public pinned IP path and error clarity, but leaves per-reconcile memoization and 429-state propagation for a follow-up.

Validation performed:
- `go test ./pkg/provider/... -count=1`
- From `tests/`: `go test ./e2e/network -run '^$'`
- Manual standalone replay confirmed the validation event and no ingress assignment.

#### Does this PR introduce a user-facing change?

```release-note
External LoadBalancer Services with invalid or non-public pinned LoadBalancer IPs now fail fast with a validation error instead of listing Azure Public IPs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Other doc]: https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq#what-address-ranges-can-i-use-in-my-virtual-networks
```
