### PR TITLE
[Generated by SRE Agent] Clarify Dependabot CLA policy blockers

### DIFF
--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -74,6 +74,12 @@ or overwrite unrelated files.
   compatibility issue, commit SHA, changed files, and validation result.
 - Use specific staging commands, never `git add .`.
 - Push only the current task's files.
+- Before any push-based fix, verify that the acting identity is allowed to leave
+  commits on the PR branch under the repository's commit-authorship and CLA
+  policy. If the repo or branch rejects the agent-authored commit, or would make
+  the PR less mergeable by adding a failing policy check such as EasyCLA, treat
+  it as the Pri 50 `Toolchain / SDK / policy blocker` row instead of leaving the
+  pushed commit in place.
 - Resolve guard rows from PR metadata and the `go.mod` diff before any CI or log
   I/O. When a guard row marked Stop matches, follow its linked
   Details action and end triage immediately — do not inspect CI, sync modules,

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -121,10 +121,16 @@ within the same minor family, continue with the matching workflow below.
 Use the shared `sync-go-modules` skill from this repo.
 
 1. Read `.agents/skills/sync-go-modules/SKILL.md`.
-2. Run the helper from the PR checkout. If the Dependabot branch is already
+2. Before preparing a push-based fix, verify that the acting identity is allowed
+   to leave commits on the PR branch under the repository's commit-authorship
+   and CLA policy. If the repo is known to reject agent-authored commits, or if a
+   trial push would add a failing policy check such as EasyCLA and make the PR
+   less mergeable, do not continue with the push path. Escalate through
+   [Toolchain / SDK / policy](#details-toolchain--sdk--policy) instead.
+3. Run the helper from the PR checkout. If the Dependabot branch is already
    dirty only because of the dependency bump you are fixing, pass
    `--allow-dirty` as that skill describes.
-3. Inspect the diff and stage only files produced by the sync:
+4. Inspect the diff and stage only files produced by the sync:
 
 ```bash
 git diff --stat
@@ -133,14 +139,14 @@ git add <specific go.mod/go.sum/vendor files>
 git diff --cached --stat
 ```
 
-4. Commit and push the fix to the PR branch:
+5. Commit and push the fix to the PR branch:
 
 ```bash
 git commit -m "Update Go modules"
 git push
 ```
 
-5. After the push succeeds, post `/lgtm` following the shared
+6. After the push succeeds, post `/lgtm` following the shared
    [Post-push /lgtm](#details-post-push-lgtm) rule. Fill its Reason with the
    go-mod-consistency context: the pushed commit, the changed
    `go.mod`/`go.sum`/vendor files, and the `sync-go-modules` check that passed.
@@ -451,6 +457,9 @@ agent must not make on its own:
 - `dependency-review`, vulnerability, or license failures where the resolution
   may require accepting risk, excluding a finding, or changing the dependency
   version
+- Commit-authorship or CLA policy restrictions that reject the acting identity's
+  pushed commit, or would leave the PR less mergeable by introducing a failing
+  policy check such as EasyCLA
 
 When one of these matches, make no automated change: do not push code, do not
 change linter policy, do not broaden a dependency bump, do not edit generated


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Document that the Dependabot unblocker must treat commit-authorship and CLA enforcement on push-based fixes as a policy blocker, so the automation does not leave a PR less mergeable after attempting a module-sync fix.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Related: #10054

This updates the shared `unblock-dependabot-pr` skill to require a preflight check for commit-authorship / CLA policy before any push-based remediation, and to classify EasyCLA-style failures as a Pri 50 policy blocker.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

---
Created by Azure SRE Agent: [Open thread on Saw](https://sre.azure.com/agents/subscriptions/ff05f55d-22b5-44a7-b704-f9a8efd493ed/resourceGroups/aks-agent/providers/Microsoft.App/agents/niqi-test-sre-agent/views/thread/5faa8a7a-8203-44c8-b682-fbd1c7d160c3) | [Open thread on MSFT](https://sre.azure.com/externalagents/niqi-test-sre-agent/?agentUrl=https%3A%2F%2Fniqi-test-sre-agent--1e3f29b4.944b921f.eastus2.azuresre.ai#/views/thread/5faa8a7a-8203-44c8-b682-fbd1c7d160c3)
