### PR TITLE
fix: match ACR regional endpoints and DNL-enabled login servers in credential provider

### DIFF
--- a/pkg/credentialprovider/azure_credentials.go
+++ b/pkg/credentialprovider/azure_credentials.go
@@ -49,8 +49,11 @@ const (
 
 var (
 	containerRegistryUrls = []string{"*.azurecr.io", "*.azurecr.cn", "*.azurecr.de", "*.azurecr.us"}
-	// a valid acr image starts with alphanumerics, followed by corresponding acr domain name.
-	acrRE = regexp.MustCompile(`^[a-zA-Z0-9]+\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)`)
+	// a valid acr image starts with a DNS label (allowing dashes, e.g. registries with a
+	// Domain Name Label suffix such as "registry-hash.azurecr.io"), optionally followed by
+	// one more label for regional endpoints (e.g. "registry.<region>.azurecr.io"), followed
+	// by the corresponding acr domain name.
+	acrRE = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)?\.(azurecr\.io|azurecr\.cn|azurecr\.de|azurecr\.us)`)
 )
 
 // CredentialProvider is an interface implemented by the kubelet credential provider plugin to fetch

--- a/pkg/credentialprovider/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure_credentials_test.go
@@ -332,7 +332,15 @@ func TestParseACRLoginServerFromImage(t *testing.T) {
 		},
 		{
 			image:    "foo-azurecr-io.azurecr.cn",
-			expected: "",
+			expected: "foo-azurecr-io.azurecr.cn",
+		},
+		{
+			image:    "foo-abc123.azurecr.io/bar/image:version",
+			expected: "foo-abc123.azurecr.io",
+		},
+		{
+			image:    "foo.eastus.azurecr.io/bar/image:version",
+			expected: "foo.eastus.azurecr.io",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

The acr-credential-provider's `acrRE` regex, used to detect whether an
image reference targets Azure Container Registry, only matched a single
alphanumeric label before the `azurecr.*` domain (e.g. `foo.azurecr.io`).
It rejected two valid ACR login server formats:

- Registries with Domain Name Label (DNL) enabled, whose login server
  includes a dash-separated hash, e.g. `myregistry-abc123.azurecr.io`.
- ACR regional/replica endpoints, which add one extra DNS label, e.g.
  `myregistry.eastus.azurecr.io`.

When `parseACRLoginServerFromImage` fails to recognize such a hostname,
`GetCredentials` returns an empty `Auth` map for that image (see
azure_credentials.go), so kubelet attempts an anonymous pull. For
private images hosted on a DNL-enabled or regional-endpoint registry,
that pull then fails with an authentication error. Public images and
registries using the existing plain `registry.azurecr.io` format are
unaffected.

#### Approach

Update `acrRE` to allow dashes within a DNS label and one optional
additional dot-separated label before the `azurecr.*` suffix, while
keeping the domain suffix itself a literal, anchored match. The
existing anti-spoofing behavior in `parseACRLoginServerFromImage`
(requiring whatever follows the matched registry to be empty or start
with `/`) is untouched, so hostnames like `foo.azurecr.io.evil.com` are
still correctly rejected.

#### Which issue(s) this PR fixes:

Fixes #9975

#### Special notes for your reviewer:

Added test cases for a DNL-style login server (`foo-abc123.azurecr.io`)
and a regional endpoint (`foo.eastus.azurecr.io`), and updated the
`foo-azurecr-io.azurecr.cn` case, which previously documented the bug
(expected `""`) and now correctly matches. Verified the existing
`foo.azurecr.io.azurecr.cn` anti-spoofing test case still returns `""`
unchanged.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the acr-credential-provider incorrectly treating images hosted on Azure Container Registry regional endpoints or registries with Domain Name Label (DNL) enabled as non-ACR images, which caused private image pulls from those registries to fail with an authentication error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

Validation: `go build ./pkg/credentialprovider/...` and
`go test ./pkg/credentialprovider/...` both pass (all existing and new
subtests of TestParseACRLoginServerFromImage pass).

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>