### PR TITLE
fix: resolve fix-image-cves Go module minimums

### DIFF
--- a/.agents/skills/fix-image-cves/SKILL.md
+++ b/.agents/skills/fix-image-cves/SKILL.md
@@ -85,21 +85,39 @@ python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
 - `scan` runs `trivy image --detection-priority comprehensive --format json`
   and only records findings that include a non-empty `FixedVersion`.
 - Findings are classified as:
-  `GO_MODULE` for `Class="lang-pkgs"` and `Type="gobinary"`,
+  `GO_MODULE` for `Class="lang-pkgs"` and `Type="gobinary"`, except for the
+  `stdlib` and `toolchain` pseudo-packages,
+  `GO_TOOLCHAIN` for the `stdlib` and `toolchain` Go runtime pseudo-packages,
   `BASE_IMAGE` for `Class="os-pkgs"`,
   `OTHER` for everything else.
-- `plan` groups multiple GO_MODULE CVEs by module path and chooses the highest
-  `FixedVersion` across them. BASE_IMAGE findings are grouped into a
-  recommendation that requires an explicit `--base-image-target`.
-- `apply` updates Go modules in the selected module root, then mirrors the repo
-  CI behavior by discovering all tracked `go.mod` files and running
-  `go mod tidy` plus `go mod verify` in every module before `go mod vendor`.
+- GO_TOOLCHAIN findings are report-only because they require upgrading the Go
+  compiler or pinned builder image and rebuilding the affected image. They are
+  never passed to `go mod edit`, `go list -m`, or module verification.
+  `apply`, `verify`, and rescan also filter these pseudo-packages defensively
+  when reading a plan saved by an older version of the skill.
+- `plan` groups multiple GO_MODULE CVEs by module path, chooses the highest
+  `FixedVersion` as the minimum required version, and adds Go's required `v`
+  prefix when Trivy reports a digit-leading version. BASE_IMAGE findings are
+  grouped into a recommendation that requires an explicit
+  `--base-image-target`.
+- `apply` stages every unresolved Go module minimum for the same module root in
+  one `go mod edit` command, then lets `go mod tidy` resolve the complete module
+  graph using Minimal Version Selection. This avoids treating command-line
+  versions as conflicting exact `go get` requests. It then mirrors the repo CI
+  behavior by discovering all tracked `go.mod` files and running `go mod tidy`
+  plus `go mod verify` in every module before `go mod vendor`.
 - When vendoring is enabled at the repo root, `apply` also runs
   `hack/update-azure-vendor-licenses.sh` so `LICENSES/` stays in sync with
   `vendor/` and the resulting PR is self-contained.
-- `verify` does not assume a clean worktree. It compares the current repo diff
-  against the pre-existing changed files plus the files recorded during `apply`
-  so unrelated user edits do not trigger false failures.
+- `verify` accepts resolved and vendored Go module versions that are equal to or
+  higher than each planned minimum. It does not assume a clean worktree and
+  compares the current repo diff against the pre-existing changed files plus
+  the files recorded during `apply` so unrelated user edits do not trigger
+  false failures.
+- `apply` refuses planned Go modules with `replace` directives, and `verify`
+  fails resolved or vendored replacements. A replacement module's version does
+  not prove that the original module meets its CVE fix threshold; update or
+  remove the replacement explicitly before using this workflow.
 - The state file lives under `.git/fix-image-cves.json` intentionally so it
   stays untracked.
 - `verify --rescan` expects the agent to rebuild the image first. The skill

--- a/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
@@ -31,6 +31,18 @@ from typing import Any
 STATE_FILE = Path(".git/fix-image-cves.json")
 STATE_VERSION = 1
 TRIVY_DB_STALE_SECONDS = 24 * 60 * 60
+GO_TOOLCHAIN_PACKAGES = {"stdlib", "toolchain"}
+GO_SEMVER_RE = re.compile(
+    r"^v"
+    r"(?P<major>0|[1-9]\d*)"
+    r"(?:\.(?P<minor>0|[1-9]\d*)"
+    r"(?:\.(?P<patch>0|[1-9]\d*)"
+    r"(?P<prerelease>-(?:(?:0|[1-9]\d*)|(?:[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))"
+    r"(?:\.(?:(?:0|[1-9]\d*)|(?:[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r")?)?"
+    r"$"
+)
 
 
 class CommandError(RuntimeError):
@@ -231,21 +243,151 @@ def version_key(value: str) -> list[tuple[int, Any]]:
     return key
 
 
+def normalize_go_version(value: str) -> str:
+    text = value.strip()
+    if text and text[0].isdigit():
+        return f"v{text}"
+    return text
+
+
+def is_go_toolchain_package(package: str) -> bool:
+    return package.strip() in GO_TOOLCHAIN_PACKAGES
+
+
+def actionable_go_module_actions(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        action
+        for action in plan.get("go_module_actions") or []
+        if not is_go_toolchain_package(str(action.get("module") or ""))
+    ]
+
+
+def actionable_vulnerability_keys(plan: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    for key in plan.get("planned_vulnerability_keys") or []:
+        parts = str(key).split("::", 2)
+        if (
+            len(parts) == 3
+            and parts[0] == "GO_MODULE"
+            and is_go_toolchain_package(parts[2])
+        ):
+            continue
+        keys.add(str(key))
+    return keys
+
+
+def compare_values(left: Any, right: Any) -> int:
+    if left == right:
+        return 0
+    return -1 if left < right else 1
+
+
+def parse_go_semver(value: str) -> tuple[int, int, int, str] | None:
+    match = GO_SEMVER_RE.match(normalize_go_version(value))
+    if not match:
+        return None
+    return (
+        int(match.group("major")),
+        int(match.group("minor") or "0"),
+        int(match.group("patch") or "0"),
+        match.group("prerelease") or "",
+    )
+
+
+def compare_prerelease(left: str, right: str) -> int:
+    if left == right:
+        return 0
+    if left == "":
+        return 1
+    if right == "":
+        return -1
+
+    left_parts = left[1:].split(".")
+    right_parts = right[1:].split(".")
+    for left_part, right_part in zip(left_parts, right_parts):
+        if left_part == right_part:
+            continue
+        left_is_num = left_part.isdigit()
+        right_is_num = right_part.isdigit()
+        if left_is_num and right_is_num:
+            return compare_values(int(left_part), int(right_part))
+        if left_is_num != right_is_num:
+            return -1 if left_is_num else 1
+        return compare_values(left_part, right_part)
+
+    return compare_values(len(left_parts), len(right_parts))
+
+
+def compare_fixed_versions(left: str, right: str) -> int:
+    left_semver = parse_go_semver(left)
+    right_semver = parse_go_semver(right)
+    if left_semver and right_semver:
+        for left_part, right_part in zip(left_semver[:3], right_semver[:3]):
+            compared = compare_values(left_part, right_part)
+            if compared != 0:
+                return compared
+        return compare_prerelease(left_semver[3], right_semver[3])
+    if left_semver:
+        return 1
+    if right_semver:
+        return -1
+
+    return compare_values(version_key(left), version_key(right))
+
+
 def highest_fixed_version(values: list[str]) -> str:
     candidates: list[str] = []
     for value in values:
-        candidates.extend(parse_fixed_version_candidates(value))
+        candidates.extend(normalize_go_version(item) for item in parse_fixed_version_candidates(value))
     if not candidates:
         raise CommandError("No fixed versions available to compare")
-    return max(candidates, key=version_key)
+    highest = candidates[0]
+    for candidate in candidates[1:]:
+        if compare_fixed_versions(candidate, highest) > 0:
+            highest = candidate
+    return highest
+
+
+def version_at_least(actual: str, minimum: str) -> bool:
+    normalized_actual = normalize_go_version(actual)
+    normalized_minimum = normalize_go_version(minimum)
+    if not normalized_actual or not normalized_minimum:
+        return False
+    return compare_fixed_versions(normalized_actual, normalized_minimum) >= 0
+
+
+def build_go_requirement_commands(
+    go_actions: list[dict[str, Any]],
+    resolved_versions: dict[tuple[str, str], str],
+) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, str]] = {}
+    for action in go_actions:
+        module_root = action["module_root"]
+        module = action["module"]
+        fixed_version = normalize_go_version(action["fixed_version"])
+        resolved_version = resolved_versions.get((module_root, module), "")
+        if version_at_least(resolved_version, fixed_version):
+            continue
+        versions = grouped.setdefault(module_root, {})
+        current = versions.get(module)
+        if current is None or compare_fixed_versions(fixed_version, current) > 0:
+            versions[module] = fixed_version
+
+    commands = []
+    for module_root, versions in sorted(grouped.items()):
+        requirements = [f"-require={module}@{versions[module]}" for module in sorted(versions)]
+        commands.append({"cwd": module_root, "cmd": ["go", "mod", "edit", *requirements]})
+    return commands
 
 
 def sanitize_dockerfile_stage(result: dict[str, Any]) -> str:
     return "runtime" if result.get("Class") == "os-pkgs" else "unknown"
 
 
-def classify_result(result: dict[str, Any]) -> str:
+def classify_result(result: dict[str, Any], package: str = "") -> str:
     if result.get("Class") == "lang-pkgs" and result.get("Type") == "gobinary":
+        if is_go_toolchain_package(package):
+            return "GO_TOOLCHAIN"
         return "GO_MODULE"
     if result.get("Class") == "os-pkgs":
         return "BASE_IMAGE"
@@ -275,7 +417,6 @@ def parse_scan_findings(
 ) -> list[dict[str, Any]]:
     findings: list[dict[str, Any]] = []
     for result in payload.get("Results") or []:
-        classification = classify_result(result)
         target = str(result.get("Target") or "")
         class_name = str(result.get("Class") or "")
         type_name = str(result.get("Type") or "")
@@ -283,12 +424,13 @@ def parse_scan_findings(
             fixed_version = str(vuln.get("FixedVersion") or "").strip()
             if not fixed_version:
                 continue
+            package = str(vuln.get("PkgName") or "")
             finding = {
-                "category": classification,
+                "category": classify_result(result, package),
                 "class": class_name,
                 "type": type_name,
                 "target": target,
-                "package": str(vuln.get("PkgName") or ""),
+                "package": package,
                 "installed_version": str(vuln.get("InstalledVersion") or ""),
                 "fixed_version": fixed_version,
                 "id": str(vuln.get("VulnerabilityID") or ""),
@@ -303,12 +445,13 @@ def parse_scan_findings(
 
 
 def summarize_scan(findings: list[dict[str, Any]]) -> None:
-    counts = {"GO_MODULE": 0, "BASE_IMAGE": 0, "OTHER": 0}
+    counts = {"GO_MODULE": 0, "GO_TOOLCHAIN": 0, "BASE_IMAGE": 0, "OTHER": 0}
     for finding in findings:
         counts[finding["category"]] = counts.get(finding["category"], 0) + 1
     print("Scan Summary")
     print("============")
     print(f"GO_MODULE: {counts.get('GO_MODULE', 0)}")
+    print(f"GO_TOOLCHAIN: {counts.get('GO_TOOLCHAIN', 0)}")
     print(f"BASE_IMAGE: {counts.get('BASE_IMAGE', 0)}")
     print(f"OTHER: {counts.get('OTHER', 0)}")
     if not findings:
@@ -331,9 +474,13 @@ def build_plan(scan: dict[str, Any]) -> dict[str, Any]:
     base_groups: dict[tuple[str, str], dict[str, Any]] = {}
     other_findings: list[dict[str, Any]] = []
     evidence: list[dict[str, Any]] = []
+    planned_vulnerability_keys: set[str] = set()
 
     for finding in findings:
         category = finding["category"]
+        if category == "GO_MODULE" and is_go_toolchain_package(finding["package"]):
+            category = "GO_TOOLCHAIN"
+            finding = {**finding, "category": category}
         if category == "GO_MODULE":
             package = finding["package"]
             group = go_groups.setdefault(
@@ -360,6 +507,7 @@ def build_plan(scan: dict[str, Any]) -> dict[str, Any]:
                     "target_file": str(Path(finding["module_root"]) / "go.mod"),
                 }
             )
+            planned_vulnerability_keys.add(vuln_key(finding))
         elif category == "BASE_IMAGE":
             key = (finding["dockerfile"], finding["stage"])
             group = base_groups.setdefault(
@@ -392,6 +540,7 @@ def build_plan(scan: dict[str, Any]) -> dict[str, Any]:
                     "target_file": finding["dockerfile"],
                 }
             )
+            planned_vulnerability_keys.add(vuln_key(finding))
         else:
             other_findings.append(finding)
 
@@ -427,13 +576,7 @@ def build_plan(scan: dict[str, Any]) -> dict[str, Any]:
         "base_image_actions": base_actions,
         "other_findings": other_findings,
         "evidence": evidence,
-        "planned_vulnerability_keys": sorted(
-            {
-                vuln_key(finding)
-                for finding in findings
-                if finding["category"] in {"GO_MODULE", "BASE_IMAGE"}
-            }
-        ),
+        "planned_vulnerability_keys": sorted(planned_vulnerability_keys),
     }
 
 
@@ -441,6 +584,9 @@ def summarize_plan(plan: dict[str, Any]) -> None:
     go_actions = plan.get("go_module_actions") or []
     base_actions = plan.get("base_image_actions") or []
     other_findings = plan.get("other_findings") or []
+    toolchain_findings = [
+        finding for finding in other_findings if finding.get("category") == "GO_TOOLCHAIN"
+    ]
 
     print("Plan Summary")
     print("============")
@@ -464,6 +610,19 @@ def summarize_plan(plan: dict[str, Any]) -> None:
             print(
                 f"{action['dockerfile']} [{action['stage']}] "
                 f"packages={len(action['packages'])} requires --base-image-target"
+            )
+    if toolchain_findings:
+        print("")
+        print("Go Toolchain Findings (Manual Action Required)")
+        print("----------------------------------------------")
+        print(
+            "Upgrade the Go build toolchain or pinned builder image to an applicable fixed "
+            "Go release, then rebuild the image."
+        )
+        for finding in toolchain_findings:
+            print(
+                f"{finding['package']} {finding['installed_version']} -> "
+                f"{finding['fixed_version']} ({finding['id']})"
             )
 
 
@@ -570,29 +729,71 @@ def replace_dockerfile_from(repo_root: Path, dockerfile: str, stage: str, target
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def parse_vendor_modules(repo_root: Path) -> dict[str, str]:
+def parse_vendor_modules(repo_root: Path) -> dict[str, dict[str, str]]:
     path = repo_root / "vendor" / "modules.txt"
     if not path.is_file():
         return {}
-    modules: dict[str, str] = {}
+    modules: dict[str, dict[str, str]] = {}
     for line in path.read_text(encoding="utf-8").splitlines():
         if not line.startswith("# "):
             continue
         parts = line.split()
-        if len(parts) >= 3 and parts[2] != "=>":
-            modules[parts[1]] = parts[2]
+        if len(parts) < 2:
+            continue
+        module = parts[1]
+        index = 2
+        version = ""
+        if index < len(parts) and parts[index] != "=>":
+            version = parts[index]
+            index += 1
+        replacement_path = ""
+        replacement_version = ""
+        if index < len(parts) and parts[index] == "=>":
+            index += 1
+            if index < len(parts):
+                replacement_path = parts[index]
+                index += 1
+            if index < len(parts):
+                replacement_version = parts[index]
+        modules[module] = {
+            "path": module,
+            "version": version,
+            "replacement_path": replacement_path,
+            "replacement_version": replacement_version,
+        }
     return modules
 
 
-def go_list_module_version(module_dir: Path, module: str) -> str:
-    fmt = "{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}"
+def go_list_module_info(module_dir: Path, module: str) -> dict[str, str]:
     output = run(
-        ["go", "list", "-m", "-f", fmt, module],
+        ["go", "list", "-m", "-json", module],
         cwd=module_dir,
         capture=True,
         env=_go_env(),
     )
-    return output.strip()
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise CommandError(f"go list returned invalid JSON for module {module}: {exc}") from exc
+    replacement = payload.get("Replace") or {}
+    return {
+        "path": str(payload.get("Path") or module),
+        "version": str(payload.get("Version") or ""),
+        "replacement_path": str(replacement.get("Path") or ""),
+        "replacement_version": str(replacement.get("Version") or ""),
+    }
+
+
+def require_unreplaced_module(module: str, module_info: dict[str, str]) -> None:
+    replacement = module_info["replacement_path"]
+    if not replacement:
+        return
+    if module_info["replacement_version"]:
+        replacement += f"@{module_info['replacement_version']}"
+    raise CommandError(
+        f"Cannot safely apply Go module minimum for {module}: "
+        f"the module is replaced by {replacement}. Update or remove the replacement explicitly."
+    )
 
 
 def normalize_path_set(values: list[str]) -> set[str]:
@@ -628,21 +829,30 @@ def vuln_key(finding: dict[str, Any]) -> str:
 def verify_go_module_actions(repo_root: Path, plan: dict[str, Any], results: dict[str, Any]) -> bool:
     ok = True
     vendor_versions = parse_vendor_modules(repo_root)
-    for action in plan.get("go_module_actions") or []:
+    for action in actionable_go_module_actions(plan):
         module_dir = abs_from_repo(repo_root, action["module_root"])
         module = action["module"]
-        expected = action["fixed_version"]
-        actual = go_list_module_version(module_dir, module)
+        minimum = normalize_go_version(action["fixed_version"])
+        module_info = go_list_module_info(module_dir, module)
+        replacement_path = module_info["replacement_path"]
+        actual = module_info["version"]
         item = {
             "module": module,
             "module_root": action["module_root"],
-            "expected_version": expected,
+            "expected_version": minimum,
             "resolved_version": actual,
-            "go_list_ok": actual == expected,
+            "replacement_path": replacement_path,
+            "replacement_version": module_info["replacement_version"],
+            "go_list_ok": not replacement_path and version_at_least(actual, minimum),
         }
         if has_vendor_tree(repo_root) and action["module_root"] == ".":
-            item["vendor_version"] = vendor_versions.get(module, "")
-            item["vendor_ok"] = item["vendor_version"] == expected
+            vendor_info = vendor_versions.get(module) or {}
+            item["vendor_version"] = vendor_info.get("version", "")
+            item["vendor_replacement_path"] = vendor_info.get("replacement_path", "")
+            item["vendor_replacement_version"] = vendor_info.get("replacement_version", "")
+            item["vendor_ok"] = not item["vendor_replacement_path"] and version_at_least(
+                item["vendor_version"], minimum
+            )
         results.setdefault("go_module_checks", []).append(item)
         if not item["go_list_ok"] or ("vendor_ok" in item and not item["vendor_ok"]):
             ok = False
@@ -799,7 +1009,7 @@ def command_apply(args: argparse.Namespace) -> int:
     if not plan or not scan:
         raise CommandError("State file must contain scan and plan results. Run scan and plan first.")
 
-    go_actions = plan.get("go_module_actions") or []
+    go_actions = actionable_go_module_actions(plan)
     base_actions = plan.get("base_image_actions") or []
     targets = parse_base_image_targets(args.base_image_target or [])
     preexisting_paths = git_status_paths(repo_root)
@@ -819,16 +1029,28 @@ def command_apply(args: argparse.Namespace) -> int:
         go_env = _go_env()
         _check_local_go_version(repo_root, go_env)
 
-    go_commands: list[dict[str, Any]] = []
+    resolved_versions: dict[tuple[str, str], str] = {}
     for action in go_actions:
-        module_dir = abs_from_repo(repo_root, action["module_root"])
-        cmd = ["go", "get", f"{action['module']}@{action['fixed_version']}"]
+        module_root = action["module_root"]
+        module = action["module"]
+        key = (module_root, module)
+        if key in resolved_versions:
+            continue
+        module_dir = abs_from_repo(repo_root, module_root)
+        module_info = go_list_module_info(module_dir, module)
+        require_unreplaced_module(module, module_info)
+        resolved_versions[key] = module_info["version"]
+
+    go_commands: list[dict[str, Any]] = []
+    for command in build_go_requirement_commands(go_actions, resolved_versions):
+        module_dir = abs_from_repo(repo_root, command["cwd"])
+        cmd = command["cmd"]
         if args.dry_run:
             print_cmd(cmd, cwd=module_dir)
         else:
-            info(f"Running {quote_cmd(cmd)} in {action['module_root']}")
+            info(f"Running {quote_cmd(cmd)} in {command['cwd']}")
             run(cmd, cwd=module_dir, env=go_env)
-        go_commands.append({"cwd": action["module_root"], "cmd": cmd})
+        go_commands.append(command)
 
     ran_module_consistency = False
     if go_actions:
@@ -948,7 +1170,7 @@ def command_verify(args: argparse.Namespace) -> int:
     if args.rescan:
         if not args.image:
             raise CommandError("--image is required when using --rescan")
-        planned_keys = set(plan.get("planned_vulnerability_keys") or [])
+        planned_keys = actionable_vulnerability_keys(plan)
         if not run_rescan(
             repo_root,
             image=args.image,
@@ -965,12 +1187,24 @@ def command_verify(args: argparse.Namespace) -> int:
     print("Verify Summary")
     print("==============")
     for item in results.get("go_module_checks", []):
+        replacement_note = ""
+        if item.get("replacement_path"):
+            replacement = item["replacement_path"]
+            if item.get("replacement_version"):
+                replacement += f"@{item['replacement_version']}"
+            replacement_note = f", replacement={replacement}"
         vendor_note = ""
         if "vendor_ok" in item:
             vendor_note = f", vendor_ok={item['vendor_ok']}"
+            if item.get("vendor_replacement_path"):
+                vendor_replacement = item["vendor_replacement_path"]
+                if item.get("vendor_replacement_version"):
+                    vendor_replacement += f"@{item['vendor_replacement_version']}"
+                vendor_note += f", vendor_replacement={vendor_replacement}"
         print(
-            f"{item['module']} expected={item['expected_version']} "
-            f"resolved={item['resolved_version']} go_list_ok={item['go_list_ok']}{vendor_note}"
+            f"{item['module']} minimum={item['expected_version']} "
+            f"resolved={item['resolved_version']} go_list_ok={item['go_list_ok']}"
+            f"{replacement_note}{vendor_note}"
         )
     if results.get("dockerfile_checks"):
         for item in results["dockerfile_checks"]:

--- a/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest import mock
+
+import fix_image_cves
+
+
+def module_info(
+    version: str,
+    *,
+    replacement_path: str = "",
+    replacement_version: str = "",
+) -> dict[str, str]:
+    return {
+        "path": "golang.org/x/sys",
+        "version": version,
+        "replacement_path": replacement_path,
+        "replacement_version": replacement_version,
+    }
+
+
+class FixImageCVEsTest(unittest.TestCase):
+    def test_classify_result_treats_go_runtime_packages_as_toolchain(self) -> None:
+        result = {"Class": "lang-pkgs", "Type": "gobinary"}
+
+        for package in ("stdlib", "toolchain"):
+            with self.subTest(package=package):
+                self.assertEqual(
+                    fix_image_cves.classify_result(result, package),
+                    "GO_TOOLCHAIN",
+                )
+
+        self.assertEqual(
+            fix_image_cves.classify_result(result, "golang.org/x/net"),
+            "GO_MODULE",
+        )
+
+    def test_mixed_go_scan_keeps_toolchain_findings_report_only(self) -> None:
+        findings = fix_image_cves.parse_scan_findings(
+            {
+                "Results": [
+                    {
+                        "Class": "lang-pkgs",
+                        "Type": "gobinary",
+                        "Target": "cloud-controller-manager",
+                        "Vulnerabilities": [
+                            {
+                                "PkgName": "stdlib",
+                                "InstalledVersion": "v1.24.5",
+                                "FixedVersion": "1.23.12, 1.24.6",
+                                "VulnerabilityID": "CVE-2026-0001",
+                            },
+                            {
+                                "PkgName": "golang.org/x/net",
+                                "InstalledVersion": "v0.49.0",
+                                "FixedVersion": "0.55.0",
+                                "VulnerabilityID": "CVE-2026-0002",
+                            },
+                        ],
+                    }
+                ]
+            },
+            module_root=".",
+            dockerfile="Dockerfile",
+        )
+
+        plan = fix_image_cves.build_plan({"findings": findings})
+
+        self.assertEqual(
+            [action["module"] for action in plan["go_module_actions"]],
+            ["golang.org/x/net"],
+        )
+        self.assertEqual(
+            [(finding["category"], finding["package"]) for finding in plan["other_findings"]],
+            [("GO_TOOLCHAIN", "stdlib")],
+        )
+        self.assertEqual(
+            plan["planned_vulnerability_keys"],
+            ["GO_MODULE::CVE-2026-0002::golang.org/x/net"],
+        )
+
+    def test_build_plan_reclassifies_toolchain_from_older_scan_state(self) -> None:
+        finding = {
+            "category": "GO_MODULE",
+            "package": "toolchain",
+            "module_root": ".",
+            "target": "cloud-controller-manager",
+            "installed_version": "v1.24.5",
+            "fixed_version": "1.24.6",
+            "id": "CVE-2026-0003",
+        }
+
+        plan = fix_image_cves.build_plan({"findings": [finding]})
+
+        self.assertEqual(plan["go_module_actions"], [])
+        self.assertEqual(plan["planned_vulnerability_keys"], [])
+        self.assertEqual(plan["other_findings"][0]["category"], "GO_TOOLCHAIN")
+
+    def test_apply_ignores_toolchain_action_from_older_plan_state(self) -> None:
+        state = {
+            "scan": {"module_root": ".", "dockerfile": "Dockerfile"},
+            "plan": {
+                "go_module_actions": [
+                    {
+                        "module": "stdlib",
+                        "module_root": ".",
+                        "fixed_version": "v1.24.6",
+                    }
+                ],
+                "base_image_actions": [],
+            },
+        }
+        args = Namespace(repo=".", base_image_target=[], dry_run=True)
+
+        with mock.patch.object(
+            fix_image_cves, "ensure_repo_root", return_value=Path("/repo")
+        ), mock.patch.object(
+            fix_image_cves, "load_state", return_value=state
+        ), mock.patch.object(
+            fix_image_cves, "git_status_paths", return_value=set()
+        ), mock.patch.object(
+            fix_image_cves, "go_list_module_info"
+        ) as go_list, mock.patch.object(
+            fix_image_cves, "ensure_command"
+        ) as ensure_command, mock.patch.object(
+            fix_image_cves, "discover_go_modules"
+        ) as discover_modules, mock.patch("sys.stdout", io.StringIO()):
+            self.assertEqual(fix_image_cves.command_apply(args), 0)
+
+        go_list.assert_not_called()
+        ensure_command.assert_not_called()
+        discover_modules.assert_not_called()
+
+    def test_verify_ignores_toolchain_action_from_older_plan_state(self) -> None:
+        plan = {
+            "go_module_actions": [
+                {
+                    "module": "toolchain",
+                    "module_root": ".",
+                    "fixed_version": "v1.24.6",
+                }
+            ]
+        }
+        results = {}
+
+        with mock.patch.object(fix_image_cves, "go_list_module_info") as go_list, mock.patch.object(
+            fix_image_cves, "parse_vendor_modules", return_value={}
+        ):
+            self.assertTrue(
+                fix_image_cves.verify_go_module_actions(Path("/repo"), plan, results)
+            )
+
+        go_list.assert_not_called()
+
+    def test_rescan_ignores_toolchain_key_from_older_plan_state(self) -> None:
+        plan = {
+            "planned_vulnerability_keys": [
+                "GO_MODULE::CVE-2026-0001::stdlib",
+                "GO_MODULE::CVE-2026-0002::golang.org/x/net",
+                "BASE_IMAGE::CVE-2026-0003::libc6",
+            ]
+        }
+
+        self.assertEqual(
+            fix_image_cves.actionable_vulnerability_keys(plan),
+            {
+                "GO_MODULE::CVE-2026-0002::golang.org/x/net",
+                "BASE_IMAGE::CVE-2026-0003::libc6",
+            },
+        )
+
+    def test_summarize_plan_explains_manual_go_toolchain_remediation(self) -> None:
+        plan = {
+            "go_module_actions": [],
+            "base_image_actions": [],
+            "other_findings": [
+                {
+                    "category": "GO_TOOLCHAIN",
+                    "package": "stdlib",
+                    "installed_version": "v1.24.5",
+                    "fixed_version": "1.23.12, 1.24.6",
+                    "id": "CVE-2026-0001",
+                }
+            ],
+        }
+
+        output = io.StringIO()
+        with mock.patch("sys.stdout", output):
+            fix_image_cves.summarize_plan(plan)
+
+        summary = output.getvalue()
+        self.assertIn("Go Toolchain Findings (Manual Action Required)", summary)
+        self.assertIn("Upgrade the Go build toolchain or pinned builder image", summary)
+        self.assertIn("then rebuild the image", summary)
+
+    def test_highest_fixed_version_normalizes_and_uses_go_semver_order(self) -> None:
+        cases = [
+            (["0.55.0"], "v0.55.0"),
+            (["v0.55.0"], "v0.55.0"),
+            (["0.54.0, 0.55.0"], "v0.55.0"),
+            (["v1.2.3-rc.1", "v1.2.3"], "v1.2.3"),
+            (
+                [
+                    "v0.0.0-20240101000000-aaaaaaaaaaaa",
+                    "v0.0.0-20250101000000-bbbbbbbbbbbb",
+                ],
+                "v0.0.0-20250101000000-bbbbbbbbbbbb",
+            ),
+        ]
+
+        for versions, expected in cases:
+            with self.subTest(versions=versions):
+                self.assertEqual(fix_image_cves.highest_fixed_version(versions), expected)
+
+    def test_build_plan_persists_canonical_go_version(self) -> None:
+        plan = fix_image_cves.build_plan(
+            {
+                "findings": [
+                    {
+                        "category": "GO_MODULE",
+                        "package": "golang.org/x/net",
+                        "module_root": "health-probe-proxy",
+                        "target": "health-probe-proxy",
+                        "installed_version": "v0.49.0",
+                        "fixed_version": "0.55.0",
+                        "id": "CVE-2026-0001",
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(plan["go_module_actions"][0]["fixed_version"], "v0.55.0")
+
+    def test_build_go_requirement_commands_batches_and_sorts_by_module_root(self) -> None:
+        actions = [
+            {
+                "module": "golang.org/x/sys",
+                "module_root": "health-probe-proxy",
+                "fixed_version": "0.44.0",
+            },
+            {
+                "module": "golang.org/x/net",
+                "module_root": "health-probe-proxy",
+                "fixed_version": "v0.55.0",
+            },
+            {
+                "module": "golang.org/x/text",
+                "module_root": "tests",
+                "fixed_version": "0.37.0",
+            },
+            {
+                "module": "golang.org/x/sync",
+                "module_root": "tests",
+                "fixed_version": "0.20.0",
+            },
+        ]
+        resolved_versions = {
+            ("health-probe-proxy", "golang.org/x/net"): "v0.49.0",
+            ("health-probe-proxy", "golang.org/x/sys"): "v0.40.0",
+            ("tests", "golang.org/x/text"): "v0.36.0",
+            ("tests", "golang.org/x/sync"): "v0.21.0",
+        }
+
+        self.assertEqual(
+            fix_image_cves.build_go_requirement_commands(actions, resolved_versions),
+            [
+                {
+                    "cwd": "health-probe-proxy",
+                    "cmd": [
+                        "go",
+                        "mod",
+                        "edit",
+                        "-require=golang.org/x/net@v0.55.0",
+                        "-require=golang.org/x/sys@v0.44.0",
+                    ],
+                },
+                {
+                    "cwd": "tests",
+                    "cmd": [
+                        "go",
+                        "mod",
+                        "edit",
+                        "-require=golang.org/x/text@v0.37.0",
+                    ],
+                },
+            ],
+        )
+
+    @unittest.skipUnless(shutil.which("go"), "go is required for the MVS integration test")
+    def test_go_requirement_commands_allow_mvs_to_raise_transitive_minimum(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "net55").mkdir()
+            (root / "sys44").mkdir()
+            (root / "sys45").mkdir()
+            (root / "go.mod").write_text(
+                """module example.com/main
+
+go 1.20
+
+require (
+	example.com/net v0.49.0
+	example.com/sys v0.40.0
+)
+
+replace example.com/net v0.55.0 => ./net55
+replace example.com/sys v0.44.0 => ./sys44
+replace example.com/sys v0.45.0 => ./sys45
+""",
+                encoding="utf-8",
+            )
+            (root / "main.go").write_text(
+                'package main\n\nimport _ "example.com/net"\n\nfunc main() {}\n',
+                encoding="utf-8",
+            )
+            (root / "net55" / "go.mod").write_text(
+                "module example.com/net\n\ngo 1.20\n\nrequire example.com/sys v0.45.0\n",
+                encoding="utf-8",
+            )
+            (root / "net55" / "net.go").write_text(
+                'package net\n\nimport _ "example.com/sys"\n',
+                encoding="utf-8",
+            )
+            for directory in ("sys44", "sys45"):
+                (root / directory / "go.mod").write_text(
+                    "module example.com/sys\n\ngo 1.20\n",
+                    encoding="utf-8",
+                )
+                (root / directory / "sys.go").write_text("package sys\n", encoding="utf-8")
+
+            actions = [
+                {
+                    "module": "example.com/net",
+                    "module_root": ".",
+                    "fixed_version": "v0.55.0",
+                },
+                {
+                    "module": "example.com/sys",
+                    "module_root": ".",
+                    "fixed_version": "v0.44.0",
+                },
+            ]
+            commands = fix_image_cves.build_go_requirement_commands(
+                actions,
+                {
+                    (".", "example.com/net"): "v0.49.0",
+                    (".", "example.com/sys"): "v0.40.0",
+                },
+            )
+            env = {
+                **os.environ,
+                "GOCACHE": str(root / "gocache"),
+                "GOMODCACHE": str(root / "gomodcache"),
+                "GOPROXY": "off",
+                "GOSUMDB": "off",
+                "GOTOOLCHAIN": "local",
+            }
+            env.pop("GOROOT", None)
+
+            subprocess.run(commands[0]["cmd"], cwd=root, env=env, check=True, capture_output=True)
+            subprocess.run(
+                ["go", "mod", "tidy"], cwd=root, env=env, check=True, capture_output=True
+            )
+            resolved = subprocess.run(
+                ["go", "list", "-m", "-f", "{{.Path}} {{.Version}}", "example.com/net", "example.com/sys"],
+                cwd=root,
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(
+                resolved.stdout.splitlines(),
+                ["example.com/net v0.55.0", "example.com/sys v0.45.0"],
+            )
+
+    def test_version_at_least_handles_equal_higher_lower_and_missing(self) -> None:
+        cases = [
+            ("v0.44.0", "0.44.0", True),
+            ("v0.45.0", "v0.44.0", True),
+            ("v0.43.0", "v0.44.0", False),
+            ("", "v0.44.0", False),
+            ("v1.2.3", "v1.2.3-rc.1", True),
+        ]
+
+        for actual, minimum, expected in cases:
+            with self.subTest(actual=actual, minimum=minimum):
+                self.assertEqual(
+                    fix_image_cves.version_at_least(actual, minimum),
+                    expected,
+                )
+
+    def test_verify_accepts_transitive_upgrade_above_minimum(self) -> None:
+        plan = {
+            "go_module_actions": [
+                {
+                    "module": "golang.org/x/net",
+                    "module_root": "health-probe-proxy",
+                    "fixed_version": "v0.55.0",
+                },
+                {
+                    "module": "golang.org/x/sys",
+                    "module_root": "health-probe-proxy",
+                    "fixed_version": "0.44.0",
+                },
+            ]
+        }
+        results = {}
+
+        with mock.patch.object(
+            fix_image_cves,
+            "go_list_module_info",
+            side_effect=[module_info("v0.55.0"), module_info("v0.45.0")],
+        ), mock.patch.object(
+            fix_image_cves, "has_vendor_tree", return_value=False
+        ), mock.patch.object(
+            fix_image_cves, "parse_vendor_modules", return_value={}
+        ):
+            passed = fix_image_cves.verify_go_module_actions(Path("/repo"), plan, results)
+
+        self.assertTrue(passed)
+        self.assertEqual(results["go_module_checks"][1]["expected_version"], "v0.44.0")
+        self.assertTrue(results["go_module_checks"][1]["go_list_ok"])
+
+    def test_verify_rejects_lower_or_missing_resolved_version(self) -> None:
+        plan = {
+            "go_module_actions": [
+                {
+                    "module": "golang.org/x/sys",
+                    "module_root": "health-probe-proxy",
+                    "fixed_version": "v0.44.0",
+                }
+            ]
+        }
+
+        for actual in ("v0.43.0", ""):
+            with self.subTest(actual=actual), mock.patch.object(
+                fix_image_cves, "go_list_module_info", return_value=module_info(actual)
+            ), mock.patch.object(
+                fix_image_cves, "has_vendor_tree", return_value=False
+            ), mock.patch.object(
+                fix_image_cves, "parse_vendor_modules", return_value={}
+            ):
+                results = {}
+                self.assertFalse(
+                    fix_image_cves.verify_go_module_actions(Path("/repo"), plan, results)
+                )
+
+    def test_verify_checks_vendor_version_as_minimum(self) -> None:
+        plan = {
+            "go_module_actions": [
+                {
+                    "module": "golang.org/x/sys",
+                    "module_root": ".",
+                    "fixed_version": "v0.44.0",
+                }
+            ]
+        }
+
+        for vendor_version, expected in (
+            ("v0.44.0", True),
+            ("v0.45.0", True),
+            ("v0.43.0", False),
+            ("", False),
+        ):
+            with self.subTest(vendor_version=vendor_version), mock.patch.object(
+                fix_image_cves, "go_list_module_info", return_value=module_info("v0.45.0")
+            ), mock.patch.object(
+                fix_image_cves, "has_vendor_tree", return_value=True
+            ), mock.patch.object(
+                fix_image_cves,
+                "parse_vendor_modules",
+                return_value={"golang.org/x/sys": module_info(vendor_version)},
+            ):
+                results = {}
+                self.assertEqual(
+                    fix_image_cves.verify_go_module_actions(Path("/repo"), plan, results),
+                    expected,
+                )
+
+    def test_verify_rejects_module_and_vendor_replacements(self) -> None:
+        plan = {
+            "go_module_actions": [
+                {
+                    "module": "golang.org/x/sys",
+                    "module_root": ".",
+                    "fixed_version": "v0.44.0",
+                }
+            ]
+        }
+        replacement = module_info(
+            "v0.44.0",
+            replacement_path="example.com/fork/sys",
+            replacement_version="v9.0.0",
+        )
+
+        cases = [
+            (replacement, module_info("v0.45.0")),
+            (module_info("v0.45.0"), replacement),
+        ]
+        for resolved_info, vendor_info in cases:
+            with self.subTest(
+                resolved_replacement=resolved_info["replacement_path"],
+                vendor_replacement=vendor_info["replacement_path"],
+            ), mock.patch.object(
+                fix_image_cves, "go_list_module_info", return_value=resolved_info
+            ), mock.patch.object(
+                fix_image_cves, "has_vendor_tree", return_value=True
+            ), mock.patch.object(
+                fix_image_cves,
+                "parse_vendor_modules",
+                return_value={"golang.org/x/sys": vendor_info},
+            ):
+                results = {}
+                self.assertFalse(
+                    fix_image_cves.verify_go_module_actions(Path("/repo"), plan, results)
+                )
+
+    def test_apply_preflight_rejects_module_replacement(self) -> None:
+        replacement = module_info(
+            "v0.44.0",
+            replacement_path="example.com/fork/sys",
+            replacement_version="v9.0.0",
+        )
+
+        with self.assertRaisesRegex(
+            fix_image_cves.CommandError,
+            "replaced by example.com/fork/sys@v9.0.0",
+        ):
+            fix_image_cves.require_unreplaced_module("golang.org/x/sys", replacement)
+
+    def test_go_list_module_info_preserves_replacement_identity(self) -> None:
+        payload = """{
+  "Path": "golang.org/x/sys",
+  "Version": "v0.44.0",
+  "Replace": {
+    "Path": "example.com/fork/sys",
+    "Version": "v9.0.0"
+  }
+}"""
+        with mock.patch.object(fix_image_cves, "run", return_value=payload):
+            resolved = fix_image_cves.go_list_module_info(Path("/repo"), "golang.org/x/sys")
+
+        self.assertEqual(
+            resolved,
+            {
+                "path": "golang.org/x/sys",
+                "version": "v0.44.0",
+                "replacement_path": "example.com/fork/sys",
+                "replacement_version": "v9.0.0",
+            },
+        )
+
+    def test_parse_vendor_modules_preserves_replacement_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            vendor = repo_root / "vendor"
+            vendor.mkdir()
+            (vendor / "modules.txt").write_text(
+                "# golang.org/x/sys v0.44.0 => example.com/fork/sys v9.0.0\n",
+                encoding="utf-8",
+            )
+
+            modules = fix_image_cves.parse_vendor_modules(repo_root)
+
+        self.assertEqual(
+            modules["golang.org/x/sys"],
+            {
+                "path": "golang.org/x/sys",
+                "version": "v0.44.0",
+                "replacement_path": "example.com/fork/sys",
+                "replacement_version": "v9.0.0",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR fixes Go module remediation in the `fix-image-cves` shared skill.

- normalizes digit-leading Trivy fixed versions with Go's required `v` prefix
- compares fixed and resolved versions using Go semantic-version precedence
- stages unmet minimum versions with `go mod edit` and lets `go mod tidy` perform Minimal Version Selection
- verifies resolved and vendored versions as minimum thresholds
- rejects module replacements that cannot prove the original module meets its CVE threshold
- adds focused unit coverage and a network-free real-Go module resolution test

#### Which issue(s) this PR fixes:

Fixes #10633

Related: #10054

#### Special notes for your reviewer:

The Go integration test constructs a fully local module graph and runs with `GOPROXY=off` and `GOSUMDB=off`. It reproduces the reported `x/net` and `x/sys` constraint relationship and verifies that MVS resolves `x/sys` above its planned minimum.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
