### PR TITLE
Add shared build-images agent skill

### DIFF
--- a/.agents/references/testing-builds-and-headers.md
+++ b/.agents/references/testing-builds-and-headers.md
@@ -19,11 +19,12 @@ over `make test-unit` for faster feedback.
 
 ## Building Images
 
-Before building images, ask the user for `IMAGE_REGISTRY` and `IMAGE_TAG`.
+Before building images, ask the user for `IMAGE_REGISTRY` and `IMAGE_TAG`. For
+the reusable agent workflow, use `.agents/skills/build-images/`.
 
 ```sh
 IMAGE_REGISTRY=<registry> IMAGE_TAG=<tag> make build-ccm-image
-IMAGE_REGISTRY=<registry> IMAGE_TAG=<tag> make build-cnm-image
+IMAGE_REGISTRY=<registry> IMAGE_TAG=<tag> make build-node-image-linux
 ```
 
 ## File Headers

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -50,6 +50,9 @@ level small:
 - `debug-e2e-pipeline`: fetch and analyze Prow e2e pipeline failures by
   downloading build logs, JUnit reports, and node artifacts from GCS, then
   matching errors against known failure patterns
+- `build-images`: build cloud-provider-azure CCM, CNM, health-probe-proxy,
+  CCM e2e, or root CCM/CNM aggregate images with explicit tag/registry inputs
+  and optional make flag overrides
 
 ## How To Use
 

--- a/.agents/skills/build-images/SKILL.md
+++ b/.agents/skills/build-images/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: build-images
+description: Build cloud-provider-azure container images through the repo Makefile with explicit IMAGE_TAG and IMAGE_REGISTRY inputs plus optional make flag overrides. Use when the user wants to build CCM, CNM, health-probe-proxy, CCM e2e, or root CCM/CNM aggregate images, or mentions build-ccm-image, build-node-image-linux, build images, image registry, or image tag.
+---
+
+# Build Images
+
+## Workflow
+
+Use this skill to build cloud-provider-azure images from the repository
+Makefiles. Ask for `IMAGE_TAG` and `IMAGE_REGISTRY` when either value is
+missing.
+
+Replace `<SKILL_DIR>` with the path to this skill directory.
+
+Dry-run the default CCM command:
+
+```bash
+python3 <SKILL_DIR>/scripts/build_image.py \
+  --image ccm \
+  --tag <tag> \
+  --registry <registry> \
+  --dry-run
+```
+
+Build the default CCM image:
+
+```bash
+python3 <SKILL_DIR>/scripts/build_image.py \
+  --image ccm \
+  --tag <tag> \
+  --registry <registry>
+```
+
+The default CCM command is:
+
+```bash
+IMAGE_TAG=<tag> IMAGE_REGISTRY=<registry> GOEXPERIMENT=nosystemcrypto ENABLE_GIT_COMMAND=false make build-ccm-image
+```
+
+## Image Aliases
+
+Pass one of these values to `--image`:
+
+| Alias | Make target | Directory |
+|-------|-------------|-----------|
+| `ccm` | `build-ccm-image` | repo root |
+| `ccm-all` | `build-all-ccm-images` | repo root |
+| `cnm`, `cnm-linux` | `build-node-image-linux` | repo root |
+| `cnm-windows` | `build-node-image-windows` | repo root |
+| `cnm-windows-hpc` | `build-node-image-windows-hpc` | repo root |
+| `cnm-all` | `build-all-node-images` | repo root |
+| `ccm-e2e` | `build-ccm-e2e-test-image` | repo root |
+| `hpp` | `build-health-probe-proxy-image` | `health-probe-proxy/` |
+| `hpp-windows` | `build-health-probe-proxy-image-windows` | `health-probe-proxy/` |
+| `all` | `image` | repo root |
+
+`all` maps to the root `make image` target. It builds the root CCM/CNM
+aggregate only; it does not build `hpp`, `hpp-windows`, or `ccm-e2e`.
+
+`cnm-all` maps to the raw root `build-all-node-images` aggregate. Because that
+aggregate includes Windows image targets with host-side Go builds, the helper
+does not default `GOEXPERIMENT` for `cnm-all`.
+
+Do not use this skill for acr-credential-provider images. This repo exposes the
+acr-credential-provider as a binary build, not an image build target.
+
+## Flags
+
+The helper always sets `IMAGE_TAG`, `IMAGE_REGISTRY`, and
+`ENABLE_GIT_COMMAND=false` unless a default is explicitly removed with
+`--unset`.
+
+The helper defaults `GOEXPERIMENT=nosystemcrypto` only for `ccm`, `ccm-all`,
+`cnm`, and `cnm-linux`. For other aliases, pass it explicitly when desired:
+
+```bash
+python3 <SKILL_DIR>/scripts/build_image.py \
+  --image hpp \
+  --tag <tag> \
+  --registry <registry> \
+  --set GOEXPERIMENT=nosystemcrypto
+```
+
+Use repeated `--set KEY=VALUE` arguments to add or override make variables:
+
+```bash
+python3 <SKILL_DIR>/scripts/build_image.py \
+  --image cnm \
+  --tag <tag> \
+  --registry <registry> \
+  --set ARCH=arm64 \
+  --set BUILDX_EXTRA_FLAGS=--no-cache
+```
+
+Use repeated `--unset KEY` arguments to remove default flags:
+
+```bash
+python3 <SKILL_DIR>/scripts/build_image.py \
+  --image ccm \
+  --tag <tag> \
+  --registry <registry> \
+  --unset GOEXPERIMENT \
+  --unset ENABLE_GIT_COMMAND
+```
+
+`IMAGE_TAG` and `IMAGE_REGISTRY` are required inputs and cannot be unset.
+They also cannot be overridden with `--set`; use `--tag` and `--registry`.
+Passing the same key to both `--set` and `--unset` is rejected.
+
+Make control variables that can override command-line or environment values are
+reserved. Do not pass `MAKEFLAGS`, `MFLAGS`, `GNUMAKEFLAGS`, `MAKEOVERRIDES`,
+or `MAKEFILES` with `--set`; the helper rejects those keys and removes inherited
+values before running `make`.
+
+## Validation
+
+Use `--dry-run` when the user asks for the command, when checking flag changes,
+or before running an expensive build. The script prints the resolved working
+directory and shell-quoted command. When the helper removes a default or
+sanitizes inherited managed environment, dry-runs show that as `env -u KEY`.
+Without `--dry-run`, it prints the same resolved working directory and command,
+then runs `make` via `subprocess.run` without `shell=True`.

--- a/.agents/skills/build-images/scripts/build_image.py
+++ b/.agents/skills/build-images/scripts/build_image.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+REQUIRED_ENV = {"IMAGE_TAG", "IMAGE_REGISTRY"}
+MANAGED_ENV = {"IMAGE_TAG", "IMAGE_REGISTRY", "ENABLE_GIT_COMMAND", "GOEXPERIMENT"}
+MAKE_CONTROL_ENV = {
+    "GNUMAKEFLAGS",
+    "MAKEFILES",
+    "MAKEFLAGS",
+    "MAKEOVERRIDES",
+    "MFLAGS",
+}
+GOEXPERIMENT_DEFAULT = "nosystemcrypto"
+ENABLE_GIT_COMMAND_DEFAULT = "false"
+
+
+@dataclass(frozen=True)
+class ImageTarget:
+    make_target: str
+    subdir: str = "."
+    default_goexperiment: bool = False
+
+
+@dataclass(frozen=True)
+class BuildPlan:
+    cwd: Path
+    cmd: list[str]
+    env: dict[str, str]
+    unset_env: frozenset[str] = frozenset()
+
+
+IMAGE_TARGETS = {
+    "all": ImageTarget("image"),
+    "ccm": ImageTarget("build-ccm-image", default_goexperiment=True),
+    "ccm-all": ImageTarget("build-all-ccm-images", default_goexperiment=True),
+    "ccm-e2e": ImageTarget("build-ccm-e2e-test-image"),
+    "cnm": ImageTarget("build-node-image-linux", default_goexperiment=True),
+    "cnm-all": ImageTarget("build-all-node-images"),
+    "cnm-linux": ImageTarget("build-node-image-linux", default_goexperiment=True),
+    "cnm-windows": ImageTarget("build-node-image-windows"),
+    "cnm-windows-hpc": ImageTarget("build-node-image-windows-hpc"),
+    "hpp": ImageTarget("build-health-probe-proxy-image", "health-probe-proxy"),
+    "hpp-windows": ImageTarget(
+        "build-health-probe-proxy-image-windows", "health-probe-proxy"
+    ),
+}
+
+
+def validate_env_key(key: str) -> None:
+    if not ENV_KEY_RE.match(key):
+        raise ValueError(f"invalid flag name {key!r}")
+
+
+def parse_set_value(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise ValueError(f"--set expects KEY=VALUE, got {value!r}")
+    key, env_value = value.split("=", 1)
+    validate_env_key(key)
+    if key == "IMAGE_TAG":
+        raise ValueError("IMAGE_TAG must be provided with --tag, not --set")
+    if key == "IMAGE_REGISTRY":
+        raise ValueError("IMAGE_REGISTRY must be provided with --registry, not --set")
+    if key in MAKE_CONTROL_ENV:
+        raise ValueError(f"{key} is reserved and cannot be provided with --set")
+    return key, env_value
+
+
+def script_repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def build_plan(
+    *,
+    image: str,
+    tag: str,
+    registry: str,
+    repo_root: Path,
+    set_values: list[str] | None = None,
+    unset_values: list[str] | None = None,
+    inherited_env: Mapping[str, str] | None = None,
+) -> BuildPlan:
+    image_key = image.lower()
+    if image_key not in IMAGE_TARGETS:
+        aliases = ", ".join(sorted(IMAGE_TARGETS))
+        raise ValueError(f"unknown image alias {image!r}; expected one of: {aliases}")
+    if not tag:
+        raise ValueError("--tag must not be empty")
+    if not registry:
+        raise ValueError("--registry must not be empty")
+    target = IMAGE_TARGETS[image_key]
+
+    unset_env = set[str]()
+    for key in unset_values or []:
+        validate_env_key(key)
+        if key in REQUIRED_ENV:
+            raise ValueError(f"{key} is required and cannot be unset")
+        unset_env.add(key)
+
+    set_entries = [parse_set_value(value) for value in set_values or []]
+    set_keys = {key for key, _ in set_entries}
+    conflicts = set_keys.intersection(unset_env)
+    if conflicts:
+        keys = ", ".join(sorted(conflicts))
+        raise ValueError(f"{keys} cannot be passed with both --set and --unset")
+
+    env = {
+        "IMAGE_TAG": tag,
+        "IMAGE_REGISTRY": registry,
+    }
+    if target.default_goexperiment:
+        env["GOEXPERIMENT"] = GOEXPERIMENT_DEFAULT
+    env["ENABLE_GIT_COMMAND"] = ENABLE_GIT_COMMAND_DEFAULT
+
+    for key in unset_env:
+        env.pop(key, None)
+
+    for key, env_value in set_entries:
+        env[key] = env_value
+
+    for key in REQUIRED_ENV:
+        if not env.get(key):
+            raise ValueError(f"{key} is required and cannot be empty")
+
+    unset_managed_env = {
+        key
+        for key in MANAGED_ENV
+        if key not in env and key not in set_keys and key not in REQUIRED_ENV
+    }
+    unset_env.update(unset_managed_env)
+    if inherited_env is not None:
+        unset_env.update(key for key in MAKE_CONTROL_ENV if key in inherited_env)
+    return BuildPlan(
+        cwd=repo_root / target.subdir,
+        cmd=["make", target.make_target],
+        env=env,
+        unset_env=frozenset(unset_env),
+    )
+
+
+def quote_env_assignment(key: str, value: str) -> str:
+    return f"{key}={shlex.quote(value)}"
+
+
+def format_command(plan: BuildPlan) -> str:
+    unset_parts: list[str] = []
+    if plan.unset_env:
+        unset_parts.append("env")
+        for key in sorted(plan.unset_env):
+            unset_parts.extend(["-u", shlex.quote(key)])
+    env_parts = [quote_env_assignment(key, value) for key, value in plan.env.items()]
+    cmd_parts = [shlex.quote(part) for part in plan.cmd]
+    return " ".join([*unset_parts, *env_parts, *cmd_parts])
+
+
+def format_dry_run(plan: BuildPlan) -> str:
+    return f"cwd: {plan.cwd}\ncommand: {format_command(plan)}"
+
+
+def find_repo_root(start: Path) -> Path:
+    _ = start
+    return script_repo_root()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build cloud-provider-azure images with explicit tag and registry inputs.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--image", required=True, choices=sorted(IMAGE_TARGETS))
+    parser.add_argument("--tag", required=True, help="IMAGE_TAG value to use")
+    parser.add_argument("--registry", required=True, help="IMAGE_REGISTRY value to use")
+    parser.add_argument(
+        "--set",
+        dest="set_values",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="add or override an environment/make variable",
+    )
+    parser.add_argument(
+        "--unset",
+        dest="unset_values",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help="remove a default environment/make variable",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the resolved working directory and command without building",
+    )
+    return parser.parse_args(argv)
+
+
+def run_plan(plan: BuildPlan) -> int:
+    env = os.environ.copy()
+    for key in MAKE_CONTROL_ENV:
+        env.pop(key, None)
+    for key in plan.unset_env:
+        env.pop(key, None)
+    env.update(plan.env)
+    print(format_dry_run(plan))
+    return subprocess.run(plan.cmd, cwd=plan.cwd, env=env, check=False).returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        plan = build_plan(
+            image=args.image,
+            tag=args.tag,
+            registry=args.registry,
+            repo_root=find_repo_root(Path.cwd()),
+            set_values=args.set_values,
+            unset_values=args.unset_values,
+            inherited_env=os.environ,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        print(format_dry_run(plan))
+        return 0
+    return run_plan(plan)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/build-images/scripts/test_build_image.py
+++ b/.agents/skills/build-images/scripts/test_build_image.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+from io import StringIO
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+import build_image
+
+
+class BuildImageTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = Path("/repo")
+
+    def test_ccm_uses_default_command(self) -> None:
+        plan = build_image.build_plan(
+            image="ccm",
+            tag="dev",
+            registry="example.azurecr.io/cpa",
+            repo_root=self.repo,
+        )
+
+        self.assertEqual(plan.cwd, self.repo)
+        self.assertEqual(plan.cmd, ["make", "build-ccm-image"])
+        self.assertEqual(
+            build_image.format_command(plan),
+            "IMAGE_TAG=dev IMAGE_REGISTRY=example.azurecr.io/cpa "
+            "GOEXPERIMENT=nosystemcrypto ENABLE_GIT_COMMAND=false "
+            "make build-ccm-image",
+        )
+
+    def test_aliases_use_expected_targets_directories_and_defaults(self) -> None:
+        cases = [
+            ("all", "image", self.repo, False),
+            ("ccm", "build-ccm-image", self.repo, True),
+            ("ccm-all", "build-all-ccm-images", self.repo, True),
+            ("ccm-e2e", "build-ccm-e2e-test-image", self.repo, False),
+            ("cnm", "build-node-image-linux", self.repo, True),
+            ("cnm-all", "build-all-node-images", self.repo, False),
+            ("cnm-linux", "build-node-image-linux", self.repo, True),
+            ("cnm-windows", "build-node-image-windows", self.repo, False),
+            ("cnm-windows-hpc", "build-node-image-windows-hpc", self.repo, False),
+            (
+                "hpp",
+                "build-health-probe-proxy-image",
+                self.repo / "health-probe-proxy",
+                False,
+            ),
+            (
+                "hpp-windows",
+                "build-health-probe-proxy-image-windows",
+                self.repo / "health-probe-proxy",
+                False,
+            ),
+        ]
+
+        for image, make_target, cwd, default_goexperiment in cases:
+            with self.subTest(image=image):
+                plan = build_image.build_plan(
+                    image=image,
+                    tag="dev",
+                    registry="example.azurecr.io/cpa",
+                    repo_root=self.repo,
+                )
+
+                self.assertEqual(plan.cwd, cwd)
+                self.assertEqual(plan.cmd, ["make", make_target])
+                self.assertEqual(plan.env["IMAGE_TAG"], "dev")
+                self.assertEqual(plan.env["IMAGE_REGISTRY"], "example.azurecr.io/cpa")
+                self.assertEqual(plan.env["ENABLE_GIT_COMMAND"], "false")
+                if default_goexperiment:
+                    self.assertEqual(plan.env["GOEXPERIMENT"], "nosystemcrypto")
+                else:
+                    self.assertNotIn("GOEXPERIMENT", plan.env)
+
+    def test_can_set_and_unset_make_flags(self) -> None:
+        plan = build_image.build_plan(
+            image="cnm",
+            tag="dev",
+            registry="example.azurecr.io/cpa",
+            repo_root=self.repo,
+            set_values=["ARCH=arm64"],
+            unset_values=["GOEXPERIMENT"],
+        )
+
+        self.assertEqual(plan.cwd, self.repo)
+        self.assertEqual(plan.cmd, ["make", "build-node-image-linux"])
+        self.assertEqual(
+            build_image.format_command(plan),
+            "env -u GOEXPERIMENT "
+            "IMAGE_TAG=dev IMAGE_REGISTRY=example.azurecr.io/cpa "
+            "ENABLE_GIT_COMMAND=false ARCH=arm64 "
+            "make build-node-image-linux",
+        )
+
+    def test_can_explicitly_set_goexperiment_for_non_default_alias(self) -> None:
+        plan = build_image.build_plan(
+            image="hpp",
+            tag="dev",
+            registry="example.azurecr.io/cpa",
+            repo_root=self.repo,
+            set_values=["GOEXPERIMENT=nosystemcrypto"],
+        )
+
+        self.assertEqual(plan.env["GOEXPERIMENT"], "nosystemcrypto")
+
+    def test_rejects_unknown_image_alias(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unknown image alias"):
+            build_image.build_plan(
+                image="acr",
+                tag="dev",
+                registry="example.azurecr.io/cpa",
+                repo_root=self.repo,
+            )
+
+    def test_rejects_unsetting_required_image_inputs(self) -> None:
+        for key in ("IMAGE_TAG", "IMAGE_REGISTRY"):
+            with self.subTest(key=key):
+                with self.assertRaisesRegex(ValueError, "required"):
+                    build_image.build_plan(
+                        image="ccm",
+                        tag="dev",
+                        registry="example.azurecr.io/cpa",
+                        repo_root=self.repo,
+                        unset_values=[key],
+                    )
+
+    def test_rejects_setting_required_image_inputs(self) -> None:
+        for value in ("IMAGE_TAG=other", "IMAGE_REGISTRY=other"):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "--tag|--registry"):
+                    build_image.build_plan(
+                        image="ccm",
+                        tag="dev",
+                        registry="example.azurecr.io/cpa",
+                        repo_root=self.repo,
+                        set_values=[value],
+                    )
+
+    def test_rejects_setting_make_control_environment(self) -> None:
+        for value in (
+            "MAKEFLAGS=IMAGE_TAG=other",
+            "MFLAGS=IMAGE_REGISTRY=other",
+            "GNUMAKEFLAGS=IMAGE_TAG=other",
+            "MAKEOVERRIDES=IMAGE_TAG=other",
+            "MAKEFILES=/tmp/override.mk",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "reserved"):
+                    build_image.build_plan(
+                        image="ccm",
+                        tag="dev",
+                        registry="example.azurecr.io/cpa",
+                        repo_root=self.repo,
+                        set_values=[value],
+                    )
+
+    def test_rejects_set_unset_conflicts(self) -> None:
+        with self.assertRaisesRegex(ValueError, "both --set and --unset"):
+            build_image.build_plan(
+                image="ccm",
+                tag="dev",
+                registry="example.azurecr.io/cpa",
+                repo_root=self.repo,
+                set_values=["ARCH=arm64"],
+                unset_values=["ARCH"],
+            )
+
+    def test_main_dry_run_prints_command_without_running_make(self) -> None:
+        stdout = StringIO()
+
+        with mock.patch.object(
+            build_image, "find_repo_root", return_value=self.repo
+        ), mock.patch.object(build_image.subprocess, "run") as run_mock, redirect_stdout(
+            stdout
+        ):
+            self.assertEqual(
+                build_image.main(
+                    [
+                        "--image",
+                        "ccm",
+                        "--tag",
+                        "dev",
+                        "--registry",
+                        "example.azurecr.io/cpa",
+                        "--dry-run",
+                    ]
+                ),
+                0,
+            )
+
+        run_mock.assert_not_called()
+        self.assertEqual(
+            stdout.getvalue(),
+            "cwd: /repo\n"
+            "command: IMAGE_TAG=dev IMAGE_REGISTRY=example.azurecr.io/cpa "
+            "GOEXPERIMENT=nosystemcrypto ENABLE_GIT_COMMAND=false "
+            "make build-ccm-image\n",
+        )
+
+    def test_dry_run_shows_inherited_make_control_cleanup(self) -> None:
+        plan = build_image.build_plan(
+            image="ccm",
+            tag="dev",
+            registry="example.azurecr.io/cpa",
+            repo_root=self.repo,
+            inherited_env={"MAKEFLAGS": "IMAGE_TAG=other"},
+        )
+
+        self.assertEqual(
+            build_image.format_command(plan),
+            "env -u MAKEFLAGS "
+            "IMAGE_TAG=dev IMAGE_REGISTRY=example.azurecr.io/cpa "
+            "GOEXPERIMENT=nosystemcrypto ENABLE_GIT_COMMAND=false "
+            "make build-ccm-image",
+        )
+
+    def test_run_plan_prints_command_and_cleans_env(self) -> None:
+        plan = build_image.build_plan(
+            image="hpp",
+            tag="dev",
+            registry="example.azurecr.io/cpa",
+            repo_root=self.repo,
+            unset_values=["ENABLE_GIT_COMMAND"],
+        )
+        completed = subprocess.CompletedProcess(args=plan.cmd, returncode=7)
+
+        stdout = StringIO()
+        with mock.patch.dict(
+            os.environ,
+            {"GOEXPERIMENT": "systemcrypto", "ENABLE_GIT_COMMAND": "true"},
+            clear=True,
+        ), mock.patch.object(
+            build_image.subprocess, "run", return_value=completed
+        ) as run_mock, redirect_stdout(stdout):
+            self.assertEqual(build_image.run_plan(plan), 7)
+
+        run_mock.assert_called_once()
+        self.assertEqual(
+            stdout.getvalue(),
+            "cwd: /repo/health-probe-proxy\n"
+            "command: env -u ENABLE_GIT_COMMAND -u GOEXPERIMENT "
+            "IMAGE_TAG=dev IMAGE_REGISTRY=example.azurecr.io/cpa "
+            "make build-health-probe-proxy-image\n",
+        )
+        _, kwargs = run_mock.call_args
+        self.assertEqual(
+            run_mock.call_args.args[0], ["make", "build-health-probe-proxy-image"]
+        )
+        self.assertEqual(kwargs["cwd"], self.repo / "health-probe-proxy")
+        self.assertFalse(kwargs.get("shell", False))
+        self.assertNotIn("GOEXPERIMENT", kwargs["env"])
+        self.assertNotIn("ENABLE_GIT_COMMAND", kwargs["env"])
+        self.assertEqual(kwargs["env"]["IMAGE_TAG"], "dev")
+        self.assertEqual(kwargs["env"]["IMAGE_REGISTRY"], "example.azurecr.io/cpa")
+
+    def test_run_plan_scrubs_inherited_make_control_environment(self) -> None:
+        plan = build_image.build_plan(
+            image="ccm",
+            tag="dev",
+            registry="example.azurecr.io/cpa",
+            repo_root=self.repo,
+        )
+        completed = subprocess.CompletedProcess(args=plan.cmd, returncode=0)
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "MAKEFLAGS": "IMAGE_TAG=other",
+                "MFLAGS": "IMAGE_REGISTRY=other",
+                "GNUMAKEFLAGS": "IMAGE_TAG=other",
+                "MAKEOVERRIDES": "IMAGE_TAG=other",
+                "MAKEFILES": "/tmp/override.mk",
+                "PATH": "/usr/bin",
+            },
+            clear=True,
+        ), mock.patch.object(
+            build_image.subprocess, "run", return_value=completed
+        ) as run_mock, redirect_stdout(StringIO()):
+            self.assertEqual(build_image.run_plan(plan), 0)
+
+        _, kwargs = run_mock.call_args
+        for key in (
+            "MAKEFLAGS",
+            "MFLAGS",
+            "GNUMAKEFLAGS",
+            "MAKEOVERRIDES",
+            "MAKEFILES",
+        ):
+            with self.subTest(key=key):
+                self.assertNotIn(key, kwargs["env"])
+        self.assertEqual(kwargs["env"]["PATH"], "/usr/bin")
+        self.assertEqual(kwargs["env"]["IMAGE_TAG"], "dev")
+        self.assertEqual(kwargs["env"]["IMAGE_REGISTRY"], "example.azurecr.io/cpa")
+
+    def test_find_repo_root_uses_script_location_not_caller_git_state(self) -> None:
+        script_path = (
+            self.repo
+            / ".agents"
+            / "skills"
+            / "build-images"
+            / "scripts"
+            / "build_image.py"
+        )
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch(
+            "build_image.__file__",
+            str(script_path),
+        ):
+            self.assertEqual(build_image.find_repo_root(Path(temp_dir)), self.repo)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a repo-owned shared `build-images` skill under `.agents/skills/` for building cloud-provider-azure images through the existing Makefile targets. The skill includes a Python helper that requires explicit `IMAGE_TAG` and `IMAGE_REGISTRY`, supports CCM/CNM/HPP aliases, dry-runs shell-quoted commands, allows controlled `--set` / `--unset` flag changes, and scrubs make-control environment overrides before real execution.

Also updates the shared skill catalog and build guidance, including the actual Linux CNM target name.

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

Validation performed:
- `PYTHONDONTWRITEBYTECODE=1 python3 .agents/skills/build-images/scripts/test_build_image.py`
- helper `--help` and dry-runs for `ccm`, `cnm --set ARCH=arm64 --unset GOEXPERIMENT`, `hpp`, `all`, and `cnm-all`
- reserved `--set MAKEFLAGS=...` rejection and inherited `MAKEFLAGS` dry-run cleanup
- `quick_validate.py .agents/skills/build-images` with temporary PyYAML under `/tmp`
- `git diff --check`
- targeted boilerplate check for the new Python files

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
