### PR TITLE
feat(azclient): add ThrottleError type with RetryAfter field

### DIFF
--- a/pkg/azclient/policy/retryrepectthrottled/throttle.go
+++ b/pkg/azclient/policy/retryrepectthrottled/throttle.go
@@ -32,6 +32,15 @@ var (
 	ErrTooManyRequest = errors.New("throttled due to too many requests")
 )
 
+// ThrottleError wraps ErrTooManyRequest with the RetryAfter time parsed from
+// the ARM response or read from the local gate timer.
+type ThrottleError struct {
+	RetryAfter time.Time
+}
+
+func (e *ThrottleError) Error() string { return ErrTooManyRequest.Error() }
+func (e *ThrottleError) Unwrap() error { return ErrTooManyRequest }
+
 func NewThrottlingPolicy() policy.Policy {
 	return &ThrottlingPolicy{
 		RetryAfterReader: time.Now(),
@@ -65,7 +74,7 @@ func (p *ThrottlingPolicy) Do(req *policy.Request) (*http.Response, error) {
 
 func (p *ThrottlingPolicy) processThrottlePolicy(timer *time.Time, req *policy.Request) (*http.Response, error) {
 	if timer.After(time.Now()) {
-		return nil, ErrTooManyRequest
+		return nil, &ThrottleError{RetryAfter: *timer}
 	}
 	resp, err := req.Next()
 	if err != nil {
@@ -86,7 +95,7 @@ func (p *ThrottlingPolicy) processThrottlePolicy(timer *time.Time, req *policy.R
 			*timer = t
 		}
 
-		return resp, ErrTooManyRequest
+		return resp, &ThrottleError{RetryAfter: *timer}
 	}
 	return resp, nil
 }

--- a/pkg/azclient/policy/retryrepectthrottled/throttle_test.go
+++ b/pkg/azclient/policy/retryrepectthrottled/throttle_test.go
@@ -18,6 +18,7 @@ package retryrepectthrottled_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -78,6 +79,90 @@ var _ = ginkgo.Describe("Throttle", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			_, err = pipeline.Do(req)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Describe("ThrottleError", func() {
+		before := time.Now()
+		rfc1123Future := time.Now().Add(120 * time.Second).UTC()
+		pastTimer := time.Now().Add(-1 * time.Hour)
+		futureTimer := time.Now().Add(30 * time.Second)
+
+		ginkgo.DescribeTable("should populate RetryAfter correctly",
+			func(initialTimer *time.Time, responseStatus int, retryAfterValue string, check func(time.Time)) {
+				throttlePolicy := &retryrepectthrottled.ThrottlingPolicy{}
+				if initialTimer != nil {
+					throttlePolicy.RetryAfterWriter = *initialTimer
+				}
+				pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, &policy.ClientOptions{
+					PerCallPolicies: []policy.Policy{
+						throttlePolicy,
+						utils.FuncPolicyWrapper(
+							func(*policy.Request) (*http.Response, error) {
+								header := http.Header{}
+								if retryAfterValue != "" {
+									header.Set("Retry-After", retryAfterValue)
+								}
+								return &http.Response{
+									StatusCode: responseStatus,
+									Body:       http.NoBody,
+									Header:     header,
+								}, nil
+							},
+						),
+					},
+				})
+				req, err := runtime.NewRequest(context.Background(), http.MethodPut, "http://localhost:8080")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = pipeline.Do(req)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				var throttleErr *retryrepectthrottled.ThrottleError
+				gomega.Expect(errors.As(err, &throttleErr)).To(gomega.BeTrue())
+				check(throttleErr.RetryAfter)
+			},
+			ginkgo.Entry("ARM 429 with integer seconds Retry-After",
+				nil, http.StatusTooManyRequests, "60",
+				func(retryAfter time.Time) {
+					gomega.Expect(retryAfter).To(gomega.BeTemporally(">=", before.Add(60*time.Second), time.Second))
+				}),
+			ginkgo.Entry("ARM 429 with RFC1123 Retry-After",
+				nil, http.StatusTooManyRequests, rfc1123Future.Format(time.RFC1123),
+				func(retryAfter time.Time) {
+					gomega.Expect(retryAfter).To(gomega.BeTemporally("~", rfc1123Future, time.Second))
+				}),
+			ginkgo.Entry("ARM 429 without Retry-After header",
+				nil, http.StatusTooManyRequests, "",
+				func(retryAfter time.Time) {
+					gomega.Expect(retryAfter).To(gomega.BeTemporally("<=", time.Now(), time.Second))
+				}),
+			ginkgo.Entry("ARM 429 with unparsable Retry-After",
+				&pastTimer, http.StatusTooManyRequests, "not-a-number-or-date",
+				func(retryAfter time.Time) {
+					gomega.Expect(retryAfter).To(gomega.BeTemporally("~", pastTimer, time.Millisecond))
+				}),
+			ginkgo.Entry("local gate path with active timer",
+				&futureTimer, http.StatusOK, "",
+				func(retryAfter time.Time) {
+					gomega.Expect(retryAfter).To(gomega.BeTemporally("~", futureTimer, time.Millisecond))
+				}),
+		)
+
+		ginkgo.It("should satisfy errors.Is(err, ErrTooManyRequest) for ThrottleError", func() {
+			err := &retryrepectthrottled.ThrottleError{RetryAfter: time.Now()}
+			gomega.Expect(errors.Is(err, retryrepectthrottled.ErrTooManyRequest)).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should allow errors.As to extract ThrottleError with correct RetryAfter", func() {
+			expected := time.Now().Add(42 * time.Second)
+			var err error = &retryrepectthrottled.ThrottleError{RetryAfter: expected}
+			var throttleErr *retryrepectthrottled.ThrottleError
+			gomega.Expect(errors.As(err, &throttleErr)).To(gomega.BeTrue())
+			gomega.Expect(throttleErr.RetryAfter).To(gomega.BeTemporally("~", expected, time.Millisecond))
+		})
+
+		ginkgo.It("should return the same error string as ErrTooManyRequest", func() {
+			err := &retryrepectthrottled.ThrottleError{RetryAfter: time.Now()}
+			gomega.Expect(err.Error()).To(gomega.Equal(retryrepectthrottled.ErrTooManyRequest.Error()))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add `ThrottleError` wrapping `ErrTooManyRequest` with a `RetryAfter time.Time` field. Both 429 and local-gate paths in `processThrottlePolicy` now return `&ThrottleError{RetryAfter: *timer}`. Backward compatible via `Unwrap`.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10270

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
