### PR TITLE
[release-1.33] Add toleration on VM shown up delay in ARM/ARG for new nodes

### DIFF
--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -1006,5 +1007,179 @@ func TestCloud_InstanceExists(t *testing.T) {
 		exist, err := cloud.InstanceExists(ctx, node)
 		assert.NoError(t, err)
 		assert.True(t, exist)
+	})
+	t.Run("should report a recently created node as existing when its instance is not yet in ARM", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.NodeInstanceNotFoundGracePeriodInSeconds = 300
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetInstanceIDByNodeName(gomock.Any(), "foo").Return("", cloudprovider.InstanceNotFound)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.True(t, exist)
+	})
+	t.Run("should report a node as not existing when its instance is not in ARM after the grace period", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.NodeInstanceNotFoundGracePeriodInSeconds = 300
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+			},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetInstanceIDByNodeName(gomock.Any(), "foo").Return("", cloudprovider.InstanceNotFound)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+	t.Run("should report a recently created node as not existing when the grace period is disabled", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.NodeInstanceNotFoundGracePeriodInSeconds = 0
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Second)),
+			},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetInstanceIDByNodeName(gomock.Any(), "foo").Return("", cloudprovider.InstanceNotFound)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+	t.Run("should report a node as not existing when its creation timestamp is zero", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.NodeInstanceNotFoundGracePeriodInSeconds = 300
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetInstanceIDByNodeName(gomock.Any(), "foo").Return("", cloudprovider.InstanceNotFound)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+	t.Run("should return true when the instance exists by provider id", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		providerID := "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm"
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "vm"},
+			Spec:       v1.NodeSpec{ProviderID: providerID},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetNodeNameByProviderID(gomock.Any(), providerID).Return(types.NodeName("vm"), nil)
+		cloud.VMSet.(*MockVMSet).EXPECT().GetInstanceIDByNodeName(gomock.Any(), "vm").Return("vm-id", nil)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.True(t, exist)
+	})
+	t.Run("should return the error when looking up the instance by provider id fails", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		providerID := "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm"
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "vm"},
+			Spec:       v1.NodeSpec{ProviderID: providerID},
+		}
+
+		expectedErr := fmt.Errorf("internal server error")
+		cloud.VMSet.(*MockVMSet).EXPECT().GetNodeNameByProviderID(gomock.Any(), providerID).Return(types.NodeName(""), expectedErr)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.False(t, exist)
+	})
+	t.Run("should report a recently created node as existing when it is not found by provider id", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.NodeInstanceNotFoundGracePeriodInSeconds = 300
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		providerID := "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm"
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "vm",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			},
+			Spec: v1.NodeSpec{ProviderID: providerID},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetNodeNameByProviderID(gomock.Any(), providerID).Return(types.NodeName(""), cloudprovider.InstanceNotFound)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.True(t, exist)
+	})
+	t.Run("should report a node as not existing when it is not found by provider id after the grace period", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.NodeInstanceNotFoundGracePeriodInSeconds = 300
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		providerID := "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm"
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "vm",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+			},
+			Spec: v1.NodeSpec{ProviderID: providerID},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetNodeNameByProviderID(gomock.Any(), providerID).Return(types.NodeName(""), cloudprovider.InstanceNotFound)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+	t.Run("should report a recently created node as not existing when it is not found by provider id and the grace period is disabled", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.NodeInstanceNotFoundGracePeriodInSeconds = 0
+		cloud.VMSet = NewMockVMSet(ctrl)
+
+		ctx := context.Background()
+		providerID := "azure:///subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm"
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "vm",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Second)),
+			},
+			Spec: v1.NodeSpec{ProviderID: providerID},
+		}
+
+		cloud.VMSet.(*MockVMSet).EXPECT().GetNodeNameByProviderID(gomock.Any(), providerID).Return(types.NodeName(""), cloudprovider.InstanceNotFound)
+
+		exist, err := cloud.InstanceExists(ctx, node)
+		assert.NoError(t, err)
+		assert.False(t, exist)
 	})
 }

--- a/pkg/provider/azure_instances_v2.go
+++ b/pkg/provider/azure_instances_v2.go
@@ -19,6 +19,9 @@ package provider
 import (
 	"context"
 	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,7 +54,7 @@ func (az *Cloud) InstanceExists(ctx context.Context, node *v1.Node) (bool, error
 		providerID, err = cloudprovider.GetInstanceProviderID(ctx, az, types.NodeName(node.Name))
 		if err != nil {
 			if strings.Contains(err.Error(), cloudprovider.InstanceNotFound.Error()) {
-				return false, nil
+				return az.tolerateInstanceNotFoundForNewNode(logger, node), nil
 			}
 
 			logger.Error(err, "failed to get the provider ID by node name", "node", node.Name)
@@ -59,7 +62,42 @@ func (az *Cloud) InstanceExists(ctx context.Context, node *v1.Node) (bool, error
 		}
 	}
 
-	return az.InstanceExistsByProviderID(ctx, providerID)
+	exists, err := az.InstanceExistsByProviderID(ctx, providerID)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return az.tolerateInstanceNotFoundForNewNode(logger, node), nil
+	}
+	return true, nil
+}
+
+// tolerateInstanceNotFoundForNewNode reports whether a node whose backing
+// VM/VMSS instance cannot be found in ARM should still be treated as existing.
+// A newly registered node may bootstrap and join the cluster before its
+// instance has propagated into ARM. Deleting such a node based on a transient
+// "instance not found" result is incorrect, so within
+// NodeInstanceNotFoundGracePeriodInSeconds (measured from the node's creation
+// timestamp) the node is reported as existing.
+// See https://github.com/kubernetes-sigs/cloud-provider-azure/issues/10604.
+func (az *Cloud) tolerateInstanceNotFoundForNewNode(logger logr.Logger, node *v1.Node) bool {
+	gracePeriod := time.Duration(az.NodeInstanceNotFoundGracePeriodInSeconds) * time.Second
+	if gracePeriod <= 0 {
+		return false
+	}
+
+	if node.CreationTimestamp.IsZero() {
+		return false
+	}
+
+	nodeAge := time.Since(node.CreationTimestamp.Time)
+	if nodeAge >= gracePeriod {
+		return false
+	}
+
+	logger.V(2).Info("Instance not found in ARM but the node is still within the grace period; reporting it as existing to avoid premature deletion",
+		"nodeName", node.Name, "nodeAge", nodeAge.String(), "gracePeriod", gracePeriod.String())
+	return true
 }
 
 // InstanceShutdown returns true if the instance is shutdown according to the cloud provider.

--- a/pkg/provider/config/azure.go
+++ b/pkg/provider/config/azure.go
@@ -172,6 +172,14 @@ type Config struct {
 	ClusterServiceSharedLoadBalancerHealthProbePort int32 `json:"clusterServiceSharedLoadBalancerHealthProbePort,omitempty" yaml:"clusterServiceSharedLoadBalancerHealthProbePort,omitempty"`
 	// ClusterServiceSharedLoadBalancerHealthProbePath defines the target path of the shared health probe. Default to `/healthz`.
 	ClusterServiceSharedLoadBalancerHealthProbePath string `json:"clusterServiceSharedLoadBalancerHealthProbePath,omitempty" yaml:"clusterServiceSharedLoadBalancerHealthProbePath,omitempty"`
+
+	// NodeInstanceNotFoundGracePeriodInSeconds is the period, measured from a node's
+	// creation timestamp, during which a node whose backing VM/VMSS instance is not yet
+	// visible in ARM is still reported as existing. This tolerates the delay between a
+	// node registering itself in the cluster and its backing instance propagating into
+	// ARM, preventing the cloud-node-lifecycle controller from deleting the node
+	// prematurely. If not set, it defaults to 0, which disables the grace period.
+	NodeInstanceNotFoundGracePeriodInSeconds int `json:"nodeInstanceNotFoundGracePeriodInSeconds,omitempty" yaml:"nodeInstanceNotFoundGracePeriodInSeconds,omitempty"`
 }
 
 // HasExtendedLocation returns true if extendedlocation prop are specified.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR is a cherry-pick of #10605 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add a configurable grace period (nodeInstanceNotFoundGracePeriodInSeconds) in the cloud config for newly registered Kubernetes nodes whose backing Azure VM/VMSS instance is not immediately visible in ARM.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
