### PR TITLE
docs: add dependabot unblocker automation prompt

### DIFF
--- a/.agents/automations/dependabot-pr-unblocker.md
+++ b/.agents/automations/dependabot-pr-unblocker.md
@@ -1,0 +1,16 @@
+Run the repository skill at `.agents/skills/unblock-dependabot-pr/` for
+currently open Dependabot pull requests with failed CI.
+
+Read `.agents/skills/unblock-dependabot-pr/SKILL.md` first and follow it as the
+source of truth. Do not duplicate or override the skill's workflow. List open
+Dependabot PRs in `kubernetes-sigs/cloud-provider-azure`, identify the ones
+with failed checks, and apply the skill to each such PR by PR number or URL.
+
+If the skill requires user judgment, permission, or conflict resolution, stop
+for that PR and report the blocker instead of guessing. If no open Dependabot
+PRs have failed checks, say so briefly.
+
+Output a concise Markdown table:
+| PR | Failed checks | Action | Result | Follow-up |
+Use Markdown links for PRs, and include pending checks or residual risks in
+`Follow-up`.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds `.agents/automations/dependabot-pr-unblocker.md`, a repository prompt file copied from the existing Dependabot PR unblocker automation. This keeps the automation prompt versioned with the shared agent assets.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Prompt-only change. It does not change `.agents/skills/unblock-dependabot-pr/` or runtime code.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```