### PR TITLE
fix: getServicePIPName returns empty for IPv6 on IPv4-only service

### DIFF
--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -388,6 +388,9 @@ func getServicePIPName(service *v1.Service, isIPv6 bool) string {
 				return name
 			}
 		}
+		if isIPv6 && !v6Enabled {
+			return ""
+		}
 		return service.Annotations[consts.ServiceAnnotationPIPNameDualStack[false]]
 	}
 

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -419,6 +419,9 @@ func getServicePIPPrefixID(service *v1.Service, isIPv6 bool) string {
 				return id
 			}
 		}
+		if isIPv6 && !v6Enabled {
+			return ""
+		}
 		return service.Annotations[consts.ServiceAnnotationPIPPrefixIDDualStack[false]]
 	}
 

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -898,6 +898,21 @@ func TestGetServicePIPPrefixID(t *testing.T) {
 			"pip-prefix-id",
 		},
 		{
+			"From ServiceAnnotationPIPPrefixIDDualStack IPv6 request on IPv4 single stack",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						consts.ServiceAnnotationPIPPrefixIDDualStack[false]: "pip-prefix-id",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				},
+			},
+			true,
+			"",
+		},
+		{
 			"From ServiceAnnotationPIPPrefixIDDualStack IPv6 single stack",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -790,6 +790,21 @@ func TestGetServicePIPName(t *testing.T) {
 			"pip-name",
 		},
 		{
+			"From ServiceAnnotationPIPName IPv6 request on IPv4 single stack",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						consts.ServiceAnnotationPIPNameDualStack[false]: "pip-name",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					IPFamilies: []v1.IPFamily{v1.IPv4Protocol},
+				},
+			},
+			true,
+			"",
+		},
+		{
 			"From ServiceAnnotationPIPName IPv6 single stack",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -971,7 +986,7 @@ func TestGetServicePIPNames(t *testing.T) {
 				consts.ServiceAnnotationPIPNameDualStack[false]: "pip-name-ipv4",
 			},
 			ipFamilies: []v1.IPFamily{v1.IPv4Protocol},
-			expected:   []string{"pip-name-ipv4", "pip-name-ipv4"},
+			expected:   []string{"pip-name-ipv4"},
 		},
 		{
 			desc: "IPv6 only",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`getServicePIPName` returned the IPv4 PIP annotation when called with `isIPv6=true` on a single-stack IPv4 service, causing `getServicePIPNames` to return `["pip", "pip"]`. This led to redundant `findMatchedPIP` API calls in `serviceOwnsFrontendIP` and `getLoadBalancerNameByPIPName`.

This PR returns `""` early when `isIPv6=true` and the service has no IPv6 family. The same guard is applied to `getServicePIPPrefixID` for consistency, though its callers are currently protected by `v6Enabled` gating.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10169

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: IPv6 PIP name lookup on single-stack IPv4 services incorrectly returned the IPv4 annotation value, causing redundant public IP lookups.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
