### PR TITLE
WIP: Get interconnect group/subgroup from structured IMDS

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -45,6 +45,8 @@ const (
 	LabelPlatformSubFaultDomain = "topology.kubernetes.azure.com/sub-fault-domain"
 	// LabelPlatformInterconnectGroup is the label key of Platform Interconnect Group
 	LabelPlatformInterconnectGroup = "topology.kubernetes.azure.com/interconnect-group"
+	// LabelPlatformInterconnectSubgroup is the label key of Platform Interconnect Subgroup
+	LabelPlatformInterconnectSubgroup = "topology.kubernetes.azure.com/interconnect-subgroup"
 
 	// TagNameInterconnectGroup is the tag name in IMDS tagsList for Platform Interconnect Group
 	TagNameInterconnectGroup = "Platform_Interconnect_Group"

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -91,3 +91,8 @@ func (np *IMDSNodeProvider) GetPlatformSubFaultDomain(ctx context.Context) (stri
 func (np *IMDSNodeProvider) GetInterconnectGroupID(ctx context.Context) (string, error) {
 	return np.azure.GetInterconnectGroupID(ctx)
 }
+
+// GetInterconnectSubgroupID returns the Interconnect Subgroup ID from IMDS.
+func (np *IMDSNodeProvider) GetInterconnectSubgroupID(ctx context.Context) (string, error) {
+	return np.azure.GetInterconnectSubgroupID(ctx)
+}

--- a/pkg/node/nodearm.go
+++ b/pkg/node/nodearm.go
@@ -95,3 +95,8 @@ func (np *ARMNodeProvider) GetPlatformSubFaultDomain(_ context.Context) (string,
 func (np *ARMNodeProvider) GetInterconnectGroupID(_ context.Context) (string, error) {
 	return "", nil
 }
+
+// GetInterconnectSubgroupID returns empty string for ARM provider.
+func (np *ARMNodeProvider) GetInterconnectSubgroupID(_ context.Context) (string, error) {
+	return "", nil
+}

--- a/pkg/nodemanager/mock/mock_node_provider.go
+++ b/pkg/nodemanager/mock/mock_node_provider.go
@@ -74,6 +74,21 @@ func (mr *MockNodeProviderMockRecorder) GetInterconnectGroupID(ctx any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInterconnectGroupID", reflect.TypeOf((*MockNodeProvider)(nil).GetInterconnectGroupID), ctx)
 }
 
+// GetInterconnectSubgroupID mocks base method.
+func (m *MockNodeProvider) GetInterconnectSubgroupID(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInterconnectSubgroupID", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInterconnectSubgroupID indicates an expected call of GetInterconnectSubgroupID.
+func (mr *MockNodeProviderMockRecorder) GetInterconnectSubgroupID(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInterconnectSubgroupID", reflect.TypeOf((*MockNodeProvider)(nil).GetInterconnectSubgroupID), ctx)
+}
+
 // GetPlatformSubFaultDomain mocks base method.
 func (m *MockNodeProvider) GetPlatformSubFaultDomain(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/nodemanager/nodemanager.go
+++ b/pkg/nodemanager/nodemanager.go
@@ -65,6 +65,8 @@ type NodeProvider interface {
 	GetPlatformSubFaultDomain(ctx context.Context) (string, error)
 	// GetInterconnectGroupID returns the Interconnect Group ID from IMDS if set.
 	GetInterconnectGroupID(ctx context.Context) (string, error)
+	// GetInterconnectSubgroupID returns the Interconnect Subgroup ID from IMDS if set.
+	GetInterconnectSubgroupID(ctx context.Context) (string, error)
 }
 
 // labelReconcile holds information about a label to reconcile and how to reconcile it.
@@ -548,6 +550,14 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Co
 		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(consts.LabelPlatformInterconnectGroup, interconnectGroupID))
 	}
 
+	interconnectSubgroupID, err := cnc.getInterconnectSubgroupID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get interconnectSubgroupID: %w", err)
+	}
+	if interconnectSubgroupID != "" {
+		nodeModifiers = append(nodeModifiers, addCloudNodeLabel(consts.LabelPlatformInterconnectSubgroup, interconnectSubgroupID))
+	}
+
 	return nodeModifiers, nil
 }
 
@@ -702,6 +712,14 @@ func (cnc *CloudNodeController) getInterconnectGroupID(ctx context.Context) (str
 		return "", fmt.Errorf("cnc.getInterconnectGroupID: %w", err)
 	}
 	return ig, nil
+}
+
+func (cnc *CloudNodeController) getInterconnectSubgroupID(ctx context.Context) (string, error) {
+	isg, err := cnc.nodeProvider.GetInterconnectSubgroupID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("cnc.getInterconnectSubgroupID: %w", err)
+	}
+	return isg, nil
 }
 
 func (cnc *CloudNodeController) updateNetworkingCondition(node *v1.Node, networkReady bool) error {

--- a/pkg/nodemanager/nodemanager_test.go
+++ b/pkg/nodemanager/nodemanager_test.go
@@ -184,6 +184,7 @@ func TestNodeInitialized(t *testing.T) {
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain(ctx).Return("1", nil)
 	mockNP.EXPECT().GetInterconnectGroupID(ctx).Return("group-123", nil)
+	mockNP.EXPECT().GetInterconnectSubgroupID(ctx).Return("subgroup-123", nil)
 
 	cloudNodeController := NewCloudNodeController(
 		"node0",
@@ -202,6 +203,7 @@ func TestNodeInitialized(t *testing.T) {
 	assert.Equal(t, 0, len(fnh.UpdatedNodes[0].Spec.Taints), "Node Taint was not removed after cloud init")
 	assert.Equal(t, "1", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformSubFaultDomain])
 	assert.Equal(t, "group-123", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformInterconnectGroup])
+	assert.Equal(t, "subgroup-123", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformInterconnectSubgroup])
 }
 
 func TestUpdateCloudNode(t *testing.T) {
@@ -265,6 +267,7 @@ func TestUpdateCloudNode(t *testing.T) {
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain(ctx).Return("1", nil)
 	mockNP.EXPECT().GetInterconnectGroupID(ctx).Return("group-456", nil)
+	mockNP.EXPECT().GetInterconnectSubgroupID(ctx).Return("subgroup-456", nil)
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := NewCloudNodeController(
@@ -287,6 +290,7 @@ func TestUpdateCloudNode(t *testing.T) {
 	assert.Equal(t, "NetworkUnavailable", string(fnh.UpdatedNodes[0].Status.Conditions[0].Type), "Node Condition NetworkUnavailable was not updated")
 	assert.Equal(t, "1", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformSubFaultDomain])
 	assert.Equal(t, "group-456", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformInterconnectGroup])
+	assert.Equal(t, "subgroup-456", fnh.UpdatedNodes[0].Labels[consts.LabelPlatformInterconnectSubgroup])
 }
 
 // This test checks that a node without the external cloud provider taint are NOT cloudprovider initialized
@@ -402,6 +406,7 @@ func TestZoneInitialized(t *testing.T) {
 		}, nil).AnyTimes()
 		mockNP.EXPECT().GetPlatformSubFaultDomain(ctx).Return("", nil)
 		mockNP.EXPECT().GetInterconnectGroupID(ctx).Return("", nil)
+		mockNP.EXPECT().GetInterconnectSubgroupID(ctx).Return("", nil)
 
 		eventBroadcaster := record.NewBroadcaster()
 		cloudNodeController := &CloudNodeController{
@@ -485,6 +490,7 @@ func TestZoneInitialized(t *testing.T) {
 		}, nil).AnyTimes()
 		mockNP.EXPECT().GetPlatformSubFaultDomain(ctx).Return("", nil)
 		mockNP.EXPECT().GetInterconnectGroupID(ctx).Return("", nil)
+		mockNP.EXPECT().GetInterconnectSubgroupID(ctx).Return("", nil)
 
 		eventBroadcaster := record.NewBroadcaster()
 		cloudNodeController := &CloudNodeController{
@@ -584,6 +590,7 @@ func TestAddCloudNode(t *testing.T) {
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain(gomock.Any()).Return("", nil)
 	mockNP.EXPECT().GetInterconnectGroupID(gomock.Any()).Return("", nil)
+	mockNP.EXPECT().GetInterconnectSubgroupID(gomock.Any()).Return("", nil)
 
 	factory := informers.NewSharedInformerFactory(fnh, 0)
 	nodeInformer := factory.Core().V1().Nodes()
@@ -750,6 +757,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain(ctx).Return("", nil)
 	mockNP.EXPECT().GetInterconnectGroupID(ctx).Return("", nil)
+	mockNP.EXPECT().GetInterconnectSubgroupID(ctx).Return("", nil)
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := NewCloudNodeController(
@@ -1174,6 +1182,7 @@ func TestNodeProviderID(t *testing.T) {
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain(ctx).Return("", nil).AnyTimes()
 	mockNP.EXPECT().GetInterconnectGroupID(ctx).Return("", nil).AnyTimes()
+	mockNP.EXPECT().GetInterconnectSubgroupID(ctx).Return("", nil).AnyTimes()
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := &CloudNodeController{
@@ -1262,6 +1271,7 @@ func TestNodeProviderIDAlreadySet(t *testing.T) {
 	}, nil).AnyTimes()
 	mockNP.EXPECT().GetPlatformSubFaultDomain(ctx).Return("", nil).AnyTimes()
 	mockNP.EXPECT().GetInterconnectGroupID(ctx).Return("", nil).AnyTimes()
+	mockNP.EXPECT().GetInterconnectSubgroupID(ctx).Return("", nil).AnyTimes()
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := &CloudNodeController{

--- a/pkg/provider/azure_instance_metadata.go
+++ b/pkg/provider/azure_instance_metadata.go
@@ -83,6 +83,8 @@ type ComputeMetadata struct {
 	VMScaleSetName         string `json:"vmScaleSetName,omitempty"`
 	SubscriptionID         string `json:"subscriptionId,omitempty"`
 	ResourceID             string `json:"resourceId,omitempty"`
+	InterconnectGroupID    string `json:"interconnectGroupId,omitempty"`
+	InterconnectSubgroupID string `json:"interconnectSubgroupId,omitempty"`
 	TagsList               []Tag  `json:"tagsList,omitempty"`
 }
 
@@ -301,7 +303,6 @@ func (az *Cloud) GetPlatformSubFaultDomain(ctx context.Context) (string, error) 
 }
 
 // GetInterconnectGroupID returns the Platform Interconnect Group ID from IMDS if set.
-// It reads the value from the Platform_Interconnect_Group tag in tagsList.
 func (az *Cloud) GetInterconnectGroupID(ctx context.Context) (string, error) {
 	logger := log.FromContextOrBackground(ctx).WithName("GetInterconnectGroupID")
 	if az.UseInstanceMetadata {
@@ -312,6 +313,11 @@ func (az *Cloud) GetInterconnectGroupID(ctx context.Context) (string, error) {
 		if metadata.Compute == nil {
 			_ = az.Metadata.imsCache.Delete(consts.MetadataCacheKey)
 			return "", errors.New("failure of getting compute information from instance metadata")
+		}
+
+		if metadata.Compute.InterconnectGroupID != "" {
+			logger.V(2).Info("found Interconnect Group ID from IMDS", "InterconnectGroupID", metadata.Compute.InterconnectGroupID)
+			return metadata.Compute.InterconnectGroupID, nil
 		}
 
 		// Check tagsList for Platform_Interconnect_Group tag
@@ -328,6 +334,29 @@ func (az *Cloud) GetInterconnectGroupID(ctx context.Context) (string, error) {
 
 		// Tag not found - this is normal for VMs without Interconnect Groups
 		logger.V(4).Info("Tag not found in IMDS", "tagName", consts.TagNameInterconnectGroup)
+	}
+	return "", nil
+}
+
+// GetInterconnectSubgroupID returns the Platform Interconnect Subgroup ID from IMDS if set.
+func (az *Cloud) GetInterconnectSubgroupID(ctx context.Context) (string, error) {
+	logger := log.FromContextOrBackground(ctx).WithName("GetInterconnectSubgroupID")
+	if az.UseInstanceMetadata {
+		metadata, err := az.Metadata.GetMetadata(ctx, azcache.CacheReadTypeUnsafe)
+		if err != nil {
+			return "", err
+		}
+		if metadata.Compute == nil {
+			_ = az.Metadata.imsCache.Delete(consts.MetadataCacheKey)
+			return "", errors.New("failure of getting compute information from instance metadata")
+		}
+
+		if metadata.Compute.InterconnectSubgroupID != "" {
+			logger.V(2).Info("found Interconnect Subgroup ID from IMDS", "InterconnectSubgroupID", metadata.Compute.InterconnectSubgroupID)
+			return metadata.Compute.InterconnectSubgroupID, nil
+		}
+
+		logger.V(4).Info("Interconnect Subgroup ID not found in IMDS")
 	}
 	return "", nil
 }

--- a/pkg/provider/azure_instance_metadata_test.go
+++ b/pkg/provider/azure_instance_metadata_test.go
@@ -161,6 +161,20 @@ func TestGetInterconnectGroupID(t *testing.T) {
 		expectedErr         bool
 	}{
 		{
+			name:                "InterconnectGroupId field present",
+			useInstanceMetadata: true,
+			respString:          `{"compute":{"interconnectGroupId":"group-from-field"}}`,
+			expectedID:          "group-from-field",
+			expectedErr:         false,
+		},
+		{
+			name:                "InterconnectGroupId field takes precedence over tag",
+			useInstanceMetadata: true,
+			respString:          `{"compute":{"interconnectGroupId":"group-from-field","tagsList":[{"name":"Platform_Interconnect_Group","value":"group-from-tag"}]}}`,
+			expectedID:          "group-from-field",
+			expectedErr:         false,
+		},
+		{
 			name:                "InterconnectGroup tag present",
 			useInstanceMetadata: true,
 			respString:          `{"compute":{"tagsList":[{"name":"Platform_Interconnect_Group","value":"group-123"},{"name":"Other_Tag","value":"other"}]}}`,
@@ -223,6 +237,81 @@ func TestGetInterconnectGroupID(t *testing.T) {
 			assert.NoError(t, err)
 
 			id, err := cloud.GetInterconnectGroupID(context.TODO())
+
+			if tc.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedID, id)
+			}
+		})
+	}
+}
+
+func TestGetInterconnectSubgroupID(t *testing.T) {
+	testCases := []struct {
+		name                string
+		useInstanceMetadata bool
+		respString          string
+		expectedID          string
+		expectedErr         bool
+	}{
+		{
+			name:                "InterconnectSubgroupId field present",
+			useInstanceMetadata: true,
+			respString:          `{"compute":{"interconnectSubgroupId":"subgroup-123"}}`,
+			expectedID:          "subgroup-123",
+			expectedErr:         false,
+		},
+		{
+			name:                "InterconnectSubgroupId field absent",
+			useInstanceMetadata: true,
+			respString:          `{"compute":{}}`,
+			expectedID:          "",
+			expectedErr:         false,
+		},
+		{
+			name:                "InterconnectSubgroupId field present with empty value",
+			useInstanceMetadata: true,
+			respString:          `{"compute":{"interconnectSubgroupId":""}}`,
+			expectedID:          "",
+			expectedErr:         false,
+		},
+		{
+			name:                "Compute metadata is nil",
+			useInstanceMetadata: true,
+			respString:          `{}`,
+			expectedID:          "",
+			expectedErr:         true,
+		},
+		{
+			name:                "UseInstanceMetadata false",
+			useInstanceMetadata: false,
+			respString:          `{"compute":{"interconnectSubgroupId":"subgroup-123"}}`,
+			expectedID:          "",
+			expectedErr:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := &Cloud{
+				Config: config.Config{
+					Location:            "eastus",
+					UseInstanceMetadata: tc.useInstanceMetadata,
+				},
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprint(w, tc.respString)
+			}))
+			defer server.Close()
+
+			var err error
+			cloud.Metadata, err = NewInstanceMetadataService(server.URL + "/")
+			assert.NoError(t, err)
+
+			id, err := cloud.GetInterconnectSubgroupID(context.TODO())
 
 			if tc.expectedErr {
 				assert.Error(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

interconnectGroupId and interconnectSubgroupId are getting exposed as first class entries in the IMDS machine info document. 
This PR updates the search logic for interconnectGroupId to look for the compute field (and have it take precedence over the tags) and also adds support for interconnectSubGroupId values



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds support for topology.kubernetes.azure.com/interconnect-subgroup node label and updates logic for population topology.kubernetes.azure.com/interconnect-group
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
