### PR TITLE
chore(dependabot): ignore azclient modules updates and add go ignore to releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -349,6 +349,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-major"
       - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
+      - dependency-name: "go"
     groups:
       all:
         applies-to: version-updates
@@ -429,6 +430,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-major"
       - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
+      - dependency-name: "go"
     groups:
       all:
         applies-to: version-updates
@@ -509,6 +511,7 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-major"
       - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
+      - dependency-name: "go"
     groups:
       all:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
       - dependency-name: "go"
     groups:
       all:
@@ -48,6 +49,7 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
       - dependency-name: "go"
     groups:
       all:
@@ -346,6 +348,7 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
     groups:
       all:
         applies-to: version-updates
@@ -425,6 +428,7 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
     groups:
       all:
         applies-to: version-updates
@@ -504,6 +508,7 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
     groups:
       all:
         applies-to: version-updates
@@ -582,6 +587,7 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      - dependency-name: "sigs.k8s.io/cloud-provider-azure/pkg/azclient*"
       - dependency-name: "go"
     groups:
       all:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds dependabot ignore rules for `sigs.k8s.io/cloud-provider-azure/pkg/azclient*` (all update types) on gomod entries: root `/`, `/tests`, and all release branch `/` entries.

A patch bump of azclient submodule entries could transitively pull in a newer k8s.io minor via `go mod tidy` bypassing the existing `k8s.io/*` ignore rule.

azclient bumps on root or tests are now manual-only. azclient submodule entries (`/pkg/azclient/*`) are unchanged.

Also adds missing `go` ignore to release-1.34/1.35/1.36 for consistency with master and release-1.33.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
