### PR TITLE
docs: make dependabot unblocker failure list pluggable

### DIFF
--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -33,8 +33,8 @@ Then walk the catalog as an explicit phased algorithm:
 
 > **Phase 0 — Guard (metadata/diff only).** Before running `gh pr checks`,
 > reading `statusCheckRollup`, or fetching any Prow log, evaluate every Phase-0
-> row whose Detection signal is computable from PR metadata and the `go.mod`
-> diff alone. If a Phase-0 row matches and is marked Stop, take its Action
+> row whose Signal is computable from PR metadata and the `go.mod` diff alone.
+> If a Phase-0 row matches and is marked Stop, follow its linked Details action
 > (e.g. `/close`) and **end triage immediately** — do not inspect CI, sync
 > modules, retest, `/lgtm`, or report no-action.
 >
@@ -43,10 +43,11 @@ Then walk the catalog as an explicit phased algorithm:
 > "unblocked" until every failing job maps to a matched row.
 >
 > **Phase 2 — Act.** Walk matched Phase-2 rows by ascending Priority, honoring
-> each row's Preconditions/Exclusions. Track the actions already taken this
-> triage: if an action reruns CI (a push), skip any later row whose only effect
-> would be to retest jobs that the push will rerun. Prefer the push-triggered
-> rerun. A Phase-2 row marked Stop ends triage after it is handled.
+> each row's linked Details preconditions and exclusions. Track the actions
+> already taken this triage: if an action reruns CI (a push), skip any later row
+> whose only effect would be to retest jobs that the push will rerun. Prefer the
+> push-triggered rerun. A Phase-2 row marked Stop ends triage after it is
+> handled.
 
 Phase 1 inspects CI only after no Phase-0 stop fired:
 
@@ -75,14 +76,14 @@ or overwrite unrelated files.
 - Use specific staging commands, never `git add .`.
 - Push only the current task's files.
 - Resolve Phase-0 guard rows from PR metadata and the `go.mod` diff before any
-  CI or log I/O. When a Phase-0 row marked Stop matches, take its Action and end
-  triage immediately — do not inspect CI, sync modules, retest, comment `/lgtm`,
-  or report that no action is needed.
+  CI or log I/O. When a Phase-0 row marked Stop matches, follow its linked
+  Details action and end triage immediately — do not inspect CI, sync modules,
+  retest, comment `/lgtm`, or report that no action is needed.
 - Act on matched rows in ascending Priority within each phase, and take a row's
-  Action only when its Preconditions/Exclusions hold.
-- When a row's Action reruns CI (a push), skip any later row whose only effect
-  would be to retest the jobs that push will rerun; prefer the push-triggered
-  rerun.
+  linked Details action only when its Details preconditions and exclusions hold.
+- When a row's Details action reruns CI (a push), skip any later row whose only
+  effect would be to retest the jobs that push will rerun; prefer the
+  push-triggered rerun.
 - Stamp every non-final action (a Phase-2 `Stop=no` comment or push that leaves
   the PR for another CI round) with this triage's attempt number, counted from
   the PR's own comment history. Once the automated retry budget is spent, an

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -20,36 +20,35 @@ Expected inputs:
 
 Load the catalog at [`references/failure-patterns.md`](references/failure-patterns.md);
 it is the source of truth for which failure patterns exist. The engine never
-hard-codes a pattern — it walks the catalog by the phased algorithm below.
+hard-codes a pattern — it walks the catalog by the staged algorithm below.
 
-Fetch PR metadata and changed dependencies first; these feed Phase 0 before any
+Fetch PR metadata and changed dependencies first; these feed guard rows before any
 CI or log I/O:
 
 ```bash
 gh pr view <pr> --json number,title,headRefName,headRepositoryOwner,headRefOid,baseRefName,author,labels,mergeable
 ```
 
-Then walk the catalog as an explicit phased algorithm:
+Then walk the catalog as an explicit staged algorithm:
 
-> **Phase 0 — Guard (metadata/diff only).** Before running `gh pr checks`,
-> reading `statusCheckRollup`, or fetching any Prow log, evaluate every Phase-0
-> row whose Signal is computable from PR metadata and the `go.mod` diff alone.
-> If a Phase-0 row matches and is marked Stop, follow its linked Details action
+> **Guard stage — metadata/diff only.** Before running `gh pr checks`, reading
+> `statusCheckRollup`, or fetching any Prow log, evaluate every guard row whose
+> Signal is computable from PR metadata and the `go.mod` diff alone. If a guard
+> row matches and is marked Stop, follow its linked Details action
 > (e.g. `/close`) and **end triage immediately** — do not inspect CI, sync
 > modules, retest, `/lgtm`, or report no-action.
 >
-> **Phase 1 — Classify.** Only if no Phase-0 stop fired: fetch CI status and
+> **Classification gate.** Only if no guard Stop fired: fetch CI status and
 > checkout as needed, then classify every failing required job. A PR is not
-> "unblocked" until every failing job maps to a matched row.
+> "unblocked" until every failing required job maps to a matched act row.
 >
-> **Phase 2 — Act.** Walk matched Phase-2 rows by ascending Priority, honoring
+> **Act stage.** Walk matched act rows by ascending Priority, honoring
 > each row's linked Details preconditions and exclusions. Track the actions
 > already taken this triage: if an action reruns CI (a push), skip any later row
 > whose only effect would be to retest jobs that the push will rerun. Prefer the
-> push-triggered rerun. A Phase-2 row marked Stop ends triage after it is
-> handled.
+> push-triggered rerun. An act row marked Stop ends triage after it is handled.
 
-Phase 1 inspects CI only after no Phase-0 stop fired:
+Classification inspects CI only after no guard Stop fired:
 
 ```bash
 gh pr view <pr> --json number,title,headRefName,headRepositoryOwner,headRefOid,baseRefName,author,labels,mergeable,statusCheckRollup
@@ -75,21 +74,21 @@ or overwrite unrelated files.
   compatibility issue, commit SHA, changed files, and validation result.
 - Use specific staging commands, never `git add .`.
 - Push only the current task's files.
-- Resolve Phase-0 guard rows from PR metadata and the `go.mod` diff before any
-  CI or log I/O. When a Phase-0 row marked Stop matches, follow its linked
+- Resolve guard rows from PR metadata and the `go.mod` diff before any CI or log
+  I/O. When a guard row marked Stop matches, follow its linked
   Details action and end triage immediately — do not inspect CI, sync modules,
   retest, comment `/lgtm`, or report that no action is needed.
-- Act on matched rows in ascending Priority within each phase, and take a row's
+- Act on matched rows in ascending Priority within each stage, and take a row's
   linked Details action only when its Details preconditions and exclusions hold.
 - When a row's Details action reruns CI (a push), skip any later row whose only
   effect would be to retest the jobs that push will rerun; prefer the
   push-triggered rerun.
-- Stamp every non-final action (a Phase-2 `Stop=no` comment or push that leaves
+- Stamp every non-final action (an act-stage `Stop=no` comment or push that leaves
   the PR for another CI round) with this triage's attempt number, counted from
   the PR's own comment history. Once the automated retry budget is spent, an
   `escalate` row makes no change to the PR — no comment, no checks, no push — and
   the PR is reported as needing human review in the final output. All of this is
-  catalog-driven: the Phase-0 retry-budget guard reads the stamps before any
+  catalog-driven: the retry-budget guard reads the stamps before any
   CI/log I/O, and the shared attempt-stamp rule writes them. Do not invent a
   separate counter.
 - A row marked Stop ends triage after it is handled.

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -83,19 +83,21 @@ or overwrite unrelated files.
 - When a row's Details action reruns CI (a push), skip any later row whose only
   effect would be to retest the jobs that push will rerun; prefer the
   push-triggered rerun.
-- Stamp every non-final action (an act-stage `Stop=no` comment or push that leaves
-  the PR for another CI round) with this triage's attempt number, counted from
-  the PR's own comment history. Once the automated retry budget is spent, an
-  `escalate` row makes no change to the PR — no comment, no checks, no push — and
-  the PR is reported as needing human review in the final output. All of this is
-  catalog-driven: the retry-budget guard reads the stamps before any
+- Stamp every non-final action (an act-stage `Stop=no` comment, push, or GitHub
+  Actions rerun that leaves the PR for another CI round) with this triage's
+  attempt number, counted from the PR's own comment history. Once the automated
+  retry budget is spent, an `escalate` row makes no change to the PR — no
+  comment, no checks, no push — and the PR is reported as needing human review
+  in the final output. All of this is catalog-driven: the retry-budget guard
+  reads the stamps before any
   CI/log I/O, and the shared attempt-stamp rule writes them. Do not invent a
   separate counter.
 - A row marked Stop ends triage after it is handled.
-- Rerun a failed job only with a per-job `/test <job-name>` comment, and only
-  for failures already classified as transient or safe to rerun. Do not use
-  `/retest`; rerun each failed job by name so a still-broken required job is
-  never blanket-rerun.
+- Use the retry mechanism for the CI system that produced the failure, and only
+  after the failure is classified as transient or safe to rerun. For Prow jobs,
+  rerun with a per-job `/test <job-name>` comment; never use `/retest`. For
+  GitHub Actions check runs, rerun through GitHub Actions (`gh run rerun`), not
+  through a PR slash command.
 - Report pending jobs, `tide` status, and any residual risk clearly instead of
   claiming the PR is green before CI finishes. When an `escalate` row matched
   (retry budget spent, or a toolchain / SDK / policy blocker), report the PR as

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -18,27 +18,45 @@ Expected inputs:
 
 ## Triage First
 
-1. Inspect the PR metadata and changed dependencies before checking CI:
+Load the catalog at [`references/failure-patterns.md`](references/failure-patterns.md);
+it is the source of truth for which failure patterns exist. The engine never
+hard-codes a pattern — it walks the catalog by the phased algorithm below.
+
+Fetch PR metadata and changed dependencies first; these feed Phase 0 before any
+CI or log I/O:
 
 ```bash
 gh pr view <pr> --json number,title,headRefName,headRepositoryOwner,headRefOid,baseRefName,author,labels,mergeable
 ```
 
-2. Run the [Kubernetes Minor Version Guard](#kubernetes-minor-version-guard)
-   immediately for Dependabot Go module PRs. If the guard finds a disallowed
-   minor-family change, close the PR and stop before inspecting CI, syncing
-   modules, retesting, commenting `/lgtm`, or reporting that no unblock action
-   is needed.
+Then walk the catalog as an explicit phased algorithm:
 
-3. Inspect CI only after the minor version guard passes:
+> **Phase 0 — Guard (metadata/diff only).** Before running `gh pr checks`,
+> reading `statusCheckRollup`, or fetching any Prow log, evaluate every Phase-0
+> row whose Detection signal is computable from PR metadata and the `go.mod`
+> diff alone. If a Phase-0 row matches and is marked Stop, take its Action
+> (e.g. `/close`) and **end triage immediately** — do not inspect CI, sync
+> modules, retest, `/lgtm`, or report no-action.
+>
+> **Phase 1 — Classify.** Only if no Phase-0 stop fired: fetch CI status and
+> checkout as needed, then classify every failing required job. A PR is not
+> "unblocked" until every failing job maps to a matched row.
+>
+> **Phase 2 — Act.** Walk matched Phase-2 rows by ascending Priority, honoring
+> each row's Preconditions/Exclusions. Track the actions already taken this
+> triage: if an action reruns CI (a push), skip any later row whose only effect
+> would be to retest jobs that the push will rerun. Prefer the push-triggered
+> rerun. A Phase-2 row marked Stop ends triage after it is handled.
+
+Phase 1 inspects CI only after no Phase-0 stop fired:
 
 ```bash
 gh pr view <pr> --json number,title,headRefName,headRepositoryOwner,headRefOid,baseRefName,author,labels,mergeable,statusCheckRollup
 gh pr checks <pr>
 ```
 
-4. If the local checkout is needed, fetch and check out the PR head, then check
-   for unrelated work:
+If the local checkout is needed, fetch and check out the PR head, then check
+for unrelated work:
 
 ```bash
 gh pr checkout <pr>
@@ -48,209 +66,6 @@ git status --short
 Stop and report a conflict if unrelated uncommitted changes exist. Do not stage
 or overwrite unrelated files.
 
-5. Classify every failing required job. Do not treat a PR as unblocked until all
-   non-pending failures have a clear action.
-
-6. If no checks are failing and the only pending status is `tide`, follow the
-   [Only Tide Pending](#only-tide-pending) path.
-
-## Kubernetes Minor Version Guard
-
-Run this guard for every Dependabot Go module PR before inspecting CI or taking
-an unblock action. The goal is to close Kubernetes minor-version bumps early
-instead of spending automation time on checks that should not unblock the PR.
-
-Inspect the PR diff for `go.mod` changes to Kubernetes modules:
-
-```bash
-gh pr diff <pr> --patch | grep -E '^[+-][[:space:]]+(require[[:space:]]+)?(k8s\.io/[[:alnum:]_.\-/]+)[[:space:]]+v0\.[0-9]+\.[0-9]+'
-```
-
-Then apply these rules:
-
-- Compare removed and added lines by module path. A patch-only bump within the
-  same minor family is allowed, even when that minor family was already
-  mismatched with the release branch before the PR. For example, on
-  `release-1.34`, `k8s.io/api v0.35.4` to `v0.35.6` is allowed because the PR
-  did not introduce the `v0.35.x` family.
-- For any branch, an existing `k8s.io/*` module must not move from one minor
-  family to another, such as `v0.36.x` to `v0.37.x`, unless the user explicitly
-  asks for that Kubernetes minor bump.
-- For a PR targeting `release-1.N`, a newly added `k8s.io/*` module that has no
-  removed counterpart in the diff must use the `v0.N.x` family unless the user
-  explicitly asks for a different Kubernetes minor family.
-- The PR must not introduce a new mixed minor-family set. Existing mixed
-  families may receive patch bumps, but a new module or changed module must not
-  add a minor family that was not already present in the corresponding removed
-  `k8s.io/*` lines.
-
-If the guard finds a disallowed minor-family change, comment `/close` and stop
-for that PR. Put `/close` on the first line so Prow can parse it, then include
-the base branch, mismatched module lines, and expected minor family:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/close
-
-Reason: closing because this Dependabot PR introduces a disallowed Kubernetes minor-family change.
-Base branch: release-1.N; expected new k8s.io modules to use v0.N.x, or existing modules to stay in their removed minor family.
-Mismatched modules:
-- k8s.io/example v0.X.Y -> v0.Z.W
-EOF
-```
-
-Do not inspect CI, run module sync, comment `/lgtm`, post `/retest` or `/test`,
-or report the PR as requiring no action. Report the `/close` comment plus the
-mismatched module lines, the base branch, and the expected minor family. For a
-changed existing module, the expected minor family is the module's removed
-version; for a newly added module on `release-1.N`, it is `v0.N.x`.
-
-If the guard finds no `k8s.io/*` module changes, or only patch-level updates
-within the same minor family, continue with the matching workflow below.
-
-## go-mod-consistency Failed
-
-Use the shared `sync-go-modules` skill from this repo.
-
-1. Read `.agents/skills/sync-go-modules/SKILL.md`.
-2. Run the helper from the PR checkout. If the Dependabot branch is already
-   dirty only because of the dependency bump you are fixing, pass
-   `--allow-dirty` as that skill describes.
-3. Inspect the diff and stage only files produced by the sync:
-
-```bash
-git diff --stat
-git status --short
-git add <specific go.mod/go.sum/vendor files>
-git diff --cached --stat
-```
-
-4. Commit and push the fix to the PR branch:
-
-```bash
-git commit -m "Update Go modules"
-git push
-```
-
-5. After the push succeeds, comment `/lgtm` on the PR. Put `/lgtm` on the first
-   line so Prow can parse it, then name the pushed commit, changed module files,
-   and validation that passed:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/lgtm
-
-Reason: pushed a go-mod-consistency fix for this Dependabot PR.
-Commit: <sha>
-Files: <go.mod/go.sum/vendor files changed>
-Validation: <sync-go-modules check command> passed.
-EOF
-```
-
-The push reruns CI. Do not add `/retest` just for the old failed
-`go-mod-consistency` run after pushing a new commit.
-
-## Only Tide Pending
-
-Use this path when the current status rollup has no failed checks and the only
-pending status is `tide`.
-
-Check the PR labels from `gh pr view`. If the PR does not already have the
-`lgtm` label, comment `/lgtm` so Tide can re-evaluate the PR. Put `/lgtm` on the
-first line, then say that Tide is the only pending status and no checks are
-failing:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/lgtm
-
-Reason: no checks are failing, Tide is the only pending status, and the PR does not already have the lgtm label.
-EOF
-```
-
-If the PR already has the `lgtm` label, do not post a duplicate `/lgtm`
-comment. Report that no unblock action was needed and Tide is the only
-remaining pending status.
-
-Do not use this path when any non-Tide check is pending or failed. Report those
-checks explicitly and handle them through the matching workflow instead.
-
-## Azure Public IP Quota e2e Failures
-
-Use this path only when the failed jobs are exclusively
-`pull-cloud-provider-azure-e2e-*` jobs and the failing logs show one of:
-
-- `PublicIPCountLimitReached`
-- `PublicIPPrefixCountLimitReached`
-
-Confirm the failure text from the job logs before retesting. If any non-e2e job
-also failed, handle that failure separately before blanket retesting.
-
-Retest options:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/test <job-name>
-
-Reason: rerunning this failed e2e job because its current Prow log contains <PublicIPCountLimitReached or PublicIPPrefixCountLimitReached> and no non-e2e failure remains.
-EOF
-```
-
-Use one `/test <job-name>` comment per failed e2e job when you want a narrow
-rerun. Put `/test <job-name>` on the first line, then include the quota marker
-found in that job's current Prow log.
-
-Use `/retest` only when all current failed jobs are safe to rerun. Put `/retest`
-on the first line, then say every current failure was confirmed as an e2e
-public-IP quota flake and no non-e2e failure remains:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/retest
-
-Reason: rerunning all failed jobs because every current failure is an e2e public-IP quota flake confirmed in Prow logs, and no non-e2e failure remains.
-EOF
-```
-
-If you are already pushing a commit for another fix, prefer the push-triggered
-CI rerun instead of adding a separate retest comment.
-
-## Other Common Dependabot Blockers
-
-Discuss these with the user before changing code or CI policy:
-
-- `golangci-lint` or `Analyze (go)` fails with a Go toolchain mismatch, such as
-  `panic: file requires newer Go version ... (application built with ...)`
-- `golangci-lint` `typecheck` failures after an Azure SDK or Kubernetes module
-  bump
-- Mixed Azure SDK major versions, such as `armcompute/v6` consumers in a PR
-  that updated packages to `armcompute/v7`
-- `dependency-review`, vulnerability, or license failures where the resolution
-  may require accepting risk, excluding a finding, or changing the dependency
-  version
-- The PR is labeled `needs-rebase` or `mergeable` reports `CONFLICTING`
-
-For dependency, toolchain, and policy failures, collect the failing job names,
-the smallest representative log snippets, current dependency versions, and a
-proposed narrow fix. Ask before changing linter policy, broadening a dependency
-bump, or editing generated Dependabot PR metadata.
-
-If the PR still needs a rebase after other common blockers have been fixed,
-ask Dependabot to rebase the branch instead of manually rewriting the generated
-PR branch. Put `@dependabot rebase` on the first line, then say the local
-blockers are resolved and the remaining blocker is rebase state:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-@dependabot rebase
-
-Reason: local blockers are resolved, but the PR still needs rebase before Tide can merge it.
-EOF
-```
-
-Do this after local fixes and pushes are complete so Dependabot rebases the
-latest branch state.
-
 ## PR Update Rules
 
 - Preserve the generated Dependabot PR body. If a manual compatibility fix was
@@ -259,17 +74,30 @@ latest branch state.
   compatibility issue, commit SHA, changed files, and validation result.
 - Use specific staging commands, never `git add .`.
 - Push only the current task's files.
-- Run the Kubernetes minor version guard before inspecting CI, module sync,
-  retest comments, `/lgtm` comments, or no-action reports for Dependabot Go
-  module PRs.
-- If the Kubernetes minor version guard fails, comment `/close` and stop.
-- Use `/lgtm` after a successful module-sync push when the PR is otherwise ready
-  for review.
-- Use `/lgtm` when no checks are failing, `tide` is the only pending status,
-  and the PR does not already have the `lgtm` label.
-- If the PR needs rebase after other blockers are resolved, comment
-  `@dependabot rebase` rather than manually force-pushing a rebase.
-- Use `/retest` only for failures already classified as transient or safe to
+- Resolve Phase-0 guard rows from PR metadata and the `go.mod` diff before any
+  CI or log I/O. When a Phase-0 row marked Stop matches, take its Action and end
+  triage immediately — do not inspect CI, sync modules, retest, comment `/lgtm`,
+  or report that no action is needed.
+- Act on matched rows in ascending Priority within each phase, and take a row's
+  Action only when its Preconditions/Exclusions hold.
+- When a row's Action reruns CI (a push), skip any later row whose only effect
+  would be to retest the jobs that push will rerun; prefer the push-triggered
   rerun.
+- Stamp every non-final action (a Phase-2 `Stop=no` comment or push that leaves
+  the PR for another CI round) with this triage's attempt number, counted from
+  the PR's own comment history. Once the automated retry budget is spent, an
+  `escalate` row makes no change to the PR — no comment, no checks, no push — and
+  the PR is reported as needing human review in the final output. All of this is
+  catalog-driven: the Phase-0 retry-budget guard reads the stamps before any
+  CI/log I/O, and the shared attempt-stamp rule writes them. Do not invent a
+  separate counter.
+- A row marked Stop ends triage after it is handled.
+- Rerun a failed job only with a per-job `/test <job-name>` comment, and only
+  for failures already classified as transient or safe to rerun. Do not use
+  `/retest`; rerun each failed job by name so a still-broken required job is
+  never blanket-rerun.
 - Report pending jobs, `tide` status, and any residual risk clearly instead of
-  claiming the PR is green before CI finishes.
+  claiming the PR is green before CI finishes. When an `escalate` row matched
+  (retry budget spent, or a toolchain / SDK / policy blocker), report the PR as
+  needing human review, naming the failing jobs and the blocker, rather than
+  claiming it was unblocked.

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -50,6 +50,7 @@ or acting on a row.
 | 30 | 2 | Public-IP quota e2e flake | Public-IP quota marker in e2e log | auto-fix | no | [Details: Public-IP quota e2e](#details-public-ip-quota-e2e) |
 | 35 | 2 | Image-build registry flake e2e | Registry 5xx during pre-test image build | auto-fix | no | [Details: Image-build registry flake](#details-image-build-registry-flake) |
 | 37 | 2 | Cluster-provisioning node-readiness timeout e2e | Node readiness timeout during pre-test cluster provisioning | auto-fix | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
+| 39 | 2 | Prow pod scheduling timeout e2e | Prow job pod never schedules | auto-fix | no | [Details: Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout) |
 | 40 | 2 | Only Tide pending | No failed checks; only `tide` pending | auto-fix | no | [Details: Only Tide pending](#details-only-tide-pending) |
 | 50 | 2 | Toolchain / SDK / policy blocker | Toolchain, typecheck, SDK-major, or dependency-policy blocker | escalate | yes | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
 
@@ -189,7 +190,8 @@ terminating triage. Today that is [go-mod-consistency](#details-go-mod-consisten
 (push + `/lgtm`) and the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
 rule used by [Public-IP quota e2e](#details-public-ip-quota-e2e),
 [Image-build registry flake](#details-image-build-registry-flake), and
-[Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout)
+[Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout),
+and [Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout)
 (each `/test <job-name>`). Link here from a new non-final pattern instead of
 copying the stamp recipe.
 
@@ -230,27 +232,28 @@ automated retry round.
 ## Details: Shared e2e flake rerun
 
 Shared action for Phase-2 e2e rows that are classified as safe transient
-failures. Pattern-specific Details must supply the log fingerprint and any extra
-exclusions before using this rule.
+failures. Pattern-specific Details must supply the fingerprint evidence and any
+extra exclusions before using this rule.
 
 Before rerunning:
 
 - The failed jobs are exclusively `pull-*-e2e-*`; no non-e2e failure remains.
-- Each job being rerun has the pattern-specific fingerprint in its current Prow
-  log.
+- Each job being rerun has the pattern-specific fingerprint in current Prow
+  evidence: build log, `prowjob.json`, `podinfo.json`, or another listed
+  artifact.
 - The pattern-specific exclusions do not apply.
 - A push in this triage has not already rerun the same job; prefer the
   push-triggered CI rerun when there is one.
 
 Rerun each failed e2e job with its own `/test <job-name>` comment. Put
 `/test <job-name>` on the first line, then include the fingerprint evidence from
-that job's current Prow log:
+that job's current Prow artifacts:
 
 ```bash
 gh pr comment <pr> --body-file - <<'EOF'
 /test <job-name>
 
-Reason: rerunning this failed e2e job because its current Prow log shows <pattern-specific evidence> and no non-flake failure remains.
+Reason: rerunning this failed e2e job because its current Prow artifacts show <pattern-specific evidence> and no non-flake failure remains.
 Unblock attempt: <N+1>
 EOF
 ```
@@ -320,6 +323,32 @@ failure separately instead of retesting.
 If the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
 and fill the evidence with the node-timeout marker, `EXIT_VALUE=124`, and the
 fact that no test ran.
+
+## Details: Prow pod scheduling timeout
+
+Use this path only when a failed `pull-*-e2e-*` job never starts because Prow
+cannot schedule the job pod. This is a Prow infrastructure/capacity failure, not
+a cloud-provider-azure test failure.
+
+Confirm from the current Prow artifacts before retesting:
+
+- `prowjob.json` has `status.state` = `error` and `status.description` =
+  `Pod scheduling timeout.`
+- The artifact root has no `build-log.txt`, or the build log never reaches the
+  job entrypoint or any Ginkgo output.
+- `finished.json` has `result` = `error`.
+- `podinfo.json` shows the job pod stayed `Pending`, with `PodScheduled=False`
+  and `reason=Unschedulable`, or `FailedScheduling` events such as
+  `Insufficient cpu`, `Insufficient memory`, `No preemption victims`, or
+  `all available instance types exceed limits`.
+
+If the job pod starts and the build log reaches cluster provisioning or test
+execution, use a more specific pattern instead. If any non-e2e job failed,
+handle that failure separately instead of retesting.
+
+If the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
+and fill the evidence with `Pod scheduling timeout.` plus the `podinfo.json`
+Unschedulable / FailedScheduling capacity marker.
 
 ## Details: Only Tide pending
 

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -1,0 +1,445 @@
+# Dependabot Failure Pattern Catalog
+
+This catalog is the pluggable pattern list for the
+[`unblock-dependabot-pr`](../SKILL.md) engine. The engine never hard-codes a
+pattern; it walks the table below by the phased algorithm in `SKILL.md`. Adding
+a newly discovered failure pattern is a single-file edit here: append a row to
+the table and add a matching `## Details: <name>` subsection.
+
+Details subsections are **normative** — read the linked Details before matching
+or acting on a row.
+
+## Row schema
+
+| Column | Purpose |
+|--------|---------|
+| **Priority** | Gap-numbered (10, 20, 30…). Within a phase, the engine acts on matched rows low→high. New patterns slot into gaps without renumbering. |
+| **Phase** | `0` (guard, metadata/diff only) / `1` (classify) / `2` (act). Binds the row to an engine phase so guard rows are resolved before any CI/log I/O. |
+| **Pattern** | Short human name. |
+| **Detection signal** | What to match — the diff grep, the failing job name, or the log marker. A Phase-0 row's signal must be computable from metadata and the `go.mod` diff alone. |
+| **Preconditions / Exclusions** | Negative and dependency guards that must hold for the Action to be valid (e.g. "only e2e jobs failed", "no non-Tide check pending", "after other blockers resolved"). Never dropped into prose only. |
+| **Autonomy** | `close` / `auto-fix` / `escalate` / `bot-rebase`. Governs whether the agent acts alone (see Autonomy values below). |
+| **Action** | One-line summary of the fix or Prow comment. |
+| **Stop** | `yes` = short-circuit; end triage after this row is handled. |
+| **Details** | Markdown anchor link to the pattern's `## Details: <name>` subsection in the same file. Details are **normative** — the agent must read them before matching/acting. `—` only when the Action and Preconditions cells are complete on their own. |
+
+## Autonomy values
+
+- `close` — comment `/close` and stop (disallowed change).
+- `auto-fix` — the agent may act alone (push, `/lgtm`, `/test <job-name>`)
+  because the fix is deterministic and low-risk.
+- `escalate` — the agent makes no automated change: it posts no PR comment, runs
+  no checks, syncs no modules, and does not touch code, CI policy, or dependency
+  versions. It stops working the PR and reports it as needing human review in its
+  final output. Used both as a Phase-0 guard when the automated retry budget is
+  spent (Retry budget exhausted) and as a Phase-2 flag when a blocker needs a
+  human policy or toolchain decision (Toolchain / SDK / policy).
+- `bot-rebase` — post a bot directive (`@dependabot rebase`) that regenerates
+  the branch, then stop; distinct from `escalate` because it directs another
+  bot to regenerate the branch rather than handing the PR to a human reviewer.
+  The needs-rebase row uses this as a Phase-0 guard: a conflicting branch is
+  detected from metadata and handed to Dependabot before any CI/log I/O, since a
+  rebase invalidates a stale CI run anyway.
+
+## Catalog
+
+| Pri | Phase | Pattern | Detection signal | Preconditions / Exclusions | Autonomy | Action | Stop | Details |
+|-----|-------|---------|------------------|----------------------------|----------|--------|------|---------|
+| 10 | 0 | K8s minor-version bump | `go.mod` diff moves a `k8s.io/*` module across minor families (guard rules) | Computed from metadata + diff only, before any CI/log read | close | Comment `/close` + reason | yes | [Details: K8s minor-version guard](#details-k8s-minor-version-guard) |
+| 15 | 0 | Needs rebase | `needs-rebase` label or `mergeable` = CONFLICTING | Computed from metadata only, before any CI/log read; evaluate after the K8s close-guard | bot-rebase | Comment `@dependabot rebase` | yes | [Details: Needs rebase](#details-needs-rebase) |
+| 17 | 0 | Retry budget exhausted | Highest `Unblock attempt: N` stamp in PR comment history is `>= 3` (a 4th attempt would exceed the budget of 3) | Computed from comment metadata only, before any CI/log read; evaluate after the needs-rebase guard | escalate | Do nothing; report the PR as needing human review in the final output | yes | [Details: Retry budget exhausted](#details-retry-budget-exhausted) |
+| 20 | 2 | go-mod-consistency failed | `go-mod-consistency` job failed | Clean tree, or dirty only because of the dependency bump; stage only sync output | auto-fix | Run `sync-go-modules`, push, `/lgtm` | no | [Details: go-mod-consistency](#details-go-mod-consistency) |
+| 30 | 2 | Public-IP quota e2e flake | Failing log has `PublicIPCountLimitReached` / `PublicIPPrefixCountLimitReached` | Only `pull-*-e2e-*` failed; no non-e2e failure remains; skip if a push this triage already reruns the job | auto-fix | `/test <job>` per failed job | no | [Details: Public-IP quota e2e](#details-public-ip-quota-e2e) |
+| 35 | 2 | Image-build registry flake e2e | Failing e2e log has a container-registry 5xx during image build before any test runs, e.g. `502 Bad Gateway` from `registry-1.docker.io` resolving the BuildKit `docker/dockerfile` frontend | Only `pull-*-e2e-*` failed and the failure is in the image-build phase (no Ginkgo spec ran); no non-flake failure remains; skip if a push this triage already reruns the job | auto-fix | `/test <job>` per failed job | no | [Details: Image-build registry flake](#details-image-build-registry-flake) |
+| 37 | 2 | Cluster-provisioning node-readiness timeout e2e | Failing e2e log has `timed out waiting for the condition on nodes/<name>` during CAPZ cluster bring-up and ends with `EXIT_VALUE=124`, before any Ginkgo spec ran | Only `pull-*-e2e-*` failed and the timeout is in the cluster-provisioning phase (no Ginkgo spec ran); no non-flake failure remains; skip if a push this triage already reruns the job | auto-fix | `/test <job>` per failed job | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
+| 40 | 2 | Only Tide pending | No failed checks; only `tide` pending | PR does not already have `lgtm` label; no non-Tide check pending or failed | auto-fix | `/lgtm` | no | [Details: Only Tide pending](#details-only-tide-pending) |
+| 50 | 2 | Toolchain / SDK / policy blocker | Go-version panic, typecheck, mixed SDK majors, or dependency-review/license failure | Needs a human policy, toolchain, or dependency-version decision the agent must not make autonomously | escalate | Do nothing; report the PR as needing human review in the final output | no | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
+
+The **Details** cell links to the pattern's `## Details: <name>` subsection
+below (a GitHub-style slug of the heading), or is `—` when the Action cell is a
+complete instruction. Appending a pattern adds a row plus a subsection and
+points the row at the new slug; no existing links move.
+
+## Details: K8s minor-version guard
+
+Run this guard for every Dependabot Go module PR before inspecting CI or taking
+an unblock action. The goal is to close Kubernetes minor-version bumps early
+instead of spending automation time on checks that should not unblock the PR.
+
+Inspect the PR diff for `go.mod` changes to Kubernetes modules:
+
+```bash
+gh pr diff <pr> --patch | grep -E '^[+-][[:space:]]+(require[[:space:]]+)?(k8s\.io/[[:alnum:]_.\-/]+)[[:space:]]+v0\.[0-9]+\.[0-9]+'
+```
+
+Then apply these rules:
+
+- Compare removed and added lines by module path. A patch-only bump within the
+  same minor family is allowed, even when that minor family was already
+  mismatched with the release branch before the PR. For example, on
+  `release-1.34`, `k8s.io/api v0.35.4` to `v0.35.6` is allowed because the PR
+  did not introduce the `v0.35.x` family.
+- For any branch, an existing `k8s.io/*` module must not move from one minor
+  family to another, such as `v0.36.x` to `v0.37.x`, unless the user explicitly
+  asks for that Kubernetes minor bump.
+- For a PR targeting `release-1.N`, a newly added `k8s.io/*` module that has no
+  removed counterpart in the diff must use the `v0.N.x` family unless the user
+  explicitly asks for a different Kubernetes minor family.
+- The PR must not introduce a new mixed minor-family set. Existing mixed
+  families may receive patch bumps, but a new module or changed module must not
+  add a minor family that was not already present in the corresponding removed
+  `k8s.io/*` lines.
+
+If the guard finds a disallowed minor-family change, comment `/close` and stop
+for that PR. Put `/close` on the first line so Prow can parse it, then include
+the base branch, mismatched module lines, and expected minor family:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/close
+
+Reason: closing because this Dependabot PR introduces a disallowed Kubernetes minor-family change.
+Base branch: release-1.N; expected new k8s.io modules to use v0.N.x, or existing modules to stay in their removed minor family.
+Mismatched modules:
+- k8s.io/example v0.X.Y -> v0.Z.W
+EOF
+```
+
+Do not inspect CI, run module sync, comment `/lgtm`, post `/retest` or `/test`,
+or report the PR as requiring no action. Report the `/close` comment plus the
+mismatched module lines, the base branch, and the expected minor family. For a
+changed existing module, the expected minor family is the module's removed
+version; for a newly added module on `release-1.N`, it is `v0.N.x`.
+
+If the guard finds no `k8s.io/*` module changes, or only patch-level updates
+within the same minor family, continue with the matching workflow below.
+
+## Details: go-mod-consistency
+
+Use the shared `sync-go-modules` skill from this repo.
+
+1. Read `.agents/skills/sync-go-modules/SKILL.md`.
+2. Run the helper from the PR checkout. If the Dependabot branch is already
+   dirty only because of the dependency bump you are fixing, pass
+   `--allow-dirty` as that skill describes.
+3. Inspect the diff and stage only files produced by the sync:
+
+```bash
+git diff --stat
+git status --short
+git add <specific go.mod/go.sum/vendor files>
+git diff --cached --stat
+```
+
+4. Commit and push the fix to the PR branch:
+
+```bash
+git commit -m "Update Go modules"
+git push
+```
+
+5. After the push succeeds, post `/lgtm` following the shared
+   [Post-push /lgtm](#details-post-push-lgtm) rule. Fill its Reason with the
+   go-mod-consistency context: the pushed commit, the changed
+   `go.mod`/`go.sum`/vendor files, and the `sync-go-modules` check that passed.
+
+## Details: Post-push /lgtm
+
+Shared rule for any pattern whose Action pushes a commit to the PR branch
+(today: [go-mod-consistency](#details-go-mod-consistency)). Link here from a new
+push-based pattern instead of copying the `/lgtm` recipe.
+
+Readiness gate — post `/lgtm` only when the push leaves the PR otherwise ready
+for review:
+
+- Every other failing required job this triage is already resolved or maps to a
+  matched row whose Action has been taken.
+- No `escalate` blocker (e.g. the Pri 50
+  [Toolchain / SDK / policy](#details-toolchain--sdk--policy) row) matched this
+  triage. If one did, the PR needs human review and must not be approved — a
+  push that fixes one job must not `/lgtm` a PR that still needs a policy or
+  toolchain decision.
+
+When the gate holds, put `/lgtm` on the first line so Prow can parse it, then
+give a Reason naming the pushed commit, the changed files, and the validation
+that passed. Because this Action pushes a commit and leaves the PR for another
+CI round, it is a non-final action: stamp it with this round's attempt number per
+the [Attempt stamp](#details-attempt-stamp) rule (`Unblock attempt: <N+1>`,
+using the same `N + 1` as any other non-final comment this round):
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/lgtm
+
+Reason: pushed a fix for this Dependabot PR and the PR is otherwise ready for review.
+Commit: <sha>
+Files: <files changed by the push>
+Validation: <check command> passed.
+Unblock attempt: <N+1>
+EOF
+```
+
+The push reruns CI. Do not add a `/test <job-name>` comment just for the old
+failed run after pushing a new commit; the push-triggered rerun supersedes it.
+
+## Details: Attempt stamp
+
+Shared rule for any Phase-2 non-final action — a `Stop=no` row whose Action
+posts a comment or push that leaves the PR for another CI round rather than
+terminating triage. Today that is [go-mod-consistency](#details-go-mod-consistency)
+(push + `/lgtm`), [Public-IP quota e2e](#details-public-ip-quota-e2e),
+[Image-build registry flake](#details-image-build-registry-flake), and
+[Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout)
+(each `/test <job-name>`). Link here from a new non-final pattern instead of
+copying the stamp recipe.
+
+The skill keeps no state between runs, so the attempt count lives in the PR's
+own comment history. Count triage **rounds**, not comments: one triage may push
+a module-sync fix and rerun three e2e jobs, but that is a single attempt.
+
+Compute the next attempt number once, at the start of Phase 2, before posting
+any non-final comment this round:
+
+```bash
+# Highest existing "Unblock attempt: N" stamp across all PR comments; 0 if none.
+gh pr view <pr> --json comments \
+  --jq '[.comments[].body | capture("Unblock attempt: (?<n>[0-9]+)"; "g").n | tonumber] | max // 0'
+```
+
+Let `N` be that maximum. This round's attempt number is `N + 1`. Use the **same**
+`N + 1` for every non-final comment posted this round, so a round that pushes a
+fix and reruns three jobs stamps `Unblock attempt: <N+1>` on all four comments
+rather than incrementing per comment.
+
+Add the stamp as its own line in the `Reason` block of each non-final comment,
+after the existing Reason text:
+
+```
+Unblock attempt: <N+1>
+```
+
+The stamp is what the Phase-0 [Retry budget exhausted](#details-retry-budget-exhausted)
+guard reads on the next run. Terminal actions do not stamp: `/close`
+(K8s guard), `@dependabot rebase` (needs-rebase), the `escalate`
+[Toolchain / SDK / policy](#details-toolchain--sdk--policy) and
+[Retry budget exhausted](#details-retry-budget-exhausted) handoffs (which post no
+comment at all), and the [Only Tide pending](#details-only-tide-pending) `/lgtm`
+carry no `Unblock attempt:` line, because none of them hand the PR to another
+automated retry round.
+
+## Details: Public-IP quota e2e
+
+Use this path only when the failed jobs are exclusively
+`pull-cloud-provider-azure-e2e-*` jobs and the failing logs show one of:
+
+- `PublicIPCountLimitReached`
+- `PublicIPPrefixCountLimitReached`
+
+Confirm the failure text from the job logs before retesting. If any non-e2e job
+also failed, handle that failure separately before blanket retesting.
+
+Rerun each failed e2e job with its own `/test <job-name>` comment. Put
+`/test <job-name>` on the first line, then include the quota marker found in that
+job's current Prow log:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/test <job-name>
+
+Reason: rerunning this failed e2e job because its current Prow log contains <PublicIPCountLimitReached or PublicIPPrefixCountLimitReached> and no non-e2e failure remains.
+Unblock attempt: <N+1>
+EOF
+```
+
+Post one such comment per failed e2e job. Do not use `/retest`; rerun each
+failed job by name so a still-broken required job is never blanket-rerun.
+
+If you are already pushing a commit for another fix, prefer the push-triggered
+CI rerun instead of adding a separate `/test` comment.
+
+## Details: Image-build registry flake
+
+Use this path only when the failed jobs are exclusively
+`pull-cloud-provider-azure-e2e-*` jobs and the failure happened in the
+pre-test image-build phase — before any Ginkgo spec ran — because a container
+registry returned a transient 5xx while BuildKit resolved a frontend or pulled
+a base image. The canonical fingerprint is a `502 Bad Gateway` from
+`registry-1.docker.io` while resolving the `docker/dockerfile` frontend, ending
+the build with a non-zero `make` exit (for example `make ... Error 2`,
+`EXIT_VALUE=2`) and no test output.
+
+Confirm from the job log before retesting:
+
+- The 5xx / registry error appears during image build (BuildKit, `docker build`,
+  or `make ... image`), not inside a running test.
+- No Ginkgo spec started — there is no `Running Suite` / `[It]` / spec summary,
+  so the failure cannot be a real test regression.
+
+If any Ginkgo spec ran and failed, or any non-e2e job failed, handle that
+failure separately instead of retesting.
+
+Rerun each failed e2e job with its own `/test <job-name>` comment. Put
+`/test <job-name>` on the first line, then include the registry error and the
+image-build phase marker found in that job's current Prow log:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/test <job-name>
+
+Reason: rerunning this failed e2e job because its current Prow log shows a transient container-registry 5xx during the image-build phase (before any test ran) and no non-flake failure remains.
+Unblock attempt: <N+1>
+EOF
+```
+
+Post one such comment per failed e2e job. Do not use `/retest`; rerun each
+failed job by name so a still-broken required job is never blanket-rerun.
+
+If you are already pushing a commit for another fix, prefer the push-triggered
+CI rerun instead of adding a separate `/test` comment.
+
+## Details: Cluster-provisioning node-readiness timeout
+
+Use this path only when the failed jobs are exclusively
+`pull-cloud-provider-azure-e2e-*` jobs and the failure is a CAPZ
+cluster-provisioning timeout — the harness gave up waiting for workload nodes to
+become Ready before any test ran. The canonical fingerprint is one or more
+`timed out waiting for the condition on nodes/<node-name>` lines during cluster
+bring-up, with the run ending in `EXIT_VALUE=124` (the `timeout` wrapper killed
+the wait) and no test output.
+
+Confirm from the job log before retesting:
+
+- One or more `timed out waiting for the condition on nodes/...` lines appear
+  during cluster provisioning (after `kubectl wait --for=condition=Ready`), not
+  inside a running test.
+- The run ends with `EXIT_VALUE=124` (or an equivalent `timeout`-driven
+  non-zero exit), which marks a watchdog timeout rather than a test assertion.
+- No Ginkgo spec started — there is no `Running Suite` / `[It]` / spec summary,
+  so the failure cannot be a real test regression.
+
+If any Ginkgo spec ran and failed, or any non-e2e job failed, handle that
+failure separately instead of retesting.
+
+Rerun each failed e2e job with its own `/test <job-name>` comment. Put
+`/test <job-name>` on the first line, then include the node-timeout marker and
+the provisioning-phase evidence found in that job's current Prow log:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/test <job-name>
+
+Reason: rerunning this failed e2e job because its current Prow log shows a cluster-provisioning node-readiness timeout (`timed out waiting for the condition on nodes/...`, EXIT_VALUE=124, before any test ran) and no non-flake failure remains.
+Unblock attempt: <N+1>
+EOF
+```
+
+Post one such comment per failed e2e job. Do not use `/retest`; rerun each
+failed job by name so a still-broken required job is never blanket-rerun.
+
+If you are already pushing a commit for another fix, prefer the push-triggered
+CI rerun instead of adding a separate `/test` comment.
+
+## Details: Only Tide pending
+
+Use this path when the current status rollup has no failed checks and the only
+pending status is `tide`.
+
+Check the PR labels from `gh pr view`. If the PR does not already have the
+`lgtm` label, comment `/lgtm` so Tide can re-evaluate the PR. Put `/lgtm` on the
+first line, then say that Tide is the only pending status and no checks are
+failing:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/lgtm
+
+Reason: no checks are failing, Tide is the only pending status, and the PR does not already have the lgtm label.
+EOF
+```
+
+If the PR already has the `lgtm` label, do not post a duplicate `/lgtm`
+comment. Report that no unblock action was needed and Tide is the only
+remaining pending status.
+
+Do not use this path when any non-Tide check is pending or failed. Report those
+checks explicitly and handle them through the matching workflow instead.
+
+## Details: Toolchain / SDK / policy
+
+These blockers need a human policy, toolchain, or dependency-version decision the
+agent must not make on its own:
+
+- `golangci-lint` or `Analyze (go)` fails with a Go toolchain mismatch, such as
+  `panic: file requires newer Go version ... (application built with ...)`
+- `golangci-lint` `typecheck` failures after an Azure SDK or Kubernetes module
+  bump
+- Mixed Azure SDK major versions, such as `armcompute/v6` consumers in a PR
+  that updated packages to `armcompute/v7`
+- `dependency-review`, vulnerability, or license failures where the resolution
+  may require accepting risk, excluding a finding, or changing the dependency
+  version
+
+When one of these matches, make no automated change: do not push code, do not
+change linter policy, do not broaden a dependency bump, do not edit generated
+Dependabot PR metadata, and do not `/lgtm`. Stop working the PR and report it as
+needing human review in the final output, naming the failing job(s) and the
+blocker type so a reviewer knows where to look.
+
+## Details: Needs rebase
+
+Evaluate this guard from PR metadata right after the K8s minor-version guard,
+before reading CI status or any Prow log. If the PR carries the `needs-rebase`
+label or `gh pr view` reports `mergeable` = `CONFLICTING`, the branch is out of
+date and `@dependabot rebase` will regenerate it — so classifying CI, syncing
+modules, or pushing a local fix first would be wasted work against a stale
+branch.
+
+Ask Dependabot to rebase the branch instead of manually rewriting the generated
+PR branch. Put `@dependabot rebase` on the first line, then say the branch is in
+a needs-rebase / conflicting state and must be rebased before Tide can merge it:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+@dependabot rebase
+
+Reason: the PR is in a needs-rebase or conflicting state and must be rebased before Tide can merge it.
+EOF
+```
+
+After posting the comment, stop triage for this PR. Do not inspect CI, sync
+modules, retest, comment `/lgtm`, or report no-action; Dependabot will push a
+rebased branch and a fresh CI run to triage next time.
+
+## Details: Retry budget exhausted
+
+Evaluate this guard from PR comment metadata as a Phase-0 step, right after the
+[Needs rebase](#details-needs-rebase) guard and before reading CI status or any
+Prow log. Its purpose is to cap automated churn: once this skill has already
+tried to unblock a PR three times without success, a fourth automated attempt is
+unlikely to help, so the PR goes to human reviewers instead of burning more
+CI on the same failing jobs.
+
+The count comes from the `Unblock attempt: N` stamps that non-final actions
+leave on the PR (see [Attempt stamp](#details-attempt-stamp)). Read the highest
+stamp already present:
+
+```bash
+gh pr view <pr> --json comments \
+  --jq '[.comments[].body | capture("Unblock attempt: (?<n>[0-9]+)"; "g").n | tonumber] | max // 0'
+```
+
+Let `N` be that maximum. The budget is three attempts, so:
+
+- `N < 3` — budget remains. Do not escalate; continue triage. A new non-final
+  action this run will stamp `Unblock attempt: <N+1>` per the
+  [Attempt stamp](#details-attempt-stamp) rule.
+- `N >= 3` — the budget is spent (a fourth attempt would exceed three). Stop
+  working the PR: make no automated change and report it as needing human review
+  in the final output.
+
+Escalation makes no change to the PR — no comment, no checks, no module sync, no
+push, no `/lgtm`. Because it posts nothing, it leaves no `Unblock attempt:` stamp
+and is safe to re-evaluate on every later run: once `N >= 3` the guard simply
+keeps reporting the PR as needing human review until a human resolves it. Report
+the PR in the final output with its remaining failing jobs so a reviewer knows
+where to look.

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -16,12 +16,10 @@ or acting on a row.
 | **Priority** | Gap-numbered (10, 20, 30…). Within a phase, the engine acts on matched rows low→high. New patterns slot into gaps without renumbering. |
 | **Phase** | `0` (guard, metadata/diff only) / `1` (classify) / `2` (act). Binds the row to an engine phase so guard rows are resolved before any CI/log I/O. |
 | **Pattern** | Short human name. |
-| **Detection signal** | What to match — the diff grep, the failing job name, or the log marker. A Phase-0 row's signal must be computable from metadata and the `go.mod` diff alone. |
-| **Preconditions / Exclusions** | Negative and dependency guards that must hold for the Action to be valid (e.g. "only e2e jobs failed", "no non-Tide check pending", "after other blockers resolved"). Never dropped into prose only. |
+| **Signal** | Compact routing hint: the diff marker, failing job name, or log fingerprint. A Phase-0 signal must be computable before CI/log I/O. |
 | **Autonomy** | `close` / `auto-fix` / `escalate` / `bot-rebase`. Governs whether the agent acts alone (see Autonomy values below). |
-| **Action** | One-line summary of the fix or Prow comment. |
 | **Stop** | `yes` = short-circuit; end triage after this row is handled. |
-| **Details** | Markdown anchor link to the pattern's `## Details: <name>` subsection in the same file. Details are **normative** — the agent must read them before matching/acting. `—` only when the Action and Preconditions cells are complete on their own. |
+| **Details** | Markdown anchor link to the pattern's `## Details: <name>` subsection in the same file. Details are **normative** and contain the full match criteria, preconditions, exclusions, and action. |
 
 ## Autonomy values
 
@@ -43,22 +41,23 @@ or acting on a row.
 
 ## Catalog
 
-| Pri | Phase | Pattern | Detection signal | Preconditions / Exclusions | Autonomy | Action | Stop | Details |
-|-----|-------|---------|------------------|----------------------------|----------|--------|------|---------|
-| 10 | 0 | K8s minor-version bump | `go.mod` diff moves a `k8s.io/*` module across minor families (guard rules) | Computed from metadata + diff only, before any CI/log read | close | Comment `/close` + reason | yes | [Details: K8s minor-version guard](#details-k8s-minor-version-guard) |
-| 15 | 0 | Needs rebase | `needs-rebase` label or `mergeable` = CONFLICTING | Computed from metadata only, before any CI/log read; evaluate after the K8s close-guard | bot-rebase | Comment `@dependabot rebase` | yes | [Details: Needs rebase](#details-needs-rebase) |
-| 17 | 0 | Retry budget exhausted | Highest `Unblock attempt: N` stamp in PR comment history is `>= 3` (a 4th attempt would exceed the budget of 3) | Computed from comment metadata only, before any CI/log read; evaluate after the needs-rebase guard | escalate | Do nothing; report the PR as needing human review in the final output | yes | [Details: Retry budget exhausted](#details-retry-budget-exhausted) |
-| 20 | 2 | go-mod-consistency failed | `go-mod-consistency` job failed | Clean tree, or dirty only because of the dependency bump; stage only sync output | auto-fix | Run `sync-go-modules`, push, `/lgtm` | no | [Details: go-mod-consistency](#details-go-mod-consistency) |
-| 30 | 2 | Public-IP quota e2e flake | Failing log has `PublicIPCountLimitReached` / `PublicIPPrefixCountLimitReached` | Only `pull-*-e2e-*` failed; no non-e2e failure remains; skip if a push this triage already reruns the job | auto-fix | `/test <job>` per failed job | no | [Details: Public-IP quota e2e](#details-public-ip-quota-e2e) |
-| 35 | 2 | Image-build registry flake e2e | Failing e2e log has a container-registry 5xx during image build before any test runs, e.g. `502 Bad Gateway` from `registry-1.docker.io` resolving the BuildKit `docker/dockerfile` frontend | Only `pull-*-e2e-*` failed and the failure is in the image-build phase (no Ginkgo spec ran); no non-flake failure remains; skip if a push this triage already reruns the job | auto-fix | `/test <job>` per failed job | no | [Details: Image-build registry flake](#details-image-build-registry-flake) |
-| 37 | 2 | Cluster-provisioning node-readiness timeout e2e | Failing e2e log has `timed out waiting for the condition on nodes/<name>` during CAPZ cluster bring-up and ends with `EXIT_VALUE=124`, before any Ginkgo spec ran | Only `pull-*-e2e-*` failed and the timeout is in the cluster-provisioning phase (no Ginkgo spec ran); no non-flake failure remains; skip if a push this triage already reruns the job | auto-fix | `/test <job>` per failed job | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
-| 40 | 2 | Only Tide pending | No failed checks; only `tide` pending | PR does not already have `lgtm` label; no non-Tide check pending or failed | auto-fix | `/lgtm` | no | [Details: Only Tide pending](#details-only-tide-pending) |
-| 50 | 2 | Toolchain / SDK / policy blocker | Go-version panic, typecheck, mixed SDK majors, or dependency-review/license failure | Needs a human policy, toolchain, or dependency-version decision the agent must not make autonomously | escalate | Do nothing; report the PR as needing human review in the final output | no | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
+| Pri | Phase | Pattern | Signal | Autonomy | Stop | Details |
+|-----|-------|---------|--------|----------|------|---------|
+| 10 | 0 | K8s minor-version bump | `k8s.io/*` `go.mod` minor-family change | close | yes | [Details: K8s minor-version guard](#details-k8s-minor-version-guard) |
+| 15 | 0 | Needs rebase | `needs-rebase` label or `mergeable` = CONFLICTING | bot-rebase | yes | [Details: Needs rebase](#details-needs-rebase) |
+| 17 | 0 | Retry budget exhausted | Highest `Unblock attempt: N` is `>= 3` | escalate | yes | [Details: Retry budget exhausted](#details-retry-budget-exhausted) |
+| 20 | 2 | go-mod-consistency failed | `go-mod-consistency` failed | auto-fix | no | [Details: go-mod-consistency](#details-go-mod-consistency) |
+| 30 | 2 | Public-IP quota e2e flake | Public-IP quota marker in e2e log | auto-fix | no | [Details: Public-IP quota e2e](#details-public-ip-quota-e2e) |
+| 35 | 2 | Image-build registry flake e2e | Registry 5xx during pre-test image build | auto-fix | no | [Details: Image-build registry flake](#details-image-build-registry-flake) |
+| 37 | 2 | Cluster-provisioning node-readiness timeout e2e | Node readiness timeout during pre-test cluster provisioning | auto-fix | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
+| 40 | 2 | Only Tide pending | No failed checks; only `tide` pending | auto-fix | no | [Details: Only Tide pending](#details-only-tide-pending) |
+| 50 | 2 | Toolchain / SDK / policy blocker | Toolchain, typecheck, SDK-major, or dependency-policy blocker | escalate | yes | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
 
 The **Details** cell links to the pattern's `## Details: <name>` subsection
-below (a GitHub-style slug of the heading), or is `—` when the Action cell is a
-complete instruction. Appending a pattern adds a row plus a subsection and
-points the row at the new slug; no existing links move.
+below (a GitHub-style slug of the heading). Appending a pattern adds a row plus
+a subsection and points the row at the new slug; no existing links move. Keep
+the table short: put full match criteria, preconditions, exclusions, and action
+steps in Details, not in routing columns.
 
 ## Details: K8s minor-version guard
 
@@ -69,7 +68,7 @@ instead of spending automation time on checks that should not unblock the PR.
 Inspect the PR diff for `go.mod` changes to Kubernetes modules:
 
 ```bash
-gh pr diff <pr> --patch | grep -E '^[+-][[:space:]]+(require[[:space:]]+)?(k8s\.io/[[:alnum:]_.\-/]+)[[:space:]]+v0\.[0-9]+\.[0-9]+'
+gh pr diff <pr> --patch | rg '^[+-][[:space:]]+(require[[:space:]]+)?(k8s\.io/[[:alnum:]_.\/-]+)[[:space:]]+v0\.[0-9]+\.[0-9]+' || true
 ```
 
 Then apply these rules:
@@ -145,7 +144,7 @@ git push
 
 ## Details: Post-push /lgtm
 
-Shared rule for any pattern whose Action pushes a commit to the PR branch
+Shared rule for any pattern whose action pushes a commit to the PR branch
 (today: [go-mod-consistency](#details-go-mod-consistency)). Link here from a new
 push-based pattern instead of copying the `/lgtm` recipe.
 
@@ -153,7 +152,7 @@ Readiness gate — post `/lgtm` only when the push leaves the PR otherwise ready
 for review:
 
 - Every other failing required job this triage is already resolved or maps to a
-  matched row whose Action has been taken.
+  matched row whose action has been taken.
 - No `escalate` blocker (e.g. the Pri 50
   [Toolchain / SDK / policy](#details-toolchain--sdk--policy) row) matched this
   triage. If one did, the PR needs human review and must not be approved — a
@@ -162,7 +161,7 @@ for review:
 
 When the gate holds, put `/lgtm` on the first line so Prow can parse it, then
 give a Reason naming the pushed commit, the changed files, and the validation
-that passed. Because this Action pushes a commit and leaves the PR for another
+that passed. Because this action pushes a commit and leaves the PR for another
 CI round, it is a non-final action: stamp it with this round's attempt number per
 the [Attempt stamp](#details-attempt-stamp) rule (`Unblock attempt: <N+1>`,
 using the same `N + 1` as any other non-final comment this round):
@@ -184,10 +183,11 @@ failed run after pushing a new commit; the push-triggered rerun supersedes it.
 
 ## Details: Attempt stamp
 
-Shared rule for any Phase-2 non-final action — a `Stop=no` row whose Action
+Shared rule for any Phase-2 non-final action — a `Stop=no` row whose action
 posts a comment or push that leaves the PR for another CI round rather than
 terminating triage. Today that is [go-mod-consistency](#details-go-mod-consistency)
-(push + `/lgtm`), [Public-IP quota e2e](#details-public-ip-quota-e2e),
+(push + `/lgtm`) and the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
+rule used by [Public-IP quota e2e](#details-public-ip-quota-e2e),
 [Image-build registry flake](#details-image-build-registry-flake), and
 [Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout)
 (each `/test <job-name>`). Link here from a new non-final pattern instead of
@@ -227,6 +227,37 @@ comment at all), and the [Only Tide pending](#details-only-tide-pending) `/lgtm`
 carry no `Unblock attempt:` line, because none of them hand the PR to another
 automated retry round.
 
+## Details: Shared e2e flake rerun
+
+Shared action for Phase-2 e2e rows that are classified as safe transient
+failures. Pattern-specific Details must supply the log fingerprint and any extra
+exclusions before using this rule.
+
+Before rerunning:
+
+- The failed jobs are exclusively `pull-*-e2e-*`; no non-e2e failure remains.
+- Each job being rerun has the pattern-specific fingerprint in its current Prow
+  log.
+- The pattern-specific exclusions do not apply.
+- A push in this triage has not already rerun the same job; prefer the
+  push-triggered CI rerun when there is one.
+
+Rerun each failed e2e job with its own `/test <job-name>` comment. Put
+`/test <job-name>` on the first line, then include the fingerprint evidence from
+that job's current Prow log:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/test <job-name>
+
+Reason: rerunning this failed e2e job because its current Prow log shows <pattern-specific evidence> and no non-flake failure remains.
+Unblock attempt: <N+1>
+EOF
+```
+
+Post one such comment per failed e2e job. Do not use `/retest`; rerun each
+failed job by name so a still-broken required job is never blanket-rerun.
+
 ## Details: Public-IP quota e2e
 
 Use this path only when the failed jobs are exclusively
@@ -235,27 +266,9 @@ Use this path only when the failed jobs are exclusively
 - `PublicIPCountLimitReached`
 - `PublicIPPrefixCountLimitReached`
 
-Confirm the failure text from the job logs before retesting. If any non-e2e job
-also failed, handle that failure separately before blanket retesting.
-
-Rerun each failed e2e job with its own `/test <job-name>` comment. Put
-`/test <job-name>` on the first line, then include the quota marker found in that
-job's current Prow log:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/test <job-name>
-
-Reason: rerunning this failed e2e job because its current Prow log contains <PublicIPCountLimitReached or PublicIPPrefixCountLimitReached> and no non-e2e failure remains.
-Unblock attempt: <N+1>
-EOF
-```
-
-Post one such comment per failed e2e job. Do not use `/retest`; rerun each
-failed job by name so a still-broken required job is never blanket-rerun.
-
-If you are already pushing a commit for another fix, prefer the push-triggered
-CI rerun instead of adding a separate `/test` comment.
+Confirm the failure text from each job's current Prow log before retesting. If
+the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
+and fill the evidence with the quota marker found in that job's log.
 
 ## Details: Image-build registry flake
 
@@ -278,24 +291,8 @@ Confirm from the job log before retesting:
 If any Ginkgo spec ran and failed, or any non-e2e job failed, handle that
 failure separately instead of retesting.
 
-Rerun each failed e2e job with its own `/test <job-name>` comment. Put
-`/test <job-name>` on the first line, then include the registry error and the
-image-build phase marker found in that job's current Prow log:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/test <job-name>
-
-Reason: rerunning this failed e2e job because its current Prow log shows a transient container-registry 5xx during the image-build phase (before any test ran) and no non-flake failure remains.
-Unblock attempt: <N+1>
-EOF
-```
-
-Post one such comment per failed e2e job. Do not use `/retest`; rerun each
-failed job by name so a still-broken required job is never blanket-rerun.
-
-If you are already pushing a commit for another fix, prefer the push-triggered
-CI rerun instead of adding a separate `/test` comment.
+If the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
+and fill the evidence with the registry 5xx plus the image-build phase marker.
 
 ## Details: Cluster-provisioning node-readiness timeout
 
@@ -320,24 +317,9 @@ Confirm from the job log before retesting:
 If any Ginkgo spec ran and failed, or any non-e2e job failed, handle that
 failure separately instead of retesting.
 
-Rerun each failed e2e job with its own `/test <job-name>` comment. Put
-`/test <job-name>` on the first line, then include the node-timeout marker and
-the provisioning-phase evidence found in that job's current Prow log:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-/test <job-name>
-
-Reason: rerunning this failed e2e job because its current Prow log shows a cluster-provisioning node-readiness timeout (`timed out waiting for the condition on nodes/...`, EXIT_VALUE=124, before any test ran) and no non-flake failure remains.
-Unblock attempt: <N+1>
-EOF
-```
-
-Post one such comment per failed e2e job. Do not use `/retest`; rerun each
-failed job by name so a still-broken required job is never blanket-rerun.
-
-If you are already pushing a commit for another fix, prefer the push-triggered
-CI rerun instead of adding a separate `/test` comment.
+If the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
+and fill the evidence with the node-timeout marker, `EXIT_VALUE=124`, and the
+fact that no test ran.
 
 ## Details: Only Tide pending
 

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -24,7 +24,8 @@ or acting on a row.
 ## Autonomy values
 
 - `close` — comment `/close` and stop (disallowed change).
-- `auto-fix` — the agent may act alone (push, `/lgtm`, `/test <job-name>`)
+- `auto-fix` — the agent may act alone (push, `/lgtm`, `/test <job-name>`,
+  `gh run rerun`)
   because the fix is deterministic and low-risk.
 - `escalate` — the agent makes no automated change: it posts no PR comment, runs
   no checks, syncs no modules, and does not touch code, CI policy, or dependency
@@ -52,6 +53,7 @@ or acting on a row.
 | 37 | act | Cluster-provisioning node-readiness timeout e2e | Node readiness timeout during pre-test cluster provisioning | auto-fix | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
 | 39 | act | Prow pod scheduling timeout e2e | Prow job pod never schedules | auto-fix | no | [Details: Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout) |
 | 40 | act | Only Tide pending | No failed checks; only `tide` pending | auto-fix | no | [Details: Only Tide pending](#details-only-tide-pending) |
+| 45 | act | GitHub Actions transient failure | Failed GitHub Actions `CheckRun` with runner/service transient evidence | auto-fix | no | [Details: GitHub Actions transient failure](#details-github-actions-transient-failure) |
 | 50 | act | Toolchain / SDK / policy blocker | Toolchain, typecheck, SDK-major, or dependency-policy blocker | escalate | yes | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
 
 The **Details** cell links to the pattern's `## Details: <name>` subsection
@@ -185,15 +187,18 @@ failed run after pushing a new commit; the push-triggered rerun supersedes it.
 ## Details: Attempt stamp
 
 Shared rule for any act-stage non-final action — a `Stop=no` row whose action
-posts a comment or push that leaves the PR for another CI round rather than
-terminating triage. Today that is [go-mod-consistency](#details-go-mod-consistency)
-(push + `/lgtm`) and the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
-rule used by [Public-IP quota e2e](#details-public-ip-quota-e2e),
-[Image-build registry flake](#details-image-build-registry-flake), and
+posts a comment, pushes, or triggers a CI rerun that leaves the PR for another
+CI round rather than terminating triage. Today that is
+[go-mod-consistency](#details-go-mod-consistency) (push + `/lgtm`),
+the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun) rule used by
+[Public-IP quota e2e](#details-public-ip-quota-e2e),
+[Image-build registry flake](#details-image-build-registry-flake),
 [Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout),
 and [Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout)
-(each `/test <job-name>`). Link here from a new non-final pattern instead of
-copying the stamp recipe.
+(each `/test <job-name>`), and
+[GitHub Actions transient failure](#details-github-actions-transient-failure)
+(`gh run rerun`). Link here from a new non-final pattern instead of copying the
+stamp recipe.
 
 The skill keeps no state between runs, so the attempt count lives in the PR's
 own comment history. Count triage **rounds**, not comments: one triage may push
@@ -214,7 +219,9 @@ fix and reruns three jobs stamps `Unblock attempt: <N+1>` on all four comments
 rather than incrementing per comment.
 
 Add the stamp as its own line in the `Reason` block of each non-final comment,
-after the existing Reason text:
+after the existing Reason text. GitHub Actions reruns are triggered by API rather
+than by PR slash command; after the rerun succeeds, record the attempt with a
+plain informational comment that has no slash command.
 
 ```
 Unblock attempt: <N+1>
@@ -375,6 +382,58 @@ remaining pending status.
 Do not use this path when any non-Tide check is pending or failed. Report those
 checks explicitly and handle them through the matching workflow instead.
 
+## Details: GitHub Actions transient failure
+
+Use this path only for failed GitHub Actions `CheckRun` entries, not Prow
+`StatusContext` jobs. The failure must be retryable infrastructure or GitHub
+Actions service noise, not a deterministic repository command failure.
+
+Confirm from `gh pr view --json statusCheckRollup`, `gh run view`, and the
+current GitHub Actions logs before rerunning:
+
+- The failed item is a GitHub Actions `CheckRun` with a `detailsUrl` under
+  `https://github.com/.../actions/runs/...`.
+- The failed job log shows runner, service, download, cache, or network evidence
+  that is outside the repository's code path, such as a GitHub Actions service
+  error, runner shutdown, action download failure, cache service 5xx, or
+  transient network failure before the checked command produced a meaningful
+  project error.
+- No failed step contains a deterministic compile, test, lint, module, license,
+  vulnerability, or policy failure. Those must use a more specific row or the
+  [Toolchain / SDK / policy](#details-toolchain--sdk--policy) escalation row.
+- Every other failing required job either matches this row or another act row
+  whose action has been taken. Do not rerun one GitHub Actions job while leaving
+  another failing required job unclassified.
+
+Rerun through GitHub Actions, not through a PR slash command:
+
+```bash
+# Rerun every failed job in the workflow run when all failed jobs are retryable.
+gh run rerun <run-id> --failed
+```
+
+If only one failed job in the workflow is retryable, rerun that specific job.
+Use the job's `databaseId`, not the numeric job id from the browser URL:
+
+```bash
+gh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId, conclusion}'
+gh run rerun <run-id> --job <databaseId>
+```
+
+Do not comment `/retest`, `/test <job-name>`, or any other Prow directive for a
+GitHub Actions check. Record the retry-budget attempt with a plain informational
+comment after `gh run rerun` succeeds:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+Reason: reran GitHub Actions check <check-name> because its current logs show <transient evidence>.
+Run: <run-url>
+Unblock attempt: <N+1>
+EOF
+```
+
+Report the rerun command, workflow run id, and target job(s) in the final output.
+
 ## Details: Toolchain / SDK / policy
 
 These blockers need a human policy, toolchain, or dependency-version decision the
@@ -386,6 +445,9 @@ agent must not make on its own:
   bump
 - Mixed Azure SDK major versions, such as `armcompute/v6` consumers in a PR
   that updated packages to `armcompute/v7`
+- GitHub Actions failures where the failed step reached a deterministic
+  repository command error instead of matching
+  [GitHub Actions transient failure](#details-github-actions-transient-failure)
 - `dependency-review`, vulnerability, or license failures where the resolution
   may require accepting risk, excluding a finding, or changing the dependency
   version

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -2,7 +2,7 @@
 
 This catalog is the pluggable pattern list for the
 [`unblock-dependabot-pr`](../SKILL.md) engine. The engine never hard-codes a
-pattern; it walks the table below by the phased algorithm in `SKILL.md`. Adding
+pattern; it walks the table below by the staged algorithm in `SKILL.md`. Adding
 a newly discovered failure pattern is a single-file edit here: append a row to
 the table and add a matching `## Details: <name>` subsection.
 
@@ -13,10 +13,10 @@ or acting on a row.
 
 | Column | Purpose |
 |--------|---------|
-| **Priority** | Gap-numbered (10, 20, 30…). Within a phase, the engine acts on matched rows low→high. New patterns slot into gaps without renumbering. |
-| **Phase** | `0` (guard, metadata/diff only) / `1` (classify) / `2` (act). Binds the row to an engine phase so guard rows are resolved before any CI/log I/O. |
+| **Priority** | Gap-numbered (10, 20, 30…). Within a stage, the engine acts on matched rows low→high. New patterns slot into gaps without renumbering. |
+| **Stage** | `guard` (metadata/diff/comment-history only) or `act` (CI/log/artifact-based action). Classification is an engine gate between these stages, not a catalog row. |
 | **Pattern** | Short human name. |
-| **Signal** | Compact routing hint: the diff marker, failing job name, or log fingerprint. A Phase-0 signal must be computable before CI/log I/O. |
+| **Signal** | Compact routing hint: the diff marker, failing job name, or log fingerprint. A guard signal must be computable before CI/log I/O. |
 | **Autonomy** | `close` / `auto-fix` / `escalate` / `bot-rebase`. Governs whether the agent acts alone (see Autonomy values below). |
 | **Stop** | `yes` = short-circuit; end triage after this row is handled. |
 | **Details** | Markdown anchor link to the pattern's `## Details: <name>` subsection in the same file. Details are **normative** and contain the full match criteria, preconditions, exclusions, and action. |
@@ -29,30 +29,30 @@ or acting on a row.
 - `escalate` — the agent makes no automated change: it posts no PR comment, runs
   no checks, syncs no modules, and does not touch code, CI policy, or dependency
   versions. It stops working the PR and reports it as needing human review in its
-  final output. Used both as a Phase-0 guard when the automated retry budget is
-  spent (Retry budget exhausted) and as a Phase-2 flag when a blocker needs a
+  final output. Used both as a guard when the automated retry budget is spent
+  (Retry budget exhausted) and as an act-stage flag when a blocker needs a
   human policy or toolchain decision (Toolchain / SDK / policy).
 - `bot-rebase` — post a bot directive (`@dependabot rebase`) that regenerates
   the branch, then stop; distinct from `escalate` because it directs another
   bot to regenerate the branch rather than handing the PR to a human reviewer.
-  The needs-rebase row uses this as a Phase-0 guard: a conflicting branch is
-  detected from metadata and handed to Dependabot before any CI/log I/O, since a
-  rebase invalidates a stale CI run anyway.
+  The needs-rebase row uses this as a guard: a conflicting branch is detected
+  from metadata and handed to Dependabot before any CI/log I/O, since a rebase
+  invalidates a stale CI run anyway.
 
 ## Catalog
 
-| Pri | Phase | Pattern | Signal | Autonomy | Stop | Details |
+| Pri | Stage | Pattern | Signal | Autonomy | Stop | Details |
 |-----|-------|---------|--------|----------|------|---------|
-| 10 | 0 | K8s minor-version bump | `k8s.io/*` `go.mod` minor-family change | close | yes | [Details: K8s minor-version guard](#details-k8s-minor-version-guard) |
-| 15 | 0 | Needs rebase | `needs-rebase` label or `mergeable` = CONFLICTING | bot-rebase | yes | [Details: Needs rebase](#details-needs-rebase) |
-| 17 | 0 | Retry budget exhausted | Highest `Unblock attempt: N` is `>= 3` | escalate | yes | [Details: Retry budget exhausted](#details-retry-budget-exhausted) |
-| 20 | 2 | go-mod-consistency failed | `go-mod-consistency` failed | auto-fix | no | [Details: go-mod-consistency](#details-go-mod-consistency) |
-| 30 | 2 | Public-IP quota e2e flake | Public-IP quota marker in e2e log | auto-fix | no | [Details: Public-IP quota e2e](#details-public-ip-quota-e2e) |
-| 35 | 2 | Image-build registry flake e2e | Registry 5xx during pre-test image build | auto-fix | no | [Details: Image-build registry flake](#details-image-build-registry-flake) |
-| 37 | 2 | Cluster-provisioning node-readiness timeout e2e | Node readiness timeout during pre-test cluster provisioning | auto-fix | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
-| 39 | 2 | Prow pod scheduling timeout e2e | Prow job pod never schedules | auto-fix | no | [Details: Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout) |
-| 40 | 2 | Only Tide pending | No failed checks; only `tide` pending | auto-fix | no | [Details: Only Tide pending](#details-only-tide-pending) |
-| 50 | 2 | Toolchain / SDK / policy blocker | Toolchain, typecheck, SDK-major, or dependency-policy blocker | escalate | yes | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
+| 10 | guard | K8s minor-version bump | `k8s.io/*` `go.mod` minor-family change | close | yes | [Details: K8s minor-version guard](#details-k8s-minor-version-guard) |
+| 15 | guard | Needs rebase | `needs-rebase` label or `mergeable` = CONFLICTING | bot-rebase | yes | [Details: Needs rebase](#details-needs-rebase) |
+| 17 | guard | Retry budget exhausted | Highest `Unblock attempt: N` is `>= 3` | escalate | yes | [Details: Retry budget exhausted](#details-retry-budget-exhausted) |
+| 20 | act | go-mod-consistency failed | `go-mod-consistency` failed | auto-fix | no | [Details: go-mod-consistency](#details-go-mod-consistency) |
+| 30 | act | Public-IP quota e2e flake | Public-IP quota marker in e2e log | auto-fix | no | [Details: Public-IP quota e2e](#details-public-ip-quota-e2e) |
+| 35 | act | Image-build registry flake e2e | Registry 5xx during pre-test image build | auto-fix | no | [Details: Image-build registry flake](#details-image-build-registry-flake) |
+| 37 | act | Cluster-provisioning node-readiness timeout e2e | Node readiness timeout during pre-test cluster provisioning | auto-fix | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
+| 39 | act | Prow pod scheduling timeout e2e | Prow job pod never schedules | auto-fix | no | [Details: Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout) |
+| 40 | act | Only Tide pending | No failed checks; only `tide` pending | auto-fix | no | [Details: Only Tide pending](#details-only-tide-pending) |
+| 50 | act | Toolchain / SDK / policy blocker | Toolchain, typecheck, SDK-major, or dependency-policy blocker | escalate | yes | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
 
 The **Details** cell links to the pattern's `## Details: <name>` subsection
 below (a GitHub-style slug of the heading). Appending a pattern adds a row plus
@@ -184,7 +184,7 @@ failed run after pushing a new commit; the push-triggered rerun supersedes it.
 
 ## Details: Attempt stamp
 
-Shared rule for any Phase-2 non-final action — a `Stop=no` row whose action
+Shared rule for any act-stage non-final action — a `Stop=no` row whose action
 posts a comment or push that leaves the PR for another CI round rather than
 terminating triage. Today that is [go-mod-consistency](#details-go-mod-consistency)
 (push + `/lgtm`) and the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
@@ -199,7 +199,7 @@ The skill keeps no state between runs, so the attempt count lives in the PR's
 own comment history. Count triage **rounds**, not comments: one triage may push
 a module-sync fix and rerun three e2e jobs, but that is a single attempt.
 
-Compute the next attempt number once, at the start of Phase 2, before posting
+Compute the next attempt number once, at the start of the act stage, before posting
 any non-final comment this round:
 
 ```bash
@@ -220,8 +220,8 @@ after the existing Reason text:
 Unblock attempt: <N+1>
 ```
 
-The stamp is what the Phase-0 [Retry budget exhausted](#details-retry-budget-exhausted)
-guard reads on the next run. Terminal actions do not stamp: `/close`
+The stamp is what the guard-stage [Retry budget exhausted](#details-retry-budget-exhausted)
+row reads on the next run. Terminal actions do not stamp: `/close`
 (K8s guard), `@dependabot rebase` (needs-rebase), the `escalate`
 [Toolchain / SDK / policy](#details-toolchain--sdk--policy) and
 [Retry budget exhausted](#details-retry-budget-exhausted) handoffs (which post no
@@ -231,7 +231,7 @@ automated retry round.
 
 ## Details: Shared e2e flake rerun
 
-Shared action for Phase-2 e2e rows that are classified as safe transient
+Shared action for act-stage e2e rows that are classified as safe transient
 failures. Pattern-specific Details must supply the fingerprint evidence and any
 extra exclusions before using this rule.
 
@@ -423,7 +423,7 @@ rebased branch and a fresh CI run to triage next time.
 
 ## Details: Retry budget exhausted
 
-Evaluate this guard from PR comment metadata as a Phase-0 step, right after the
+Evaluate this guard from PR comment metadata as a guard-stage step, right after the
 [Needs rebase](#details-needs-rebase) guard and before reading CI status or any
 Prow log. Its purpose is to cap automated churn: once this skill has already
 tried to unblock a PR three times without success, a fourth automated attempt is


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactors the `unblock-dependabot-pr` agent skill (under `.agents/skills/`) from a
monolithic body into a thin engine plus an appendable failure-pattern catalog, so
adding a newly discovered CI failure mode is a single table-row edit instead of a
rewrite of the skill.

- Split the skill into a thin engine (`SKILL.md`) that walks the catalog by a
  staged algorithm, and a data-driven catalog (`references/failure-patterns.md`)
  where each failure mode is one table row plus a `## Details:` subsection.
- Model triage as guard rows, a classification gate, and act rows: guard rows
  run from metadata, diff, and comment history before any CI or log I/O;
  classification maps every failing required job to a known act row; act rows run
  by ascending priority with action-effect de-duplication.
- Promote needs-rebase and retry-budget checks to guard rows, while keeping
  transient CI and e2e failure handling in act rows.
- Add a retry-budget guard that stops automated retries and reports the PR as
  needing human review after three attempts, with attempt counts derived
  statelessly from `Unblock attempt: N` stamps in the PR's own comment history.
- Add a GitHub Actions transient-failure pattern that reruns matching failed
  Actions jobs with `gh run rerun`, not with Prow slash commands such as
  `/retest` or `/test`.

No product code, build, or runtime behavior changes; this only touches agent
skill documentation.

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

Scope is limited to `.agents/skills/unblock-dependabot-pr/`. The catalog has
only `guard` and `act` stages; classification is an engine gate, not a catalog
row. The safety invariant is unchanged: every failing required job must map to a
matched act row before the skill takes an automated action.

Retry actions now explicitly follow the CI system that produced the failure:
Prow jobs use per-job `/test <job-name>` comments and never `/retest`, while
GitHub Actions check runs use `gh run rerun`. Autonomy tokens (`close`,
`auto-fix`, `escalate`, `bot-rebase`) remain labels whose procedures live in
each row's `## Details:` section, so patterns can be appended without touching
control flow.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
