### PR TITLE
feat(multi-slb): add retry for local service backend pool updater

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -561,6 +561,12 @@ const (
 	LoadBalancerBackendPoolUpdateOperationRemove LoadBalancerBackendPoolUpdateOperation = "remove"
 
 	DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds = 30
+	DefaultLoadBalancerBackendPoolUpdateMaxRetries        = 3
+
+	// Event reason constants for loadBalancerBackendPoolUpdater.
+	LoadBalancerBackendPoolUpdateRetrying = "LoadBalancerBackendPoolUpdateRetrying"
+	LoadBalancerBackendPoolUpdateFailed   = "LoadBalancerBackendPoolUpdateFailed"
+	LoadBalancerBackendPoolUpdated        = "LoadBalancerBackendPoolUpdated"
 
 	ServiceNameLabel = "kubernetes.io/service-name"
 )

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -568,6 +568,12 @@ const (
 	LoadBalancerBackendPoolUpdateOperationRemove LoadBalancerBackendPoolUpdateOperation = "remove"
 
 	DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds = 30
+	DefaultLoadBalancerBackendPoolUpdateMaxRetries        = 3
+
+	// Event reason constants for loadBalancerBackendPoolUpdater.
+	LoadBalancerBackendPoolUpdateRetrying = "LoadBalancerBackendPoolUpdateRetrying"
+	LoadBalancerBackendPoolUpdateFailed   = "LoadBalancerBackendPoolUpdateFailed"
+	LoadBalancerBackendPoolUpdated        = "LoadBalancerBackendPoolUpdated"
 
 	ServiceNameLabel = "kubernetes.io/service-name"
 )

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -39,6 +39,7 @@ import (
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader"
@@ -547,6 +548,12 @@ func (az *Cloud) checkEnableMultipleStandardLoadBalancers() error {
 
 	if az.LoadBalancerBackendPoolUpdateIntervalInSeconds == 0 {
 		az.LoadBalancerBackendPoolUpdateIntervalInSeconds = consts.DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds
+	}
+
+	if az.LoadBalancerBackendPoolUpdateMaxRetries == nil {
+		az.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(consts.DefaultLoadBalancerBackendPoolUpdateMaxRetries)
+	} else if *az.LoadBalancerBackendPoolUpdateMaxRetries < 0 {
+		az.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(0)
 	}
 
 	return nil

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -39,6 +39,7 @@ import (
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader"
@@ -567,6 +568,12 @@ func (az *Cloud) checkEnableMultipleStandardLoadBalancers() error {
 
 	if az.LoadBalancerBackendPoolUpdateIntervalInSeconds == 0 {
 		az.LoadBalancerBackendPoolUpdateIntervalInSeconds = consts.DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds
+	}
+
+	if az.LoadBalancerBackendPoolUpdateMaxRetries == nil {
+		az.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(consts.DefaultLoadBalancerBackendPoolUpdateMaxRetries)
+	} else if *az.LoadBalancerBackendPoolUpdateMaxRetries < 0 {
+		az.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(0)
 	}
 
 	return nil

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -18,11 +18,15 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	v1 "k8s.io/api/core/v1"
 	discovery_v1 "k8s.io/api/discovery/v1"
@@ -34,6 +38,7 @@ import (
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -65,6 +70,8 @@ type loadBalancerBackendPoolUpdateOperation struct {
 	backendPoolName  string
 	kind             consts.LoadBalancerBackendPoolUpdateOperation
 	nodeIPs          []string
+	retryAttempts    int
+	nextEligibleAt   time.Time
 }
 
 func (op *loadBalancerBackendPoolUpdateOperation) wait() batchOperationResult {
@@ -203,11 +210,37 @@ func (updater *loadBalancerBackendPoolUpdater) groupOperations(ctx context.Conte
 			continue
 		}
 
+		// Check if the Service still exists in the informer. Catches the case where
+		// EnsureLoadBalancerDeleted failed partway, leaving a stale map entry.
+		if _, exists, err := updater.az.getLatestService(lbOp.serviceName, false); err == nil && !exists {
+			logger.V(4).Info("Service not found in informer, skip the operation", "service", lbOp.serviceName)
+			continue
+		}
+
 		key := fmt.Sprintf("%s:%s", lbOp.loadBalancerName, lbOp.backendPoolName)
 		groups[key] = append(groups[key], op)
 	}
 
 	return groups
+}
+
+// hasParkedOperations returns true if any operation has a nextEligibleAt in the future.
+func (updater *loadBalancerBackendPoolUpdater) hasParkedOperations(ops []batchOperation) bool {
+	now := time.Now()
+	for _, op := range ops {
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		if lbOp.nextEligibleAt.After(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// requeueOperations prepends operations back to the front of the queue.
+func (updater *loadBalancerBackendPoolUpdater) requeueOperations(ops []batchOperation) {
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+	updater.operations = append(ops, updater.operations...)
 }
 
 // process processes all operations in the loadBalancerBackendPoolUpdater.
@@ -242,9 +275,20 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 	groups := updater.groupOperations(ctx, ops)
 
 	for key, ops := range groups {
+		if ctx.Err() != nil {
+			break
+		}
+
 		parts := strings.Split(key, ":")
 		lbName, poolName := parts[0], parts[1]
 		operationName := fmt.Sprintf("%s/%s", lbName, poolName)
+
+		// If any op in the group has nextEligibleAt in the future,
+		// requeue the entire group without making ARM calls or emitting events.
+		if updater.hasParkedOperations(ops) {
+			updater.requeueOperations(ops)
+			continue
+		}
 
 		mc := metrics.NewMetricContext(
 			"services_local",      // prefix name, differ from "services" in main reconciliation loop
@@ -256,8 +300,7 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 
 		bp, err := updater.az.NetworkClientFactory.GetBackendAddressPoolClient().Get(ctx, updater.az.ResourceGroup, lbName, poolName)
 		if err != nil {
-			mc.ObserveOperationWithResult(false)
-			updater.processError(err, operationName, ops...)
+			updater.handleGroupError(ctx, mc, err, operationName, ops)
 			continue
 		}
 
@@ -281,39 +324,139 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 			logger.V(2).Info("updating backend pool", "loadBalancer", lbName, "backendPool", poolName)
 			_, err = updater.az.NetworkClientFactory.GetBackendAddressPoolClient().CreateOrUpdate(ctx, updater.az.ResourceGroup, lbName, poolName, *bp)
 			if err != nil {
-				mc.ObserveOperationWithResult(false)
-				updater.processError(err, operationName, ops...)
+				updater.handleGroupError(ctx, mc, err, operationName, ops)
 				continue
 			}
 		}
 		mc.ObserveOperationWithResult(true)
-		updater.notify(newBatchOperationResult(operationName, true, nil), ops...)
+		updater.notify(ctx, v1.EventTypeNormal, consts.LoadBalancerBackendPoolUpdated, "Load balancer backend pool updated successfully", ops...)
 	}
 }
 
-// processError mark the operations as retriable if the error is retriable,
-// and fail all operations if the error is not retriable.
-func (updater *loadBalancerBackendPoolUpdater) processError(
-	rerr error,
-	operationName string,
-	operations ...batchOperation,
-) {
-	logger := log.Background().WithName("loadBalancerBackendPoolUpdater.processError")
-	if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); !exists && err == nil {
-		logger.V(4).Info("backend pool not found for operation, skip updating", "operation", operationName)
+type updaterErrorClass int
+
+const (
+	errClassStale updaterErrorClass = iota
+	errClassRetriable
+	errClassSDKExhausted
+	errClassTerminal
+)
+
+// classifyUpdaterError classifies an error for retry decisions.
+func classifyUpdaterError(err error) updaterErrorClass {
+	if exists, checkErr := errutils.CheckResourceExistsFromAzcoreError(err); !exists && checkErr == nil {
+		return errClassStale
+	}
+
+	var throttleErr *retryrepectthrottled.ThrottleError
+	if errors.As(err, &throttleErr) {
+		return errClassRetriable
+	}
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		if respErr.StatusCode == http.StatusConflict || respErr.StatusCode == http.StatusPreconditionFailed {
+			return errClassRetriable
+		}
+		// SDK-retriable statuses are terminal because the SDK already retried.
+		if slices.Contains(retryrepectthrottled.GetRetriableStatusCode(), respErr.StatusCode) {
+			return errClassSDKExhausted
+		}
+	}
+
+	return errClassTerminal
+}
+
+// handleGroupError classifies the error and either drops, retries, or fails the group.
+// For user-facing documentation of retry behavior, see
+// https://cloud-provider-azure.sigs.k8s.io/topics/multislb/#retry-behavior
+func (updater *loadBalancerBackendPoolUpdater) handleGroupError(ctx context.Context, mc *metrics.MetricContext, err error, operationName string, ops []batchOperation) {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.handleGroupError")
+
+	// On shutdown, drop silently.
+	if ctx.Err() != nil {
+		logger.V(4).Info("Context canceled, dropping operations", "operation", operationName, "ops", len(ops))
 		return
 	}
 
-	// Fail all operations if not retriable.
-	updater.notify(newBatchOperationResult(operationName, false, rerr), operations...)
+	class := classifyUpdaterError(err)
+	switch class {
+	case errClassStale:
+		logger.V(4).Info("Backend pool not found, skipped update", "operation", operationName)
 
+	case errClassSDKExhausted:
+		mc.ObserveOperationWithResult(false)
+		updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+			fmt.Sprintf("Backend pool update failed (SDK retries exhausted): %v.", err), ops...)
+
+	case errClassTerminal:
+		mc.ObserveOperationWithResult(false)
+		updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+			fmt.Sprintf("Backend pool update failed (non-retriable): %v.", err), ops...)
+
+	case errClassRetriable:
+		var throttleErr *retryrepectthrottled.ThrottleError
+		errors.As(err, &throttleErr)
+
+		var opsToRequeue []batchOperation
+		var exhaustedOps []batchOperation
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+
+			// Re-check relevance before requeue.
+			si, found := updater.az.getLocalServiceInfo(strings.ToLower(lbOp.serviceName))
+			if !found || !strings.EqualFold(si.lbName, lbOp.loadBalancerName) {
+				logger.V(4).Info("Operation is stale before requeue, dropped",
+					"service", lbOp.serviceName, "loadBalancer", lbOp.loadBalancerName)
+				continue
+			}
+
+			if lbOp.retryAttempts >= *updater.az.LoadBalancerBackendPoolUpdateMaxRetries {
+				exhaustedOps = append(exhaustedOps, op)
+			} else {
+				lbOp.retryAttempts++
+				if throttleErr != nil && throttleErr.RetryAfter.After(time.Now()) {
+					lbOp.nextEligibleAt = throttleErr.RetryAfter
+				}
+				opsToRequeue = append(opsToRequeue, op)
+			}
+		}
+
+		// TODO: The desired-state model (one op per service/pool) would eliminate
+		// the case where a single Service receives both Failed and Retrying events
+		// in the same tick.
+
+		if len(exhaustedOps) > 0 {
+			mc.ObserveOperationWithResult(false)
+			updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+				fmt.Sprintf("Backend pool update failed after %d retries: %v. To retrigger, cause a reconciliation for the Service (e.g., add or update any annotation on the Service).", *updater.az.LoadBalancerBackendPoolUpdateMaxRetries, err), exhaustedOps...)
+		}
+
+		if len(opsToRequeue) > 0 {
+			updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateRetrying,
+				fmt.Sprintf("Backend pool update failed, will retry: %v.", err), opsToRequeue...)
+			updater.requeueOperations(opsToRequeue)
+		}
+	}
 }
 
-// notify notifies the operations with the result.
-func (updater *loadBalancerBackendPoolUpdater) notify(res batchOperationResult, operations ...batchOperation) {
+// notify emits an event for each distinct Service among the provided operations.
+func (updater *loadBalancerBackendPoolUpdater) notify(ctx context.Context, eventType, reason, msg string, operations ...batchOperation) {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.notify")
+	seen := make(map[string]struct{})
 	for _, op := range operations {
-		updater.az.processBatchOperationResult(op, res)
-		break
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		key := strings.ToLower(lbOp.serviceName)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		svc, _, _ := updater.az.getLatestService(lbOp.serviceName, false)
+		if svc == nil {
+			logger.V(4).Info("Service not found, skipped event", "service", lbOp.serviceName)
+			continue
+		}
+		updater.az.Event(svc, eventType, reason, msg)
 	}
 }
 
@@ -435,25 +578,6 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 				az.endpointSlicesCache.Delete(strings.ToLower(fmt.Sprintf("%s/%s", es.Namespace, es.Name)))
 			},
 		})
-}
-
-func (az *Cloud) processBatchOperationResult(op batchOperation, res batchOperationResult) {
-	lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
-	var svc *v1.Service
-	svc, _, _ = az.getLatestService(lbOp.serviceName, false)
-	if svc == nil {
-		klog.Warningf("Service %s not found, skip sending event", lbOp.serviceName)
-		return
-	}
-	if !res.success {
-		var errStr string
-		if res.err != nil {
-			errStr = res.err.Error()
-		}
-		az.Event(svc, v1.EventTypeWarning, "LoadBalancerBackendPoolUpdateFailed", errStr)
-	} else {
-		az.Event(svc, v1.EventTypeNormal, "LoadBalancerBackendPoolUpdated", "Load balancer backend pool updated successfully")
-	}
 }
 
 // getServiceNameOfEndpointSlice gets the service name of an EndpointSlice.

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -18,11 +18,15 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +39,7 @@ import (
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -66,6 +71,8 @@ type loadBalancerBackendPoolUpdateOperation struct {
 	backendPoolName  string
 	kind             consts.LoadBalancerBackendPoolUpdateOperation
 	nodeIPs          []string
+	retryAttempts    int
+	nextEligibleAt   time.Time
 }
 
 func (op *loadBalancerBackendPoolUpdateOperation) wait() batchOperationResult {
@@ -204,11 +211,36 @@ func (updater *loadBalancerBackendPoolUpdater) groupOperations(ctx context.Conte
 			continue
 		}
 
+		// Skip if deleted or deleting; the map entry persists until EnsureLoadBalancerDeleted completes.
+		if svc, exists, err := updater.az.getLatestService(lbOp.serviceName, false); err == nil && (!exists || (svc != nil && svc.DeletionTimestamp != nil)) {
+			logger.V(4).Info("Service deleted or deleting, skip the operation", "service", lbOp.serviceName)
+			continue
+		}
+
 		key := fmt.Sprintf("%s:%s", lbOp.loadBalancerName, lbOp.backendPoolName)
 		groups[key] = append(groups[key], op)
 	}
 
 	return groups
+}
+
+// hasParkedOperations returns true if any operation has a nextEligibleAt in the future.
+func (updater *loadBalancerBackendPoolUpdater) hasParkedOperations(ops []batchOperation) bool {
+	now := time.Now()
+	for _, op := range ops {
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		if lbOp.nextEligibleAt.After(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// requeueOperations prepends operations back to the front of the queue.
+func (updater *loadBalancerBackendPoolUpdater) requeueOperations(ops []batchOperation) {
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+	updater.operations = append(ops, updater.operations...)
 }
 
 // process processes all operations in the loadBalancerBackendPoolUpdater.
@@ -243,9 +275,20 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 	groups := updater.groupOperations(ctx, ops)
 
 	for key, ops := range groups {
+		if ctx.Err() != nil {
+			break
+		}
+
 		parts := strings.Split(key, ":")
 		lbName, poolName := parts[0], parts[1]
 		operationName := fmt.Sprintf("%s/%s", lbName, poolName)
+
+		// If any op in the group has nextEligibleAt in the future,
+		// requeue the entire group without making ARM calls or emitting events.
+		if updater.hasParkedOperations(ops) {
+			updater.requeueOperations(ops)
+			continue
+		}
 
 		mc := metrics.NewMetricContext(
 			"services_local",      // prefix name, differ from "services" in main reconciliation loop
@@ -257,8 +300,7 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 
 		bp, err := updater.az.NetworkClientFactory.GetBackendAddressPoolClient().Get(ctx, updater.az.ResourceGroup, lbName, poolName)
 		if err != nil {
-			mc.ObserveOperationWithResult(false)
-			updater.processError(err, operationName, ops...)
+			updater.handleGroupError(ctx, mc, err, operationName, ops)
 			continue
 		}
 
@@ -282,39 +324,151 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 			logger.V(2).Info("updating backend pool", "loadBalancer", lbName, "backendPool", poolName)
 			_, err = updater.az.NetworkClientFactory.GetBackendAddressPoolClient().CreateOrUpdate(ctx, updater.az.ResourceGroup, lbName, poolName, *bp)
 			if err != nil {
-				mc.ObserveOperationWithResult(false)
-				updater.processError(err, operationName, ops...)
+				updater.handleGroupError(ctx, mc, err, operationName, ops)
 				continue
 			}
 		}
 		mc.ObserveOperationWithResult(true)
-		updater.notify(newBatchOperationResult(operationName, true, nil), ops...)
+		updater.notify(ctx, v1.EventTypeNormal, consts.LoadBalancerBackendPoolUpdated, "Load balancer backend pool updated successfully", ops...)
 	}
 }
 
-// processError mark the operations as retriable if the error is retriable,
-// and fail all operations if the error is not retriable.
-func (updater *loadBalancerBackendPoolUpdater) processError(
-	rerr error,
-	operationName string,
-	operations ...batchOperation,
-) {
-	logger := log.Background().WithName("loadBalancerBackendPoolUpdater.processError")
-	if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); !exists && err == nil {
-		logger.V(4).Info("backend pool not found for operation, skip updating", "operation", operationName)
+type updaterErrorClass int
+
+const (
+	errClassStale updaterErrorClass = iota
+	errClassRetriable
+	errClassSDKExhausted
+	errClassTerminal
+)
+
+// classifyUpdaterError classifies an error for retry decisions.
+func classifyUpdaterError(err error) updaterErrorClass {
+	if exists, checkErr := errutils.CheckResourceExistsFromAzcoreError(err); !exists && checkErr == nil {
+		return errClassStale
+	}
+
+	var throttleErr *retryrepectthrottled.ThrottleError
+	if errors.As(err, &throttleErr) {
+		return errClassRetriable
+	}
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		if respErr.StatusCode == http.StatusConflict || respErr.StatusCode == http.StatusPreconditionFailed {
+			return errClassRetriable
+		}
+		// SDK-retriable statuses are terminal because the SDK already retried.
+		if slices.Contains(retryrepectthrottled.GetRetriableStatusCode(), respErr.StatusCode) {
+			return errClassSDKExhausted
+		}
+	}
+
+	return errClassTerminal
+}
+
+// handleGroupError classifies the error and either drops, retries, or fails the group.
+// For user-facing documentation of retry behavior, see
+// https://cloud-provider-azure.sigs.k8s.io/topics/multislb/#retry-behavior
+func (updater *loadBalancerBackendPoolUpdater) handleGroupError(ctx context.Context, mc *metrics.MetricContext, err error, operationName string, ops []batchOperation) {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.handleGroupError")
+
+	// On shutdown, drop silently.
+	if ctx.Err() != nil {
+		logger.V(4).Info("Context canceled, dropping operations", "operation", operationName, "ops", len(ops))
 		return
 	}
 
-	// Fail all operations if not retriable.
-	updater.notify(newBatchOperationResult(operationName, false, rerr), operations...)
+	class := classifyUpdaterError(err)
+	switch class {
+	case errClassStale:
+		logger.V(4).Info("Backend pool not found, skipped update", "operation", operationName)
 
+	case errClassSDKExhausted:
+		mc.ObserveOperationWithResult(false)
+		updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+			fmt.Sprintf("Backend pool update failed (SDK retries exhausted): %v.", err), ops...)
+
+	case errClassTerminal:
+		mc.ObserveOperationWithResult(false)
+		updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+			fmt.Sprintf("Backend pool update failed (non-retriable): %v.", err), ops...)
+
+	case errClassRetriable:
+		var throttleErr *retryrepectthrottled.ThrottleError
+		errors.As(err, &throttleErr)
+
+		var opsToRequeue []batchOperation
+		var exhaustedOps []batchOperation
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+
+			// Re-check relevance before requeue.
+			si, found := updater.az.getLocalServiceInfo(strings.ToLower(lbOp.serviceName))
+			if !found {
+				logger.V(4).Info("Service is not a local service, dropped before requeue",
+					"service", lbOp.serviceName, "loadBalancer", lbOp.loadBalancerName)
+				continue
+			}
+			if !strings.EqualFold(si.lbName, lbOp.loadBalancerName) {
+				logger.V(4).Info("Service is not associated with the load balancer, dropped before requeue",
+					"service", lbOp.serviceName,
+					"previous load balancer", lbOp.loadBalancerName,
+					"current load balancer", si.lbName)
+				continue
+			}
+			if svc, exists, err := updater.az.getLatestService(lbOp.serviceName, false); err == nil && (!exists || (svc != nil && svc.DeletionTimestamp != nil)) {
+				logger.V(4).Info("Service deleted or deleting, dropped before requeue",
+					"service", lbOp.serviceName, "loadBalancer", lbOp.loadBalancerName)
+				continue
+			}
+
+			if lbOp.retryAttempts >= *updater.az.LoadBalancerBackendPoolUpdateMaxRetries {
+				exhaustedOps = append(exhaustedOps, op)
+			} else {
+				lbOp.retryAttempts++
+				if throttleErr != nil && throttleErr.RetryAfter.After(time.Now()) {
+					lbOp.nextEligibleAt = throttleErr.RetryAfter
+				}
+				opsToRequeue = append(opsToRequeue, op)
+			}
+		}
+
+		// TODO: The desired-state model (one op per service/pool) would eliminate
+		// the case where a single Service receives both Failed and Retrying events
+		// in the same tick.
+
+		if len(exhaustedOps) > 0 {
+			mc.ObserveOperationWithResult(false)
+			updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+				fmt.Sprintf("Backend pool update failed after %d retries: %v. To retrigger, cause a reconciliation for the Service (e.g., add or update any annotation on the Service).", *updater.az.LoadBalancerBackendPoolUpdateMaxRetries, err), exhaustedOps...)
+		}
+
+		if len(opsToRequeue) > 0 {
+			updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateRetrying,
+				fmt.Sprintf("Backend pool update failed, will retry: %v.", err), opsToRequeue...)
+			updater.requeueOperations(opsToRequeue)
+		}
+	}
 }
 
-// notify notifies the operations with the result.
-func (updater *loadBalancerBackendPoolUpdater) notify(res batchOperationResult, operations ...batchOperation) {
+// notify emits an event for each distinct Service among the provided operations.
+func (updater *loadBalancerBackendPoolUpdater) notify(ctx context.Context, eventType, reason, msg string, operations ...batchOperation) {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.notify")
+	seen := make(map[string]struct{})
 	for _, op := range operations {
-		updater.az.processBatchOperationResult(op, res)
-		break
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		key := strings.ToLower(lbOp.serviceName)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		svc, _, _ := updater.az.getLatestService(lbOp.serviceName, false)
+		if svc == nil {
+			logger.V(4).Info("Service not found, skipped event", "service", lbOp.serviceName)
+			continue
+		}
+		updater.az.Event(svc, eventType, reason, msg)
 	}
 }
 
@@ -439,25 +593,6 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 				az.endpointSlicesCache.Delete(strings.ToLower(fmt.Sprintf("%s/%s", endpointSlice.Namespace, endpointSlice.Name)))
 			},
 		})
-}
-
-func (az *Cloud) processBatchOperationResult(op batchOperation, res batchOperationResult) {
-	lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
-	var svc *v1.Service
-	svc, _, _ = az.getLatestService(lbOp.serviceName, false)
-	if svc == nil {
-		klog.Warningf("Service %s not found, skip sending event", lbOp.serviceName)
-		return
-	}
-	if !res.success {
-		var errStr string
-		if res.err != nil {
-			errStr = res.err.Error()
-		}
-		az.Event(svc, v1.EventTypeWarning, "LoadBalancerBackendPoolUpdateFailed", errStr)
-	} else {
-		az.Event(svc, v1.EventTypeNormal, "LoadBalancerBackendPoolUpdated", "Load balancer backend pool updated successfully")
-	}
 }
 
 // getServiceNameOfEndpointSlice gets the service name of an EndpointSlice.

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -38,13 +39,42 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/backendaddresspoolclient/mock_backendaddresspoolclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 	utilsets "sigs.k8s.io/cloud-provider-azure/pkg/util/sets"
 )
+
+// getBackendPoolUpdaterMetrics returns the current latency observation count
+// and failure count for the local service backend pool updater metric.
+func getBackendPoolUpdaterMetrics(t *testing.T) (latencyCount uint64, failureCount float64) {
+	t.Helper()
+	const request = "services_local_update_backend_pool"
+	families, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, f := range families {
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "request" && lp.GetValue() == request {
+					switch f.GetName() {
+					case "cloudprovider_azure_op_duration_seconds":
+						latencyCount = m.GetHistogram().GetSampleCount()
+					case "cloudprovider_azure_op_failure_count":
+						failureCount = m.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+	return
+}
 
 func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -223,9 +253,14 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb2"})
 			}
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "ns1"
 			client := fake.NewSimpleClientset(&svc)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			mockbpClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			if len(tc.existingBackendPools) > 0 {
 				mockbpClient.EXPECT().Get(
@@ -385,9 +420,14 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			cloud.localServiceNameToServiceInfoMap = sync.Map{}
 			cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "ns1"
 			client := fake.NewSimpleClientset(&svc)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			mockLBClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			mockLBClient.EXPECT().Get(
@@ -551,9 +591,14 @@ func TestEndpointSlicesInformer(t *testing.T) {
 				cloud.localServiceNameToServiceInfoMap.Store("test/svc1", &serviceInfo{lbName: "lb1"})
 			}
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "test"
 			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
 			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
@@ -660,9 +705,14 @@ func TestEndpointSlicesInformerDeduplicatesNodeIPs(t *testing.T) {
 			}
 
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "test"
 			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 
 			// Create updater without starting run() so we can inspect queued operations.
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Hour)
@@ -730,6 +780,10 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 			cloud.KubeClient = client
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
 			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
@@ -934,6 +988,96 @@ func TestDrainOperations(t *testing.T) {
 	})
 }
 
+func TestHasParkedOperations(t *testing.T) {
+	cloud := &Cloud{}
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+	for _, tc := range []struct {
+		name     string
+		ops      []batchOperation
+		expected bool
+	}{
+		{name: "empty slice", ops: nil, expected: false},
+		{name: "zero nextEligibleAt", ops: []batchOperation{
+			getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}),
+		}, expected: false},
+		{name: "past nextEligibleAt", ops: func() []batchOperation {
+			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op.nextEligibleAt = time.Now().Add(-time.Minute)
+			return []batchOperation{op}
+		}(), expected: false},
+		{name: "future nextEligibleAt", ops: func() []batchOperation {
+			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op.nextEligibleAt = time.Now().Add(5 * time.Minute)
+			return []batchOperation{op}
+		}(), expected: true},
+		{name: "mix of past and future", ops: func() []batchOperation {
+			op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+			op2.nextEligibleAt = time.Now().Add(5 * time.Minute)
+			return []batchOperation{op1, op2}
+		}(), expected: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, u.hasParkedOperations(tc.ops))
+		})
+	}
+}
+
+func TestRequeueOperations(t *testing.T) {
+	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+	op3 := getAddIPsToBackendPoolOperation("ns1/svc3", "lb1", "pool1", []string{"10.0.0.3"})
+
+	t.Run("requeue to empty queue", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		u.requeueOperations([]batchOperation{op1, op2})
+
+		ops := u.drainOperations()
+		assert.Equal(t, []batchOperation{op1, op2}, ops)
+	})
+
+	t.Run("requeue prepends before existing", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(op3)
+
+		u.requeueOperations([]batchOperation{op1, op2})
+
+		ops := u.drainOperations()
+		assert.Equal(t, []batchOperation{op1, op2, op3}, ops)
+	})
+
+	t.Run("acquires updater lock", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		u.lock.Lock()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			u.requeueOperations([]batchOperation{op1})
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("requeueOperations returned while lock was held")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		u.lock.Unlock()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("requeueOperations did not complete after lock released")
+		}
+	})
+}
+
 func TestGroupOperations(t *testing.T) {
 	addPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 	removePool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
@@ -998,9 +1142,22 @@ func TestGroupOperations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cloud := &Cloud{}
+			var svcObjects []runtime.Object
 			for k, v := range tc.localServices {
 				cloud.localServiceNameToServiceInfoMap.Store(k, v)
+				parts := strings.Split(k, "/")
+				svcObjects = append(svcObjects, &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: parts[0], Name: parts[1]},
+				})
 			}
+			client := fake.NewSimpleClientset(svcObjects...)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
 			groups := u.groupOperations(context.Background(), tc.operations)
@@ -1014,6 +1171,27 @@ func TestGroupOperations(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("skips operation for service in map but deleted from informer", func(t *testing.T) {
+		cloud := &Cloud{}
+		cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+		// Informer has no Service object (simulates failed deletion leaving stale map entry).
+		client := fake.NewSimpleClientset()
+		informerFactory := informers.NewSharedInformerFactory(client, 0)
+		cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+		stopCh := make(chan struct{})
+		t.Cleanup(func() { close(stopCh) })
+		informerFactory.Start(stopCh)
+		informerFactory.WaitForCacheSync(stopCh)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+
+		groups := u.groupOperations(context.Background(), []batchOperation{op})
+
+		assert.Equal(t, 0, len(groups))
+	})
 }
 
 func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *testing.T) {
@@ -1025,9 +1203,14 @@ func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *tes
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
 	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
@@ -1085,9 +1268,14 @@ func TestLoadBalancerBackendPoolUpdaterAddOperationNotBlockedDuringProcess(t *te
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// Block the ARM Get call so process() is in the middle of ARM work.
 	armBlocked := make(chan struct{})
@@ -1189,9 +1377,14 @@ func TestLoadBalancerBackendPoolUpdaterCompletesOnUnlockFailure(t *testing.T) {
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// Fail the second lease update (releaseLease), let the first (acquireLease) pass.
 	var updateCount int32
@@ -1242,9 +1435,14 @@ func TestLoadBalancerBackendPoolUpdaterFiltersOperationsWhenLBChangedDuringProce
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// No ARM mock expectations. The operation targets lb1 but the service moves
 	// to lb2 while process() is blocked on serviceReconcileLock, so groupOperations
@@ -1294,9 +1492,14 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// No ARM mock expectations. removeOperation cancels the operation
 	// before process() drains the queue.
@@ -1334,4 +1537,979 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	u.lock.Lock()
 	assert.Equal(t, 0, len(u.operations))
 	u.lock.Unlock()
+}
+
+// setupRetryTest creates a Cloud with a fake event recorder, service lister,
+// and mock backend pool client for retry tests. Each call creates a fresh
+// gomock.Controller scoped to t (auto-Finish via t.Cleanup). svcNames defaults
+// to ["svc1"] when omitted. All services are registered in
+// localServiceNameToServiceInfoMap with lbName "lb1".
+func setupRetryTest(t *testing.T, maxRetries int, svcNames ...string) (
+	*Cloud, *record.FakeRecorder, *mock_backendaddresspoolclient.MockInterface,
+) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+
+	if len(svcNames) == 0 {
+		svcNames = []string{"svc1"}
+	}
+
+	var svcObjects []runtime.Object
+	for _, name := range svcNames {
+		cloud.localServiceNameToServiceInfoMap.Store("default/"+name, &serviceInfo{lbName: "lb1"})
+		svc := getTestService(name, v1.ProtocolTCP, nil, false)
+		svcObjects = append(svcObjects, &svc)
+	}
+	cloud.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(maxRetries)
+
+	fakeRecorder := record.NewFakeRecorder(100)
+	cloud.eventRecorder = fakeRecorder
+
+	client := fake.NewSimpleClientset(svcObjects...)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	mockBP := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+	return cloud, fakeRecorder, mockBP
+}
+
+// drainEvents reads all buffered events from a FakeRecorder without blocking.
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// assertEventReasons asserts events match the expected reasons in order.
+func assertEventReasons(t *testing.T, events []string, expectedReasons ...string) {
+	t.Helper()
+	if len(events) != len(expectedReasons) {
+		t.Fatalf("expected %d events, got %d: %v", len(expectedReasons), len(events), events)
+	}
+	for i, reason := range expectedReasons {
+		assert.Contains(t, events[i], reason)
+	}
+}
+
+func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
+	// Error Classification
+	for _, tc := range []struct {
+		name              string
+		maxRetries        int
+		getErr            error
+		createOrUpdateErr error
+		expectedQueue     int
+		expectedEventType string
+		expectedEvent     string
+		terminalMsg       string
+	}{
+		{
+			name:              "successful update emits Updated event",
+			maxRetries:        3,
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeNormal,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdated,
+		},
+		{
+			name:              "500 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusInternalServerError},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "408 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusRequestTimeout},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "502 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusBadGateway},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "503 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusServiceUnavailable},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "504 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusGatewayTimeout},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:          "404 not found is dropped without event",
+			maxRetries:    3,
+			getErr:        &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			expectedQueue: 0,
+		},
+		{
+			name:              "non-ARM error emits Failed event",
+			maxRetries:        3,
+			getErr:            fmt.Errorf("connection reset"),
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "non-retriable",
+		},
+		{
+			name:              "retriable 409 with MaxRetries 0 emits Failed event on first failure",
+			maxRetries:        0,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+		},
+		{
+			name:              "409 conflict requeues and emits Retrying event",
+			maxRetries:        3,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+			expectedQueue:     1,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateRetrying,
+		},
+		{
+			name:              "412 precondition failed requeues and emits Retrying event",
+			maxRetries:        3,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+			expectedQueue:     1,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateRetrying,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, tc.maxRetries)
+
+			if tc.getErr != nil {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(nil, tc.getErr).Times(1)
+			} else {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+					getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+				).Times(1)
+				mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			}
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(context.Background())
+
+			assert.Equal(t, tc.expectedQueue, u.countOperations())
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+
+			switch tc.expectedEvent {
+			case consts.LoadBalancerBackendPoolUpdateFailed:
+				assert.Equal(t, latencyBefore+1, latencyAfter, "failed operation should record one metric observation")
+				assert.Equal(t, failureBefore+1, failureAfter, "failed operation should increment failure counter")
+			case consts.LoadBalancerBackendPoolUpdated:
+				assert.Equal(t, latencyBefore+1, latencyAfter, "successful operation should record one metric observation")
+				assert.Equal(t, failureBefore, failureAfter, "successful operation should not increment failure counter")
+			case consts.LoadBalancerBackendPoolUpdateRetrying:
+				assert.Equal(t, latencyBefore, latencyAfter, "retrying operation should not record any metric")
+				assert.Equal(t, failureBefore, failureAfter, "retrying operation should not increment failure counter")
+			default:
+				assert.Equal(t, latencyBefore, latencyAfter, "stale operation should not record any metric")
+				assert.Equal(t, failureBefore, failureAfter, "stale operation should not increment failure counter")
+			}
+
+			events := drainEvents(recorder)
+			if tc.expectedEvent == "" {
+				assert.Empty(t, events, "expected no events")
+			} else {
+				assert.Equal(t, 1, len(events), "expected exactly one event")
+				if len(events) > 0 {
+					assert.Contains(t, events[0], tc.expectedEventType, "unexpected event type")
+					assert.Contains(t, events[0], tc.expectedEvent)
+
+					// Assert message format based on error classification.
+					if tc.terminalMsg != "" {
+						assert.Contains(t, events[0], tc.terminalMsg)
+					} else {
+						assert.NotContains(t, events[0], "SDK retries exhausted")
+						assert.NotContains(t, events[0], "non-retriable")
+					}
+					switch tc.expectedEvent {
+					case consts.LoadBalancerBackendPoolUpdateFailed:
+						if tc.terminalMsg == "" {
+							assert.Contains(t, events[0], "retries")
+							assert.Contains(t, events[0], "retrigger")
+						}
+					case consts.LoadBalancerBackendPoolUpdateRetrying:
+						assert.Contains(t, events[0], "will retry")
+					case consts.LoadBalancerBackendPoolUpdated:
+						assert.Contains(t, events[0], "updated successfully")
+					}
+
+					// Assert the causal error string appears in the event message.
+					errToCheck := tc.getErr
+					if errToCheck == nil {
+						errToCheck = tc.createOrUpdateErr
+					}
+					if errToCheck != nil {
+						assert.Contains(t, events[0], errToCheck.Error())
+					}
+				}
+			}
+		})
+	}
+
+	// Retriable Error Paths
+	for _, tc := range []struct {
+		name              string
+		getErr            error
+		createOrUpdateErr error
+	}{
+		{
+			name:   "ThrottleError from Get parks until RetryAfter",
+			getErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+		{
+			name:              "ThrottleError from CreateOrUpdate parks until RetryAfter",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			if tc.getErr != nil {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(nil, tc.getErr).Times(1)
+			} else {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+					getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+				).Times(1)
+				mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			}
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			// Tick 1: ThrottleError, requeues with backoff.
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+			assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying)
+
+			latencyBeforePark, failureBeforePark := getBackendPoolUpdaterMetrics(t)
+
+			// Tick 2: still parked, skipped.
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfterPark, failureAfterPark := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBeforePark, latencyAfterPark, "parked tick should not record any metric")
+			assert.Equal(t, failureBeforePark, failureAfterPark, "parked tick should not increment failure counter")
+
+			ops := u.drainOperations()
+			assert.Equal(t, 1, len(ops))
+			lbOp := ops[0].(*loadBalancerBackendPoolUpdateOperation)
+			assert.Equal(t, 1, lbOp.retryAttempts, "retryAttempts should not increment on parked tick")
+			assert.True(t, lbOp.nextEligibleAt.After(time.Now()), "nextEligibleAt should still be in the future")
+		})
+	}
+
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "ThrottleError with past RetryAfter requeues without parking",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(-time.Second)},
+		},
+		{
+			name:              "409 requeues then succeeds on next tick",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			// Tick 1: retriable error, requeues.
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			// Tick 2: succeeds.
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+
+			u.process(context.Background())
+			assert.Equal(t, 0, u.countOperations())
+
+			assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdated)
+		})
+	}
+
+	// Parking Behavior
+	t.Run("parked op in group blocks entire group from processing", func(t *testing.T) {
+		cloud, recorder, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops should not make ARM calls.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		parkedOp := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		parkedOp.nextEligibleAt = time.Now().Add(5 * time.Minute)
+		parkedOp.retryAttempts = 1
+		u.addOperation(parkedOp)
+
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"}))
+
+		u.process(context.Background())
+
+		// Both ops should be requeued without ARM calls, retryAttempts unchanged.
+		ops := u.drainOperations()
+		assert.Equal(t, 2, len(ops))
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+			if lbOp.nodeIPs[0] == "10.0.0.1" {
+				assert.Equal(t, 1, lbOp.retryAttempts, "parked op retryAttempts should be unchanged")
+			} else {
+				assert.Equal(t, 0, lbOp.retryAttempts, "fresh op retryAttempts should be unchanged")
+			}
+		}
+
+		assert.Empty(t, drainEvents(recorder), "expected no events")
+	})
+
+	t.Run("fresh op added while group is parked is applied after parked op on eligible tick", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Tick 1: fresh remove added during call, ThrottleError parks.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").DoAndReturn(
+			func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+				u.addOperation(getRemoveIPsFromBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+				return nil, &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(100 * time.Millisecond)}
+			},
+		).Times(1)
+		// Tick 2: both ops applied in order, succeeds.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, bp armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				assert.Empty(t, bp.Properties.LoadBalancerBackendAddresses,
+					"expected empty pool: parked add should be applied before fresh remove")
+				return nil, nil
+			},
+		).Times(1)
+
+		u.process(context.Background())
+		assert.Equal(t, 2, u.countOperations())
+
+		// Sleep so nextEligibleAt passes.
+		time.Sleep(150 * time.Millisecond)
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	// Retry Budget
+	t.Run("repeated failures exhaust retry budget and emit failed event with guidance", func(t *testing.T) {
+		cloud, recorder, mockBP := setupRetryTest(t, 1)
+
+		conflictErr := &azcore.ResponseError{StatusCode: http.StatusConflict}
+		// Tick 1: 409, requeues (retryAttempts 0->1, within budget).
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, conflictErr,
+		).Times(1)
+		// Tick 2: 409, exhausted (retryAttempts=1 >= maxRetries).
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, conflictErr,
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		events := drainEvents(recorder)
+		assertEventReasons(t, events, consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdateFailed)
+		assert.Contains(t, events[1], "after 1 retries")
+		assert.Contains(t, events[1], conflictErr.Error())
+		assert.Contains(t, events[1], "retrigger")
+		assert.NotContains(t, events[1], "SDK retries exhausted")
+		assert.NotContains(t, events[1], "non-retriable")
+	})
+
+	t.Run("each op in group maintains its own retry counter across failures", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA.retryAttempts = 1
+		u.addOperation(opA)
+
+		opB := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"})
+		u.addOperation(opB)
+
+		u.process(context.Background())
+
+		// Both requeued since neither exhausted (maxRetries=3).
+		assert.Equal(t, 2, u.countOperations())
+
+		ops := u.drainOperations()
+		assert.Equal(t, 2, len(ops))
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+			if lbOp.nodeIPs[0] == "10.0.0.1" {
+				assert.Equal(t, 2, lbOp.retryAttempts) // was 1, now 2
+			} else {
+				assert.Equal(t, 1, lbOp.retryAttempts) // was 0, now 1
+			}
+		}
+	})
+
+	t.Run("exhausted op is dropped while remaining op with budget is requeued", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 2, "svc1", "svc2")
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA.retryAttempts = 2
+		u.addOperation(opA)
+
+		opB := getAddIPsToBackendPoolOperation("default/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+		u.addOperation(opB)
+
+		u.process(context.Background())
+
+		assert.Equal(t, 1, u.countOperations())
+		ops := u.drainOperations()
+		assert.Equal(t, "default/svc2", ops[0].(*loadBalancerBackendPoolUpdateOperation).serviceName)
+	})
+
+	t.Run("retry followed by success records success metric without failure metric", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		// Tick 1: 409, requeues.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+		// Tick 2: succeeds.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, failureBefore, failureAfter, "failure metric should not increment for retried-then-succeeded operation")
+		assert.Equal(t, latencyBefore+1, latencyAfter, "expected exactly one metric observation (success)")
+	})
+
+	// Event Dedup
+	type opSpec struct {
+		svcKey        string
+		ips           []string
+		retryAttempts int
+	}
+	for _, tc := range []struct {
+		name            string
+		maxRetries      int
+		svcNames        []string
+		ops             []opSpec
+		expectedQueue   int
+		expectedReasons []string
+	}{
+		{
+			name:       "multiple services in same group each receive their own event",
+			maxRetries: 3,
+			svcNames:   []string{"svc1", "svc2"},
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc2", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   2,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+		{
+			name:       "multiple ops for same service produce only one event",
+			maxRetries: 3,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   2,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+		{
+			name:       "two exhausted ops for same service produce only one failed event",
+			maxRetries: 0,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   0,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed},
+		},
+		{
+			// This edge case (same service receiving both events) is a consequence of the
+			// diff-based operation model and will be eliminated by the desired-state follow-up.
+			name:       "same service with mixed budgets emits Failed before Retrying",
+			maxRetries: 2,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}, retryAttempts: 2},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   1,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed, consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, tc.maxRetries, tc.svcNames...)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+				nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			for _, op := range tc.ops {
+				o := getAddIPsToBackendPoolOperation(op.svcKey, "lb1", "pool1", op.ips)
+				o.retryAttempts = op.retryAttempts
+				u.addOperation(o)
+			}
+
+			u.process(context.Background())
+
+			assert.Equal(t, tc.expectedQueue, u.countOperations())
+			assertEventReasons(t, drainEvents(recorder), tc.expectedReasons...)
+		})
+	}
+
+	// Staleness
+	for _, tc := range []struct {
+		name      string
+		mutateMap func(*Cloud)
+	}{
+		{
+			name: "op that becomes stale during ARM call is dropped at requeue",
+			mutateMap: func(cloud *Cloud) {
+				cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+			},
+		},
+		{
+			name: "op with changed load balancer during ARM call is dropped at requeue",
+			mutateMap: func(cloud *Cloud) {
+				cloud.localServiceNameToServiceInfoMap.Store("default/svc1", &serviceInfo{lbName: "lb2"})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+				func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+					tc.mutateMap(cloud)
+					return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+				},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(context.Background())
+
+			assert.Equal(t, 0, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+			assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+		})
+	}
+
+	t.Run("op that becomes stale between ticks is dropped at next grouping", func(t *testing.T) {
+		cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		// Tick 1: 409, requeues.
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		// Delete service from map between ticks.
+		cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+
+		// Tick 2: stale, filtered without call.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		// Only the retrying event from tick 1 should be present.
+		assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying)
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
+
+	t.Run("parked op that becomes stale is dropped when eligible", func(t *testing.T) {
+		cloud, recorder, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops and stale ops should not make ARM calls.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		// Add op with nextEligibleAt in the near future.
+		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op.nextEligibleAt = time.Now().Add(50 * time.Millisecond)
+		op.retryAttempts = 1
+		u.addOperation(op)
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		// Tick 1: not yet eligible, skipped.
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		// Sleep past nextEligibleAt and delete service.
+		time.Sleep(60 * time.Millisecond)
+		cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+
+		// Tick 2: eligible but stale, filtered.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		// No events on either tick (parked, then stale drop).
+		assert.Empty(t, drainEvents(recorder), "expected no events")
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
+
+	// Lifecycle
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "removeOperation removes parked op from queue",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+		{
+			name:              "removeOperation removes requeued op from queue",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, _, mockBP := setupRetryTest(t, 3)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+				nil, tc.createOrUpdateErr,
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+
+			u.removeOperation("default/svc1")
+			assert.Equal(t, 0, u.countOperations())
+		})
+	}
+
+	t.Run("retry requeue is serialized with removeOperation under serviceReconcileLock", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		armBlocked := make(chan struct{})
+		armUnblock := make(chan struct{})
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				close(armBlocked)
+				<-armUnblock
+				return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+			},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Start process() in goroutine; it acquires serviceReconcileLock.
+		processDone := make(chan struct{})
+		go func() {
+			defer close(processDone)
+			u.process(context.Background())
+		}()
+
+		// Wait for process() to be mid-ARM-call.
+		<-armBlocked
+
+		// Simulate main reconcile path trying to acquire serviceReconcileLock.
+		lockAcquired := make(chan struct{})
+		lockDone := make(chan struct{})
+		go func() {
+			cloud.serviceReconcileLock.Lock()
+			close(lockAcquired)
+			u.removeOperation("default/svc1")
+			cloud.serviceReconcileLock.Unlock()
+			close(lockDone)
+		}()
+
+		// Verify lock is NOT acquired while process() is mid-flight.
+		select {
+		case <-lockAcquired:
+			t.Fatal("serviceReconcileLock acquired while process() is mid-flight")
+		case <-time.After(200 * time.Millisecond):
+			// Expected: blocked.
+		}
+
+		// Unblock ARM; returns 409, requeues, then releases lock.
+		close(armUnblock)
+		<-processDone
+
+		// Wait for lock goroutine to fully complete.
+		select {
+		case <-lockDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("lock goroutine did not complete")
+		}
+
+		// Op was requeued by process, then removed by removeOperation.
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	t.Run("retry requeue is serialized with service deletion under serviceReconcileLock", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		armBlocked := make(chan struct{})
+		armUnblock := make(chan struct{})
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				close(armBlocked)
+				<-armUnblock
+				return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+			},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Start process() in goroutine; it acquires serviceReconcileLock.
+		processDone := make(chan struct{})
+		go func() {
+			defer close(processDone)
+			u.process(context.Background())
+		}()
+
+		// Wait for process() to be mid-ARM-call.
+		<-armBlocked
+
+		// Simulate main reconcile path trying to delete service from map.
+		lockAcquired := make(chan struct{})
+		lockDone := make(chan struct{})
+		go func() {
+			cloud.serviceReconcileLock.Lock()
+			close(lockAcquired)
+			cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+			cloud.serviceReconcileLock.Unlock()
+			close(lockDone)
+		}()
+
+		// Verify lock is NOT acquired while process() is mid-flight.
+		select {
+		case <-lockAcquired:
+			t.Fatal("serviceReconcileLock acquired while process() is mid-flight")
+		case <-time.After(200 * time.Millisecond):
+			// Expected: blocked.
+		}
+
+		// Unblock ARM; returns 409, requeues, then releases lock.
+		close(armUnblock)
+		<-processDone
+
+		// Wait for lock goroutine to fully complete.
+		select {
+		case <-lockDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("lock goroutine did not complete")
+		}
+
+		// Op was requeued by process (queue == 1), map delete happened after.
+		assert.Equal(t, 1, u.countOperations())
+
+		// Next tick: groupOperations filters the stale op.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "context canceled during ARM call drops op without event",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+		{
+			name:              "ARM call returns context.Canceled on shutdown and op is dropped without event",
+			createOrUpdateErr: context.Canceled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+				func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+					cancel()
+					return nil, tc.createOrUpdateErr
+				},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(ctx)
+
+			assert.Equal(t, 0, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+			assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+		})
+	}
+
+	t.Run("shutdown with parked ops drops all without event", func(t *testing.T) {
+		cloud, recorder, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops with canceled context should never reach ARM.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op.nextEligibleAt = time.Now().Add(5 * time.Minute)
+		op.retryAttempts = 1
+		u.addOperation(op)
+
+		// Cancel context before calling process (simulates shutdown).
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		u.process(ctx)
+
+		// Op was drained and discarded (not requeued).
+		assert.Equal(t, 0, u.countOperations())
+		assert.Empty(t, drainEvents(recorder), "expected no events on shutdown")
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
 }

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -40,13 +41,42 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/backendaddresspoolclient/mock_backendaddresspoolclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 	utilsets "sigs.k8s.io/cloud-provider-azure/pkg/util/sets"
 )
+
+// getBackendPoolUpdaterMetrics returns the current latency observation count
+// and failure count for the local service backend pool updater metric.
+func getBackendPoolUpdaterMetrics(t *testing.T) (latencyCount uint64, failureCount float64) {
+	t.Helper()
+	const request = "services_local_update_backend_pool"
+	families, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, f := range families {
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "request" && lp.GetValue() == request {
+					switch f.GetName() {
+					case "cloudprovider_azure_op_duration_seconds":
+						latencyCount = m.GetHistogram().GetSampleCount()
+					case "cloudprovider_azure_op_failure_count":
+						failureCount = m.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+	return
+}
 
 func TestEndpointSliceFromDeleteEvent(t *testing.T) {
 	endpointSlice := &discovery_v1.EndpointSlice{
@@ -268,9 +298,14 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb2"})
 			}
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "ns1"
 			client := fake.NewSimpleClientset(&svc)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			mockbpClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			if len(tc.existingBackendPools) > 0 {
 				mockbpClient.EXPECT().Get(
@@ -430,9 +465,14 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			cloud.localServiceNameToServiceInfoMap = sync.Map{}
 			cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "ns1"
 			client := fake.NewSimpleClientset(&svc)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			mockLBClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			mockLBClient.EXPECT().Get(
@@ -596,9 +636,14 @@ func TestEndpointSlicesInformer(t *testing.T) {
 				cloud.localServiceNameToServiceInfoMap.Store("test/svc1", &serviceInfo{lbName: "lb1"})
 			}
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "test"
 			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
 			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
@@ -705,9 +750,14 @@ func TestEndpointSlicesInformerDeduplicatesNodeIPs(t *testing.T) {
 			}
 
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "test"
 			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 
 			// Create updater without starting run() so we can inspect queued operations.
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Hour)
@@ -775,6 +825,10 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 			cloud.KubeClient = client
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
 			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
@@ -979,6 +1033,96 @@ func TestDrainOperations(t *testing.T) {
 	})
 }
 
+func TestHasParkedOperations(t *testing.T) {
+	cloud := &Cloud{}
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+	for _, tc := range []struct {
+		name     string
+		ops      []batchOperation
+		expected bool
+	}{
+		{name: "empty slice", ops: nil, expected: false},
+		{name: "zero nextEligibleAt", ops: []batchOperation{
+			getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}),
+		}, expected: false},
+		{name: "past nextEligibleAt", ops: func() []batchOperation {
+			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op.nextEligibleAt = time.Now().Add(-time.Minute)
+			return []batchOperation{op}
+		}(), expected: false},
+		{name: "future nextEligibleAt", ops: func() []batchOperation {
+			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op.nextEligibleAt = time.Now().Add(5 * time.Minute)
+			return []batchOperation{op}
+		}(), expected: true},
+		{name: "mix of past and future", ops: func() []batchOperation {
+			op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+			op2.nextEligibleAt = time.Now().Add(5 * time.Minute)
+			return []batchOperation{op1, op2}
+		}(), expected: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, u.hasParkedOperations(tc.ops))
+		})
+	}
+}
+
+func TestRequeueOperations(t *testing.T) {
+	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+	op3 := getAddIPsToBackendPoolOperation("ns1/svc3", "lb1", "pool1", []string{"10.0.0.3"})
+
+	t.Run("requeue to empty queue", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		u.requeueOperations([]batchOperation{op1, op2})
+
+		ops := u.drainOperations()
+		assert.Equal(t, []batchOperation{op1, op2}, ops)
+	})
+
+	t.Run("requeue prepends before existing", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(op3)
+
+		u.requeueOperations([]batchOperation{op1, op2})
+
+		ops := u.drainOperations()
+		assert.Equal(t, []batchOperation{op1, op2, op3}, ops)
+	})
+
+	t.Run("acquires updater lock", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		u.lock.Lock()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			u.requeueOperations([]batchOperation{op1})
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("requeueOperations returned while lock was held")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		u.lock.Unlock()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("requeueOperations did not complete after lock released")
+		}
+	})
+}
+
 func TestGroupOperations(t *testing.T) {
 	addPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 	removePool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
@@ -1043,9 +1187,22 @@ func TestGroupOperations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cloud := &Cloud{}
+			var svcObjects []runtime.Object
 			for k, v := range tc.localServices {
 				cloud.localServiceNameToServiceInfoMap.Store(k, v)
+				parts := strings.Split(k, "/")
+				svcObjects = append(svcObjects, &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: parts[0], Name: parts[1]},
+				})
 			}
+			client := fake.NewSimpleClientset(svcObjects...)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
 			groups := u.groupOperations(context.Background(), tc.operations)
@@ -1059,6 +1216,50 @@ func TestGroupOperations(t *testing.T) {
 			}
 		})
 	}
+
+	for _, tc := range []struct {
+		name      string
+		svcObject *v1.Service
+	}{
+		{
+			name: "skips operation for service in map but deleted from informer",
+		},
+		{
+			name: "skips operation for service with DeletionTimestamp",
+			svcObject: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "ns1",
+					Name:              "svc1",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"service.kubernetes.io/load-balancer-cleanup"},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := &Cloud{}
+			cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+			var objs []runtime.Object
+			if tc.svcObject != nil {
+				objs = append(objs, tc.svcObject)
+			}
+			client := fake.NewSimpleClientset(objs...)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+
+			groups := u.groupOperations(context.Background(), []batchOperation{op})
+
+			assert.Equal(t, 0, len(groups))
+		})
+	}
 }
 
 func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *testing.T) {
@@ -1070,9 +1271,14 @@ func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *tes
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
 	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
@@ -1130,9 +1336,14 @@ func TestLoadBalancerBackendPoolUpdaterAddOperationNotBlockedDuringProcess(t *te
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// Block the ARM Get call so process() is in the middle of ARM work.
 	armBlocked := make(chan struct{})
@@ -1234,9 +1445,14 @@ func TestLoadBalancerBackendPoolUpdaterCompletesOnUnlockFailure(t *testing.T) {
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// Fail the second lease update (releaseLease), let the first (acquireLease) pass.
 	var updateCount int32
@@ -1287,9 +1503,14 @@ func TestLoadBalancerBackendPoolUpdaterFiltersOperationsWhenLBChangedDuringProce
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// No ARM mock expectations. The operation targets lb1 but the service moves
 	// to lb2 while process() is blocked on serviceReconcileLock, so groupOperations
@@ -1339,9 +1560,14 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// No ARM mock expectations. removeOperation cancels the operation
 	// before process() drains the queue.
@@ -1379,4 +1605,998 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	u.lock.Lock()
 	assert.Equal(t, 0, len(u.operations))
 	u.lock.Unlock()
+}
+
+// setupRetryTest creates a Cloud with a fake event recorder, service lister,
+// and mock backend pool client for retry tests. Each call creates a fresh
+// gomock.Controller scoped to t (auto-Finish via t.Cleanup). svcNames defaults
+// to ["svc1"] when omitted. All services are registered in
+// localServiceNameToServiceInfoMap with lbName "lb1".
+func setupRetryTest(t *testing.T, maxRetries int, svcNames ...string) (
+	*Cloud, *record.FakeRecorder, *mock_backendaddresspoolclient.MockInterface, cache.Store,
+) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+
+	if len(svcNames) == 0 {
+		svcNames = []string{"svc1"}
+	}
+
+	var svcObjects []runtime.Object
+	for _, name := range svcNames {
+		cloud.localServiceNameToServiceInfoMap.Store("default/"+name, &serviceInfo{lbName: "lb1"})
+		svc := getTestService(name, v1.ProtocolTCP, nil, false)
+		svcObjects = append(svcObjects, &svc)
+	}
+	cloud.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(maxRetries)
+
+	fakeRecorder := record.NewFakeRecorder(100)
+	cloud.eventRecorder = fakeRecorder
+
+	client := fake.NewSimpleClientset(svcObjects...)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	svcStore := informerFactory.Core().V1().Services().Informer().GetStore()
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	mockBP := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+	return cloud, fakeRecorder, mockBP, svcStore
+}
+
+// drainEvents reads all buffered events from a FakeRecorder without blocking.
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// assertEventReasons asserts events match the expected reasons in order.
+func assertEventReasons(t *testing.T, events []string, expectedReasons ...string) {
+	t.Helper()
+	if len(events) != len(expectedReasons) {
+		t.Fatalf("expected %d events, got %d: %v", len(expectedReasons), len(events), events)
+	}
+	for i, reason := range expectedReasons {
+		assert.Contains(t, events[i], reason)
+	}
+}
+
+func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
+	// Error Classification
+	for _, tc := range []struct {
+		name              string
+		maxRetries        int
+		getErr            error
+		createOrUpdateErr error
+		expectedQueue     int
+		expectedEventType string
+		expectedEvent     string
+		terminalMsg       string
+	}{
+		{
+			name:              "successful update emits Updated event",
+			maxRetries:        3,
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeNormal,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdated,
+		},
+		{
+			name:              "500 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusInternalServerError},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "408 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusRequestTimeout},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "502 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusBadGateway},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "503 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusServiceUnavailable},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "504 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusGatewayTimeout},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:          "404 not found is dropped without event",
+			maxRetries:    3,
+			getErr:        &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			expectedQueue: 0,
+		},
+		{
+			name:              "non-ARM error emits Failed event",
+			maxRetries:        3,
+			getErr:            fmt.Errorf("connection reset"),
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "non-retriable",
+		},
+		{
+			name:              "retriable 409 with MaxRetries 0 emits Failed event on first failure",
+			maxRetries:        0,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+		},
+		{
+			name:              "409 conflict requeues and emits Retrying event",
+			maxRetries:        3,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+			expectedQueue:     1,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateRetrying,
+		},
+		{
+			name:              "412 precondition failed requeues and emits Retrying event",
+			maxRetries:        3,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+			expectedQueue:     1,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateRetrying,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP, _ := setupRetryTest(t, tc.maxRetries)
+
+			if tc.getErr != nil {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(nil, tc.getErr).Times(1)
+			} else {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+					getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+				).Times(1)
+				mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			}
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(context.Background())
+
+			assert.Equal(t, tc.expectedQueue, u.countOperations())
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+
+			switch tc.expectedEvent {
+			case consts.LoadBalancerBackendPoolUpdateFailed:
+				assert.Equal(t, latencyBefore+1, latencyAfter, "failed operation should record one metric observation")
+				assert.Equal(t, failureBefore+1, failureAfter, "failed operation should increment failure counter")
+			case consts.LoadBalancerBackendPoolUpdated:
+				assert.Equal(t, latencyBefore+1, latencyAfter, "successful operation should record one metric observation")
+				assert.Equal(t, failureBefore, failureAfter, "successful operation should not increment failure counter")
+			case consts.LoadBalancerBackendPoolUpdateRetrying:
+				assert.Equal(t, latencyBefore, latencyAfter, "retrying operation should not record any metric")
+				assert.Equal(t, failureBefore, failureAfter, "retrying operation should not increment failure counter")
+			default:
+				assert.Equal(t, latencyBefore, latencyAfter, "stale operation should not record any metric")
+				assert.Equal(t, failureBefore, failureAfter, "stale operation should not increment failure counter")
+			}
+
+			events := drainEvents(recorder)
+			if tc.expectedEvent == "" {
+				assert.Empty(t, events, "expected no events")
+			} else {
+				assert.Equal(t, 1, len(events), "expected exactly one event")
+				if len(events) > 0 {
+					assert.Contains(t, events[0], tc.expectedEventType, "unexpected event type")
+					assert.Contains(t, events[0], tc.expectedEvent)
+
+					// Assert message format based on error classification.
+					if tc.terminalMsg != "" {
+						assert.Contains(t, events[0], tc.terminalMsg)
+					} else {
+						assert.NotContains(t, events[0], "SDK retries exhausted")
+						assert.NotContains(t, events[0], "non-retriable")
+					}
+					switch tc.expectedEvent {
+					case consts.LoadBalancerBackendPoolUpdateFailed:
+						if tc.terminalMsg == "" {
+							assert.Contains(t, events[0], "retries")
+							assert.Contains(t, events[0], "retrigger")
+						}
+					case consts.LoadBalancerBackendPoolUpdateRetrying:
+						assert.Contains(t, events[0], "will retry")
+					case consts.LoadBalancerBackendPoolUpdated:
+						assert.Contains(t, events[0], "updated successfully")
+					}
+
+					// Assert the causal error string appears in the event message.
+					errToCheck := tc.getErr
+					if errToCheck == nil {
+						errToCheck = tc.createOrUpdateErr
+					}
+					if errToCheck != nil {
+						assert.Contains(t, events[0], errToCheck.Error())
+					}
+				}
+			}
+		})
+	}
+
+	// Retriable Error Paths
+	for _, tc := range []struct {
+		name              string
+		getErr            error
+		createOrUpdateErr error
+	}{
+		{
+			name:   "ThrottleError from Get parks until RetryAfter",
+			getErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+		{
+			name:              "ThrottleError from CreateOrUpdate parks until RetryAfter",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP, _ := setupRetryTest(t, 3)
+
+			if tc.getErr != nil {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(nil, tc.getErr).Times(1)
+			} else {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+					getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+				).Times(1)
+				mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			}
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			// Tick 1: ThrottleError, requeues with backoff.
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+			assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying)
+
+			latencyBeforePark, failureBeforePark := getBackendPoolUpdaterMetrics(t)
+
+			// Tick 2: still parked, skipped.
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfterPark, failureAfterPark := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBeforePark, latencyAfterPark, "parked tick should not record any metric")
+			assert.Equal(t, failureBeforePark, failureAfterPark, "parked tick should not increment failure counter")
+
+			ops := u.drainOperations()
+			assert.Equal(t, 1, len(ops))
+			lbOp := ops[0].(*loadBalancerBackendPoolUpdateOperation)
+			assert.Equal(t, 1, lbOp.retryAttempts, "retryAttempts should not increment on parked tick")
+			assert.True(t, lbOp.nextEligibleAt.After(time.Now()), "nextEligibleAt should still be in the future")
+		})
+	}
+
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "ThrottleError with past RetryAfter requeues without parking",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(-time.Second)},
+		},
+		{
+			name:              "409 requeues then succeeds on next tick",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP, _ := setupRetryTest(t, 3)
+
+			// Tick 1: retriable error, requeues.
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			// Tick 2: succeeds.
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+
+			u.process(context.Background())
+			assert.Equal(t, 0, u.countOperations())
+
+			assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdated)
+		})
+	}
+
+	// Parking Behavior
+	t.Run("parked op in group blocks entire group from processing", func(t *testing.T) {
+		cloud, recorder, _, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops should not make ARM calls.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		parkedOp := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		parkedOp.nextEligibleAt = time.Now().Add(5 * time.Minute)
+		parkedOp.retryAttempts = 1
+		u.addOperation(parkedOp)
+
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"}))
+
+		u.process(context.Background())
+
+		// Both ops should be requeued without ARM calls, retryAttempts unchanged.
+		ops := u.drainOperations()
+		assert.Equal(t, 2, len(ops))
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+			if lbOp.nodeIPs[0] == "10.0.0.1" {
+				assert.Equal(t, 1, lbOp.retryAttempts, "parked op retryAttempts should be unchanged")
+			} else {
+				assert.Equal(t, 0, lbOp.retryAttempts, "fresh op retryAttempts should be unchanged")
+			}
+		}
+
+		assert.Empty(t, drainEvents(recorder), "expected no events")
+	})
+
+	t.Run("fresh op added while group is parked is applied after parked op on eligible tick", func(t *testing.T) {
+		cloud, _, mockBP, _ := setupRetryTest(t, 3)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Tick 1: fresh remove added during call, ThrottleError parks.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").DoAndReturn(
+			func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+				u.addOperation(getRemoveIPsFromBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+				return nil, &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(100 * time.Millisecond)}
+			},
+		).Times(1)
+		// Tick 2: both ops applied in order, succeeds.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, bp armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				assert.Empty(t, bp.Properties.LoadBalancerBackendAddresses,
+					"expected empty pool: parked add should be applied before fresh remove")
+				return nil, nil
+			},
+		).Times(1)
+
+		u.process(context.Background())
+		assert.Equal(t, 2, u.countOperations())
+
+		// Sleep so nextEligibleAt passes.
+		time.Sleep(150 * time.Millisecond)
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	// Retry Budget
+	t.Run("repeated failures exhaust retry budget and emit failed event with guidance", func(t *testing.T) {
+		cloud, recorder, mockBP, _ := setupRetryTest(t, 1)
+
+		conflictErr := &azcore.ResponseError{StatusCode: http.StatusConflict}
+		// Tick 1: 409, requeues (retryAttempts 0->1, within budget).
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, conflictErr,
+		).Times(1)
+		// Tick 2: 409, exhausted (retryAttempts=1 >= maxRetries).
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, conflictErr,
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		events := drainEvents(recorder)
+		assertEventReasons(t, events, consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdateFailed)
+		assert.Contains(t, events[1], "after 1 retries")
+		assert.Contains(t, events[1], conflictErr.Error())
+		assert.Contains(t, events[1], "retrigger")
+		assert.NotContains(t, events[1], "SDK retries exhausted")
+		assert.NotContains(t, events[1], "non-retriable")
+	})
+
+	t.Run("each op in group maintains its own retry counter across failures", func(t *testing.T) {
+		cloud, _, mockBP, _ := setupRetryTest(t, 3)
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA.retryAttempts = 1
+		u.addOperation(opA)
+
+		opB := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"})
+		u.addOperation(opB)
+
+		u.process(context.Background())
+
+		// Both requeued since neither exhausted (maxRetries=3).
+		assert.Equal(t, 2, u.countOperations())
+
+		ops := u.drainOperations()
+		assert.Equal(t, 2, len(ops))
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+			if lbOp.nodeIPs[0] == "10.0.0.1" {
+				assert.Equal(t, 2, lbOp.retryAttempts) // was 1, now 2
+			} else {
+				assert.Equal(t, 1, lbOp.retryAttempts) // was 0, now 1
+			}
+		}
+	})
+
+	t.Run("exhausted op is dropped while remaining op with budget is requeued", func(t *testing.T) {
+		cloud, _, mockBP, _ := setupRetryTest(t, 2, "svc1", "svc2")
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA.retryAttempts = 2
+		u.addOperation(opA)
+
+		opB := getAddIPsToBackendPoolOperation("default/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+		u.addOperation(opB)
+
+		u.process(context.Background())
+
+		assert.Equal(t, 1, u.countOperations())
+		ops := u.drainOperations()
+		assert.Equal(t, "default/svc2", ops[0].(*loadBalancerBackendPoolUpdateOperation).serviceName)
+	})
+
+	t.Run("retry followed by success records success metric without failure metric", func(t *testing.T) {
+		cloud, _, mockBP, _ := setupRetryTest(t, 3)
+
+		// Tick 1: 409, requeues.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+		// Tick 2: succeeds.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, failureBefore, failureAfter, "failure metric should not increment for retried-then-succeeded operation")
+		assert.Equal(t, latencyBefore+1, latencyAfter, "expected exactly one metric observation (success)")
+	})
+
+	// Event Dedup
+	type opSpec struct {
+		svcKey        string
+		ips           []string
+		retryAttempts int
+	}
+	for _, tc := range []struct {
+		name            string
+		maxRetries      int
+		svcNames        []string
+		ops             []opSpec
+		expectedQueue   int
+		expectedReasons []string
+	}{
+		{
+			name:       "multiple services in same group each receive their own event",
+			maxRetries: 3,
+			svcNames:   []string{"svc1", "svc2"},
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc2", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   2,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+		{
+			name:       "multiple ops for same service produce only one event",
+			maxRetries: 3,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   2,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+		{
+			name:       "two exhausted ops for same service produce only one failed event",
+			maxRetries: 0,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   0,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed},
+		},
+		{
+			// This edge case (same service receiving both events) is a consequence of the
+			// diff-based operation model and will be eliminated by the desired-state follow-up.
+			name:       "same service with mixed budgets emits Failed before Retrying",
+			maxRetries: 2,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}, retryAttempts: 2},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   1,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed, consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP, _ := setupRetryTest(t, tc.maxRetries, tc.svcNames...)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+				nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			for _, op := range tc.ops {
+				o := getAddIPsToBackendPoolOperation(op.svcKey, "lb1", "pool1", op.ips)
+				o.retryAttempts = op.retryAttempts
+				u.addOperation(o)
+			}
+
+			u.process(context.Background())
+
+			assert.Equal(t, tc.expectedQueue, u.countOperations())
+			assertEventReasons(t, drainEvents(recorder), tc.expectedReasons...)
+		})
+	}
+
+	// Staleness
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Cloud, cache.Store, *v1.Service)
+	}{
+		{
+			name: "op that becomes stale during ARM call is dropped at requeue",
+			mutate: func(cloud *Cloud, _ cache.Store, _ *v1.Service) {
+				cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+			},
+		},
+		{
+			name: "op with changed load balancer during ARM call is dropped at requeue",
+			mutate: func(cloud *Cloud, _ cache.Store, _ *v1.Service) {
+				cloud.localServiceNameToServiceInfoMap.Store("default/svc1", &serviceInfo{lbName: "lb2"})
+			},
+		},
+		{
+			name: "op for service marked for deletion during ARM call is dropped at requeue",
+			mutate: func(_ *Cloud, store cache.Store, svc *v1.Service) {
+				deletingSvc := svc.DeepCopy()
+				now := metav1.Now()
+				deletingSvc.DeletionTimestamp = &now
+				deletingSvc.Finalizers = []string{"service.kubernetes.io/load-balancer-cleanup"}
+				_ = store.Update(deletingSvc)
+			},
+		},
+		{
+			name: "op for service gone from informer during ARM call is dropped at requeue",
+			mutate: func(_ *Cloud, store cache.Store, svc *v1.Service) {
+				_ = store.Delete(svc)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP, svcStore := setupRetryTest(t, 3)
+
+			svcObj := svcStore.List()[0].(*v1.Service)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+				func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+					tc.mutate(cloud, svcStore, svcObj)
+					return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+				},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(context.Background())
+
+			assert.Equal(t, 0, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+			assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+		})
+	}
+
+	t.Run("op that becomes stale between ticks is dropped at next grouping", func(t *testing.T) {
+		cloud, recorder, mockBP, _ := setupRetryTest(t, 3)
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		// Tick 1: 409, requeues.
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		// Delete service from map between ticks.
+		cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+
+		// Tick 2: stale, filtered without call.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		// Only the retrying event from tick 1 should be present.
+		assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying)
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
+
+	t.Run("parked op that becomes stale is dropped when eligible", func(t *testing.T) {
+		cloud, recorder, _, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops and stale ops should not make ARM calls.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		// Add op with nextEligibleAt in the near future.
+		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op.nextEligibleAt = time.Now().Add(50 * time.Millisecond)
+		op.retryAttempts = 1
+		u.addOperation(op)
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		// Tick 1: not yet eligible, skipped.
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		// Sleep past nextEligibleAt and delete service.
+		time.Sleep(60 * time.Millisecond)
+		cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+
+		// Tick 2: eligible but stale, filtered.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		// No events on either tick (parked, then stale drop).
+		assert.Empty(t, drainEvents(recorder), "expected no events")
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
+
+	// Lifecycle
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "removeOperation removes parked op from queue",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+		{
+			name:              "removeOperation removes requeued op from queue",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, _, mockBP, _ := setupRetryTest(t, 3)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+				nil, tc.createOrUpdateErr,
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+
+			u.removeOperation("default/svc1")
+			assert.Equal(t, 0, u.countOperations())
+		})
+	}
+
+	t.Run("retry requeue is serialized with removeOperation under serviceReconcileLock", func(t *testing.T) {
+		cloud, _, mockBP, _ := setupRetryTest(t, 3)
+
+		armBlocked := make(chan struct{})
+		armUnblock := make(chan struct{})
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				close(armBlocked)
+				<-armUnblock
+				return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+			},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Start process() in goroutine; it acquires serviceReconcileLock.
+		processDone := make(chan struct{})
+		go func() {
+			defer close(processDone)
+			u.process(context.Background())
+		}()
+
+		// Wait for process() to be mid-ARM-call.
+		<-armBlocked
+
+		// Simulate main reconcile path trying to acquire serviceReconcileLock.
+		lockAcquired := make(chan struct{})
+		lockDone := make(chan struct{})
+		go func() {
+			cloud.serviceReconcileLock.Lock()
+			close(lockAcquired)
+			u.removeOperation("default/svc1")
+			cloud.serviceReconcileLock.Unlock()
+			close(lockDone)
+		}()
+
+		// Verify lock is NOT acquired while process() is mid-flight.
+		select {
+		case <-lockAcquired:
+			t.Fatal("serviceReconcileLock acquired while process() is mid-flight")
+		case <-time.After(200 * time.Millisecond):
+			// Expected: blocked.
+		}
+
+		// Unblock ARM; returns 409, requeues, then releases lock.
+		close(armUnblock)
+		<-processDone
+
+		// Wait for lock goroutine to fully complete.
+		select {
+		case <-lockDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("lock goroutine did not complete")
+		}
+
+		// Op was requeued by process, then removed by removeOperation.
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	t.Run("retry requeue is serialized with service deletion under serviceReconcileLock", func(t *testing.T) {
+		cloud, _, mockBP, _ := setupRetryTest(t, 3)
+
+		armBlocked := make(chan struct{})
+		armUnblock := make(chan struct{})
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				close(armBlocked)
+				<-armUnblock
+				return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+			},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Start process() in goroutine; it acquires serviceReconcileLock.
+		processDone := make(chan struct{})
+		go func() {
+			defer close(processDone)
+			u.process(context.Background())
+		}()
+
+		// Wait for process() to be mid-ARM-call.
+		<-armBlocked
+
+		// Simulate main reconcile path trying to delete service from map.
+		lockAcquired := make(chan struct{})
+		lockDone := make(chan struct{})
+		go func() {
+			cloud.serviceReconcileLock.Lock()
+			close(lockAcquired)
+			cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+			cloud.serviceReconcileLock.Unlock()
+			close(lockDone)
+		}()
+
+		// Verify lock is NOT acquired while process() is mid-flight.
+		select {
+		case <-lockAcquired:
+			t.Fatal("serviceReconcileLock acquired while process() is mid-flight")
+		case <-time.After(200 * time.Millisecond):
+			// Expected: blocked.
+		}
+
+		// Unblock ARM; returns 409, requeues, then releases lock.
+		close(armUnblock)
+		<-processDone
+
+		// Wait for lock goroutine to fully complete.
+		select {
+		case <-lockDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("lock goroutine did not complete")
+		}
+
+		// Op was requeued by process (queue == 1), map delete happened after.
+		assert.Equal(t, 1, u.countOperations())
+
+		// Next tick: groupOperations filters the stale op.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "context canceled during ARM call drops op without event",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+		{
+			name:              "ARM call returns context.Canceled on shutdown and op is dropped without event",
+			createOrUpdateErr: context.Canceled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP, _ := setupRetryTest(t, 3)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+				func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+					cancel()
+					return nil, tc.createOrUpdateErr
+				},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(ctx)
+
+			assert.Equal(t, 0, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+			assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+		})
+	}
+
+	t.Run("shutdown with parked ops drops all without event", func(t *testing.T) {
+		cloud, recorder, _, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops with canceled context should never reach ARM.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op.nextEligibleAt = time.Now().Add(5 * time.Minute)
+		op.retryAttempts = 1
+		u.addOperation(op)
+
+		// Cancel context before calling process (simulates shutdown).
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		u.process(ctx)
+
+		// Op was drained and discarded (not requeued).
+		assert.Equal(t, 0, u.countOperations())
+		assert.Empty(t, drainEvents(recorder), "expected no events on shutdown")
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
 }

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2747,6 +2747,52 @@ func TestCheckEnableMultipleStandardLoadBalancers(t *testing.T) {
 	assert.Equal(t, "duplicated primary VMSet vmss-2 in multiple standard load balancer configurations lb2", err.Error())
 }
 
+func TestLoadBalancerBackendPoolUpdateMaxRetriesNormalization(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    *int
+		expected int
+	}{
+		{"nil defaults to 3", nil, 3},
+		{"explicit 0 stays 0", ptr.To(0), 0},
+		{"explicit 5 stays 5", ptr.To(5), 5},
+		{"negative value is normalized to 0", ptr.To(-1), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			az := GetTestCloud(ctrl)
+			az.LoadBalancerBackendPoolConfigurationType = consts.LoadBalancerBackendPoolConfigurationTypeNodeIP
+			az.MultipleStandardLoadBalancerConfigurations = []providerconfig.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "kubernetes",
+					MultipleStandardLoadBalancerConfigurationSpec: providerconfig.MultipleStandardLoadBalancerConfigurationSpec{
+						PrimaryVMSet: "vmss-0",
+					},
+				},
+			}
+			az.LoadBalancerBackendPoolUpdateMaxRetries = tc.input
+
+			err := az.checkEnableMultipleStandardLoadBalancers()
+			assert.NoError(t, err)
+			assert.NotNil(t, az.LoadBalancerBackendPoolUpdateMaxRetries)
+			assert.Equal(t, tc.expected, *az.LoadBalancerBackendPoolUpdateMaxRetries)
+		})
+	}
+}
+
+func TestParseConfigPreservesMaxRetriesZero(t *testing.T) {
+	// Explicit 0 is preserved as non-nil pointer.
+	cfg, err := providerconfig.ParseConfig(strings.NewReader(`{"loadBalancerBackendPoolUpdateMaxRetries": 0}`))
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+	assert.Equal(t, 0, *cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+
+	// Absent field results in nil pointer.
+	cfg, err = providerconfig.ParseConfig(strings.NewReader(`{}`))
+	assert.NoError(t, err)
+	assert.Nil(t, cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+}
+
 func TestIsNodeReady(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2956,6 +2956,52 @@ func TestCheckEnableMultipleStandardLoadBalancers(t *testing.T) {
 	assert.Equal(t, "duplicated primary VMSet vmss-2 in multiple standard load balancer configurations lb2", err.Error())
 }
 
+func TestLoadBalancerBackendPoolUpdateMaxRetriesNormalization(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    *int
+		expected int
+	}{
+		{"nil defaults to 3", nil, 3},
+		{"explicit 0 stays 0", ptr.To(0), 0},
+		{"explicit 5 stays 5", ptr.To(5), 5},
+		{"negative value is normalized to 0", ptr.To(-1), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			az := GetTestCloud(ctrl)
+			az.LoadBalancerBackendPoolConfigurationType = consts.LoadBalancerBackendPoolConfigurationTypeNodeIP
+			az.MultipleStandardLoadBalancerConfigurations = []providerconfig.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "kubernetes",
+					MultipleStandardLoadBalancerConfigurationSpec: providerconfig.MultipleStandardLoadBalancerConfigurationSpec{
+						PrimaryVMSet: "vmss-0",
+					},
+				},
+			}
+			az.LoadBalancerBackendPoolUpdateMaxRetries = tc.input
+
+			err := az.checkEnableMultipleStandardLoadBalancers()
+			assert.NoError(t, err)
+			assert.NotNil(t, az.LoadBalancerBackendPoolUpdateMaxRetries)
+			assert.Equal(t, tc.expected, *az.LoadBalancerBackendPoolUpdateMaxRetries)
+		})
+	}
+}
+
+func TestParseConfigPreservesMaxRetriesZero(t *testing.T) {
+	// Explicit 0 is preserved as non-nil pointer.
+	cfg, err := providerconfig.ParseConfig(strings.NewReader(`{"loadBalancerBackendPoolUpdateMaxRetries": 0}`))
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+	assert.Equal(t, 0, *cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+
+	// Absent field results in nil pointer.
+	cfg, err = providerconfig.ParseConfig(strings.NewReader(`{}`))
+	assert.NoError(t, err)
+	assert.Nil(t, cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+}
+
 func TestIsNodeReady(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/provider/config/azure.go
+++ b/pkg/provider/config/azure.go
@@ -162,6 +162,9 @@ type Config struct {
 	RouteUpdateIntervalInSeconds int `json:"routeUpdateIntervalInSeconds,omitempty" yaml:"routeUpdateIntervalInSeconds,omitempty"`
 	// LoadBalancerBackendPoolUpdateIntervalInSeconds is the interval for updating load balancer backend pool of local services. Default is 30 seconds.
 	LoadBalancerBackendPoolUpdateIntervalInSeconds int `json:"loadBalancerBackendPoolUpdateIntervalInSeconds,omitempty" yaml:"loadBalancerBackendPoolUpdateIntervalInSeconds,omitempty"`
+	// LoadBalancerBackendPoolUpdateMaxRetries is the maximum number of retries for a failed backend pool update operation of local services.
+	// nil = use default (3), 0 = disable retry. The total attempts = 1 + maxRetries.
+	LoadBalancerBackendPoolUpdateMaxRetries *int `json:"loadBalancerBackendPoolUpdateMaxRetries,omitempty" yaml:"loadBalancerBackendPoolUpdateMaxRetries,omitempty"`
 
 	// ClusterServiceLoadBalancerHealthProbeMode determines the health probe mode for cluster service load balancer.
 	// Supported values are `shared` and `servicenodeport`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds bounded retry for retriable errors in the local service backend pool updater. Previously, any error dropped the batch permanently with a failure metric. Non-404 errors also emitted a failure event.

Now errors are classified into three categories. Retriable errors (409 Conflict, 412 Precondition Failed, ThrottleError) are requeued with a per-op retry counter up to `loadBalancerBackendPoolUpdateMaxRetries` (default 3, configurable, 0 disables). ThrottleError with a future RetryAfter parks the group until eligible. Terminal errors (non-retriable: SDK-retried statuses, non-ARM errors, and unrecognized status codes) are reported and dropped as before. Stale 404 errors are dropped silently without event or metric (previously recorded a failure metric).

Events are deduplicated per service per tick, fixing the previous notify() that only reported the first operation in a batch due to an unconditional break. Retried operations are prepended to the queue to preserve chronological diff ordering. Operations are re-checked for relevance (service still exists, LB mapping unchanged) before requeuing, and all operations are dropped silently on shutdown.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10270

#### Special notes for your reviewer:
Design doc: #10417
Documentation update for `topics/multislb` #10648

Deferred to follow-up PR (#10730):
- Desired-state operation model (one op per service/pool, eliminating duplicate events for mixed-budget groups)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat(multi-slb): add bounded retry for local service backend pool updates. Retriable errors (409, 412, throttle) are retried up to 3 times by default. Configure with `loadBalancerBackendPoolUpdateMaxRetries` (0 disables). New event `LoadBalancerBackendPoolUpdateRetrying` signals a retry is pending. 404 errors no longer count as failures in metrics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
