### PR TITLE
feat(multi-slb): use desired state operation for local service backend pool updater

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -561,6 +561,12 @@ const (
 	LoadBalancerBackendPoolUpdateOperationRemove LoadBalancerBackendPoolUpdateOperation = "remove"
 
 	DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds = 30
+	DefaultLoadBalancerBackendPoolUpdateMaxRetries        = 3
+
+	// Event reason constants for loadBalancerBackendPoolUpdater.
+	LoadBalancerBackendPoolUpdateRetrying = "LoadBalancerBackendPoolUpdateRetrying"
+	LoadBalancerBackendPoolUpdateFailed   = "LoadBalancerBackendPoolUpdateFailed"
+	LoadBalancerBackendPoolUpdated        = "LoadBalancerBackendPoolUpdated"
 
 	ServiceNameLabel = "kubernetes.io/service-name"
 )

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -554,12 +554,7 @@ const (
 	VMSSTagForBatchOperation = "aks-managed-coordination"
 )
 
-type LoadBalancerBackendPoolUpdateOperation string
-
 const (
-	LoadBalancerBackendPoolUpdateOperationAdd    LoadBalancerBackendPoolUpdateOperation = "add"
-	LoadBalancerBackendPoolUpdateOperationRemove LoadBalancerBackendPoolUpdateOperation = "remove"
-
 	DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds = 30
 	DefaultLoadBalancerBackendPoolUpdateMaxRetries        = 3
 

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -39,6 +39,7 @@ import (
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader"
@@ -547,6 +548,12 @@ func (az *Cloud) checkEnableMultipleStandardLoadBalancers() error {
 
 	if az.LoadBalancerBackendPoolUpdateIntervalInSeconds == 0 {
 		az.LoadBalancerBackendPoolUpdateIntervalInSeconds = consts.DefaultLoadBalancerBackendPoolUpdateIntervalInSeconds
+	}
+
+	if az.LoadBalancerBackendPoolUpdateMaxRetries == nil {
+		az.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(consts.DefaultLoadBalancerBackendPoolUpdateMaxRetries)
+	} else if *az.LoadBalancerBackendPoolUpdateMaxRetries < 0 {
+		az.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(0)
 	}
 
 	return nil

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -18,11 +18,15 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	v1 "k8s.io/api/core/v1"
 	discovery_v1 "k8s.io/api/discovery/v1"
@@ -34,6 +38,7 @@ import (
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -65,6 +70,8 @@ type loadBalancerBackendPoolUpdateOperation struct {
 	backendPoolName  string
 	kind             consts.LoadBalancerBackendPoolUpdateOperation
 	nodeIPs          []string
+	retryAttempts    int
+	nextEligibleAt   time.Time
 }
 
 func (op *loadBalancerBackendPoolUpdateOperation) wait() batchOperationResult {
@@ -203,11 +210,37 @@ func (updater *loadBalancerBackendPoolUpdater) groupOperations(ctx context.Conte
 			continue
 		}
 
+		// Check if the Service still exists in the informer. Catches the case where
+		// EnsureLoadBalancerDeleted failed partway, leaving a stale map entry.
+		if _, exists, err := updater.az.getLatestService(lbOp.serviceName, false); err == nil && !exists {
+			logger.V(4).Info("Service not found in informer, skip the operation", "service", lbOp.serviceName)
+			continue
+		}
+
 		key := fmt.Sprintf("%s:%s", lbOp.loadBalancerName, lbOp.backendPoolName)
 		groups[key] = append(groups[key], op)
 	}
 
 	return groups
+}
+
+// hasParkedOperations returns true if any operation has a nextEligibleAt in the future.
+func (updater *loadBalancerBackendPoolUpdater) hasParkedOperations(ops []batchOperation) bool {
+	now := time.Now()
+	for _, op := range ops {
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		if lbOp.nextEligibleAt.After(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// requeueOperations prepends operations back to the front of the queue.
+func (updater *loadBalancerBackendPoolUpdater) requeueOperations(ops []batchOperation) {
+	updater.lock.Lock()
+	defer updater.lock.Unlock()
+	updater.operations = append(ops, updater.operations...)
 }
 
 // process processes all operations in the loadBalancerBackendPoolUpdater.
@@ -242,9 +275,20 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 	groups := updater.groupOperations(ctx, ops)
 
 	for key, ops := range groups {
+		if ctx.Err() != nil {
+			break
+		}
+
 		parts := strings.Split(key, ":")
 		lbName, poolName := parts[0], parts[1]
 		operationName := fmt.Sprintf("%s/%s", lbName, poolName)
+
+		// If any op in the group has nextEligibleAt in the future,
+		// requeue the entire group without making ARM calls or emitting events.
+		if updater.hasParkedOperations(ops) {
+			updater.requeueOperations(ops)
+			continue
+		}
 
 		mc := metrics.NewMetricContext(
 			"services_local",      // prefix name, differ from "services" in main reconciliation loop
@@ -256,8 +300,7 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 
 		bp, err := updater.az.NetworkClientFactory.GetBackendAddressPoolClient().Get(ctx, updater.az.ResourceGroup, lbName, poolName)
 		if err != nil {
-			mc.ObserveOperationWithResult(false)
-			updater.processError(err, operationName, ops...)
+			updater.handleGroupError(ctx, mc, err, operationName, ops)
 			continue
 		}
 
@@ -281,39 +324,139 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 			logger.V(2).Info("updating backend pool", "loadBalancer", lbName, "backendPool", poolName)
 			_, err = updater.az.NetworkClientFactory.GetBackendAddressPoolClient().CreateOrUpdate(ctx, updater.az.ResourceGroup, lbName, poolName, *bp)
 			if err != nil {
-				mc.ObserveOperationWithResult(false)
-				updater.processError(err, operationName, ops...)
+				updater.handleGroupError(ctx, mc, err, operationName, ops)
 				continue
 			}
 		}
 		mc.ObserveOperationWithResult(true)
-		updater.notify(newBatchOperationResult(operationName, true, nil), ops...)
+		updater.notify(ctx, v1.EventTypeNormal, consts.LoadBalancerBackendPoolUpdated, "Load balancer backend pool updated successfully", ops...)
 	}
 }
 
-// processError mark the operations as retriable if the error is retriable,
-// and fail all operations if the error is not retriable.
-func (updater *loadBalancerBackendPoolUpdater) processError(
-	rerr error,
-	operationName string,
-	operations ...batchOperation,
-) {
-	logger := log.Background().WithName("loadBalancerBackendPoolUpdater.processError")
-	if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); !exists && err == nil {
-		logger.V(4).Info("backend pool not found for operation, skip updating", "operation", operationName)
+type updaterErrorClass int
+
+const (
+	errClassStale updaterErrorClass = iota
+	errClassRetriable
+	errClassSDKExhausted
+	errClassTerminal
+)
+
+// classifyUpdaterError classifies an error for retry decisions.
+func classifyUpdaterError(err error) updaterErrorClass {
+	if exists, checkErr := errutils.CheckResourceExistsFromAzcoreError(err); !exists && checkErr == nil {
+		return errClassStale
+	}
+
+	var throttleErr *retryrepectthrottled.ThrottleError
+	if errors.As(err, &throttleErr) {
+		return errClassRetriable
+	}
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		if respErr.StatusCode == http.StatusConflict || respErr.StatusCode == http.StatusPreconditionFailed {
+			return errClassRetriable
+		}
+		// SDK-retriable statuses are terminal because the SDK already retried.
+		if slices.Contains(retryrepectthrottled.GetRetriableStatusCode(), respErr.StatusCode) {
+			return errClassSDKExhausted
+		}
+	}
+
+	return errClassTerminal
+}
+
+// handleGroupError classifies the error and either drops, retries, or fails the group.
+// For user-facing documentation of retry behavior, see
+// https://cloud-provider-azure.sigs.k8s.io/topics/multislb/#retry-behavior
+func (updater *loadBalancerBackendPoolUpdater) handleGroupError(ctx context.Context, mc *metrics.MetricContext, err error, operationName string, ops []batchOperation) {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.handleGroupError")
+
+	// On shutdown, drop silently.
+	if ctx.Err() != nil {
+		logger.V(4).Info("Context canceled, dropping operations", "operation", operationName, "ops", len(ops))
 		return
 	}
 
-	// Fail all operations if not retriable.
-	updater.notify(newBatchOperationResult(operationName, false, rerr), operations...)
+	class := classifyUpdaterError(err)
+	switch class {
+	case errClassStale:
+		logger.V(4).Info("Backend pool not found, skipped update", "operation", operationName)
 
+	case errClassSDKExhausted:
+		mc.ObserveOperationWithResult(false)
+		updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+			fmt.Sprintf("Backend pool update failed (SDK retries exhausted): %v.", err), ops...)
+
+	case errClassTerminal:
+		mc.ObserveOperationWithResult(false)
+		updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+			fmt.Sprintf("Backend pool update failed (non-retriable): %v.", err), ops...)
+
+	case errClassRetriable:
+		var throttleErr *retryrepectthrottled.ThrottleError
+		errors.As(err, &throttleErr)
+
+		var opsToRequeue []batchOperation
+		var exhaustedOps []batchOperation
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+
+			// Re-check relevance before requeue.
+			si, found := updater.az.getLocalServiceInfo(strings.ToLower(lbOp.serviceName))
+			if !found || !strings.EqualFold(si.lbName, lbOp.loadBalancerName) {
+				logger.V(4).Info("Operation is stale before requeue, dropped",
+					"service", lbOp.serviceName, "loadBalancer", lbOp.loadBalancerName)
+				continue
+			}
+
+			if lbOp.retryAttempts >= *updater.az.LoadBalancerBackendPoolUpdateMaxRetries {
+				exhaustedOps = append(exhaustedOps, op)
+			} else {
+				lbOp.retryAttempts++
+				if throttleErr != nil && throttleErr.RetryAfter.After(time.Now()) {
+					lbOp.nextEligibleAt = throttleErr.RetryAfter
+				}
+				opsToRequeue = append(opsToRequeue, op)
+			}
+		}
+
+		// TODO: The desired-state model (one op per service/pool) would eliminate
+		// the case where a single Service receives both Failed and Retrying events
+		// in the same tick.
+
+		if len(exhaustedOps) > 0 {
+			mc.ObserveOperationWithResult(false)
+			updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
+				fmt.Sprintf("Backend pool update failed after %d retries: %v. To retrigger, cause a reconciliation for the Service (e.g., add or update any annotation on the Service).", *updater.az.LoadBalancerBackendPoolUpdateMaxRetries, err), exhaustedOps...)
+		}
+
+		if len(opsToRequeue) > 0 {
+			updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateRetrying,
+				fmt.Sprintf("Backend pool update failed, will retry: %v.", err), opsToRequeue...)
+			updater.requeueOperations(opsToRequeue)
+		}
+	}
 }
 
-// notify notifies the operations with the result.
-func (updater *loadBalancerBackendPoolUpdater) notify(res batchOperationResult, operations ...batchOperation) {
+// notify emits an event for each distinct Service among the provided operations.
+func (updater *loadBalancerBackendPoolUpdater) notify(ctx context.Context, eventType, reason, msg string, operations ...batchOperation) {
+	logger := log.FromContextOrBackground(ctx).WithName("loadBalancerBackendPoolUpdater.notify")
+	seen := make(map[string]struct{})
 	for _, op := range operations {
-		updater.az.processBatchOperationResult(op, res)
-		break
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		key := strings.ToLower(lbOp.serviceName)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		svc, _, _ := updater.az.getLatestService(lbOp.serviceName, false)
+		if svc == nil {
+			logger.V(4).Info("Service not found, skipped event", "service", lbOp.serviceName)
+			continue
+		}
+		updater.az.Event(svc, eventType, reason, msg)
 	}
 }
 
@@ -435,25 +578,6 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 				az.endpointSlicesCache.Delete(strings.ToLower(fmt.Sprintf("%s/%s", es.Namespace, es.Name)))
 			},
 		})
-}
-
-func (az *Cloud) processBatchOperationResult(op batchOperation, res batchOperationResult) {
-	lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
-	var svc *v1.Service
-	svc, _, _ = az.getLatestService(lbOp.serviceName, false)
-	if svc == nil {
-		klog.Warningf("Service %s not found, skip sending event", lbOp.serviceName)
-		return
-	}
-	if !res.success {
-		var errStr string
-		if res.err != nil {
-			errStr = res.err.Error()
-		}
-		az.Event(svc, v1.EventTypeWarning, "LoadBalancerBackendPoolUpdateFailed", errStr)
-	} else {
-		az.Event(svc, v1.EventTypeNormal, "LoadBalancerBackendPoolUpdated", "Load balancer backend pool updated successfully")
-	}
 }
 
 // getServiceNameOfEndpointSlice gets the service name of an EndpointSlice.

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -68,7 +68,6 @@ type loadBalancerBackendPoolUpdateOperation struct {
 	serviceName      string
 	loadBalancerName string
 	backendPoolName  string
-	kind             consts.LoadBalancerBackendPoolUpdateOperation
 	nodeIPs          []string
 	retryAttempts    int
 	nextEligibleAt   time.Time
@@ -106,39 +105,49 @@ func (updater *loadBalancerBackendPoolUpdater) run(ctx context.Context) {
 	logger.Error(err, "stopped")
 }
 
-// getAddIPsToBackendPoolOperation creates a new loadBalancerBackendPoolUpdateOperation
-// that adds nodeIPs to the backend pool.
-func getAddIPsToBackendPoolOperation(serviceName, loadBalancerName, backendPoolName string, nodeIPs []string) *loadBalancerBackendPoolUpdateOperation {
+// getDesiredStateOperation creates a new loadBalancerBackendPoolUpdateOperation
+// representing the full desired IP set for a backend pool.
+func getDesiredStateOperation(serviceName, loadBalancerName, backendPoolName string, nodeIPs []string) *loadBalancerBackendPoolUpdateOperation {
 	return &loadBalancerBackendPoolUpdateOperation{
 		serviceName:      serviceName,
 		loadBalancerName: loadBalancerName,
 		backendPoolName:  backendPoolName,
-		kind:             consts.LoadBalancerBackendPoolUpdateOperationAdd,
 		nodeIPs:          nodeIPs,
 	}
 }
 
-// getRemoveIPsFromBackendPoolOperation creates a new loadBalancerBackendPoolUpdateOperation
-// that removes nodeIPs from the backend pool.
-func getRemoveIPsFromBackendPoolOperation(serviceName, loadBalancerName, backendPoolName string, nodeIPs []string) *loadBalancerBackendPoolUpdateOperation {
-	return &loadBalancerBackendPoolUpdateOperation{
-		serviceName:      serviceName,
-		loadBalancerName: loadBalancerName,
-		backendPoolName:  backendPoolName,
-		kind:             consts.LoadBalancerBackendPoolUpdateOperationRemove,
-		nodeIPs:          nodeIPs,
-	}
-}
-
-// addOperation adds an operation to the loadBalancerBackendPoolUpdater.
+// addOperation adds or replaces an operation in the loadBalancerBackendPoolUpdater.
+// If an operation with the same (serviceName, loadBalancerName, backendPoolName) already
+// exists and the desired IPs differ, its nodeIPs are replaced and retryAttempts is reset.
+// If the desired IPs are unchanged, the existing operation is left untouched to preserve
+// retry state. nextEligibleAt is always preserved because ARM throttling is independent
+// of desired state content.
 func (updater *loadBalancerBackendPoolUpdater) addOperation(operation batchOperation) batchOperation {
 	logger := log.Background().WithName("loadBalancerBackendPoolUpdater.addOperation")
 	updater.lock.Lock()
 	defer updater.lock.Unlock()
 
 	op := operation.(*loadBalancerBackendPoolUpdateOperation)
+	for _, existing := range updater.operations {
+		existingOp := existing.(*loadBalancerBackendPoolUpdateOperation)
+		if strings.EqualFold(existingOp.serviceName, op.serviceName) &&
+			strings.EqualFold(existingOp.loadBalancerName, op.loadBalancerName) &&
+			strings.EqualFold(existingOp.backendPoolName, op.backendPoolName) {
+			// Skips if desired IPs are unchanged, don't reset retry state.
+			if areNodeIPsEqual(existingOp.nodeIPs, op.nodeIPs) {
+				return existing
+			}
+			logger.V(4).Info("Replacing operation in load balancer backend pool updater",
+				"serviceName", op.serviceName,
+				"loadBalancerName", op.loadBalancerName,
+				"backendPoolName", op.backendPoolName,
+				"nodeIPs", strings.Join(op.nodeIPs, ","))
+			existingOp.nodeIPs = op.nodeIPs
+			existingOp.retryAttempts = 0
+			return existing
+		}
+	}
 	logger.V(4).Info("Add operation to load balancer backend pool updater",
-		"kind", op.kind,
 		"serviceName", op.serviceName,
 		"loadBalancerName", op.loadBalancerName,
 		"backendPoolName", op.backendPoolName,
@@ -157,7 +166,6 @@ func (updater *loadBalancerBackendPoolUpdater) removeOperation(serviceName strin
 		op := updater.operations[i].(*loadBalancerBackendPoolUpdateOperation)
 		if strings.EqualFold(op.serviceName, serviceName) {
 			logger.V(4).Info("Remove all operations targeting to the specific service",
-				"kind", op.kind,
 				"serviceName", op.serviceName,
 				"loadBalancerName", op.loadBalancerName,
 				"backendPoolName", op.backendPoolName,
@@ -237,10 +245,40 @@ func (updater *loadBalancerBackendPoolUpdater) hasParkedOperations(ops []batchOp
 }
 
 // requeueOperations prepends operations back to the front of the queue.
+// Operations targeting a pool that already has a pending op in the queue are
+// dropped because the queued op represents a fresher desired state.
 func (updater *loadBalancerBackendPoolUpdater) requeueOperations(ops []batchOperation) {
+	logger := log.Background().WithName("loadBalancerBackendPoolUpdater.requeueOperations")
 	updater.lock.Lock()
 	defer updater.lock.Unlock()
-	updater.operations = append(ops, updater.operations...)
+
+	var toRequeue []batchOperation
+	for _, op := range ops {
+		lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+		stale := false
+		for _, existing := range updater.operations {
+			existingOp := existing.(*loadBalancerBackendPoolUpdateOperation)
+			if strings.EqualFold(existingOp.serviceName, lbOp.serviceName) &&
+				strings.EqualFold(existingOp.loadBalancerName, lbOp.loadBalancerName) &&
+				strings.EqualFold(existingOp.backendPoolName, lbOp.backendPoolName) {
+				// Transfer the later nextEligibleAt to respect ARM throttling.
+				if lbOp.nextEligibleAt.After(existingOp.nextEligibleAt) {
+					existingOp.nextEligibleAt = lbOp.nextEligibleAt
+				}
+				stale = true
+				break
+			}
+		}
+		if stale {
+			logger.V(4).Info("Skipping stale requeue, fresher op already queued",
+				"serviceName", lbOp.serviceName,
+				"loadBalancerName", lbOp.loadBalancerName,
+				"backendPoolName", lbOp.backendPoolName)
+			continue
+		}
+		toRequeue = append(toRequeue, op)
+	}
+	updater.operations = append(toRequeue, updater.operations...)
 }
 
 // process processes all operations in the loadBalancerBackendPoolUpdater.
@@ -305,21 +343,35 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 		}
 
 		var changed bool
+		// Compute desired IPs from all ops in this group.
+		desiredIPs := sets.New[string]()
 		for _, op := range ops {
 			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
-			switch lbOp.kind {
-			case consts.LoadBalancerBackendPoolUpdateOperationRemove:
-				removed := removeNodeIPAddressesFromBackendPool(bp, lbOp.nodeIPs, false, true, true)
-				changed = changed || removed
-			case consts.LoadBalancerBackendPoolUpdateOperationAdd:
-				added := updater.az.addNodeIPAddressesToBackendPool(bp, lbOp.nodeIPs)
-				changed = changed || added
-			default:
-				panic("loadBalancerBackendPoolUpdater.process: unknown operation type")
+			desiredIPs.Insert(lbOp.nodeIPs...)
+		}
+
+		// Compare with current pool IPs.
+		currentIPs := sets.New[string]()
+		for _, addr := range bp.Properties.LoadBalancerBackendAddresses {
+			if addr.Properties != nil && addr.Properties.IPAddress != nil {
+				currentIPs.Insert(*addr.Properties.IPAddress)
 			}
 		}
-		// To keep the code clean, ignore the case when `changed` is true
-		// but the backend pool object is not changed after multiple times of removal and re-adding.
+
+		// Remove IPs not in desired set, add IPs not in current pool.
+		ipsToRemove := currentIPs.Difference(desiredIPs).UnsortedList()
+		ipsToAdd := desiredIPs.Difference(currentIPs).UnsortedList()
+		// Sort for stable test assertions; order is not significant for ARM.
+		slices.Sort(ipsToAdd)
+
+		if len(ipsToRemove) > 0 {
+			changed = removeNodeIPAddressesFromBackendPool(bp, ipsToRemove, false, true, true)
+		}
+		if len(ipsToAdd) > 0 {
+			added := updater.az.addNodeIPAddressesToBackendPool(bp, ipsToAdd)
+			changed = changed || added
+		}
+
 		if changed {
 			logger.V(2).Info("updating backend pool", "loadBalancer", lbName, "backendPool", poolName)
 			_, err = updater.az.NetworkClientFactory.GetBackendAddressPoolClient().CreateOrUpdate(ctx, updater.az.ResourceGroup, lbName, poolName, *bp)
@@ -327,9 +379,9 @@ func (updater *loadBalancerBackendPoolUpdater) process(ctx context.Context) {
 				updater.handleGroupError(ctx, mc, err, operationName, ops)
 				continue
 			}
+			mc.ObserveOperationWithResult(true)
+			updater.notify(ctx, v1.EventTypeNormal, consts.LoadBalancerBackendPoolUpdated, "Load balancer backend pool updated successfully", ops...)
 		}
-		mc.ObserveOperationWithResult(true)
-		updater.notify(ctx, v1.EventTypeNormal, consts.LoadBalancerBackendPoolUpdated, "Load balancer backend pool updated successfully", ops...)
 	}
 }
 
@@ -422,10 +474,6 @@ func (updater *loadBalancerBackendPoolUpdater) handleGroupError(ctx context.Cont
 			}
 		}
 
-		// TODO: The desired-state model (one op per service/pool) would eliminate
-		// the case where a single Service receives both Failed and Retrying events
-		// in the same tick.
-
 		if len(exhaustedOps) > 0 {
 			mc.ObserveOperationWithResult(false)
 			updater.notify(ctx, v1.EventTypeWarning, consts.LoadBalancerBackendPoolUpdateFailed,
@@ -495,8 +543,7 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 				es := obj.(*discovery_v1.EndpointSlice)
 				az.endpointSlicesCache.Store(strings.ToLower(fmt.Sprintf("%s/%s", es.Namespace, es.Name)), es)
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				previousES := oldObj.(*discovery_v1.EndpointSlice)
+			UpdateFunc: func(_, newObj interface{}) {
 				newES := newObj.(*discovery_v1.EndpointSlice)
 
 				svcName := getServiceNameOfEndpointSlice(newES)
@@ -516,45 +563,41 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 				}
 				lbName, ipFamily := si.lbName, si.ipFamily
 
-				var previousIPs, currentIPs []string
-				previousNodeNameSet := utilsets.NewString()
-				currentNodeNameSet := utilsets.NewString()
-				if previousES != nil {
-					for _, ep := range previousES.Endpoints {
-						previousNodeNameSet.Insert(ptr.Deref(ep.NodeName, ""))
+				// Compute full desired IP set from all cached EndpointSlices for this service.
+				allNodeNames := utilsets.NewString()
+				az.endpointSlicesCache.Range(func(_, value interface{}) bool {
+					eps := value.(*discovery_v1.EndpointSlice)
+					if strings.EqualFold(getServiceNameOfEndpointSlice(eps), svcName) &&
+						strings.EqualFold(eps.Namespace, newES.Namespace) {
+						for _, ep := range eps.Endpoints {
+							allNodeNames.Insert(ptr.Deref(ep.NodeName, ""))
+						}
 					}
-				}
-				if newES != nil {
-					for _, ep := range newES.Endpoints {
-						currentNodeNameSet.Insert(ptr.Deref(ep.NodeName, ""))
+					return true
+				})
+
+				allIPs := make([]string, 0)
+				for _, nodeName := range allNodeNames.UnsortedList() {
+					nodeIPsSet := az.nodePrivateIPs[strings.ToLower(nodeName)]
+					if nodeIPsSet != nil {
+						allIPs = append(allIPs, nodeIPsSet.UnsortedList()...)
 					}
-				}
-				for _, previousNodeName := range previousNodeNameSet.UnsortedList() {
-					nodeIPsSet := az.nodePrivateIPs[strings.ToLower(previousNodeName)]
-					previousIPs = append(previousIPs, nodeIPsSet.UnsortedList()...)
-				}
-				for _, currentNodeName := range currentNodeNameSet.UnsortedList() {
-					nodeIPsSet := az.nodePrivateIPs[strings.ToLower(currentNodeName)]
-					currentIPs = append(currentIPs, nodeIPsSet.UnsortedList()...)
 				}
 
 				if az.backendPoolUpdater != nil {
-					var bpNames []string
 					bpNameIPv4 := getLocalServiceBackendPoolName(key, false)
 					bpNameIPv6 := getLocalServiceBackendPoolName(key, true)
+					currentIPsInBackendPools := make(map[string][]string)
 					switch strings.ToLower(ipFamily) {
 					case strings.ToLower(consts.IPVersionIPv4String):
-						bpNames = append(bpNames, bpNameIPv4)
+						currentIPsInBackendPools[bpNameIPv4] = nil
 					case strings.ToLower(consts.IPVersionIPv6String):
-						bpNames = append(bpNames, bpNameIPv6)
+						currentIPsInBackendPools[bpNameIPv6] = nil
 					default:
-						bpNames = append(bpNames, bpNameIPv4, bpNameIPv6)
+						currentIPsInBackendPools[bpNameIPv4] = nil
+						currentIPsInBackendPools[bpNameIPv6] = nil
 					}
-					currentIPsInBackendPools := make(map[string][]string)
-					for _, bpName := range bpNames {
-						currentIPsInBackendPools[bpName] = previousIPs
-					}
-					az.applyIPChangesAmongLocalServiceBackendPoolsByIPFamily(lbName, key, currentIPsInBackendPools, currentIPs)
+					az.applyIPChangesAmongLocalServiceBackendPoolsByIPFamily(lbName, key, currentIPsInBackendPools, allIPs)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -588,11 +631,9 @@ func getServiceNameOfEndpointSlice(es *discovery_v1.EndpointSlice) string {
 	return ""
 }
 
-// compareNodeIPs compares the previous and current node IPs and returns the IPs to be deleted.
-func compareNodeIPs(previousIPs, currentIPs []string) []string {
-	previousIPSet := sets.NewString(previousIPs...)
-	currentIPSet := sets.NewString(currentIPs...)
-	return previousIPSet.Difference(currentIPSet).List()
+// areNodeIPsEqual returns true if the two IP slices contain the same set of IPs.
+func areNodeIPsEqual(currentIPs, expectedIPs []string) bool {
+	return sets.NewString(currentIPs...).Equal(sets.NewString(expectedIPs...))
 }
 
 // getLocalServiceBackendPoolName gets the name of the backend pool of a local service.
@@ -745,9 +786,11 @@ func (az *Cloud) checkAndApplyLocalServiceBackendPoolUpdates(lb armnetwork.LoadB
 	for _, bp := range lb.Properties.BackendAddressPools {
 		bpName := ptr.Deref(bp.Name, "")
 		if localServiceOwnsBackendPool(serviceName, bpName) {
-			var currentIPs []string
+			currentIPs := make([]string, 0)
 			for _, address := range bp.Properties.LoadBalancerBackendAddresses {
-				currentIPs = append(currentIPs, *address.Properties.IPAddress)
+				if address.Properties != nil && address.Properties.IPAddress != nil {
+					currentIPs = append(currentIPs, *address.Properties.IPAddress)
+				}
 			}
 			currentIPsInBackendPools[bpName] = currentIPs
 		}
@@ -774,7 +817,8 @@ func (az *Cloud) applyIPChangesAmongLocalServiceBackendPoolsByIPFamily(
 		}
 	}
 
-	var ipv4, ipv6 []string
+	ipv4 := make([]string, 0)
+	ipv6 := make([]string, 0)
 	for _, ip := range expectedIPs {
 		if utilnet.IsIPv6String(ip) {
 			ipv6 = append(ipv6, ip)
@@ -794,16 +838,10 @@ func (az *Cloud) reconcileIPsInLocalServiceBackendPoolsAsync(
 ) {
 	logger := log.Background().WithName("reconcileIPsInLocalServiceBackendPoolsAsync")
 	for bpName, currentIPs := range currentIPsInBackendPools {
-		ipsToBeDeleted := compareNodeIPs(currentIPs, expectedIPs)
-		if len(ipsToBeDeleted) == 0 && len(currentIPs) == len(expectedIPs) {
+		if currentIPs != nil && areNodeIPsEqual(currentIPs, expectedIPs) {
 			logger.V(4).Info("No IP change detected for service, skip updating load balancer backend pool", "service", serviceName)
 			return
 		}
-		if len(ipsToBeDeleted) > 0 {
-			az.backendPoolUpdater.addOperation(getRemoveIPsFromBackendPoolOperation(serviceName, lbName, bpName, ipsToBeDeleted))
-		}
-		if len(expectedIPs) > 0 {
-			az.backendPoolUpdater.addOperation(getAddIPsToBackendPoolOperation(serviceName, lbName, bpName, expectedIPs))
-		}
+		az.backendPoolUpdater.addOperation(getDesiredStateOperation(serviceName, lbName, bpName, expectedIPs))
 	}
 }

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -77,13 +78,6 @@ func getBackendPoolUpdaterMetrics(t *testing.T) (latencyCount uint64, failureCou
 }
 
 func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	addOperationPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
-	removeOperationPool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
-	addOperationPool2 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool2", []string{"10.0.0.1", "10.0.0.2"})
-
 	testCases := []struct {
 		name                               string
 		operations                         []batchOperation
@@ -94,54 +88,53 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 		changeLB                           bool
 		removeOperationServiceName         string
 		expectedCreateOrUpdateBackendPools []*armnetwork.BackendAddressPool
-		expectedBackendPools               []*armnetwork.BackendAddressPool
+		expectedEventReasons               []string
 	}{
 		{
 			name:       "Add node IPs to backend pool",
-			operations: []batchOperation{addOperationPool1},
+			operations: []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
 			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-			},
+			expectedEventReasons: []string{consts.LoadBalancerBackendPoolUpdated},
 		},
 		{
 			name:       "Remove node IPs from backend pool",
-			operations: []batchOperation{addOperationPool1, removeOperationPool1},
+			operations: []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{})},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
 			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
-			},
+			expectedEventReasons: []string{consts.LoadBalancerBackendPoolUpdated},
 		},
 		{
-			name:       "Multiple operations targeting different backend pools",
-			operations: []batchOperation{addOperationPool1, addOperationPool2, removeOperationPool1},
+			name: "Multiple operations targeting different backend pools",
+			operations: []batchOperation{
+				getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+				getDesiredStateOperation("ns1/svc1", "lb1", "pool2", []string{"10.0.0.1", "10.0.0.2"}),
+			},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 				getTestBackendAddressPoolWithIPs("lb1", "pool2", []string{}),
 			},
 			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 				getTestBackendAddressPoolWithIPs("lb1", "pool2", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
-				getTestBackendAddressPoolWithIPs("lb1", "pool2", []string{"10.0.0.1", "10.0.0.2"}),
-			},
+			expectedEventReasons: []string{consts.LoadBalancerBackendPoolUpdated, consts.LoadBalancerBackendPoolUpdated},
 		},
 		{
-			name:       "Multiple operations in two batches",
-			operations: []batchOperation{addOperationPool1, removeOperationPool1},
-			extraWait:  true,
+			name: "Multiple operations in two batches",
+			operations: []batchOperation{
+				getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+				getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{}),
+			},
+			extraWait: true,
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
@@ -150,23 +143,21 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
 			expectedGetBackendPool: getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
-			},
+			expectedEventReasons:   []string{consts.LoadBalancerBackendPoolUpdated, consts.LoadBalancerBackendPoolUpdated},
 		},
 		{
 			name:                       "remove operations by service name",
-			operations:                 []batchOperation{addOperationPool1, removeOperationPool1},
+			operations:                 []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})},
 			removeOperationServiceName: "ns1/svc1",
 		},
 		{
 			name:       "not local service",
-			operations: []batchOperation{addOperationPool1},
+			operations: []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})},
 			notLocal:   true,
 		},
 		{
 			name:       "not on this load balancer",
-			operations: []batchOperation{addOperationPool1},
+			operations: []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})},
 			changeLB:   true,
 		},
 		{
@@ -174,29 +165,23 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			operations: nil,
 		},
 		{
-			name:       "removing non-existent IPs does not trigger CreateOrUpdate",
-			operations: []batchOperation{removeOperationPool1},
+			name:       "empty desired state on empty pool does not trigger CreateOrUpdate",
+			operations: []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{})},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
-			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
 		},
 		{
 			name:       "adding already-present IPs does not trigger CreateOrUpdate",
-			operations: []batchOperation{addOperationPool1},
+			operations: []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
 		},
 		{
-			name: "add operation deduplicates IPs in empty pool",
+			name: "desired state deduplicates IPs in empty pool",
 			operations: []batchOperation{
-				getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.1", "10.0.0.2"}),
+				getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.1", "10.0.0.2"}),
 			},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
@@ -204,47 +189,28 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-			},
+			expectedEventReasons: []string{consts.LoadBalancerBackendPoolUpdated},
 		},
 		{
-			name: "remove-then-add deduplicates IPs",
-			operations: []batchOperation{
-				getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-				getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.1", "10.0.0.2", "10.0.0.2"}),
-			},
-			existingBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-			},
-			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
-			},
-		},
-		{
-			name: "add-then-remove deduplicates IPs and removes target",
-			operations: []batchOperation{
-				getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.1", "10.0.0.2", "10.0.0.2", "10.0.0.3", "10.0.0.3"}),
-				getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.2"}),
-			},
+			name:       "desired state with mixed add and remove",
+			operations: []batchOperation{getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.3"})},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
 			},
 			expectedCreateOrUpdateBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.3"}),
 			},
-			expectedBackendPools: []*armnetwork.BackendAddressPool{
-				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.3"}),
-			},
+			expectedEventReasons: []string{consts.LoadBalancerBackendPoolUpdated},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(_ *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			cloud := GetTestCloud(ctrl)
+			recorder := record.NewFakeRecorder(100)
+			cloud.eventRecorder = recorder
 			cloud.localServiceNameToServiceInfoMap = sync.Map{}
 			if !tc.notLocal {
 				cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
@@ -262,52 +228,21 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			informerFactory.Start(stopCh)
 			informerFactory.WaitForCacheSync(stopCh)
 			mockbpClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
-			if len(tc.existingBackendPools) > 0 {
-				mockbpClient.EXPECT().Get(
-					gomock.Any(),
-					gomock.Any(),
-					"lb1",
-					*tc.existingBackendPools[0].Name,
-				).Return(tc.existingBackendPools[0], nil)
-			}
-			if len(tc.existingBackendPools) == 2 {
-				mockbpClient.EXPECT().Get(
-					gomock.Any(),
-					gomock.Any(),
-					"lb1",
-					*tc.existingBackendPools[1].Name,
-				).Return(tc.existingBackendPools[1], nil)
+			for _, bp := range tc.existingBackendPools {
+				mockbpClient.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", *bp.Name).Return(bp, nil)
 			}
 			if tc.extraWait {
-				mockbpClient.EXPECT().Get(
-					gomock.Any(),
-					gomock.Any(),
-					"lb1",
-					*tc.expectedGetBackendPool.Name,
-				).Return(tc.expectedGetBackendPool, nil)
+				mockbpClient.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", *tc.expectedGetBackendPool.Name).Return(tc.expectedGetBackendPool, nil)
 			}
-			if len(tc.expectedCreateOrUpdateBackendPools) > 0 {
-				mockbpClient.EXPECT().CreateOrUpdate(
-					gomock.Any(),
-					gomock.Any(),
-					"lb1",
-					*tc.expectedCreateOrUpdateBackendPools[0].Name,
-					*tc.expectedCreateOrUpdateBackendPools[0],
-				).Return(nil, nil)
-			}
-			if len(tc.existingBackendPools) == 2 || tc.extraWait {
-				mockbpClient.EXPECT().CreateOrUpdate(
-					gomock.Any(),
-					gomock.Any(),
-					"lb1",
-					*tc.expectedCreateOrUpdateBackendPools[1].Name,
-					*tc.expectedCreateOrUpdateBackendPools[1],
-				).Return(nil, nil)
+			for _, expectedBP := range tc.expectedCreateOrUpdateBackendPools {
+				mockbpClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", *expectedBP.Name, *expectedBP).Return(nil, nil)
 			}
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
+
+			latencyBefore, _ := getBackendPoolUpdaterMetrics(t)
 
 			// Use WaitGroup to properly synchronize goroutine completion
 			var wg sync.WaitGroup
@@ -317,7 +252,6 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				u.run(ctx)
 			}()
 
-			results := sync.Map{}
 			operationsDone := make(chan struct{})
 			var operationsWg sync.WaitGroup
 
@@ -327,8 +261,6 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				go func() {
 					defer operationsWg.Done()
 					u.addOperation(op)
-					result := op.wait()
-					results.Store(result, true)
 				}()
 				// Small delay to ensure operations are properly queued
 				time.Sleep(50 * time.Millisecond)
@@ -361,12 +293,16 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 			// Ensure proper cleanup - cancel context and wait for goroutine
 			cancel()
 			wg.Wait()
+
+			assertEventReasons(t, drainEvents(recorder), tc.expectedEventReasons...)
+			latencyAfter, _ := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, uint64(len(tc.expectedEventReasons)), latencyAfter-latencyBefore)
 		})
 	}
 }
 
 func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
-	addOperationPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
+	desiredOpPool1 := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
 
 	testCases := []struct {
 		name                               string
@@ -380,7 +316,7 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 	}{
 		{
 			name:       "Non-retriable error when getting backend pool",
-			operations: []batchOperation{addOperationPool1},
+			operations: []batchOperation{desiredOpPool1},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
@@ -391,7 +327,7 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 		},
 		{
 			name:       "Non-retriable error when updating backend pool",
-			operations: []batchOperation{addOperationPool1},
+			operations: []batchOperation{desiredOpPool1},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
@@ -403,7 +339,7 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 		},
 		{
 			name:       "Backend pool not found",
-			operations: []batchOperation{addOperationPool1},
+			operations: []batchOperation{desiredOpPool1},
 			existingBackendPools: []*armnetwork.BackendAddressPool{
 				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}),
 			},
@@ -412,7 +348,7 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(_ *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -665,50 +601,123 @@ func TestEndpointSlicesInformer(t *testing.T) {
 	}
 }
 
-func TestEndpointSlicesInformerDeduplicatesNodeIPs(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
+func TestEndpointSlicesInformerDesiredState(t *testing.T) {
 	for _, tc := range []struct {
-		name        string
-		existingEPS *discovery_v1.EndpointSlice
-		updatedEPS  *discovery_v1.EndpointSlice
-		expectedOps []*loadBalancerBackendPoolUpdateOperation
+		name                string
+		ipFamily            string
+		updatedEPS          *discovery_v1.EndpointSlice
+		otherEndpointSlices []*discovery_v1.EndpointSlice
+		existingQueueOps    []*loadBalancerBackendPoolUpdateOperation
+		nodePrivateIPs      map[string]*utilsets.IgnoreCaseSet
+		expectedOps         []*loadBalancerBackendPoolUpdateOperation
 	}{
 		{
-			name:        "multiple endpoints on same node produces unique IPs",
-			existingEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1"),
-			updatedEPS:  getTestEndpointSlice("eps1", "test", "svc1", "node2", "node2", "node2"),
+			name:       "multiple endpoints on same node produces unique IPs",
+			updatedEPS: getTestEndpointSlice("eps1", "test", "svc1", "node2", "node2", "node2"),
+			nodePrivateIPs: map[string]*utilsets.IgnoreCaseSet{
+				"node2": utilsets.NewString("10.0.0.2"),
+			},
 			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
-				getRemoveIPsFromBackendPoolOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.1"}),
-				getAddIPsToBackendPoolOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.2"}),
+				getDesiredStateOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.2"}),
 			},
 		},
 		{
-			name:        "unchanged node set with different endpoint counts is a no-op",
-			existingEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1", "node1"),
-			updatedEPS:  getTestEndpointSlice("eps1", "test", "svc1", "node1", "node1", "node1"),
+			name:       "unchanged node set preserves retry state on existing op",
+			updatedEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1", "node1", "node1"),
+			existingQueueOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "test/svc1", loadBalancerName: "lb1", backendPoolName: "test-svc1", nodeIPs: []string{"10.0.0.1"}, retryAttempts: 2},
+			},
+			nodePrivateIPs: map[string]*utilsets.IgnoreCaseSet{
+				"node1": utilsets.NewString("10.0.0.1"),
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "test/svc1", loadBalancerName: "lb1", backendPoolName: "test-svc1", nodeIPs: []string{"10.0.0.1"}, retryAttempts: 2},
+			},
+		},
+		{
+			name:       "update includes IPs from all EndpointSlices for the service",
+			updatedEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1", "node3"),
+			otherEndpointSlices: []*discovery_v1.EndpointSlice{
+				getTestEndpointSlice("eps2", "test", "svc1", "node2"),
+			},
+			nodePrivateIPs: map[string]*utilsets.IgnoreCaseSet{
+				"node1": utilsets.NewString("10.0.0.1"),
+				"node2": utilsets.NewString("10.0.0.2"),
+				"node3": utilsets.NewString("10.0.0.3"),
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				getDesiredStateOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}),
+			},
+		},
+		{
+			name:       "removing endpoints excludes their node IPs",
+			updatedEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1"),
+			nodePrivateIPs: map[string]*utilsets.IgnoreCaseSet{
+				"node1": utilsets.NewString("10.0.0.1"),
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				getDesiredStateOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.1"}),
+			},
+		},
+		{
+			name:       "node with multiple IPs includes all",
+			updatedEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1"),
+			nodePrivateIPs: map[string]*utilsets.IgnoreCaseSet{
+				"node1": utilsets.NewString("10.0.0.1", "10.0.0.2"),
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				getDesiredStateOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.1", "10.0.0.2"}),
+			},
+		},
+		{
+			name:       "scale to zero endpoints enqueues empty desired state",
+			updatedEPS: getTestEndpointSlice("eps1", "test", "svc1"),
+			nodePrivateIPs: map[string]*utilsets.IgnoreCaseSet{
+				"node1": utilsets.NewString("10.0.0.1"),
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				getDesiredStateOperation("test/svc1", "lb1", "test-svc1", []string{}),
+			},
+		},
+		{
+			name:       "dual-stack service produces one op per pool",
+			ipFamily:   consts.IPVersionDualStackString,
+			updatedEPS: getTestEndpointSlice("eps1", "test", "svc1", "node1"),
+			nodePrivateIPs: map[string]*utilsets.IgnoreCaseSet{
+				"node1": utilsets.NewString("10.0.0.1", "fd00::1"),
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				getDesiredStateOperation("test/svc1", "lb1", "test-svc1-ipv6", []string{"fd00::1"}),
+				getDesiredStateOperation("test/svc1", "lb1", "test-svc1", []string{"10.0.0.1"}),
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			cloud := GetTestCloud(ctrl)
 			cloud.localServiceNameToServiceInfoMap = sync.Map{}
-			cloud.localServiceNameToServiceInfoMap.Store("test/svc1", newServiceInfo(consts.IPVersionIPv4String, "lb1"))
+			ipFamily := tc.ipFamily
+			if ipFamily == "" {
+				ipFamily = consts.IPVersionIPv4String
+			}
+			cloud.localServiceNameToServiceInfoMap.Store("test/svc1", newServiceInfo(ipFamily, "lb1"))
 			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
 			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
 				{Name: "lb1"},
 			}
-			cloud.nodePrivateIPs = map[string]*utilsets.IgnoreCaseSet{
-				"node1": utilsets.NewString("10.0.0.1"),
-				"node2": utilsets.NewString("10.0.0.2"),
-			}
+			cloud.nodePrivateIPs = tc.nodePrivateIPs
 
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
 			svc.Namespace = "test"
-			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
+			client := fake.NewSimpleClientset(&svc, getTestEndpointSlice("eps1", "test", "svc1"))
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			for _, eps := range tc.otherEndpointSlices {
+				cloud.endpointSlicesCache.Store(
+					fmt.Sprintf("%s/%s", eps.Namespace, eps.Name), eps)
+			}
 			stopCh := make(chan struct{})
 			t.Cleanup(func() { close(stopCh) })
 			informerFactory.Start(stopCh)
@@ -717,6 +726,10 @@ func TestEndpointSlicesInformerDeduplicatesNodeIPs(t *testing.T) {
 			// Create updater without starting run() so we can inspect queued operations.
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Hour)
 			cloud.backendPoolUpdater = u
+
+			for _, op := range tc.existingQueueOps {
+				u.addOperation(op)
+			}
 
 			cloud.setUpEndpointSlicesInformer(informerFactory)
 			stopChan := make(chan struct{})
@@ -736,6 +749,13 @@ func TestEndpointSlicesInformerDeduplicatesNodeIPs(t *testing.T) {
 			var actual []*loadBalancerBackendPoolUpdateOperation
 			for _, op := range ops {
 				actual = append(actual, op.(*loadBalancerBackendPoolUpdateOperation))
+			}
+			// Sort nodeIPs for stable comparison; order is not significant at runtime.
+			for _, op := range actual {
+				slices.Sort(op.nodeIPs)
+			}
+			for _, op := range tc.expectedOps {
+				slices.Sort(op.nodeIPs)
 			}
 			assert.Equal(t, tc.expectedOps, actual)
 		})
@@ -761,15 +781,45 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 	defer ctrl.Finish()
 
 	for _, tc := range []struct {
-		description string
-		existingEPS *discovery_v1.EndpointSlice
+		description  string
+		existingEPS  *discovery_v1.EndpointSlice
+		existingIPv4 []string
+		existingIPv6 []string
+		expectedIPv4 []string
+		expectedIPv6 []string
 	}{
 		{
-			description: "should update backend pool as expected",
-			existingEPS: getTestEndpointSlice("eps1", "default", "svc1", "node2"),
+			description:  "should update backend pool as expected",
+			existingEPS:  getTestEndpointSlice("eps1", "default", "svc1", "node2"),
+			existingIPv4: []string{"10.0.0.1"},
+			existingIPv6: []string{"fd00::1"},
+			expectedIPv4: []string{"10.0.0.2"},
+			expectedIPv6: []string{"fd00::2"},
 		},
 		{
-			description: "should not report an error if failed to get the endpointslice",
+			description:  "should not report an error if failed to get the endpointslice",
+			existingIPv4: []string{"10.0.0.1"},
+			existingIPv6: []string{"fd00::1"},
+		},
+		{
+			description:  "should not update backend pool when IPs already match",
+			existingEPS:  getTestEndpointSlice("eps1", "default", "svc1", "node1"),
+			existingIPv4: []string{"10.0.0.1"},
+			existingIPv6: []string{"fd00::1"},
+		},
+		{
+			description:  "should remove all IPs when endpoints scale to zero",
+			existingEPS:  getTestEndpointSlice("eps1", "default", "svc1"),
+			existingIPv4: []string{"10.0.0.1"},
+			existingIPv6: []string{"fd00::1"},
+			expectedIPv4: []string{},
+			expectedIPv6: []string{},
+		},
+		{
+			description:  "should not update when empty pool and empty endpoints",
+			existingEPS:  getTestEndpointSlice("eps1", "default", "svc1"),
+			existingIPv4: []string{},
+			existingIPv6: []string{},
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
@@ -800,8 +850,8 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 				cloud.endpointSlicesCache.Store(fmt.Sprintf("%s/%s", tc.existingEPS.Name, tc.existingEPS.Namespace), tc.existingEPS)
 			}
 
-			existingBackendPool := getTestBackendAddressPoolWithIPs("lb1", "default-svc1", []string{"10.0.0.1"})
-			existingBackendPoolIPv6 := getTestBackendAddressPoolWithIPs("lb1", "default-svc1-ipv6", []string{"fd00::1"})
+			existingBackendPool := getTestBackendAddressPoolWithIPs("lb1", "default-svc1", tc.existingIPv4)
+			existingBackendPoolIPv6 := getTestBackendAddressPoolWithIPs("lb1", "default-svc1-ipv6", tc.existingIPv6)
 			existingLB := armnetwork.LoadBalancer{
 				Name: ptr.To("lb1"),
 				Properties: &armnetwork.LoadBalancerPropertiesFormat{
@@ -811,13 +861,15 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 					},
 				},
 			}
-			expectedBackendPool := getTestBackendAddressPoolWithIPs("lb1", "default-svc1", []string{"10.0.0.2"})
-			expectedBackendPoolIPv6 := getTestBackendAddressPoolWithIPs("lb1", "default-svc1-ipv6", []string{"fd00::2"})
 			mockLBClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
-			if tc.existingEPS != nil {
+			if tc.expectedIPv4 != nil {
+				expectedBackendPool := getTestBackendAddressPoolWithIPs("lb1", "default-svc1", tc.expectedIPv4)
 				mockLBClient.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "default-svc1").Return(existingBackendPool, nil)
-				mockLBClient.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "default-svc1-ipv6").Return(existingBackendPoolIPv6, nil)
 				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "default-svc1", *expectedBackendPool).Return(nil, nil)
+			}
+			if tc.expectedIPv6 != nil {
+				expectedBackendPoolIPv6 := getTestBackendAddressPoolWithIPs("lb1", "default-svc1-ipv6", tc.expectedIPv6)
+				mockLBClient.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "default-svc1-ipv6").Return(existingBackendPoolIPv6, nil)
 				mockLBClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "default-svc1-ipv6", *expectedBackendPoolIPv6).Return(nil, nil)
 			}
 
@@ -861,11 +913,194 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 			wg.Wait()
 		})
 	}
+
+	t.Run("should not panic on nil address properties", func(t *testing.T) {
+		cloud := GetTestCloud(ctrl)
+		cloud.localServiceNameToServiceInfoMap.Store("default/svc1", newServiceInfo(consts.IPVersionIPv4String, "lb1"))
+		cloud.nodePrivateIPs = map[string]*utilsets.IgnoreCaseSet{
+			"node1": utilsets.NewString("10.0.0.1"),
+		}
+		cloud.endpointSlicesCache.Store("eps1/default", getTestEndpointSlice("eps1", "default", "svc1", "node1"))
+		cloud.backendPoolUpdater = newLoadBalancerBackendPoolUpdater(cloud, time.Hour)
+
+		svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+		bp := getTestBackendAddressPoolWithIPs("lb1", "default-svc1", []string{"10.0.0.1"})
+		bp.Properties.LoadBalancerBackendAddresses = append(
+			bp.Properties.LoadBalancerBackendAddresses,
+			&armnetwork.LoadBalancerBackendAddress{Properties: nil},
+		)
+		existingLB := armnetwork.LoadBalancer{
+			Name: ptr.To("lb1"),
+			Properties: &armnetwork.LoadBalancerPropertiesFormat{
+				BackendAddressPools: []*armnetwork.BackendAddressPool{bp},
+			},
+		}
+
+		err := cloud.checkAndApplyLocalServiceBackendPoolUpdates(existingLB, &svc)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAreNodeIPsEqual(t *testing.T) {
+	for _, tc := range []struct {
+		desc                    string
+		currentIPs, expectedIPs []string
+		equal                   bool
+	}{
+		{
+			desc:        "same IPs same order",
+			currentIPs:  []string{"10.0.0.1", "10.0.0.2"},
+			expectedIPs: []string{"10.0.0.1", "10.0.0.2"},
+			equal:       true,
+		},
+		{
+			desc:        "same IPs different order",
+			currentIPs:  []string{"10.0.0.2", "10.0.0.1"},
+			expectedIPs: []string{"10.0.0.1", "10.0.0.2"},
+			equal:       true,
+		},
+		{
+			desc:        "expected IPs need add and delete",
+			currentIPs:  []string{"10.0.0.1"},
+			expectedIPs: []string{"10.0.0.2"},
+			equal:       false,
+		},
+		{
+			desc:        "expected IPs need add",
+			currentIPs:  []string{"10.0.0.1"},
+			expectedIPs: []string{"10.0.0.1", "10.0.0.2"},
+			equal:       false,
+		},
+		{
+			desc:        "expected IPs need delete",
+			currentIPs:  []string{"10.0.0.1", "10.0.0.2"},
+			expectedIPs: []string{"10.0.0.1"},
+			equal:       false,
+		},
+		{
+			desc:  "no IPs",
+			equal: true,
+		},
+		{
+			desc:       "expected IPs are empty",
+			currentIPs: []string{"10.0.0.1"},
+			equal:      false,
+		},
+		{
+			desc:        "nil current with expected IPs",
+			currentIPs:  nil,
+			expectedIPs: []string{"10.0.0.1"},
+			equal:       false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, tc.equal, areNodeIPsEqual(tc.currentIPs, tc.expectedIPs))
+		})
+	}
+}
+
+func TestAddOperation(t *testing.T) {
+	futureTime := time.Now().Add(1 * time.Hour)
+
+	for _, tc := range []struct {
+		name        string
+		ops         []*loadBalancerBackendPoolUpdateOperation
+		expectedOps []*loadBalancerBackendPoolUpdateOperation
+	}{
+		{
+			name: "replaces op for same target with latest IPs",
+			ops: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1", "10.0.0.2"}},
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.3", "10.0.0.4"}},
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.3", "10.0.0.4"}},
+			},
+		},
+		{
+			name: "different services are independent",
+			ops: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1"}},
+				{serviceName: "ns1/svc2", loadBalancerName: "lb1", backendPoolName: "pool2", nodeIPs: []string{"10.0.0.2"}},
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1"}},
+				{serviceName: "ns1/svc2", loadBalancerName: "lb1", backendPoolName: "pool2", nodeIPs: []string{"10.0.0.2"}},
+			},
+		},
+		{
+			name: "different pools are independent",
+			ops: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "poolA", nodeIPs: []string{"10.0.0.1"}},
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "poolB", nodeIPs: []string{"10.0.0.2"}},
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "poolA", nodeIPs: []string{"10.0.0.1"}},
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "poolB", nodeIPs: []string{"10.0.0.2"}},
+			},
+		},
+		{
+			name: "preserves nextEligibleAt on replace",
+			ops: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1"}, nextEligibleAt: futureTime},
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.3"}},
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.3"}, nextEligibleAt: futureTime},
+			},
+		},
+		{
+			name: "resets retryAttempts on replace",
+			ops: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1"}, retryAttempts: 2},
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.3"}},
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.3"}},
+			},
+		},
+		{
+			name: "skips when IPs unchanged",
+			ops: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1", "10.0.0.2"}, retryAttempts: 2, nextEligibleAt: futureTime},
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1", "10.0.0.2"}},
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1", "10.0.0.2"}, retryAttempts: 2, nextEligibleAt: futureTime},
+			},
+		},
+		{
+			name: "replace with empty desired state",
+			ops: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{"10.0.0.1", "10.0.0.2"}},
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{}},
+			},
+			expectedOps: []*loadBalancerBackendPoolUpdateOperation{
+				{serviceName: "ns1/svc1", loadBalancerName: "lb1", backendPoolName: "pool1", nodeIPs: []string{}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := &Cloud{}
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+			for _, op := range tc.ops {
+				u.addOperation(op)
+			}
+
+			drained := u.drainOperations()
+			var actual []*loadBalancerBackendPoolUpdateOperation
+			for _, op := range drained {
+				actual = append(actual, op.(*loadBalancerBackendPoolUpdateOperation))
+			}
+			assert.Equal(t, tc.expectedOps, actual)
+		})
+	}
 }
 
 func TestCountOperations(t *testing.T) {
-	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
-	op2 := getRemoveIPsFromBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+	op1 := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getDesiredStateOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
 
 	tests := []struct {
 		name     string
@@ -917,8 +1152,8 @@ func TestCountOperations(t *testing.T) {
 }
 
 func TestDrainOperations(t *testing.T) {
-	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
-	op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"})
+	op1 := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getDesiredStateOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"})
 
 	testCases := []struct {
 		name       string
@@ -999,21 +1234,21 @@ func TestHasParkedOperations(t *testing.T) {
 	}{
 		{name: "empty slice", ops: nil, expected: false},
 		{name: "zero nextEligibleAt", ops: []batchOperation{
-			getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}),
+			getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}),
 		}, expected: false},
 		{name: "past nextEligibleAt", ops: func() []batchOperation {
-			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 			op.nextEligibleAt = time.Now().Add(-time.Minute)
 			return []batchOperation{op}
 		}(), expected: false},
 		{name: "future nextEligibleAt", ops: func() []batchOperation {
-			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 			op.nextEligibleAt = time.Now().Add(5 * time.Minute)
 			return []batchOperation{op}
 		}(), expected: true},
 		{name: "mix of past and future", ops: func() []batchOperation {
-			op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
-			op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+			op1 := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op2 := getDesiredStateOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
 			op2.nextEligibleAt = time.Now().Add(5 * time.Minute)
 			return []batchOperation{op1, op2}
 		}(), expected: true},
@@ -1025,9 +1260,9 @@ func TestHasParkedOperations(t *testing.T) {
 }
 
 func TestRequeueOperations(t *testing.T) {
-	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
-	op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
-	op3 := getAddIPsToBackendPoolOperation("ns1/svc3", "lb1", "pool1", []string{"10.0.0.3"})
+	op1 := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getDesiredStateOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+	op3 := getDesiredStateOperation("ns1/svc3", "lb1", "pool1", []string{"10.0.0.3"})
 
 	t.Run("requeue to empty queue", func(t *testing.T) {
 		cloud := &Cloud{}
@@ -1076,13 +1311,73 @@ func TestRequeueOperations(t *testing.T) {
 			t.Fatal("requeueOperations did not complete after lock released")
 		}
 	})
+
+	t.Run("requeue drops op if op for same target already exists", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		u.addOperation(op1)
+
+		// Stale op being requeued after failure.
+		staleOp := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.5"})
+		staleOp.retryAttempts = 1
+		u.requeueOperations([]batchOperation{staleOp})
+
+		// Only the fresh op should remain.
+		ops := u.drainOperations()
+		assert.Equal(t, 1, len(ops))
+		assert.Equal(t, op1, ops[0])
+	})
+
+	for _, tc := range []struct {
+		name                   string
+		freshNextEligibleAt    time.Time
+		staleNextEligibleAt    time.Time
+		expectedNextEligibleAt time.Time
+	}{
+		{
+			name:                   "transfers nextEligibleAt to fresh op",
+			staleNextEligibleAt:    time.Now().Add(1 * time.Hour),
+			expectedNextEligibleAt: time.Now().Add(1 * time.Hour),
+		},
+		{
+			name:                   "transfers nextEligibleAt to fresh op when its value is earlier",
+			freshNextEligibleAt:    time.Now().Add(1 * time.Hour),
+			staleNextEligibleAt:    time.Now().Add(2 * time.Hour),
+			expectedNextEligibleAt: time.Now().Add(2 * time.Hour),
+		},
+		{
+			name:                   "preserves fresh op nextEligibleAt when it is already later",
+			freshNextEligibleAt:    time.Now().Add(2 * time.Hour),
+			staleNextEligibleAt:    time.Now().Add(1 * time.Hour),
+			expectedNextEligibleAt: time.Now().Add(2 * time.Hour),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := &Cloud{}
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+			freshOp := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.3"})
+			freshOp.nextEligibleAt = tc.freshNextEligibleAt
+			u.addOperation(freshOp)
+
+			staleOp := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			staleOp.nextEligibleAt = tc.staleNextEligibleAt
+			staleOp.retryAttempts = 1
+			u.requeueOperations([]batchOperation{staleOp})
+
+			ops := u.drainOperations()
+			assert.Equal(t, 1, len(ops))
+			op := ops[0].(*loadBalancerBackendPoolUpdateOperation)
+			assert.ElementsMatch(t, []string{"10.0.0.3"}, op.nodeIPs, "fresh op IPs should be kept")
+			assert.InDelta(t, tc.expectedNextEligibleAt.UnixNano(), op.nextEligibleAt.UnixNano(), float64(time.Second), "nextEligibleAt should use max")
+		})
+	}
 }
 
 func TestGroupOperations(t *testing.T) {
-	addPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
-	removePool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
-	addPool1WithExtra := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"})
-	addPool2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"})
+	opPool1 := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	opPool2 := getDesiredStateOperation("ns1/svc2", "lb1", "pool2", []string{"10.0.0.2"})
 
 	testCases := []struct {
 		name           string
@@ -1098,43 +1393,37 @@ func TestGroupOperations(t *testing.T) {
 		},
 		{
 			name:           "groups single operation by pool key",
-			operations:     []batchOperation{addPool1},
+			operations:     []batchOperation{opPool1},
 			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
-			expectedGroups: map[string][]batchOperation{"lb1:pool1": {addPool1}},
-		},
-		{
-			name:           "groups operations targeting same pool together",
-			operations:     []batchOperation{removePool1, addPool1WithExtra},
-			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
-			expectedGroups: map[string][]batchOperation{"lb1:pool1": {removePool1, addPool1WithExtra}},
+			expectedGroups: map[string][]batchOperation{"lb1:pool1": {opPool1}},
 		},
 		{
 			name:       "groups operations targeting different pools separately",
-			operations: []batchOperation{addPool1, addPool2},
+			operations: []batchOperation{opPool1, opPool2},
 			localServices: map[string]*serviceInfo{
 				"ns1/svc1": {lbName: "lb1"},
 				"ns1/svc2": {lbName: "lb1"},
 			},
-			expectedGroups: map[string][]batchOperation{"lb1:pool1": {addPool1}, "lb1:pool2": {addPool2}},
+			expectedGroups: map[string][]batchOperation{"lb1:pool1": {opPool1}, "lb1:pool2": {opPool2}},
 		},
 		{
 			name:           "skips operations for non-local services",
-			operations:     []batchOperation{addPool1},
+			operations:     []batchOperation{opPool1},
 			localServices:  map[string]*serviceInfo{},
 			expectedGroups: map[string][]batchOperation{},
 		},
 		{
 			name:           "skips operations targeting stale load balancer",
-			operations:     []batchOperation{addPool1},
+			operations:     []batchOperation{opPool1},
 			localServices:  map[string]*serviceInfo{"ns1/svc1": {lbName: "lb2"}},
 			expectedGroups: map[string][]batchOperation{},
 		},
 		{
 			name:          "keeps valid operation when another is filtered",
-			operations:    []batchOperation{addPool1, addPool2},
+			operations:    []batchOperation{opPool1, opPool2},
 			localServices: map[string]*serviceInfo{"ns1/svc1": {lbName: "lb1"}},
 			expectedGroups: map[string][]batchOperation{
-				"lb1:pool1": {addPool1},
+				"lb1:pool1": {opPool1},
 			},
 		},
 	}
@@ -1186,7 +1475,7 @@ func TestGroupOperations(t *testing.T) {
 		informerFactory.WaitForCacheSync(stopCh)
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-		op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op := getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 
 		groups := u.groupOperations(context.Background(), []batchOperation{op})
 
@@ -1229,7 +1518,7 @@ func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *tes
 	).Return(nil, nil)
 
 	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+	u.addOperation(getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 	// Hold serviceReconcileLock to simulate the main reconcile path.
 	cloud.serviceReconcileLock.Lock()
@@ -1295,7 +1584,7 @@ func TestLoadBalancerBackendPoolUpdaterAddOperationNotBlockedDuringProcess(t *te
 	).Return(nil, nil)
 
 	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+	u.addOperation(getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 	processDone := make(chan struct{})
 	go func() {
@@ -1314,7 +1603,7 @@ func TestLoadBalancerBackendPoolUpdaterAddOperationNotBlockedDuringProcess(t *te
 	addDone := make(chan struct{})
 	go func() {
 		defer close(addDone)
-		u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.2"}))
+		u.addOperation(getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.2"}))
 	}()
 
 	select {
@@ -1358,7 +1647,7 @@ func TestLoadBalancerBackendPoolUpdaterPreservesOperationsOnLeaseLockFailure(t *
 	)
 
 	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+	u.addOperation(getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 	// No ARM mock expectations, ARM call should not happen.
 	u.process(context.Background())
@@ -1416,7 +1705,7 @@ func TestLoadBalancerBackendPoolUpdaterCompletesOnUnlockFailure(t *testing.T) {
 	).Return(nil, nil)
 
 	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+	u.addOperation(getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 	// ARM calls should complete despite unlock failure.
 	u.process(context.Background())
@@ -1449,7 +1738,7 @@ func TestLoadBalancerBackendPoolUpdaterFiltersOperationsWhenLBChangedDuringProce
 	// filters it.
 
 	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+	u.addOperation(getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 	// Hold serviceReconcileLock to simulate the main reconcile loop running.
 	cloud.serviceReconcileLock.Lock()
@@ -1505,7 +1794,7 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	// before process() drains the queue.
 
 	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-	u.addOperation(getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+	u.addOperation(getDesiredStateOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 	// Hold serviceReconcileLock to simulate the main reconcile loop running.
 	cloud.serviceReconcileLock.Lock()
@@ -1722,7 +2011,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			}
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+			u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
 
@@ -1816,7 +2105,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			}
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+			u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 			// Tick 1: ThrottleError, requeues with backoff.
 			u.process(context.Background())
@@ -1870,7 +2159,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+			u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 			u.process(context.Background())
 			assert.Equal(t, 1, u.countOperations())
@@ -1884,17 +2173,18 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 
 	// Parking Behavior
 	t.Run("parked op in group blocks entire group from processing", func(t *testing.T) {
-		cloud, recorder, _ := setupRetryTest(t, 3)
+		cloud, recorder, _ := setupRetryTest(t, 3, "svc1", "svc2")
 
 		// No ARM mock expectations: parked ops should not make ARM calls.
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
-		parkedOp := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		parkedOp := getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 		parkedOp.nextEligibleAt = time.Now().Add(5 * time.Minute)
 		parkedOp.retryAttempts = 1
 		u.addOperation(parkedOp)
 
-		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"}))
+		// Different service, same pool name (fabricated) grouped together.
+		u.addOperation(getDesiredStateOperation("default/svc2", "lb1", "pool1", []string{"10.0.0.2"}))
 
 		u.process(context.Background())
 
@@ -1911,41 +2201,6 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		}
 
 		assert.Empty(t, drainEvents(recorder), "expected no events")
-	})
-
-	t.Run("fresh op added while group is parked is applied after parked op on eligible tick", func(t *testing.T) {
-		cloud, _, mockBP := setupRetryTest(t, 3)
-
-		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
-
-		// Tick 1: fresh remove added during call, ThrottleError parks.
-		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").DoAndReturn(
-			func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
-				u.addOperation(getRemoveIPsFromBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
-				return nil, &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(100 * time.Millisecond)}
-			},
-		).Times(1)
-		// Tick 2: both ops applied in order, succeeds.
-		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
-			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
-		).Times(1)
-		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
-			func(_ context.Context, _, _, _ string, bp armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
-				assert.Empty(t, bp.Properties.LoadBalancerBackendAddresses,
-					"expected empty pool: parked add should be applied before fresh remove")
-				return nil, nil
-			},
-		).Times(1)
-
-		u.process(context.Background())
-		assert.Equal(t, 2, u.countOperations())
-
-		// Sleep so nextEligibleAt passes.
-		time.Sleep(150 * time.Millisecond)
-
-		u.process(context.Background())
-		assert.Equal(t, 0, u.countOperations())
 	})
 
 	// Retry Budget
@@ -1969,7 +2224,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		).Times(1)
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 		u.process(context.Background())
 		assert.Equal(t, 1, u.countOperations())
@@ -1987,7 +2242,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 	})
 
 	t.Run("each op in group maintains its own retry counter across failures", func(t *testing.T) {
-		cloud, _, mockBP := setupRetryTest(t, 3)
+		cloud, _, mockBP := setupRetryTest(t, 3, "svc1", "svc2")
 
 		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
 			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
@@ -1998,11 +2253,11 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
-		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA := getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 		opA.retryAttempts = 1
 		u.addOperation(opA)
 
-		opB := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"})
+		opB := getDesiredStateOperation("default/svc2", "lb1", "pool1", []string{"10.0.0.2"})
 		u.addOperation(opB)
 
 		u.process(context.Background())
@@ -2034,11 +2289,11 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
-		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA := getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 		opA.retryAttempts = 2
 		u.addOperation(opA)
 
-		opB := getAddIPsToBackendPoolOperation("default/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+		opB := getDesiredStateOperation("default/svc2", "lb1", "pool1", []string{"10.0.0.2"})
 		u.addOperation(opB)
 
 		u.process(context.Background())
@@ -2065,7 +2320,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
 
@@ -2106,16 +2361,6 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdateRetrying},
 		},
 		{
-			name:       "multiple ops for same service produce only one event",
-			maxRetries: 3,
-			ops: []opSpec{
-				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
-				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
-			},
-			expectedQueue:   2,
-			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying},
-		},
-		{
 			name:       "two exhausted ops for same service produce only one failed event",
 			maxRetries: 0,
 			ops: []opSpec{
@@ -2124,18 +2369,6 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			},
 			expectedQueue:   0,
 			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed},
-		},
-		{
-			// This edge case (same service receiving both events) is a consequence of the
-			// diff-based operation model and will be eliminated by the desired-state follow-up.
-			name:       "same service with mixed budgets emits Failed before Retrying",
-			maxRetries: 2,
-			ops: []opSpec{
-				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}, retryAttempts: 2},
-				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
-			},
-			expectedQueue:   1,
-			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed, consts.LoadBalancerBackendPoolUpdateRetrying},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2150,7 +2383,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 			for _, op := range tc.ops {
-				o := getAddIPsToBackendPoolOperation(op.svcKey, "lb1", "pool1", op.ips)
+				o := getDesiredStateOperation(op.svcKey, "lb1", "pool1", op.ips)
 				o.retryAttempts = op.retryAttempts
 				u.addOperation(o)
 			}
@@ -2161,6 +2394,173 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			assertEventReasons(t, drainEvents(recorder), tc.expectedReasons...)
 		})
 	}
+
+	// Desired-state replace interaction with retry
+	t.Run("fresh desired state after 409 resets retryAttempts and uses new IPs", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		// Tick 1: 409, requeues.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}))
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+		ops := u.drainOperations()
+		assert.Equal(t, 1, ops[0].(*loadBalancerBackendPoolUpdateOperation).retryAttempts)
+		u.requeueOperations(ops)
+
+		// New event replaces with fresh desired state.
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}))
+		assert.Equal(t, 1, u.countOperations())
+		ops = u.drainOperations()
+		assert.Equal(t, 0, ops[0].(*loadBalancerBackendPoolUpdateOperation).retryAttempts)
+		assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, ops[0].(*loadBalancerBackendPoolUpdateOperation).nodeIPs)
+		u.requeueOperations(ops)
+
+		// Tick 2: succeeds with fresh desired state.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1",
+			*getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}),
+		).Return(nil, nil).Times(1)
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	t.Run("desired state updated during Retry-After preserves nextEligibleAt and uses latest IPs", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		// Tick 1: ThrottleError parks the operation.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			nil, &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(1 * time.Hour)},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+		ops := u.drainOperations()
+		assert.True(t, ops[0].(*loadBalancerBackendPoolUpdateOperation).nextEligibleAt.After(time.Now()))
+		u.requeueOperations(ops)
+
+		// Fresh op replaces IPs but keeps nextEligibleAt.
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}))
+		assert.Equal(t, 1, u.countOperations())
+		ops = u.drainOperations()
+		op := ops[0].(*loadBalancerBackendPoolUpdateOperation)
+		assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2"}, op.nodeIPs)
+		assert.True(t, op.nextEligibleAt.After(time.Now()), "nextEligibleAt should still be in future")
+
+		// Simulate time passing.
+		op.nextEligibleAt = time.Now().Add(-1 * time.Second)
+		u.requeueOperations(ops)
+
+		// Tick 2: succeeds with latest desired state.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1",
+			*getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}),
+		).Return(nil, nil).Times(1)
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	t.Run("two services replaced independently", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3, "svc1", "svc2")
+
+		// Both fail with 409.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool2").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool2", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool2", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+		u.addOperation(getDesiredStateOperation("default/svc2", "lb1", "pool2", []string{"10.0.0.2"}))
+
+		u.process(context.Background())
+		assert.Equal(t, 2, u.countOperations())
+
+		// Replace svc1 only.
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.3"}))
+
+		ops := u.drainOperations()
+		for _, o := range ops {
+			lbOp := o.(*loadBalancerBackendPoolUpdateOperation)
+			if lbOp.serviceName == "default/svc1" {
+				assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.3"}, lbOp.nodeIPs)
+				assert.Equal(t, 0, lbOp.retryAttempts)
+			} else {
+				assert.ElementsMatch(t, []string{"10.0.0.2"}, lbOp.nodeIPs)
+				assert.Equal(t, 1, lbOp.retryAttempts)
+			}
+		}
+	})
+
+	t.Run("failed op is dropped when fresher op arrives during ARM call", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1", "10.0.0.2"}))
+
+		// Tick 1: fresh op added during call, ThrottleError parks.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").DoAndReturn(
+			func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+				u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.3", "10.0.0.4"}))
+				return nil, &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(1 * time.Hour)}
+			},
+		).Times(1)
+
+		u.process(context.Background())
+
+		// Stale op dropped, fresh op remains with transferred nextEligibleAt.
+		ops := u.drainOperations()
+		assert.Equal(t, 1, len(ops))
+		op := ops[0].(*loadBalancerBackendPoolUpdateOperation)
+		assert.Equal(t, 0, op.retryAttempts)
+		assert.True(t, op.nextEligibleAt.After(time.Now()), "fresh op should inherit throttle delay")
+
+		// Tick 2: op is parked (nextEligibleAt in future), no ARM calls.
+		u.requeueOperations(ops)
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		// Simulate time passing.
+		ops = u.drainOperations()
+		ops[0].(*loadBalancerBackendPoolUpdateOperation).nextEligibleAt = time.Now().Add(-1 * time.Second)
+		u.requeueOperations(ops)
+
+		// Tick 3: op is eligible, succeeds.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1",
+			*getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{"10.0.0.3", "10.0.0.4"}),
+		).Return(nil, nil).Times(1)
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
 
 	// Staleness
 	for _, tc := range []struct {
@@ -2194,7 +2594,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			).Times(1)
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+			u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
 
@@ -2220,7 +2620,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		).Times(1)
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
 
@@ -2250,7 +2650,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
 		// Add op with nextEligibleAt in the near future.
-		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op := getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 		op.nextEligibleAt = time.Now().Add(50 * time.Millisecond)
 		op.retryAttempts = 1
 		u.addOperation(op)
@@ -2302,7 +2702,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			).Times(1)
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+			u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 			u.process(context.Background())
 			assert.Equal(t, 1, u.countOperations())
@@ -2329,7 +2729,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		).Times(1)
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 		// Start process() in goroutine; it acquires serviceReconcileLock.
 		processDone := make(chan struct{})
@@ -2392,7 +2792,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		).Times(1)
 
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+		u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 		// Start process() in goroutine; it acquires serviceReconcileLock.
 		processDone := make(chan struct{})
@@ -2470,7 +2870,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 			).Times(1)
 
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
-			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+			u.addOperation(getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
 
 			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
 
@@ -2491,7 +2891,7 @@ func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
 		// No ARM mock expectations: parked ops with canceled context should never reach ARM.
 		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
-		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op := getDesiredStateOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 		op.nextEligibleAt = time.Now().Add(5 * time.Minute)
 		op.retryAttempts = 1
 		u.addOperation(op)

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -38,13 +39,42 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/backendaddresspoolclient/mock_backendaddresspoolclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 	utilsets "sigs.k8s.io/cloud-provider-azure/pkg/util/sets"
 )
+
+// getBackendPoolUpdaterMetrics returns the current latency observation count
+// and failure count for the local service backend pool updater metric.
+func getBackendPoolUpdaterMetrics(t *testing.T) (latencyCount uint64, failureCount float64) {
+	t.Helper()
+	const request = "services_local_update_backend_pool"
+	families, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, f := range families {
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "request" && lp.GetValue() == request {
+					switch f.GetName() {
+					case "cloudprovider_azure_op_duration_seconds":
+						latencyCount = m.GetHistogram().GetSampleCount()
+					case "cloudprovider_azure_op_failure_count":
+						failureCount = m.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+	return
+}
 
 func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -223,9 +253,14 @@ func TestLoadBalancerBackendPoolUpdater(t *testing.T) {
 				cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb2"})
 			}
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "ns1"
 			client := fake.NewSimpleClientset(&svc)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			mockbpClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			if len(tc.existingBackendPools) > 0 {
 				mockbpClient.EXPECT().Get(
@@ -385,9 +420,14 @@ func TestLoadBalancerBackendPoolUpdaterFailed(t *testing.T) {
 			cloud.localServiceNameToServiceInfoMap = sync.Map{}
 			cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "ns1"
 			client := fake.NewSimpleClientset(&svc)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			mockLBClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
 			mockLBClient.EXPECT().Get(
@@ -551,9 +591,14 @@ func TestEndpointSlicesInformer(t *testing.T) {
 				cloud.localServiceNameToServiceInfoMap.Store("test/svc1", &serviceInfo{lbName: "lb1"})
 			}
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "test"
 			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
 			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
@@ -660,9 +705,14 @@ func TestEndpointSlicesInformerDeduplicatesNodeIPs(t *testing.T) {
 			}
 
 			svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+			svc.Namespace = "test"
 			client := fake.NewSimpleClientset(&svc, tc.existingEPS)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 
 			// Create updater without starting run() so we can inspect queued operations.
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Hour)
@@ -730,6 +780,10 @@ func TestCheckAndApplyLocalServiceBackendPoolUpdates(t *testing.T) {
 			cloud.KubeClient = client
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
 			cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
 			cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
@@ -934,6 +988,96 @@ func TestDrainOperations(t *testing.T) {
 	})
 }
 
+func TestHasParkedOperations(t *testing.T) {
+	cloud := &Cloud{}
+	u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+	for _, tc := range []struct {
+		name     string
+		ops      []batchOperation
+		expected bool
+	}{
+		{name: "empty slice", ops: nil, expected: false},
+		{name: "zero nextEligibleAt", ops: []batchOperation{
+			getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"}),
+		}, expected: false},
+		{name: "past nextEligibleAt", ops: func() []batchOperation {
+			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op.nextEligibleAt = time.Now().Add(-time.Minute)
+			return []batchOperation{op}
+		}(), expected: false},
+		{name: "future nextEligibleAt", ops: func() []batchOperation {
+			op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op.nextEligibleAt = time.Now().Add(5 * time.Minute)
+			return []batchOperation{op}
+		}(), expected: true},
+		{name: "mix of past and future", ops: func() []batchOperation {
+			op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+			op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+			op2.nextEligibleAt = time.Now().Add(5 * time.Minute)
+			return []batchOperation{op1, op2}
+		}(), expected: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, u.hasParkedOperations(tc.ops))
+		})
+	}
+}
+
+func TestRequeueOperations(t *testing.T) {
+	op1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+	op2 := getAddIPsToBackendPoolOperation("ns1/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+	op3 := getAddIPsToBackendPoolOperation("ns1/svc3", "lb1", "pool1", []string{"10.0.0.3"})
+
+	t.Run("requeue to empty queue", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		u.requeueOperations([]batchOperation{op1, op2})
+
+		ops := u.drainOperations()
+		assert.Equal(t, []batchOperation{op1, op2}, ops)
+	})
+
+	t.Run("requeue prepends before existing", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(op3)
+
+		u.requeueOperations([]batchOperation{op1, op2})
+
+		ops := u.drainOperations()
+		assert.Equal(t, []batchOperation{op1, op2, op3}, ops)
+	})
+
+	t.Run("acquires updater lock", func(t *testing.T) {
+		cloud := &Cloud{}
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		u.lock.Lock()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			u.requeueOperations([]batchOperation{op1})
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("requeueOperations returned while lock was held")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		u.lock.Unlock()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("requeueOperations did not complete after lock released")
+		}
+	})
+}
+
 func TestGroupOperations(t *testing.T) {
 	addPool1 := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
 	removePool1 := getRemoveIPsFromBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
@@ -998,9 +1142,22 @@ func TestGroupOperations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cloud := &Cloud{}
+			var svcObjects []runtime.Object
 			for k, v := range tc.localServices {
 				cloud.localServiceNameToServiceInfoMap.Store(k, v)
+				parts := strings.Split(k, "/")
+				svcObjects = append(svcObjects, &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: parts[0], Name: parts[1]},
+				})
 			}
+			client := fake.NewSimpleClientset(svcObjects...)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+			stopCh := make(chan struct{})
+			t.Cleanup(func() { close(stopCh) })
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
 			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
 
 			groups := u.groupOperations(context.Background(), tc.operations)
@@ -1014,6 +1171,27 @@ func TestGroupOperations(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("skips operation for service in map but deleted from informer", func(t *testing.T) {
+		cloud := &Cloud{}
+		cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
+
+		// Informer has no Service object (simulates failed deletion leaving stale map entry).
+		client := fake.NewSimpleClientset()
+		informerFactory := informers.NewSharedInformerFactory(client, 0)
+		cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+		stopCh := make(chan struct{})
+		t.Cleanup(func() { close(stopCh) })
+		informerFactory.Start(stopCh)
+		informerFactory.WaitForCacheSync(stopCh)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		op := getAddIPsToBackendPoolOperation("ns1/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+
+		groups := u.groupOperations(context.Background(), []batchOperation{op})
+
+		assert.Equal(t, 0, len(groups))
+	})
 }
 
 func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *testing.T) {
@@ -1025,9 +1203,14 @@ func TestLoadBalancerBackendPoolUpdaterSerializesWithServiceReconcileLock(t *tes
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	existingBP := getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{})
 	mockBPClient := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
@@ -1085,9 +1268,14 @@ func TestLoadBalancerBackendPoolUpdaterAddOperationNotBlockedDuringProcess(t *te
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// Block the ARM Get call so process() is in the middle of ARM work.
 	armBlocked := make(chan struct{})
@@ -1189,9 +1377,14 @@ func TestLoadBalancerBackendPoolUpdaterCompletesOnUnlockFailure(t *testing.T) {
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// Fail the second lease update (releaseLease), let the first (acquireLease) pass.
 	var updateCount int32
@@ -1242,9 +1435,14 @@ func TestLoadBalancerBackendPoolUpdaterFiltersOperationsWhenLBChangedDuringProce
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// No ARM mock expectations. The operation targets lb1 but the service moves
 	// to lb2 while process() is blocked on serviceReconcileLock, so groupOperations
@@ -1294,9 +1492,14 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	cloud.localServiceNameToServiceInfoMap.Store("ns1/svc1", &serviceInfo{lbName: "lb1"})
 
 	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "ns1"
 	client := fake.NewSimpleClientset(&svc)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 
 	// No ARM mock expectations. removeOperation cancels the operation
 	// before process() drains the queue.
@@ -1334,4 +1537,979 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	u.lock.Lock()
 	assert.Equal(t, 0, len(u.operations))
 	u.lock.Unlock()
+}
+
+// setupRetryTest creates a Cloud with a fake event recorder, service lister,
+// and mock backend pool client for retry tests. Each call creates a fresh
+// gomock.Controller scoped to t (auto-Finish via t.Cleanup). svcNames defaults
+// to ["svc1"] when omitted. All services are registered in
+// localServiceNameToServiceInfoMap with lbName "lb1".
+func setupRetryTest(t *testing.T, maxRetries int, svcNames ...string) (
+	*Cloud, *record.FakeRecorder, *mock_backendaddresspoolclient.MockInterface,
+) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+
+	if len(svcNames) == 0 {
+		svcNames = []string{"svc1"}
+	}
+
+	var svcObjects []runtime.Object
+	for _, name := range svcNames {
+		cloud.localServiceNameToServiceInfoMap.Store("default/"+name, &serviceInfo{lbName: "lb1"})
+		svc := getTestService(name, v1.ProtocolTCP, nil, false)
+		svcObjects = append(svcObjects, &svc)
+	}
+	cloud.LoadBalancerBackendPoolUpdateMaxRetries = ptr.To(maxRetries)
+
+	fakeRecorder := record.NewFakeRecorder(100)
+	cloud.eventRecorder = fakeRecorder
+
+	client := fake.NewSimpleClientset(svcObjects...)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cloud.serviceLister = informerFactory.Core().V1().Services().Lister()
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	mockBP := cloud.NetworkClientFactory.GetBackendAddressPoolClient().(*mock_backendaddresspoolclient.MockInterface)
+	return cloud, fakeRecorder, mockBP
+}
+
+// drainEvents reads all buffered events from a FakeRecorder without blocking.
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// assertEventReasons asserts events match the expected reasons in order.
+func assertEventReasons(t *testing.T, events []string, expectedReasons ...string) {
+	t.Helper()
+	if len(events) != len(expectedReasons) {
+		t.Fatalf("expected %d events, got %d: %v", len(expectedReasons), len(events), events)
+	}
+	for i, reason := range expectedReasons {
+		assert.Contains(t, events[i], reason)
+	}
+}
+
+func TestLoadBalancerBackendPoolUpdaterRetry(t *testing.T) {
+	// Error Classification
+	for _, tc := range []struct {
+		name              string
+		maxRetries        int
+		getErr            error
+		createOrUpdateErr error
+		expectedQueue     int
+		expectedEventType string
+		expectedEvent     string
+		terminalMsg       string
+	}{
+		{
+			name:              "successful update emits Updated event",
+			maxRetries:        3,
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeNormal,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdated,
+		},
+		{
+			name:              "500 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusInternalServerError},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "408 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusRequestTimeout},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "502 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusBadGateway},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "503 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusServiceUnavailable},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:              "504 from SDK retry emits Failed event",
+			maxRetries:        3,
+			getErr:            &azcore.ResponseError{StatusCode: http.StatusGatewayTimeout},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "SDK retries exhausted",
+		},
+		{
+			name:          "404 not found is dropped without event",
+			maxRetries:    3,
+			getErr:        &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			expectedQueue: 0,
+		},
+		{
+			name:              "non-ARM error emits Failed event",
+			maxRetries:        3,
+			getErr:            fmt.Errorf("connection reset"),
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+			terminalMsg:       "non-retriable",
+		},
+		{
+			name:              "retriable 409 with MaxRetries 0 emits Failed event on first failure",
+			maxRetries:        0,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+			expectedQueue:     0,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateFailed,
+		},
+		{
+			name:              "409 conflict requeues and emits Retrying event",
+			maxRetries:        3,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+			expectedQueue:     1,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateRetrying,
+		},
+		{
+			name:              "412 precondition failed requeues and emits Retrying event",
+			maxRetries:        3,
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed},
+			expectedQueue:     1,
+			expectedEventType: v1.EventTypeWarning,
+			expectedEvent:     consts.LoadBalancerBackendPoolUpdateRetrying,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, tc.maxRetries)
+
+			if tc.getErr != nil {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(nil, tc.getErr).Times(1)
+			} else {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+					getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+				).Times(1)
+				mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			}
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(context.Background())
+
+			assert.Equal(t, tc.expectedQueue, u.countOperations())
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+
+			switch tc.expectedEvent {
+			case consts.LoadBalancerBackendPoolUpdateFailed:
+				assert.Equal(t, latencyBefore+1, latencyAfter, "failed operation should record one metric observation")
+				assert.Equal(t, failureBefore+1, failureAfter, "failed operation should increment failure counter")
+			case consts.LoadBalancerBackendPoolUpdated:
+				assert.Equal(t, latencyBefore+1, latencyAfter, "successful operation should record one metric observation")
+				assert.Equal(t, failureBefore, failureAfter, "successful operation should not increment failure counter")
+			case consts.LoadBalancerBackendPoolUpdateRetrying:
+				assert.Equal(t, latencyBefore, latencyAfter, "retrying operation should not record any metric")
+				assert.Equal(t, failureBefore, failureAfter, "retrying operation should not increment failure counter")
+			default:
+				assert.Equal(t, latencyBefore, latencyAfter, "stale operation should not record any metric")
+				assert.Equal(t, failureBefore, failureAfter, "stale operation should not increment failure counter")
+			}
+
+			events := drainEvents(recorder)
+			if tc.expectedEvent == "" {
+				assert.Empty(t, events, "expected no events")
+			} else {
+				assert.Equal(t, 1, len(events), "expected exactly one event")
+				if len(events) > 0 {
+					assert.Contains(t, events[0], tc.expectedEventType, "unexpected event type")
+					assert.Contains(t, events[0], tc.expectedEvent)
+
+					// Assert message format based on error classification.
+					if tc.terminalMsg != "" {
+						assert.Contains(t, events[0], tc.terminalMsg)
+					} else {
+						assert.NotContains(t, events[0], "SDK retries exhausted")
+						assert.NotContains(t, events[0], "non-retriable")
+					}
+					switch tc.expectedEvent {
+					case consts.LoadBalancerBackendPoolUpdateFailed:
+						if tc.terminalMsg == "" {
+							assert.Contains(t, events[0], "retries")
+							assert.Contains(t, events[0], "retrigger")
+						}
+					case consts.LoadBalancerBackendPoolUpdateRetrying:
+						assert.Contains(t, events[0], "will retry")
+					case consts.LoadBalancerBackendPoolUpdated:
+						assert.Contains(t, events[0], "updated successfully")
+					}
+
+					// Assert the causal error string appears in the event message.
+					errToCheck := tc.getErr
+					if errToCheck == nil {
+						errToCheck = tc.createOrUpdateErr
+					}
+					if errToCheck != nil {
+						assert.Contains(t, events[0], errToCheck.Error())
+					}
+				}
+			}
+		})
+	}
+
+	// Retriable Error Paths
+	for _, tc := range []struct {
+		name              string
+		getErr            error
+		createOrUpdateErr error
+	}{
+		{
+			name:   "ThrottleError from Get parks until RetryAfter",
+			getErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+		{
+			name:              "ThrottleError from CreateOrUpdate parks until RetryAfter",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			if tc.getErr != nil {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(nil, tc.getErr).Times(1)
+			} else {
+				mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+					getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+				).Times(1)
+				mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			}
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			// Tick 1: ThrottleError, requeues with backoff.
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+			assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying)
+
+			latencyBeforePark, failureBeforePark := getBackendPoolUpdaterMetrics(t)
+
+			// Tick 2: still parked, skipped.
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfterPark, failureAfterPark := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBeforePark, latencyAfterPark, "parked tick should not record any metric")
+			assert.Equal(t, failureBeforePark, failureAfterPark, "parked tick should not increment failure counter")
+
+			ops := u.drainOperations()
+			assert.Equal(t, 1, len(ops))
+			lbOp := ops[0].(*loadBalancerBackendPoolUpdateOperation)
+			assert.Equal(t, 1, lbOp.retryAttempts, "retryAttempts should not increment on parked tick")
+			assert.True(t, lbOp.nextEligibleAt.After(time.Now()), "nextEligibleAt should still be in the future")
+		})
+	}
+
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "ThrottleError with past RetryAfter requeues without parking",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(-time.Second)},
+		},
+		{
+			name:              "409 requeues then succeeds on next tick",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			// Tick 1: retriable error, requeues.
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, tc.createOrUpdateErr).Times(1)
+			// Tick 2: succeeds.
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+
+			u.process(context.Background())
+			assert.Equal(t, 0, u.countOperations())
+
+			assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdated)
+		})
+	}
+
+	// Parking Behavior
+	t.Run("parked op in group blocks entire group from processing", func(t *testing.T) {
+		cloud, recorder, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops should not make ARM calls.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		parkedOp := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		parkedOp.nextEligibleAt = time.Now().Add(5 * time.Minute)
+		parkedOp.retryAttempts = 1
+		u.addOperation(parkedOp)
+
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"}))
+
+		u.process(context.Background())
+
+		// Both ops should be requeued without ARM calls, retryAttempts unchanged.
+		ops := u.drainOperations()
+		assert.Equal(t, 2, len(ops))
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+			if lbOp.nodeIPs[0] == "10.0.0.1" {
+				assert.Equal(t, 1, lbOp.retryAttempts, "parked op retryAttempts should be unchanged")
+			} else {
+				assert.Equal(t, 0, lbOp.retryAttempts, "fresh op retryAttempts should be unchanged")
+			}
+		}
+
+		assert.Empty(t, drainEvents(recorder), "expected no events")
+	})
+
+	t.Run("fresh op added while group is parked is applied after parked op on eligible tick", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Tick 1: fresh remove added during call, ThrottleError parks.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").DoAndReturn(
+			func(_ context.Context, _, _, _ string) (*armnetwork.BackendAddressPool, error) {
+				u.addOperation(getRemoveIPsFromBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+				return nil, &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(100 * time.Millisecond)}
+			},
+		).Times(1)
+		// Tick 2: both ops applied in order, succeeds.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, bp armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				assert.Empty(t, bp.Properties.LoadBalancerBackendAddresses,
+					"expected empty pool: parked add should be applied before fresh remove")
+				return nil, nil
+			},
+		).Times(1)
+
+		u.process(context.Background())
+		assert.Equal(t, 2, u.countOperations())
+
+		// Sleep so nextEligibleAt passes.
+		time.Sleep(150 * time.Millisecond)
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	// Retry Budget
+	t.Run("repeated failures exhaust retry budget and emit failed event with guidance", func(t *testing.T) {
+		cloud, recorder, mockBP := setupRetryTest(t, 1)
+
+		conflictErr := &azcore.ResponseError{StatusCode: http.StatusConflict}
+		// Tick 1: 409, requeues (retryAttempts 0->1, within budget).
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, conflictErr,
+		).Times(1)
+		// Tick 2: 409, exhausted (retryAttempts=1 >= maxRetries).
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, conflictErr,
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		events := drainEvents(recorder)
+		assertEventReasons(t, events, consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdateFailed)
+		assert.Contains(t, events[1], "after 1 retries")
+		assert.Contains(t, events[1], conflictErr.Error())
+		assert.Contains(t, events[1], "retrigger")
+		assert.NotContains(t, events[1], "SDK retries exhausted")
+		assert.NotContains(t, events[1], "non-retriable")
+	})
+
+	t.Run("each op in group maintains its own retry counter across failures", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA.retryAttempts = 1
+		u.addOperation(opA)
+
+		opB := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.2"})
+		u.addOperation(opB)
+
+		u.process(context.Background())
+
+		// Both requeued since neither exhausted (maxRetries=3).
+		assert.Equal(t, 2, u.countOperations())
+
+		ops := u.drainOperations()
+		assert.Equal(t, 2, len(ops))
+		for _, op := range ops {
+			lbOp := op.(*loadBalancerBackendPoolUpdateOperation)
+			if lbOp.nodeIPs[0] == "10.0.0.1" {
+				assert.Equal(t, 2, lbOp.retryAttempts) // was 1, now 2
+			} else {
+				assert.Equal(t, 1, lbOp.retryAttempts) // was 0, now 1
+			}
+		}
+	})
+
+	t.Run("exhausted op is dropped while remaining op with budget is requeued", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 2, "svc1", "svc2")
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		opA := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		opA.retryAttempts = 2
+		u.addOperation(opA)
+
+		opB := getAddIPsToBackendPoolOperation("default/svc2", "lb1", "pool1", []string{"10.0.0.2"})
+		u.addOperation(opB)
+
+		u.process(context.Background())
+
+		assert.Equal(t, 1, u.countOperations())
+		ops := u.drainOperations()
+		assert.Equal(t, "default/svc2", ops[0].(*loadBalancerBackendPoolUpdateOperation).serviceName)
+	})
+
+	t.Run("retry followed by success records success metric without failure metric", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		// Tick 1: 409, requeues.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+		// Tick 2: succeeds.
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(nil, nil).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, failureBefore, failureAfter, "failure metric should not increment for retried-then-succeeded operation")
+		assert.Equal(t, latencyBefore+1, latencyAfter, "expected exactly one metric observation (success)")
+	})
+
+	// Event Dedup
+	type opSpec struct {
+		svcKey        string
+		ips           []string
+		retryAttempts int
+	}
+	for _, tc := range []struct {
+		name            string
+		maxRetries      int
+		svcNames        []string
+		ops             []opSpec
+		expectedQueue   int
+		expectedReasons []string
+	}{
+		{
+			name:       "multiple services in same group each receive their own event",
+			maxRetries: 3,
+			svcNames:   []string{"svc1", "svc2"},
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc2", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   2,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying, consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+		{
+			name:       "multiple ops for same service produce only one event",
+			maxRetries: 3,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   2,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+		{
+			name:       "two exhausted ops for same service produce only one failed event",
+			maxRetries: 0,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   0,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed},
+		},
+		{
+			// This edge case (same service receiving both events) is a consequence of the
+			// diff-based operation model and will be eliminated by the desired-state follow-up.
+			name:       "same service with mixed budgets emits Failed before Retrying",
+			maxRetries: 2,
+			ops: []opSpec{
+				{svcKey: "default/svc1", ips: []string{"10.0.0.1"}, retryAttempts: 2},
+				{svcKey: "default/svc1", ips: []string{"10.0.0.2"}},
+			},
+			expectedQueue:   1,
+			expectedReasons: []string{consts.LoadBalancerBackendPoolUpdateFailed, consts.LoadBalancerBackendPoolUpdateRetrying},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, tc.maxRetries, tc.svcNames...)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+				nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			for _, op := range tc.ops {
+				o := getAddIPsToBackendPoolOperation(op.svcKey, "lb1", "pool1", op.ips)
+				o.retryAttempts = op.retryAttempts
+				u.addOperation(o)
+			}
+
+			u.process(context.Background())
+
+			assert.Equal(t, tc.expectedQueue, u.countOperations())
+			assertEventReasons(t, drainEvents(recorder), tc.expectedReasons...)
+		})
+	}
+
+	// Staleness
+	for _, tc := range []struct {
+		name      string
+		mutateMap func(*Cloud)
+	}{
+		{
+			name: "op that becomes stale during ARM call is dropped at requeue",
+			mutateMap: func(cloud *Cloud) {
+				cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+			},
+		},
+		{
+			name: "op with changed load balancer during ARM call is dropped at requeue",
+			mutateMap: func(cloud *Cloud) {
+				cloud.localServiceNameToServiceInfoMap.Store("default/svc1", &serviceInfo{lbName: "lb2"})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+				func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+					tc.mutateMap(cloud)
+					return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+				},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(context.Background())
+
+			assert.Equal(t, 0, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+			assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+		})
+	}
+
+	t.Run("op that becomes stale between ticks is dropped at next grouping", func(t *testing.T) {
+		cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+			nil, &azcore.ResponseError{StatusCode: http.StatusConflict},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		// Tick 1: 409, requeues.
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		// Delete service from map between ticks.
+		cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+
+		// Tick 2: stale, filtered without call.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		// Only the retrying event from tick 1 should be present.
+		assertEventReasons(t, drainEvents(recorder), consts.LoadBalancerBackendPoolUpdateRetrying)
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
+
+	t.Run("parked op that becomes stale is dropped when eligible", func(t *testing.T) {
+		cloud, recorder, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops and stale ops should not make ARM calls.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		// Add op with nextEligibleAt in the near future.
+		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op.nextEligibleAt = time.Now().Add(50 * time.Millisecond)
+		op.retryAttempts = 1
+		u.addOperation(op)
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		// Tick 1: not yet eligible, skipped.
+		u.process(context.Background())
+		assert.Equal(t, 1, u.countOperations())
+
+		// Sleep past nextEligibleAt and delete service.
+		time.Sleep(60 * time.Millisecond)
+		cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+
+		// Tick 2: eligible but stale, filtered.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+
+		// No events on either tick (parked, then stale drop).
+		assert.Empty(t, drainEvents(recorder), "expected no events")
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
+
+	// Lifecycle
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "removeOperation removes parked op from queue",
+			createOrUpdateErr: &retryrepectthrottled.ThrottleError{RetryAfter: time.Now().Add(5 * time.Minute)},
+		},
+		{
+			name:              "removeOperation removes requeued op from queue",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, _, mockBP := setupRetryTest(t, 3)
+
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).Return(
+				nil, tc.createOrUpdateErr,
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			u.process(context.Background())
+			assert.Equal(t, 1, u.countOperations())
+
+			u.removeOperation("default/svc1")
+			assert.Equal(t, 0, u.countOperations())
+		})
+	}
+
+	t.Run("retry requeue is serialized with removeOperation under serviceReconcileLock", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		armBlocked := make(chan struct{})
+		armUnblock := make(chan struct{})
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				close(armBlocked)
+				<-armUnblock
+				return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+			},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Start process() in goroutine; it acquires serviceReconcileLock.
+		processDone := make(chan struct{})
+		go func() {
+			defer close(processDone)
+			u.process(context.Background())
+		}()
+
+		// Wait for process() to be mid-ARM-call.
+		<-armBlocked
+
+		// Simulate main reconcile path trying to acquire serviceReconcileLock.
+		lockAcquired := make(chan struct{})
+		lockDone := make(chan struct{})
+		go func() {
+			cloud.serviceReconcileLock.Lock()
+			close(lockAcquired)
+			u.removeOperation("default/svc1")
+			cloud.serviceReconcileLock.Unlock()
+			close(lockDone)
+		}()
+
+		// Verify lock is NOT acquired while process() is mid-flight.
+		select {
+		case <-lockAcquired:
+			t.Fatal("serviceReconcileLock acquired while process() is mid-flight")
+		case <-time.After(200 * time.Millisecond):
+			// Expected: blocked.
+		}
+
+		// Unblock ARM; returns 409, requeues, then releases lock.
+		close(armUnblock)
+		<-processDone
+
+		// Wait for lock goroutine to fully complete.
+		select {
+		case <-lockDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("lock goroutine did not complete")
+		}
+
+		// Op was requeued by process, then removed by removeOperation.
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	t.Run("retry requeue is serialized with service deletion under serviceReconcileLock", func(t *testing.T) {
+		cloud, _, mockBP := setupRetryTest(t, 3)
+
+		armBlocked := make(chan struct{})
+		armUnblock := make(chan struct{})
+		mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+			getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+		).Times(1)
+		mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+			func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+				close(armBlocked)
+				<-armUnblock
+				return nil, &azcore.ResponseError{StatusCode: http.StatusConflict}
+			},
+		).Times(1)
+
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+		u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+		// Start process() in goroutine; it acquires serviceReconcileLock.
+		processDone := make(chan struct{})
+		go func() {
+			defer close(processDone)
+			u.process(context.Background())
+		}()
+
+		// Wait for process() to be mid-ARM-call.
+		<-armBlocked
+
+		// Simulate main reconcile path trying to delete service from map.
+		lockAcquired := make(chan struct{})
+		lockDone := make(chan struct{})
+		go func() {
+			cloud.serviceReconcileLock.Lock()
+			close(lockAcquired)
+			cloud.localServiceNameToServiceInfoMap.Delete("default/svc1")
+			cloud.serviceReconcileLock.Unlock()
+			close(lockDone)
+		}()
+
+		// Verify lock is NOT acquired while process() is mid-flight.
+		select {
+		case <-lockAcquired:
+			t.Fatal("serviceReconcileLock acquired while process() is mid-flight")
+		case <-time.After(200 * time.Millisecond):
+			// Expected: blocked.
+		}
+
+		// Unblock ARM; returns 409, requeues, then releases lock.
+		close(armUnblock)
+		<-processDone
+
+		// Wait for lock goroutine to fully complete.
+		select {
+		case <-lockDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("lock goroutine did not complete")
+		}
+
+		// Op was requeued by process (queue == 1), map delete happened after.
+		assert.Equal(t, 1, u.countOperations())
+
+		// Next tick: groupOperations filters the stale op.
+		u.process(context.Background())
+		assert.Equal(t, 0, u.countOperations())
+	})
+
+	for _, tc := range []struct {
+		name              string
+		createOrUpdateErr error
+	}{
+		{
+			name:              "context canceled during ARM call drops op without event",
+			createOrUpdateErr: &azcore.ResponseError{StatusCode: http.StatusConflict},
+		},
+		{
+			name:              "ARM call returns context.Canceled on shutdown and op is dropped without event",
+			createOrUpdateErr: context.Canceled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud, recorder, mockBP := setupRetryTest(t, 3)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			mockBP.EXPECT().Get(gomock.Any(), gomock.Any(), "lb1", "pool1").Return(
+				getTestBackendAddressPoolWithIPs("lb1", "pool1", []string{}), nil,
+			).Times(1)
+			mockBP.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), "lb1", "pool1", gomock.Any()).DoAndReturn(
+				func(_ context.Context, _, _, _ string, _ armnetwork.BackendAddressPool) (*armnetwork.BackendAddressPool, error) {
+					cancel()
+					return nil, tc.createOrUpdateErr
+				},
+			).Times(1)
+
+			u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+			u.addOperation(getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"}))
+
+			latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+			u.process(ctx)
+
+			assert.Equal(t, 0, u.countOperations())
+			assert.Empty(t, drainEvents(recorder), "expected no events")
+
+			latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+			assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+			assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+		})
+	}
+
+	t.Run("shutdown with parked ops drops all without event", func(t *testing.T) {
+		cloud, recorder, _ := setupRetryTest(t, 3)
+
+		// No ARM mock expectations: parked ops with canceled context should never reach ARM.
+		u := newLoadBalancerBackendPoolUpdater(cloud, time.Second)
+
+		op := getAddIPsToBackendPoolOperation("default/svc1", "lb1", "pool1", []string{"10.0.0.1"})
+		op.nextEligibleAt = time.Now().Add(5 * time.Minute)
+		op.retryAttempts = 1
+		u.addOperation(op)
+
+		// Cancel context before calling process (simulates shutdown).
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		latencyBefore, failureBefore := getBackendPoolUpdaterMetrics(t)
+
+		u.process(ctx)
+
+		// Op was drained and discarded (not requeued).
+		assert.Equal(t, 0, u.countOperations())
+		assert.Empty(t, drainEvents(recorder), "expected no events on shutdown")
+
+		latencyAfter, failureAfter := getBackendPoolUpdaterMetrics(t)
+		assert.Equal(t, latencyBefore, latencyAfter, "dropped operation should not record any metric")
+		assert.Equal(t, failureBefore, failureAfter, "dropped operation should not increment failure counter")
+	})
 }

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2747,6 +2747,52 @@ func TestCheckEnableMultipleStandardLoadBalancers(t *testing.T) {
 	assert.Equal(t, "duplicated primary VMSet vmss-2 in multiple standard load balancer configurations lb2", err.Error())
 }
 
+func TestLoadBalancerBackendPoolUpdateMaxRetriesNormalization(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    *int
+		expected int
+	}{
+		{"nil defaults to 3", nil, 3},
+		{"explicit 0 stays 0", ptr.To(0), 0},
+		{"explicit 5 stays 5", ptr.To(5), 5},
+		{"negative value is normalized to 0", ptr.To(-1), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			az := GetTestCloud(ctrl)
+			az.LoadBalancerBackendPoolConfigurationType = consts.LoadBalancerBackendPoolConfigurationTypeNodeIP
+			az.MultipleStandardLoadBalancerConfigurations = []providerconfig.MultipleStandardLoadBalancerConfiguration{
+				{
+					Name: "kubernetes",
+					MultipleStandardLoadBalancerConfigurationSpec: providerconfig.MultipleStandardLoadBalancerConfigurationSpec{
+						PrimaryVMSet: "vmss-0",
+					},
+				},
+			}
+			az.LoadBalancerBackendPoolUpdateMaxRetries = tc.input
+
+			err := az.checkEnableMultipleStandardLoadBalancers()
+			assert.NoError(t, err)
+			assert.NotNil(t, az.LoadBalancerBackendPoolUpdateMaxRetries)
+			assert.Equal(t, tc.expected, *az.LoadBalancerBackendPoolUpdateMaxRetries)
+		})
+	}
+}
+
+func TestParseConfigPreservesMaxRetriesZero(t *testing.T) {
+	// Explicit 0 is preserved as non-nil pointer.
+	cfg, err := providerconfig.ParseConfig(strings.NewReader(`{"loadBalancerBackendPoolUpdateMaxRetries": 0}`))
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+	assert.Equal(t, 0, *cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+
+	// Absent field results in nil pointer.
+	cfg, err = providerconfig.ParseConfig(strings.NewReader(`{}`))
+	assert.NoError(t, err)
+	assert.Nil(t, cfg.LoadBalancerBackendPoolUpdateMaxRetries)
+}
+
 func TestIsNodeReady(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/provider/config/azure.go
+++ b/pkg/provider/config/azure.go
@@ -162,6 +162,9 @@ type Config struct {
 	RouteUpdateIntervalInSeconds int `json:"routeUpdateIntervalInSeconds,omitempty" yaml:"routeUpdateIntervalInSeconds,omitempty"`
 	// LoadBalancerBackendPoolUpdateIntervalInSeconds is the interval for updating load balancer backend pool of local services. Default is 30 seconds.
 	LoadBalancerBackendPoolUpdateIntervalInSeconds int `json:"loadBalancerBackendPoolUpdateIntervalInSeconds,omitempty" yaml:"loadBalancerBackendPoolUpdateIntervalInSeconds,omitempty"`
+	// LoadBalancerBackendPoolUpdateMaxRetries is the maximum number of retries for a failed backend pool update operation of local services.
+	// nil = use default (3), 0 = disable retry. The total attempts = 1 + maxRetries.
+	LoadBalancerBackendPoolUpdateMaxRetries *int `json:"loadBalancerBackendPoolUpdateMaxRetries,omitempty" yaml:"loadBalancerBackendPoolUpdateMaxRetries,omitempty"`
 
 	// ClusterServiceLoadBalancerHealthProbeMode determines the health probe mode for cluster service load balancer.
 	// Supported values are `shared` and `servicenodeport`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Changes the local service backend pool updater to reconcile toward a desired state instead of applying incremental changes. Previously, each EndpointSlice change was turned into separate add and remove operations by comparing the previous and current slice, and those operations were replayed against the backend pool. This depended on the accuracy of a single previous-slice snapshot, could lose membership contributed by other slices, and could queue redundant or conflicting operations for the same pool.

Now each update carries the full set of node IPs a backend pool should contain, computed from all EndpointSlices belonging to the service. On every reconcile the updater reads the pool's current membership, compares it against the desired set, and applies the additions and removals needed to converge in a single update. Because the outcome is derived from live pool state rather than a remembered delta, reconciles are idempotent and self-correcting.

Updates queued for the same pool are collapsed so only the latest desired state is kept: an update matching what is already queued is a no-op and preserves any in-progress retry state, while a changed desired state supersedes the pending one. If an update is requeued after a failure but a newer desired state has since arrived for the same pool, the stale one is dropped, carrying forward any throttling delay so ARM back-pressure is still respected.

As a result, update events and success metrics are emitted only when a pool actually changes, and a Service can no longer receive both a failure and a retry event for the same update. The reconcile path is also hardened against backend addresses that carry no IP.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #10270

#### Special notes for your reviewer:
Design doc: #10417
Documentation for `topics/multislb`: #10648

Follow-up to #10635, which deferred the desired-state operation model to this PR. It builds on #10635 and should be reviewed on top of it and merged only after #10635 has merged.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat(multi-slb): the local service backend pool updater now reconciles each backend pool to the full desired set of node IPs instead of applying incremental add/remove changes. A success event and metric are recorded only when an update is successfully applied to a backend pool, and a Service no longer receives both a failure and a retry event for the same update.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
