### PR TITLE
fix: use network subscription for zone discovery when NetworkResourceSubscriptionID is set

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -460,7 +460,7 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *azurecon
 	}
 
 	if az.zoneRepo == nil {
-		az.zoneRepo, err = zone.NewRepo(az.ComputeClientFactory.GetProviderClient())
+		az.zoneRepo, err = zone.NewRepo(az.NetworkClientFactory.GetProviderClient())
 		if err != nil {
 			return err
 		}

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -49,6 +49,8 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/interfaceclient/mock_interfaceclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/loadbalancerclient/mock_loadbalancerclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/mock_azclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/providerclient/mock_providerclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/publicipaddressclient/mock_publicipaddressclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/securitygroupclient/mock_securitygroupclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient/mock_virtualmachineclient"
@@ -2605,6 +2607,63 @@ func TestInitializeCloudFromConfig(t *testing.T) {
 
 		err := az.InitializeCloudFromConfig(context.Background(), &azureconfig, false, true)
 		assert.NoError(t, err)
+	})
+
+	t.Run("zoneRepo should be initialized with network subscription provider client", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		az := GetTestCloud(ctrl)
+
+		const (
+			tenantID              = "tenant-id"
+			networkSubscriptionID = "network-subscription-id"
+			computeSubscriptionID = "compute-subscription-id"
+		)
+
+		az.ComputeClientFactory = nil
+		az.NetworkClientFactory = nil
+		az.zoneRepo = nil
+
+		azureconfig := providerconfig.Config{}
+		azureconfig.TenantID = tenantID
+		azureconfig.NetworkResourceTenantID = tenantID
+		azureconfig.NetworkResourceSubscriptionID = networkSubscriptionID
+		azureconfig.SubscriptionID = computeSubscriptionID
+
+		networkFactory := mock_azclient.NewMockClientFactory(ctrl)
+		computeFactory := mock_azclient.NewMockClientFactory(ctrl)
+
+		// zoneRepo should be initialized from the network factory's provider client,
+		// not the compute factory's. Set expectation only on the network factory.
+		mockProviderClient := mock_providerclient.NewMockInterface(ctrl)
+		networkFactory.EXPECT().GetProviderClient().Return(mockProviderClient).Times(1)
+
+		nCall := 0
+		newARMClientFactory = func(
+			_ *azclient.ClientFactoryConfig,
+			_ *azclient.ARMClientConfig,
+			_ cloud.Configuration,
+			_ azcore.TokenCredential,
+			_ ...func(option *arm.ClientOptions),
+		) (azclient.ClientFactory, error) {
+			defer func() { nCall++ }()
+			switch nCall {
+			case 0:
+				return networkFactory, nil
+			case 1:
+				return computeFactory, nil
+			default:
+				panic("unexpected call")
+			}
+		}
+		defer func() {
+			newARMClientFactory = azclient.NewClientFactory
+		}()
+
+		err := az.InitializeCloudFromConfig(context.Background(), &azureconfig, false, false)
+		assert.NoError(t, err)
+		assert.NotNil(t, az.zoneRepo)
 	})
 }
 

--- a/pkg/provider/azure_zones.go
+++ b/pkg/provider/azure_zones.go
@@ -48,7 +48,7 @@ func (az *Cloud) refreshZones(ctx context.Context, refreshFunc func(ctx context.
 
 func (az *Cloud) syncRegionZonesMap(ctx context.Context) error {
 	logger := log.FromContextOrBackground(ctx).WithName("syncRegionZonesMap")
-	logger.V(2).Info("starting to fetch all available zones for the subscription", "subscriptionID", az.SubscriptionID)
+	logger.V(2).Info("starting to fetch all available zones for the subscription", "subscriptionID", az.getNetworkResourceSubscriptionID())
 	zones, err := az.zoneRepo.ListZones(ctx)
 	if err != nil {
 		return fmt.Errorf("list zones: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`zoneRepo` was initialized from `ComputeClientFactory` instead of `NetworkClientFactory`, causing LB frontend IP and public IP zones to be discovered from the cluster subscription instead of the network subscription.

No behavior change for single-subscription deployments.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10513

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: use network subscription for zone discovery when NetworkResourceSubscriptionID is set
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
