### PR TITLE
fix(multi-slb): select existing LB with no rules over creating a new one

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -4632,22 +4632,34 @@ func getMostEligibleLBForService(
 		return currentLBName
 	}
 
-	// 2. If the LB is eligible and not created yet, choose it because it has the fewest rules.
+	// 2. If the LB is eligible and has no load balancing rules or is not created yet,
+	// choose it because it has the fewest rules.
+	// Prefer existing LBs with no rules over non-existent ones.
+	var firstNonExistent string
 	for _, eligibleLB := range eligibleLBs {
-		var found bool
+		var found, hasRules bool
 		for i := range existingLBs {
 			existingLB := (existingLBs)[i]
 			if strings.EqualFold(trimSuffixIgnoreCase(ptr.Deref(existingLB.Name, ""), consts.InternalLoadBalancerNameSuffix), eligibleLB) &&
 				isInternalLoadBalancer(existingLB) == isInternal {
 				found = true
+				hasRules = existingLB.Properties != nil && len(existingLB.Properties.LoadBalancingRules) > 0
 				break
 			}
 		}
 
-		if !found {
-			logger.V(4).Info("choose LB as it is eligible and not existing", "eligibleLB", eligibleLB)
+		if found && !hasRules {
+			logger.V(4).Info("choose LB as it is eligible and has no load balancing rules", "eligibleLB", eligibleLB)
 			return eligibleLB
 		}
+		if !found && firstNonExistent == "" {
+			firstNonExistent = eligibleLB
+		}
+	}
+
+	if firstNonExistent != "" {
+		logger.V(4).Info("choose LB as it is eligible and not existing", "eligibleLB", firstNonExistent)
+		return firstNonExistent
 	}
 
 	// 3. If all eligible LBs are existing, choose the one with the fewest rules.

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -11434,6 +11434,7 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 								},
 							},
 						},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{{}},
 					},
 				},
 			},
@@ -11845,7 +11846,9 @@ func TestGetMostEligibleLBName(t *testing.T) {
 				{
 					Name: ptr.To("lb3"),
 					Properties: &armnetwork.LoadBalancerPropertiesFormat{
-						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{},
+						},
 					},
 				},
 			},
@@ -11878,6 +11881,79 @@ func TestGetMostEligibleLBName(t *testing.T) {
 			},
 			expectedLBName: "lb2",
 			isInternal:     true,
+		},
+		{
+			description: "should return the first eligible LB if it exists with no rules",
+			eligibleLBs: []string{"lb1", "lb2"},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
+				},
+			},
+			expectedLBName: "lb1",
+		},
+		{
+			description: "should return the first eligible LB if it exists with nil properties",
+			eligibleLBs: []string{"lb1", "lb2"},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+				},
+			},
+			expectedLBName: "lb1",
+		},
+		{
+			description: "should return the first eligible LB for internal service when only external LBs exist with no rules",
+			eligibleLBs: []string{"lb1", "lb2"},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
+				},
+			},
+			isInternal:     true,
+			expectedLBName: "lb1",
+		},
+		{
+			description: "should skip existing LB with rules and return the one with no rules",
+			eligibleLBs: []string{"lb1", "lb2", "lb3"},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb1"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+				{
+					Name: ptr.To("lb2"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
+				},
+			},
+			expectedLBName: "lb2",
+		},
+		{
+			description: "should prefer existing LB with no rules over non-existent one",
+			eligibleLBs: []string{"lb1", "lb2", "lb3"},
+			existingLBs: []*armnetwork.LoadBalancer{
+				{
+					Name: ptr.To("lb3"),
+					Properties: &armnetwork.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: []*armnetwork.LoadBalancingRule{},
+					},
+				},
+			},
+			expectedLBName: "lb3",
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In multi-SLB mode, `getMostEligibleLBForService()` skips existing LBs with zero LoadBalancingRules, causing unexpected Service placement when an LB exists for outbound traffic but has no service rules.

This PR adds a rule-count check so an existing LB with zero rules is preferred over a non-existent LB for placement.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10051

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix(multi-slb): select existing LB with no rules over creating a new one
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
