### PR TITLE
fix: match ACR regional (geo-replica) login server endpoints in credential provider

### DIFF
--- a/examples/out-of-tree/credential-provider-config-win.yaml
+++ b/examples/out-of-tree/credential-provider-config-win.yaml
@@ -9,5 +9,9 @@ providers:
   - "*.azurecr.cn"
   - "*.azurecr.de"
   - "*.azurecr.us"
+  - "*.*.geo.azurecr.io"
+  - "*.*.geo.azurecr.cn"
+  - "*.*.geo.azurecr.de"
+  - "*.*.geo.azurecr.us"
   args:
   - c:\k\azure.json

--- a/examples/out-of-tree/credential-provider-config.yaml
+++ b/examples/out-of-tree/credential-provider-config.yaml
@@ -9,6 +9,10 @@ providers:
   - "*.azurecr.cn"
   - "*.azurecr.de"
   - "*.azurecr.us"
+  - "*.*.geo.azurecr.io"
+  - "*.*.geo.azurecr.cn"
+  - "*.*.geo.azurecr.de"
+  - "*.*.geo.azurecr.us"
   - "mcr.microsoft.com"
   args:
   - /etc/kubernetes/azure.json

--- a/pkg/credentialprovider/azure_credentials.go
+++ b/pkg/credentialprovider/azure_credentials.go
@@ -49,8 +49,12 @@ const (
 
 var (
 	containerRegistryUrls = []string{"*.azurecr.io", "*.azurecr.cn", "*.azurecr.de", "*.azurecr.us"}
-	// a valid acr image starts with alphanumerics, followed by corresponding acr domain name.
-	acrRE = regexp.MustCompile(`^[a-zA-Z0-9]+\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)`)
+	// a valid acr image starts with alphanumerics, followed by an optional
+	// regional login server segment (.<region>.geo), then the corresponding
+	// acr domain name. Examples:
+	//   foo.azurecr.io                 (global login server)
+	//   foo.eastus2.geo.azurecr.io     (regional login server)
+	acrRE = regexp.MustCompile(`^[a-zA-Z0-9]+(\.[a-zA-Z0-9]+\.geo)?\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)`)
 )
 
 // CredentialProvider is an interface implemented by the kubelet credential provider plugin to fetch

--- a/pkg/credentialprovider/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure_credentials_test.go
@@ -307,6 +307,31 @@ func TestParseACRLoginServerFromImage(t *testing.T) {
 			expected: "foo.azurecr.us",
 		},
 		{
+			// regional endpoint (geo-replicated Premium registry)
+			image:    "foo.eastus2.geo.azurecr.io/bar/image:version",
+			expected: "foo.eastus2.geo.azurecr.io",
+		},
+		{
+			// regional endpoint in a sovereign cloud
+			image:    "foo.chinaeast2.geo.azurecr.cn/bar/image:version",
+			expected: "foo.chinaeast2.geo.azurecr.cn",
+		},
+		{
+			// regional-looking host with a trailing suffix must not match
+			image:    "foo.eastus2.geo.azurecr.io.example/bar/image:version",
+			expected: "",
+		},
+		{
+			// dedicated data endpoints are not login servers and must not match
+			image:    "foo.eastus2.data.azurecr.io/bar/image:version",
+			expected: "",
+		},
+		{
+			// dedicated data endpoint in a sovereign cloud must not match either
+			image:    "foo.chinaeast2.data.azurecr.cn/bar/image:version",
+			expected: "",
+		},
+		{
 			image:    "foo.azurecr.my.cloud/bar/image:version",
 			expected: "foo.azurecr.my.cloud",
 		},

--- a/tests/e2e/auth/cred.go
+++ b/tests/e2e/auth/cred.go
@@ -91,6 +91,51 @@ var _ = Describe("Azure Credential Provider", Label(utils.TestSuiteLabelCredenti
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should be able to pull private images from an acr regional (geo) endpoint without docker secrets set explicitly", func() {
+		if os.Getenv(utils.AKSTestCCM) != "" {
+			Skip("Skip the regional endpoint test on the AKS pipeline: the node credential-provider matchImages config is managed by AgentBaker (tracked in Azure/AgentBaker#8862), not by this repo")
+		}
+
+		// Regional endpoints are per-geo-replica login servers of the form
+		// <registry>.<region>.geo.azurecr.io. They require the Premium SKU and can be
+		// enabled even without geo-replication. This verifies that the ACR credential
+		// provider authenticates pulls from a regional endpoint, not only the global one.
+		err = utils.AZACRLogin()
+		Expect(err).NotTo(HaveOccurred())
+
+		registry, err := tc.CreateContainerRegistry()
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			err = tc.DeleteContainerRegistry(*registry.Name)
+			if err != nil {
+				utils.Logf("failed to cleanup registry with error: %w", err)
+			}
+		}()
+
+		// Enable regional (geo) endpoints on the Premium registry.
+		err = utils.AZACREnableRegionalEndpoints(*registry.Name, tc.GetResourceGroup())
+		Expect(err).NotTo(HaveOccurred())
+
+		image := "nginx"
+		tag, err := tc.PushImageToACR(*registry.Name, image)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tag).NotTo(Equal(""))
+
+		regionalEndpoint, err := utils.GetACRRegionalEndpoint(*registry.Name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(regionalEndpoint).NotTo(Equal(""))
+
+		acrImageURL := fmt.Sprintf("%s/%s:%s", regionalEndpoint, image, tag)
+		podTemplate := createPodPullingFromACR(image, acrImageURL, "linux")
+		err = utils.CreatePod(cs, ns.Name, podTemplate)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := utils.WaitPodTo(v1.PodRunning, cs, podTemplate, ns.Name)
+		Expect(result).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should be able to create an ACR cache and pull images from it", func() {
 		if os.Getenv(utils.AKSTestCCM) != "" {
 			Skip("Skip the test for AKS pipeline for now")

--- a/tests/e2e/utils/container_registry_utils.go
+++ b/tests/e2e/utils/container_registry_utils.go
@@ -33,15 +33,17 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// CreateContainerRegistry creates a test acr
+// CreateContainerRegistry creates a Premium test acr. Premium is used for all tests
+// so they share a single SKU, and so features such as regional (geo) endpoints, which
+// require the Premium SKU, can be enabled on the same registry.
 func (tc *AzureTestClient) CreateContainerRegistry() (acr.Registry, error) {
 	acrClient := tc.createACRClient()
 	rgName, location := tc.GetResourceGroup(), tc.GetLocation()
 	acrName := "e2eacr" + string(uuid.NewUUID())[0:4]
 	template := acr.Registry{
 		SKU: &acr.SKU{
-			Name: to.Ptr(acr.SKUNameStandard),
-			Tier: to.Ptr(acr.SKUTierStandard),
+			Name: to.Ptr(acr.SKUNamePremium),
+			Tier: to.Ptr(acr.SKUTierPremium),
 		},
 		Name:     ptr.To(acrName),
 		Location: ptr.To(location),
@@ -175,4 +177,40 @@ func printAZVersion() {
 		Logf("az version failed with output %s\n error: %w", string(output), err)
 	}
 	Logf("az version success: %s", string(output))
+}
+
+// AZACREnableRegionalEndpoints enables regional (geo) endpoints on the given acr,
+// exposing per-geo-replica login servers of the form <registry>.<region>.geo.azurecr.io.
+func AZACREnableRegionalEndpoints(acrName, rg string) (err error) {
+	printAZVersion()
+	Logf("Attempting az acr update --regional-endpoints enabled for acr %q.", acrName)
+	cmd := exec.Command("az", "acr", "update",
+		"-n", acrName,
+		"-g", rg,
+		"--regional-endpoints", "enabled")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("az acr update --regional-endpoints enabled failed with output %s\n error: %w", string(output), err)
+	}
+	Logf("az acr update --regional-endpoints enabled success.")
+	return nil
+}
+
+// GetACRRegionalEndpoint returns the regional (geo) login server hostname for the
+// given acr, for example <registry>.<region>.geo.azurecr.io.
+func GetACRRegionalEndpoint(acrName string) (string, error) {
+	Logf("Attempting az acr show-endpoints for acr %q.", acrName)
+	cmd := exec.Command("az", "acr", "show-endpoints",
+		"-n", acrName,
+		"--query", "regionalEndpoints[0].endpoint",
+		"-o", "tsv")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("az acr show-endpoints failed for acr %s with error: %w", acrName, err)
+	}
+	endpoint := strings.TrimSpace(string(output))
+	if endpoint == "" {
+		return "", fmt.Errorf("no regional endpoint found for acr %s", acrName)
+	}
+	Logf("Regional endpoint for acr %s is %q.", acrName, endpoint)
+	return endpoint, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The ACR credential provider did not recognize Azure Container Registry **regional endpoints** — the per-geo-replica login servers of the form `myregistry.<region>.geo.azurecr.io` (for example, `myregistry.eastus2.geo.azurecr.io`).

Regional endpoints are login servers for a specific geo-replica. They let clients pull an image from a chosen geo-replica for predictable routing, in-region affinity, and client-side failover, and they can be referenced directly in image references and deployment manifests. See [How regional endpoints work](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication#how-regional-endpoints-work).

The `acrRE` regex only matched a single DNS label before the ACR suffix:

```
^[a-zA-Z0-9]+\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)
```

The `[a-zA-Z0-9]+` sub-pattern matches exactly one DNS label — a single run of alphanumeric characters with no dot — so the anchored expression only accepts a **single-label** registry name directly in front of the suffix and cannot match a host with any additional dot-separated labels before it. `myregistry.eastus2.geo.azurecr.io` carries two extra labels (`eastus2` and `geo`), so it does not match `acrRE`; on the primary matching path `parseACRLoginServerFromImage` returns `""` for a regional host (the behavior the unit tests capture, where `environment == nil`). See the note under **Special notes** for exactly what this does and does not change at AKS runtime.

This PR updates `acrRE` to accept an optional `.<region>.geo` segment:

```
^[a-zA-Z0-9]+(\.[a-zA-Z0-9]+\.geo)?\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)
```

Only the `.geo` login server form is matched. **Dedicated data endpoints** (`myregistry.<region>.data.azurecr.io`) are intentionally not matched: they are layer-blob-download redirect targets (the registry issues a 307 redirect to them during a pull) and never appear as the registry host in an image reference, so they never need a credential lookup. See the [endpoint reference](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-endpoint-reference#endpoint-types) for the distinction between regional `.geo` login servers and dedicated `.data` endpoints.

The change is minimal and self-contained: `GetCredentials` already inserts an exact-host auth entry for the parsed login server, so the existing `*.azurecr.*` response wildcards need no change. The downstream guard in `parseACRLoginServerFromImage` (trim the matched host, then require the remaining string to start with `/`) still correctly rejects lookalikes such as `foo.eastus2.geo.azurecr.io.example`.

#### Which issue(s) this PR fixes:

Fixes #10667

#### Special notes for your reviewer:

This PR has three parts:
- **Provider fix:** the `acrRE` pattern in `pkg/credentialprovider/azure_credentials.go`, plus table-driven unit tests in `azure_credentials_test.go` (regional `.geo` for a public and a sovereign cloud, a negative lookalike case, and negative cases asserting dedicated data endpoints `<registry>.<region>.data.azurecr.io` do not match).
- **Recommended config:** added the `*.*.geo.azurecr.*` patterns to the example out-of-tree `matchImages` config (`examples/out-of-tree/credential-provider-config.yaml` and `-win.yaml`) so kubelet invokes the provider for 5-part regional login servers. The CI credential-provider lanes consume this config.
- **E2E coverage:** a new test in `tests/e2e/auth/cred.go` (suite `Credential`) that creates a Premium registry with regional endpoints enabled, then pulls an image via `<registry>.<region>.geo.azurecr.io` with no image pull secrets. The existing credential e2e only exercised the global endpoint. This test skips on the AKS pipeline, where the node `matchImages` is managed by AgentBaker (tracked in **Azure/AgentBaker#8862**).

`go test ./pkg/credentialprovider/...`, `gofmt -l`, and `go vet ./pkg/credentialprovider/` are clean; the `tests` module builds and vets clean.

**Manual end-to-end validation on live AKS nodes** (Premium ACR, RBAC / non-ABAC, anonymous pull disabled, regional endpoints enabled; kubelet identity holds `AcrPull` via `az aks --attach-acr`):
- **Default AKS cluster:** a pod pulling from the regional endpoint `<registry>.<region>.geo.azurecr.io` gets `ImagePullBackOff` / `401`, while the global-endpoint control pod runs. Reconfirmed on a fresh cluster.
- **Isolating the gate:** adding only the geo `matchImages` patterns to the node config and keeping the **stock (unpatched)** provider binary (sha verified unchanged), then pulling a distinct never-cached image via the regional endpoint with `imagePullPolicy: Always`, **succeeds**. So the node `matchImages` config is the functional gate for AKS regional pulls; once kubelet invokes the provider, the current provider already resolves the regional host via its `environment.ContainerRegistryDNSSuffix` substring fallback.
- This PR makes the provider's **primary `acrRE` path** match regional `.geo` hosts explicitly (instead of relying on that fallback) and adds regression tests. It is a correctness/robustness improvement rather than the functional unblock, which is the node `matchImages` change ([Azure/AgentBaker#8862](https://github.com/Azure/AgentBaker/issues/8862)).

The functional fix for AKS regional pulls is the node `matchImages` change ([Azure/AgentBaker#8862](https://github.com/Azure/AgentBaker/issues/8862)); this PR is the provider-side correctness improvement and is correct independently.

#### Does this PR introduce a user-facing change?

```release-note
Match Azure Container Registry regional (geo-replica) login server endpoints of the form `<registry>.<region>.geo.azurecr.io` explicitly in the ACR credential provider's `acrRE` pattern, instead of relying on the fallback substring match, and add regression tests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [ACR regional endpoints (login servers for geo-replicas)]: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication#how-regional-endpoints-work
- [ACR endpoint reference (regional `.geo` vs dedicated data `.data`)]: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-endpoint-reference#endpoint-types
```




