### PR TITLE
Add servicegateway folder with OWNERS

### DIFF
--- a/pkg/provider/servicegateway/OWNERS
+++ b/pkg/provider/servicegateway/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- david-kow
+
+reviewers:
+- david-kow


### PR DESCRIPTION


#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Introduces pkg/provider/servicegateway/ as a new folder and adds an OWNERS file assigning david-kow as approver and reviewer.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
