### PR TITLE
Add LoadBalancer NSG rule opt-out annotation

### DIFF
--- a/internal/testutil/fixture/kubernetes.go
+++ b/internal/testutil/fixture/kubernetes.go
@@ -106,6 +106,11 @@ func (f *KubernetesServiceFixture) WithDisableFloatingIP() *KubernetesServiceFix
 	return f
 }
 
+func (f *KubernetesServiceFixture) WithDisableLoadBalancerNSGRule() *KubernetesServiceFixture {
+	f.svc.Annotations[consts.ServiceAnnotationDisableLoadBalancerNSGRule] = "true"
+	return f
+}
+
 func (f *KubernetesServiceFixture) WithLoadBalancerSourceRanges(parts ...string) *KubernetesServiceFixture {
 	f.svc.Spec.LoadBalancerSourceRanges = parts
 	return f

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -325,6 +325,11 @@ const (
 	// If omitted, the default value is false
 	ServiceAnnotationDisableLoadBalancerFloatingIP = "service.beta.kubernetes.io/azure-disable-load-balancer-floating-ip"
 
+	// ServiceAnnotationDisableLoadBalancerNSGRule disables cloud-provider-managed NSG rules for the service.
+	// This annotation is not recommended for general use; it is a break-glass option for operators that intentionally
+	// manage the service's NSG rules themselves. If omitted, the default value is false
+	ServiceAnnotationDisableLoadBalancerNSGRule = "service.beta.kubernetes.io/azure-disable-load-balancer-nsg-rule"
+
 	// ServiceAnnotationAdditionalPublicIPs sets the additional Public IPs (split by comma) besides the service's Public IP configured on LoadBalancer.
 	// These additional Public IPs would be consumed by kube-proxy to configure the iptables rules on each node. Note they would not be configured
 	// automatically on Azure LoadBalancer. Instead, they need to be configured manually (e.g. on Azure cross-region LoadBalancer by another operator).

--- a/pkg/consts/helpers.go
+++ b/pkg/consts/helpers.go
@@ -40,6 +40,11 @@ func IsK8sServiceDisableLoadBalancerFloatingIP(service *v1.Service) bool {
 	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationDisableLoadBalancerFloatingIP, TrueAnnotationValue)
 }
 
+// IsK8sServiceDisableLoadBalancerNSGRule returns if cloud-provider-managed NSG rules are disabled in kubernetes service annotations
+func IsK8sServiceDisableLoadBalancerNSGRule(service *v1.Service) bool {
+	return expectAttributeInSvcAnnotationBeEqualTo(service.Annotations, ServiceAnnotationDisableLoadBalancerNSGRule, TrueAnnotationValue)
+}
+
 // GetHealthProbeConfigOfPortFromK8sSvcAnnotation get health probe configuration for port
 func GetHealthProbeConfigOfPortFromK8sSvcAnnotation(annotations map[string]string, port int32, key HealthProbeParams, validators ...BusinessValidator) (*string, error) {
 	return GetAttributeValueInSvcAnnotation(annotations, BuildHealthProbeAnnotationKeyForPort(port, key), validators...)

--- a/pkg/consts/helpers_test.go
+++ b/pkg/consts/helpers_test.go
@@ -145,6 +145,54 @@ func TestIsK8sServiceUsingInternalLoadBalancer(t *testing.T) {
 	}
 }
 
+func TestIsK8sServiceDisableLoadBalancerNSGRule(t *testing.T) {
+	type args struct {
+		service *v1.Service
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "disable LoadBalancer NSG rule flag is set",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ServiceAnnotationDisableLoadBalancerNSGRule: TrueAnnotationValue},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "disable LoadBalancer NSG rule flag is not set",
+			args: args{
+				service: &v1.Service{},
+			},
+			want: false,
+		},
+		{
+			name: "disable LoadBalancer NSG rule flag is corrupted",
+			args: args{
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ServiceAnnotationDisableLoadBalancerNSGRule: TrueAnnotationValue + TrueAnnotationValue},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsK8sServiceDisableLoadBalancerNSGRule(tt.args.service); got != tt.want {
+				t.Errorf("IsK8sServiceDisableLoadBalancerNSGRule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetHealthProbeConfigOfPortFromK8sSvcAnnotation(t *testing.T) {
 	type args struct {
 		annotations map[string]string

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3439,6 +3439,7 @@ func (az *Cloud) reconcileSecurityGroup(
 
 	var (
 		disableFloatingIP                                = consts.IsK8sServiceDisableLoadBalancerFloatingIP(service)
+		disableLoadBalancerNSGRule                       = consts.IsK8sServiceDisableLoadBalancerNSGRule(service)
 		lbIPAddresses, _                                 = iputil.ParseAddresses(lbIPs)
 		lbIPv4Addresses, lbIPv6Addresses                 = iputil.GroupAddressesByFamily(lbIPAddresses)
 		additionalIPv4Addresses, additionalIPv6Addresses = iputil.GroupAddressesByFamily(additionalIPs)
@@ -3492,12 +3493,14 @@ func (az *Cloud) reconcileSecurityGroup(
 		}
 	}
 
-	if wantLb {
+	if wantLb && !disableLoadBalancerNSGRule {
 		err := accessControl.PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses)
 		if err != nil {
 			logger.Error(err, "Failed to patch security group")
 			return nil, err
 		}
+	} else if wantLb {
+		logger.V(2).Info("Skipped patching security group because Service disables LoadBalancer NSG rule management")
 	}
 
 	{

--- a/pkg/provider/azure_loadbalancer_accesscontrol_test.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol_test.go
@@ -499,6 +499,54 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("with disabled floating IP and NSG rule management disabled", func(t *testing.T) {
+			var (
+				ctrl                    = gomock.NewController(t)
+				az                      = GetTestCloud(ctrl)
+				securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+				loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+				svc                     = k8sFx.Service().
+							WithDisableFloatingIP().
+							WithDisableLoadBalancerNSGRule().
+							Build()
+				securityGroup = azureFx.SecurityGroup().Build()
+				loadBalancer  = azureFx.LoadBalancer().Build()
+			)
+			defer ctrl.Finish()
+
+			{
+				kubeClient := fake.NewSimpleClientset(makeNodesByIPs(
+					append(azureFx.LoadBalancer().BackendPoolIPv4Addresses(), azureFx.LoadBalancer().BackendPoolIPv6Addresses()...),
+				)...)
+				informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+				az.serviceLister = informerFactory.Core().V1().Services().Lister()
+				az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+				informerFactory.Start(wait.NeverStop)
+				informerFactory.WaitForCacheSync(wait.NeverStop)
+			}
+
+			securityGroupClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+				Return(securityGroup, nil).
+				Times(1)
+			loadBalancerClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+				Return(loadBalancer, nil).
+				Times(1)
+			loadBalancerBackendPool.EXPECT().
+				GetBackendPrivateIPs(gomock.Any(), ClusterName, &svc, loadBalancer).
+				Return(
+					azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+					azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
+				).
+				Times(1)
+
+			sg, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
+			assert.NoError(t, err)
+			testutil.ExpectEqualInJSON(t, azureFx.SecurityGroup().Build(), sg)
+		})
+
 		t.Run("with `service.beta.kubernetes.io/azure-allowed-ip-ranges` specified", func(t *testing.T) {
 			var (
 				ctrl                    = gomock.NewController(t)
@@ -1980,6 +2028,171 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 				assert.NoError(t, err)
 			})
 		}
+	})
+
+	t.Run("update rules - disabled floating IP and NSG rule management disabled", func(t *testing.T) {
+		var (
+			ctrl                    = gomock.NewController(t)
+			az                      = GetTestCloud(ctrl)
+			securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+			loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+			loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+			loadBalancer            = azureFx.LoadBalancer().Build()
+
+			svc = k8sFx.Service().
+				WithNamespace("ns-01").
+				WithName("svc-01").
+				WithDisableFloatingIP().
+				WithDisableLoadBalancerNSGRule().
+				Build()
+		)
+		defer ctrl.Finish()
+
+		runtimeObjects := []runtime.Object{&svc}
+		runtimeObjects = append(runtimeObjects, makeNodesByIPs(
+			append(
+				azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+				azureFx.LoadBalancer().BackendPoolIPv6Addresses()...,
+			))...,
+		)
+		kubeClient := fake.NewSimpleClientset(runtimeObjects...)
+		informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+		az.serviceLister = informerFactory.Core().V1().Services().Lister()
+		az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+		informerFactory.Start(wait.NeverStop)
+		informerFactory.WaitForCacheSync(wait.NeverStop)
+
+		noiseRules := azureFx.NoiseSecurityRules()
+		staleRules := []*armnetwork.SecurityRule{
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().TCPNodePorts()).
+				WithPriority(500).
+				WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+				Build(),
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().TCPNodePorts()).
+				WithPriority(501).
+				WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+				Build(),
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().UDPNodePorts()).
+				WithPriority(502).
+				WithDestination(azureFx.LoadBalancer().BackendPoolIPv4Addresses()...).
+				Build(),
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().UDPNodePorts()).
+				WithPriority(503).
+				WithDestination(azureFx.LoadBalancer().BackendPoolIPv6Addresses()...).
+				Build(),
+		}
+		securityGroup := azureFx.SecurityGroup().WithRules(append(noiseRules, staleRules...)).Build()
+
+		securityGroupClient.EXPECT().
+			Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+			Return(securityGroup, nil).
+			Times(1)
+		securityGroupClient.EXPECT().
+			CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+			DoAndReturn(func(
+				_ context.Context,
+				_, _ string,
+				properties armnetwork.SecurityGroup,
+			) (*armnetwork.SecurityGroup, error) {
+				testutil.ExpectExactSecurityRules(t, &properties, noiseRules)
+				return nil, nil
+			}).Times(1)
+		loadBalancerClient.EXPECT().
+			Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+			Return(loadBalancer, nil).
+			Times(1)
+		loadBalancerBackendPool.EXPECT().
+			GetBackendPrivateIPs(gomock.Any(), ClusterName, &svc, loadBalancer).
+			Return(
+				azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+				azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
+			).
+			Times(1)
+
+		_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
+		assert.NoError(t, err)
+	})
+
+	t.Run("update rules - NSG rule management disabled", func(t *testing.T) {
+		var (
+			ctrl                    = gomock.NewController(t)
+			az                      = GetTestCloud(ctrl)
+			securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+			loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+			loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+			loadBalancer            = azureFx.LoadBalancer().Build()
+
+			svc = k8sFx.Service().
+				WithNamespace("ns-01").
+				WithName("svc-01").
+				WithDisableLoadBalancerNSGRule().
+				Build()
+		)
+		defer ctrl.Finish()
+
+		runtimeObjects := []runtime.Object{&svc}
+		runtimeObjects = append(runtimeObjects, makeNodesByIPs(
+			append(
+				azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+				azureFx.LoadBalancer().BackendPoolIPv6Addresses()...,
+			))...,
+		)
+		kubeClient := fake.NewSimpleClientset(runtimeObjects...)
+		informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+		az.serviceLister = informerFactory.Core().V1().Services().Lister()
+		az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+		informerFactory.Start(wait.NeverStop)
+		informerFactory.WaitForCacheSync(wait.NeverStop)
+
+		noiseRules := azureFx.NoiseSecurityRules()
+		staleRules := []*armnetwork.SecurityRule{
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().TCPPorts()).
+				WithPriority(500).
+				WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).
+				Build(),
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().TCPPorts()).
+				WithPriority(501).
+				WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).
+				Build(),
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().UDPPorts()).
+				WithPriority(502).
+				WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).
+				Build(),
+			azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, []string{securitygroup.ServiceTagInternet}, k8sFx.Service().UDPPorts()).
+				WithPriority(503).
+				WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).
+				Build(),
+		}
+		securityGroup := azureFx.SecurityGroup().WithRules(append(noiseRules, staleRules...)).Build()
+
+		securityGroupClient.EXPECT().
+			Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+			Return(securityGroup, nil).
+			Times(1)
+		securityGroupClient.EXPECT().
+			CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+			DoAndReturn(func(
+				_ context.Context,
+				_, _ string,
+				properties armnetwork.SecurityGroup,
+			) (*armnetwork.SecurityGroup, error) {
+				testutil.ExpectExactSecurityRules(t, &properties, noiseRules)
+				return nil, nil
+			}).Times(1)
+		loadBalancerClient.EXPECT().
+			Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+			Return(loadBalancer, nil).
+			Times(1)
+		loadBalancerBackendPool.EXPECT().
+			GetBackendPrivateIPs(gomock.Any(), ClusterName, &svc, loadBalancer).
+			Return(
+				azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+				azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
+			).
+			Times(1)
+
+		_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), EnsureLB)
+		assert.NoError(t, err)
 	})
 
 	t.Run("update rules - keep retain ports - disable floating IP", func(t *testing.T) {

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -442,6 +442,65 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		})
 	})
 
+	When("creating a LoadBalancer service with annotations `service.beta.kubernetes.io/azure-disable-load-balancer-floating-ip` and `service.beta.kubernetes.io/azure-disable-load-balancer-nsg-rule`", func() {
+		It("should not add a rule to allow traffic from Internet", func() {
+			var (
+				svcNodePort  int32 = 30006
+				serviceIPv4s []netip.Addr
+				serviceIPv6s []netip.Addr
+			)
+
+			By("Creating a LoadBalancer service", func() {
+				var (
+					labels = map[string]string{
+						"app": ServiceName,
+					}
+					annotations = map[string]string{
+						consts.ServiceAnnotationDisableLoadBalancerFloatingIP: "true",
+						consts.ServiceAnnotationDisableLoadBalancerNSGRule:    "true",
+					}
+					ports = []v1.ServicePort{{
+						Port:       serverPort,
+						TargetPort: intstr.FromInt32(serverPort),
+						NodePort:   svcNodePort,
+					}}
+				)
+				rv := createAndExposeDefaultServiceWithAnnotation(k8sClient, azureClient.IPFamily, ServiceName, namespace.Name, labels, annotations, ports)
+				serviceIPv4s, serviceIPv6s = groupIPsByFamily(mustParseIPs(derefSliceOfStringPtr(rv)))
+			})
+
+			var validator *SecurityGroupValidator
+			By("Getting the cluster security groups", func() {
+				rv, err := azureClient.GetClusterSecurityGroups()
+				Expect(err).NotTo(HaveOccurred())
+
+				validator = NewSecurityGroupValidator(rv)
+			})
+
+			nodeIPv4s, nodeIPv6s, err := listAgentNodeIPs(k8sClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nodeIPv4s)+len(nodeIPv6s)).NotTo(Equal(0), "Should have at least one node IP")
+			logger.Info("Fetched node IPs", "v4-IPs", nodeIPv4s, "v6-IPs", nodeIPv6s)
+
+			By("Checking if the rule for allowing traffic from Internet does not exist", func() {
+				Expect(validator.NotHasRuleForDestination(serviceIPv4s)).To(BeTrue())
+				Expect(validator.NotHasRuleForDestination(serviceIPv6s)).To(BeTrue())
+
+				var (
+					expectedProtocol    = armnetwork.SecurityRuleProtocolTCP
+					expectedSrcPrefixes = []string{"Internet"}
+					expectedDstPorts    = []string{strconv.FormatInt(int64(svcNodePort), 10)}
+				)
+				if len(nodeIPv4s) > 0 {
+					Expect(validator.HasExactAllowRule(expectedProtocol, expectedSrcPrefixes, nodeIPv4s, expectedDstPorts)).To(BeFalse())
+				}
+				if len(nodeIPv6s) > 0 {
+					Expect(validator.HasExactAllowRule(expectedProtocol, expectedSrcPrefixes, nodeIPv6s, expectedDstPorts)).To(BeFalse())
+				}
+			})
+		})
+	})
+
 	When("creating 2 LoadBalancer service with annotation `service.beta.kubernetes.io/azure-disable-load-balancer-floating-ip`", Label(utils.TestSuiteLabelNonMultiSLB), func() {
 		It("should add 2 rule to allow traffic from Internet", func() {
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `service.beta.kubernetes.io/azure-disable-load-balancer-nsg-rule` as a per-Service opt-out from cloud-provider-managed LoadBalancer NSG rules.

When the annotation is set to `true`, NSG reconciliation still cleans stale cloud-provider-managed rules for the Service and retains managed destinations, but skips patching new allow rules. This lets operators intentionally manage the Service's NSG rules outside cloud-provider-azure.

The annotation is intentionally generic for LoadBalancer Services and is not coupled to `service.beta.kubernetes.io/azure-disable-load-balancer-floating-ip`. It is documented in code as not recommended for general use and intended as a break-glass option where operators own the NSG rule lifecycle.

#### Which issue(s) this PR fixes:

Partially #10083

#### Special notes for your reviewer:

This implements option C from the issue discussion.

The key ordering is cleanup first, then skip patch, then retain/write back. That removes stale ACP-managed rules instead of orphaning them when a Service opts out.

Unit coverage includes both disabled-floating-IP backend-node rules and the floating-IP-enabled frontend-IP rules. The e2e coverage exercises the disabled-floating-IP case that motivated the issue.

#### Does this PR introduce a user-facing change?

```release-note
Added the `service.beta.kubernetes.io/azure-disable-load-balancer-nsg-rule` Service annotation to disable cloud-provider-managed LoadBalancer NSG rule creation for Services whose NSG rules are intentionally managed by operators.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
Documentation should be added in the cloud-provider-azure docs site.
```
