### PR TITLE
chore: bump azclient to v0.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubelet v0.36.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
-	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.20.9
+	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.0
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/cache v0.14.2
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.15.2
 	sigs.k8s.io/yaml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.20.9 h1:r+rYaP4LruK4B5ehxHyCQVH9Swxg0siqmMc9gPA0Oo4=
-sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.20.9/go.mod h1:nvT7njky0cliFSfD/V4f1ggxSV7qIOwvtlajWVMC8bc=
+sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.0 h1:Wc+0EuDqehOYz/o7cqY0vEQuzkrG69xG+M2AG+LVFTo=
+sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.0/go.mod h1:nvT7njky0cliFSfD/V4f1ggxSV7qIOwvtlajWVMC8bc=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/cache v0.14.2 h1:8oxoH0zPNSImdVniAMq1UauAeqbsKYTEyDSm81rY2SE=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/cache v0.14.2/go.mod h1:IoTOCX1sspsZ7zg2P4uVOKwG0jDmRVlok6msuyO4Qy8=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.15.2 h1:be6PmylCocI/CZTamSn9uQpchsXcb4SCaH9jl3KDxkQ=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -20,7 +20,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/cloud-provider-azure v0.0.0-00010101000000-000000000000
-	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.20.9
+	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.0
 )
 
 require (

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -280,8 +280,8 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0xi3g0ZcxxJ7vbWU=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
-sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.20.9 h1:r+rYaP4LruK4B5ehxHyCQVH9Swxg0siqmMc9gPA0Oo4=
-sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.20.9/go.mod h1:nvT7njky0cliFSfD/V4f1ggxSV7qIOwvtlajWVMC8bc=
+sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.0 h1:Wc+0EuDqehOYz/o7cqY0vEQuzkrG69xG+M2AG+LVFTo=
+sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.0/go.mod h1:nvT7njky0cliFSfD/V4f1ggxSV7qIOwvtlajWVMC8bc=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.15.2 h1:be6PmylCocI/CZTamSn9uQpchsXcb4SCaH9jl3KDxkQ=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.15.2/go.mod h1:bFd+YoGg9on0uMr5Y4HjFiBovY1y6GbmokVl35+zQAA=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1446,7 +1446,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.20.9
+# sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.21.0
 ## explicit; go 1.25.0
 sigs.k8s.io/cloud-provider-azure/pkg/azclient
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/accountclient

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled/throttle.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled/throttle.go
@@ -32,6 +32,15 @@ var (
 	ErrTooManyRequest = errors.New("throttled due to too many requests")
 )
 
+// ThrottleError wraps ErrTooManyRequest with the RetryAfter time parsed from
+// the ARM response or read from the local gate timer.
+type ThrottleError struct {
+	RetryAfter time.Time
+}
+
+func (e *ThrottleError) Error() string { return ErrTooManyRequest.Error() }
+func (e *ThrottleError) Unwrap() error { return ErrTooManyRequest }
+
 func NewThrottlingPolicy() policy.Policy {
 	return &ThrottlingPolicy{
 		RetryAfterReader: time.Now(),
@@ -65,7 +74,7 @@ func (p *ThrottlingPolicy) Do(req *policy.Request) (*http.Response, error) {
 
 func (p *ThrottlingPolicy) processThrottlePolicy(timer *time.Time, req *policy.Request) (*http.Response, error) {
 	if timer.After(time.Now()) {
-		return nil, ErrTooManyRequest
+		return nil, &ThrottleError{RetryAfter: *timer}
 	}
 	resp, err := req.Next()
 	if err != nil {
@@ -86,7 +95,7 @@ func (p *ThrottlingPolicy) processThrottlePolicy(timer *time.Time, req *policy.R
 			*timer = t
 		}
 
-		return resp, ErrTooManyRequest
+		return resp, &ThrottleError{RetryAfter: *timer}
 	}
 	return resp, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Bump `sigs.k8s.io/cloud-provider-azure/pkg/azclient` to v0.21.0 in the root module and tests module.

This picks up the `ThrottleError` type added in #10557, which exposes `Retry-After` duration from ARM 429 responses and local throttle gates. The type is required by the upcoming local-service backend pool updater
retry implementation (#10270).
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10270

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
