### PR TITLE
[Generated by SRE Agent] Add deterministic e2e escalation row to Dependabot skill

### DIFF
--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -54,6 +54,7 @@ or acting on a row.
 | 39 | act | Prow pod scheduling timeout e2e | Prow job pod never schedules | auto-fix | no | [Details: Prow pod scheduling timeout](#details-prow-pod-scheduling-timeout) |
 | 40 | act | Only Tide pending | No failed checks; only `tide` pending | auto-fix | no | [Details: Only Tide pending](#details-only-tide-pending) |
 | 45 | act | GitHub Actions transient failure | Failed GitHub Actions `CheckRun` with runner/service transient evidence | auto-fix | no | [Details: GitHub Actions transient failure](#details-github-actions-transient-failure) |
+| 47 | act | Deterministic test / spec failure | Current logs name a failing test, spec, or assertion after test execution started | escalate | yes | [Details: Deterministic test / spec failure](#details-deterministic-test--spec-failure) |
 | 50 | act | Toolchain / SDK / policy blocker | Toolchain, typecheck, SDK-major, or dependency-policy blocker | escalate | yes | [Details: Toolchain / SDK / policy](#details-toolchain--sdk--policy) |
 
 The **Details** cell links to the pattern's `## Details: <name>` subsection
@@ -433,6 +434,32 @@ EOF
 ```
 
 Report the rerun command, workflow run id, and target job(s) in the final output.
+
+## Details: Deterministic test / spec failure
+
+Use this path when a failed required job reached real test execution and the
+current logs show a named failing test, spec, or assertion that does not match
+an earlier safe auto-fix row.
+
+Typical evidence includes:
+
+- Ginkgo or test-suite summaries such as `Summarizing 1 Failure:`, `[FAIL]`,
+  `FAIL! --`, `--- FAIL:`, or `Unexpected error:` with a concrete spec name,
+  test name, or source file/line
+- JUnit or test output that identifies a specific failing case rather than
+  infrastructure noise
+- Prow or GitHub Actions logs showing tests actually ran (`Running Suite`,
+  `Ran <n> of <m> Specs`, individual test names, or equivalent)
+
+Do not use this path when an earlier catalog row already matched, such as a
+quota flake, pre-test image-build registry 5xx, cluster-provisioning node
+readiness timeout, pod scheduling timeout, or transient GitHub Actions runner
+failure. Those rows are the only safe retry paths.
+
+When this row matches, make no automated change: do not rerun the job, do not
+comment `/test`, do not push code, and do not `/lgtm`. Stop working the PR and
+report it as needing human review in the final output, naming the failing job(s)
+and the concrete failing test/spec evidence so a reviewer knows where to look.
 
 ## Details: Toolchain / SDK / policy
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Adds an explicit `Deterministic test / spec failure` escalation row to the shared `unblock-dependabot-pr` failure catalog so the automation can classify real test failures as human-review cases instead of relying on an implicit fallback.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Related: #10054

This was derived from the scheduled Dependabot PR unblocker run, which found several blocked Dependabot PRs failing named e2e specs rather than any of the catalog's safe retry patterns.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

---
Created by Azure SRE Agent: [Open thread on Saw](https://sre.azure.com/agents/subscriptions/ff05f55d-22b5-44a7-b704-f9a8efd493ed/resourceGroups/aks-agent/providers/Microsoft.App/agents/niqi-test-sre-agent/views/thread/6e2bb0c4-f630-4b8a-b97b-2996ce25ef10) | [Open thread on MSFT](https://sre.azure.com/externalagents/niqi-test-sre-agent/?agentUrl=https%3A%2F%2Fniqi-test-sre-agent--1e3f29b4.944b921f.eastus2.azuresre.ai#/views/thread/6e2bb0c4-f630-4b8a-b97b-2996ce25ef10)
