### PR TITLE
docs: process dependabot failures one at a time

### DIFF
--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -89,15 +89,14 @@ or overwrite unrelated files.
 - When a row's Details action reruns CI (a push), skip any later row whose only
   effect would be to retest the jobs that push will rerun; prefer the
   push-triggered rerun.
-- Stamp every non-final action (an act-stage `Stop=no` comment, push, or GitHub
-  Actions rerun that leaves the PR for another CI round) with this triage's
-  attempt number, counted from the PR's own comment history. Once the automated
-  retry budget is spent, an `escalate` row makes no change to the PR — no
-  comment, no checks, no push — and the PR is reported as needing human review
-  in the final output. All of this is catalog-driven: the retry-budget guard
-  reads the stamps before any
-  CI/log I/O, and the shared attempt-stamp rule writes them. Do not invent a
-  separate counter.
+- After all non-final actions in a triage are complete, post one plain attempt
+  summary comment with this triage's attempt number, counted from the PR's own
+  comment history. Do not add an attempt marker to individual action comments.
+  Once the automated retry budget is spent, an `escalate` row makes no change
+  to the PR — no comment, no checks, no push — and the PR is reported as needing
+  human review in the final output. All of this is catalog-driven: the
+  retry-budget guard reads the summary before any CI/log I/O, and the shared
+  attempt-stamp rule writes it. Do not invent a separate counter.
 - A row marked Stop ends triage after it is handled.
 - Use the retry mechanism for the CI system that produced the failure, and only
   after the failure is classified as transient or safe to rerun. For Prow jobs,

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -39,13 +39,16 @@ Then walk the catalog as an explicit staged algorithm:
 > modules, retest, `/lgtm`, or report no-action.
 >
 > **Classification gate.** Only if no guard Stop fired: fetch CI status and
-> checkout as needed, then classify every failing required job. A PR is not
-> "unblocked" until every failing required job maps to a matched act row.
+> checkout as needed, then build the current failed required job list. Do not
+> require a full up-front classification before acting.
 >
-> **Act stage.** Walk matched act rows by ascending Priority, honoring
-> each row's linked Details preconditions and exclusions. Track the actions
-> already taken this triage: if an action reruns CI (a push), skip any later row
-> whose only effect would be to retest jobs that the push will rerun. Prefer the
+> **Act stage.** Process failed required jobs one at a time. For one failed job,
+> walk act rows by ascending Priority, inspect only enough current evidence to
+> match a row or escalate, take that row's linked Details action, then move to
+> the next failed job. Continue until every failed required job is examined,
+> resolved, rerun, superseded by a push, or escalated. Track the actions already
+> taken this triage: if an action reruns CI (a push), skip any later row whose
+> only effect would be to retest jobs that the push will rerun. Prefer the
 > push-triggered rerun. An act row marked Stop ends triage after it is handled.
 
 Classification inspects CI only after no guard Stop fired:
@@ -78,8 +81,11 @@ or overwrite unrelated files.
   I/O. When a guard row marked Stop matches, follow its linked
   Details action and end triage immediately — do not inspect CI, sync modules,
   retest, comment `/lgtm`, or report that no action is needed.
-- Act on matched rows in ascending Priority within each stage, and take a row's
-  linked Details action only when its Details preconditions and exclusions hold.
+- After the guard stage, handle failed required jobs one by one. For each failed
+  job, walk act rows in ascending Priority and take a row's linked Details
+  action only when its Details preconditions and exclusions hold. Do not stop
+  after the first fixed or rerun job unless a Stop row fired, a push made the
+  remaining failures stale, or every failed required job has been examined.
 - When a row's Details action reruns CI (a push), skip any later row whose only
   effect would be to retest the jobs that push will rerun; prefer the
   push-triggered rerun.

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -14,7 +14,7 @@ or acting on a row.
 | Column | Purpose |
 |--------|---------|
 | **Priority** | Gap-numbered (10, 20, 30…). Within a stage, the engine acts on matched rows low→high. New patterns slot into gaps without renumbering. |
-| **Stage** | `guard` (metadata/diff/comment-history only) or `act` (CI/log/artifact-based action). Classification is an engine gate between these stages, not a catalog row. |
+| **Stage** | `guard` (metadata/diff/comment-history only) or `act` (CI/log/artifact-based action). After the guard stage, the engine processes failed required jobs one at a time instead of classifying every failure up front. |
 | **Pattern** | Short human name. |
 | **Signal** | Compact routing hint: the diff marker, failing job name, or log fingerprint. A guard signal must be computable before CI/log I/O. |
 | **Autonomy** | `close` / `auto-fix` / `escalate` / `bot-rebase`. Governs whether the agent acts alone (see Autonomy values below). |
@@ -51,7 +51,7 @@ or acting on a row.
 | 30 | act | Public-IP quota e2e flake | Public-IP quota marker in e2e log | auto-fix | no | [Details: Public-IP quota e2e](#details-public-ip-quota-e2e) |
 | 35 | act | Image-build registry flake e2e | Registry 5xx during pre-test image build | auto-fix | no | [Details: Image-build registry flake](#details-image-build-registry-flake) |
 | 37 | act | Cluster-provisioning node-readiness timeout e2e | Node readiness timeout during pre-test cluster provisioning | auto-fix | no | [Details: Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout) |
-| 39 | act | Prow pod scheduling timeout e2e | Prow job pod never schedules | auto-fix | no | [Details: Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout) |
+| 39 | act | Prow job did not start | Prow job never reaches entrypoint | auto-fix | no | [Details: Prow job did not start](#details-prow-job-did-not-start) |
 | 40 | act | Only Tide pending | No failed checks; only `tide` pending | auto-fix | no | [Details: Only Tide pending](#details-only-tide-pending) |
 | 45 | act | GitHub Actions transient failure | Failed GitHub Actions `CheckRun` with runner/service transient evidence | auto-fix | no | [Details: GitHub Actions transient failure](#details-github-actions-transient-failure) |
 | 50 | act | Toolchain / SDK / policy blocker | Toolchain, typecheck, SDK-major, or dependency-policy blocker | escalate | yes | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
@@ -192,10 +192,11 @@ CI round rather than terminating triage. Today that is
 [go-mod-consistency](#details-go-mod-consistency) (push + `/lgtm`),
 the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun) rule used by
 [Public-IP quota e2e](#details-public-ip-quota-e2e),
-[Image-build registry flake](#details-image-build-registry-flake),
-[Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout),
-and [Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout)
-(each `/test <job-name>`), and
+[Image-build registry flake](#details-image-build-registry-flake), and
+[Cluster-provisioning node-readiness timeout](#details-cluster-provisioning-node-readiness-timeout)
+(each `/test <job-name>`),
+[Prow job did not start](#details-prow-job-did-not-start)
+(`/test <job-name>`), and
 [GitHub Actions transient failure](#details-github-actions-transient-failure)
 (`gh run rerun`). Link here from a new non-final pattern instead of copying the
 stamp recipe.
@@ -244,15 +245,17 @@ extra exclusions before using this rule.
 
 Before rerunning:
 
-- The failed jobs are exclusively `pull-*-e2e-*`; no non-e2e failure remains.
+- The job being rerun is a failed `pull-*-e2e-*` job.
 - Each job being rerun has the pattern-specific fingerprint in current Prow
   evidence: build log, `prowjob.json`, `podinfo.json`, or another listed
   artifact.
 - The pattern-specific exclusions do not apply.
+- Other failed required jobs are still processed by the per-failure loop; this
+  rerun is not a substitute for examining them.
 - A push in this triage has not already rerun the same job; prefer the
   push-triggered CI rerun when there is one.
 
-Rerun each failed e2e job with its own `/test <job-name>` comment. Put
+Rerun each matched failed e2e job with its own `/test <job-name>` comment. Put
 `/test <job-name>` on the first line, then include the fingerprint evidence from
 that job's current Prow artifacts:
 
@@ -260,33 +263,32 @@ that job's current Prow artifacts:
 gh pr comment <pr> --body-file - <<'EOF'
 /test <job-name>
 
-Reason: rerunning this failed e2e job because its current Prow artifacts show <pattern-specific evidence> and no non-flake failure remains.
+Reason: rerunning this failed e2e job because its current Prow artifacts show <pattern-specific evidence> and the pattern-specific exclusions do not apply.
 Unblock attempt: <N+1>
 EOF
 ```
 
-Post one such comment per failed e2e job. Do not use `/retest`; rerun each
+Post one such comment per matched failed e2e job. Do not use `/retest`; rerun each
 failed job by name so a still-broken required job is never blanket-rerun.
 
 ## Details: Public-IP quota e2e
 
-Use this path only when the failed jobs are exclusively
-`pull-cloud-provider-azure-e2e-*` jobs and the failing logs show one of:
+Use this path only for a failed `pull-cloud-provider-azure-e2e-*` job whose log
+shows one of:
 
 - `PublicIPCountLimitReached`
 - `PublicIPPrefixCountLimitReached`
 
-Confirm the failure text from each job's current Prow log before retesting. If
+Confirm the failure text from the job's current Prow log before retesting. If
 the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
 and fill the evidence with the quota marker found in that job's log.
 
 ## Details: Image-build registry flake
 
-Use this path only when the failed jobs are exclusively
-`pull-cloud-provider-azure-e2e-*` jobs and the failure happened in the
-pre-test image-build phase — before any Ginkgo spec ran — because a container
-registry returned a transient 5xx while BuildKit resolved a frontend or pulled
-a base image. The canonical fingerprint is a `502 Bad Gateway` from
+Use this path only for a failed `pull-cloud-provider-azure-e2e-*` job whose
+failure happened in the pre-test image-build phase — before any Ginkgo spec ran
+— because a container registry returned a transient 5xx while BuildKit resolved
+a frontend or pulled a base image. The canonical fingerprint is a `502 Bad Gateway` from
 `registry-1.docker.io` while resolving the `docker/dockerfile` frontend, ending
 the build with a non-zero `make` exit (for example `make ... Error 2`,
 `EXIT_VALUE=2`) and no test output.
@@ -298,16 +300,16 @@ Confirm from the job log before retesting:
 - No Ginkgo spec started — there is no `Running Suite` / `[It]` / spec summary,
   so the failure cannot be a real test regression.
 
-If any Ginkgo spec ran and failed, or any non-e2e job failed, handle that
-failure separately instead of retesting.
+If any Ginkgo spec ran and failed, handle that failure separately instead of
+retesting. Continue the per-failure loop for other failed required jobs.
 
 If the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
 and fill the evidence with the registry 5xx plus the image-build phase marker.
 
 ## Details: Cluster-provisioning node-readiness timeout
 
-Use this path only when the failed jobs are exclusively
-`pull-cloud-provider-azure-e2e-*` jobs and the failure is a CAPZ
+Use this path only for a failed `pull-cloud-provider-azure-e2e-*` job whose
+failure is a CAPZ
 cluster-provisioning timeout — the harness gave up waiting for workload nodes to
 become Ready before any test ran. The canonical fingerprint is one or more
 `timed out waiting for the condition on nodes/<node-name>` lines during cluster
@@ -324,25 +326,26 @@ Confirm from the job log before retesting:
 - No Ginkgo spec started — there is no `Running Suite` / `[It]` / spec summary,
   so the failure cannot be a real test regression.
 
-If any Ginkgo spec ran and failed, or any non-e2e job failed, handle that
-failure separately instead of retesting.
+If any Ginkgo spec ran and failed, handle that failure separately instead of
+retesting. Continue the per-failure loop for other failed required jobs.
 
 If the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
 and fill the evidence with the node-timeout marker, `EXIT_VALUE=124`, and the
 fact that no test ran.
 
-## Details: Prow pod scheduling timeout
+## Details: Prow job did not start
 
-Use this path only when a failed `pull-*-e2e-*` job never starts because Prow
-cannot schedule the job pod. This is a Prow infrastructure/capacity failure, not
-a cloud-provider-azure test failure.
+Use this path when a failed Prow job never reaches the job entrypoint because
+Prow infrastructure or capacity prevented the job pod from starting. This covers
+pod scheduling timeouts and similar pre-entrypoint failures. It is a Prow
+infrastructure/capacity failure, not a cloud-provider-azure test failure.
 
 Confirm from the current Prow artifacts before retesting:
 
-- `prowjob.json` has `status.state` = `error` and `status.description` =
-  `Pod scheduling timeout.`
+- `prowjob.json` has `status.state` = `error` and a pre-entrypoint
+  infrastructure description such as `Pod scheduling timeout.`
 - The artifact root has no `build-log.txt`, or the build log never reaches the
-  job entrypoint or any Ginkgo output.
+  job entrypoint.
 - `finished.json` has `result` = `error`.
 - `podinfo.json` shows the job pod stayed `Pending`, with `PodScheduled=False`
   and `reason=Unschedulable`, or `FailedScheduling` events such as
@@ -350,12 +353,24 @@ Confirm from the current Prow artifacts before retesting:
   `all available instance types exceed limits`.
 
 If the job pod starts and the build log reaches cluster provisioning or test
-execution, use a more specific pattern instead. If any non-e2e job failed,
-handle that failure separately instead of retesting.
+execution, use a more specific pattern instead.
 
-If the row matches, follow [Shared e2e flake rerun](#details-shared-e2e-flake-rerun)
-and fill the evidence with `Pod scheduling timeout.` plus the `podinfo.json`
-Unschedulable / FailedScheduling capacity marker.
+If the row matches, rerun that failed Prow job with its own `/test <job-name>`
+comment. Put `/test <job-name>` on the first line, then include the artifact
+evidence proving the job never reached its entrypoint:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+/test <job-name>
+
+Reason: rerunning this failed Prow job because its current artifacts show <pre-entrypoint infrastructure evidence>.
+Unblock attempt: <N+1>
+EOF
+```
+
+Continue the per-failure loop for other failed required jobs. Do not use
+`/retest`; rerun each failed Prow job by name so a still-broken required job is
+never blanket-rerun.
 
 ## Details: Only Tide pending
 
@@ -401,9 +416,8 @@ current GitHub Actions logs before rerunning:
 - No failed step contains a deterministic compile, test, lint, module, license,
   vulnerability, or policy failure. Those must use a more specific row or the
   [Toolchain / SDK / policy](#details-toolchain--sdk--policy) escalation row.
-- Every other failing required job either matches this row or another act row
-  whose action has been taken. Do not rerun one GitHub Actions job while leaving
-  another failing required job unclassified.
+- Continue the per-failure loop after the rerun. Do not report the PR as
+  unblocked while another failed required job remains unexamined.
 
 Rerun through GitHub Actions, not through a PR slash command:
 

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -164,10 +164,8 @@ for review:
 
 When the gate holds, put `/lgtm` on the first line so Prow can parse it, then
 give a Reason naming the pushed commit, the changed files, and the validation
-that passed. Because this action pushes a commit and leaves the PR for another
-CI round, it is a non-final action: stamp it with this round's attempt number per
-the [Attempt stamp](#details-attempt-stamp) rule (`Unblock attempt: <N+1>`,
-using the same `N + 1` as any other non-final comment this round):
+that passed. Do not add an attempt marker here; record this push in the single
+end-of-triage [Attempt stamp](#details-attempt-stamp) summary:
 
 ```bash
 gh pr comment <pr> --body-file - <<'EOF'
@@ -177,7 +175,6 @@ Reason: pushed a fix for this Dependabot PR and the PR is otherwise ready for re
 Commit: <sha>
 Files: <files changed by the push>
 Validation: <check command> passed.
-Unblock attempt: <N+1>
 EOF
 ```
 
@@ -186,9 +183,9 @@ failed run after pushing a new commit; the push-triggered rerun supersedes it.
 
 ## Details: Attempt stamp
 
-Shared rule for any act-stage non-final action — a `Stop=no` row whose action
-posts a comment, pushes, or triggers a CI rerun that leaves the PR for another
-CI round rather than terminating triage. Today that is
+Shared rule for a triage round with one or more act-stage non-final actions — a
+`Stop=no` row whose action posts a comment, pushes, or triggers a CI rerun that
+leaves the PR for another CI round rather than terminating triage. Today that is
 [go-mod-consistency](#details-go-mod-consistency) (push + `/lgtm`),
 the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun) rule used by
 [Public-IP quota e2e](#details-public-ip-quota-e2e),
@@ -202,11 +199,12 @@ the [Shared e2e flake rerun](#details-shared-e2e-flake-rerun) rule used by
 stamp recipe.
 
 The skill keeps no state between runs, so the attempt count lives in the PR's
-own comment history. Count triage **rounds**, not comments: one triage may push
-a module-sync fix and rerun three e2e jobs, but that is a single attempt.
+own comment history. Count triage **rounds**, not actions or comments: one
+triage may push a module-sync fix and rerun three e2e jobs, but it is a single
+attempt with one summary comment.
 
-Compute the next attempt number once, at the start of the act stage, before posting
-any non-final comment this round:
+Compute the next attempt number once, at the start of the act stage, before
+taking any non-final action this round:
 
 ```bash
 # Highest existing "Unblock attempt: N" stamp across all PR comments; 0 if none.
@@ -214,28 +212,27 @@ gh pr view <pr> --json comments \
   --jq '[.comments[].body | capture("Unblock attempt: (?<n>[0-9]+)"; "g").n | tonumber] | max // 0'
 ```
 
-Let `N` be that maximum. This round's attempt number is `N + 1`. Use the **same**
-`N + 1` for every non-final comment posted this round, so a round that pushes a
-fix and reruns three jobs stamps `Unblock attempt: <N+1>` on all four comments
-rather than incrementing per comment.
+Let `N` be that maximum. This round's attempt number is `N + 1`. Do not add
+`Unblock attempt: <N+1>` to an individual `/test`, `/lgtm`, or GitHub Actions
+action comment. After all non-final actions taken this triage have completed,
+post exactly one plain informational comment that summarizes them:
 
-Add the stamp as its own line in the `Reason` block of each non-final comment,
-after the existing Reason text. GitHub Actions reruns are triggered by API rather
-than by PR slash command; after the rerun succeeds, record the attempt with a
-plain informational comment that has no slash command.
-
-```
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+Reason: completed this triage's automatic unblock actions:
+- <action 1>
+- <action 2>
 Unblock attempt: <N+1>
+EOF
 ```
 
-The stamp is what the guard-stage [Retry budget exhausted](#details-retry-budget-exhausted)
-row reads on the next run. Terminal actions do not stamp: `/close`
-(K8s guard), `@dependabot rebase` (needs-rebase), the `escalate`
+Post no summary when the triage takes no non-final action. The summary is what
+the guard-stage [Retry budget exhausted](#details-retry-budget-exhausted) row
+reads on the next run. Terminal actions do not cause a summary on their own:
+`/close` (K8s guard), `@dependabot rebase` (needs-rebase), the `escalate`
 [Toolchain / SDK / policy](#details-toolchain--sdk--policy) and
-[Retry budget exhausted](#details-retry-budget-exhausted) handoffs (which post no
-comment at all), and the [Only Tide pending](#details-only-tide-pending) `/lgtm`
-carry no `Unblock attempt:` line, because none of them hand the PR to another
-automated retry round.
+[Retry budget exhausted](#details-retry-budget-exhausted) handoffs, and the
+[Only Tide pending](#details-only-tide-pending) `/lgtm`.
 
 ## Details: Shared e2e flake rerun
 
@@ -264,7 +261,6 @@ gh pr comment <pr> --body-file - <<'EOF'
 /test <job-name>
 
 Reason: rerunning this failed e2e job because its current Prow artifacts show <pattern-specific evidence> and the pattern-specific exclusions do not apply.
-Unblock attempt: <N+1>
 EOF
 ```
 
@@ -364,7 +360,6 @@ gh pr comment <pr> --body-file - <<'EOF'
 /test <job-name>
 
 Reason: rerunning this failed Prow job because its current artifacts show <pre-entrypoint infrastructure evidence>.
-Unblock attempt: <N+1>
 EOF
 ```
 
@@ -435,16 +430,9 @@ gh run rerun <run-id> --job <databaseId>
 ```
 
 Do not comment `/retest`, `/test <job-name>`, or any other Prow directive for a
-GitHub Actions check. Record the retry-budget attempt with a plain informational
-comment after `gh run rerun` succeeds:
-
-```bash
-gh pr comment <pr> --body-file - <<'EOF'
-Reason: reran GitHub Actions check <check-name> because its current logs show <transient evidence>.
-Run: <run-url>
-Unblock attempt: <N+1>
-EOF
-```
+GitHub Actions check. After `gh run rerun` succeeds, include the rerun and its
+current evidence in the single end-of-triage [Attempt stamp](#details-attempt-stamp)
+summary rather than posting a separate retry comment.
 
 Report the rerun command, workflow run id, and target job(s) in the final output.
 
@@ -506,9 +494,9 @@ tried to unblock a PR three times without success, a fourth automated attempt is
 unlikely to help, so the PR goes to human reviewers instead of burning more
 CI on the same failing jobs.
 
-The count comes from the `Unblock attempt: N` stamps that non-final actions
-leave on the PR (see [Attempt stamp](#details-attempt-stamp)). Read the highest
-stamp already present:
+The count comes from the one `Unblock attempt: N` summary that each completed
+non-final triage leaves on the PR (see [Attempt stamp](#details-attempt-stamp)).
+Read the highest stamp already present:
 
 ```bash
 gh pr view <pr> --json comments \
@@ -517,9 +505,9 @@ gh pr view <pr> --json comments \
 
 Let `N` be that maximum. The budget is three attempts, so:
 
-- `N < 3` — budget remains. Do not escalate; continue triage. A new non-final
-  action this run will stamp `Unblock attempt: <N+1>` per the
-  [Attempt stamp](#details-attempt-stamp) rule.
+- `N < 3` — budget remains. Do not escalate; continue triage. If this triage
+  completes one or more non-final actions, post one `Unblock attempt: <N+1>`
+  summary per the [Attempt stamp](#details-attempt-stamp) rule.
 - `N >= 3` — the budget is spent (a fourth attempt would exceed three). Stop
   working the PR: make no automated change and report it as needing human review
   in the final output.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Refactors the Dependabot unblocker so it retries Prow jobs that fail before reaching their entrypoint, including pod scheduling failures, and examines failed required jobs one at a time after the guard stage.

The existing per-job Prow `/test <job-name>` and GitHub Actions `gh run rerun` retry mechanisms remain unchanged.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Related: #10054

The pre-entrypoint retry rule requires current Prow artifact evidence. Deterministic test and provisioning failures remain subject to their specific catalog rules.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```