### PR TITLE
Add Config.VNetResourceGroupOrDefault to the ServiceGateway difftracker

### DIFF
--- a/pkg/provider/servicegateway/difftracker/config.go
+++ b/pkg/provider/servicegateway/difftracker/config.go
@@ -44,7 +44,9 @@ type Config struct {
 	// Virtual Network name (required for backend pool configuration)
 	VNetName string
 
-	// Virtual Network resource group
+	// Resource group that contains the Virtual Network. Optional: when empty, the VNet is
+	// assumed to live in ResourceGroup (the common case). Set this for BYO-VNet clusters whose
+	// VNet is in a separate resource group (mirrors the cloud config's vnetResourceGroup).
 	VNetResourceGroup string
 }
 
@@ -53,6 +55,17 @@ func (c *Config) networkResourceSubscriptionID() string {
 		return c.NetworkResourceSubscriptionID
 	}
 	return c.SubscriptionID
+}
+
+// VNetResourceGroupOrDefault returns the resource group that contains the Virtual Network,
+// falling back to ResourceGroup when VNetResourceGroup is unset. This mirrors how the rest of
+// the cloud provider resolves the VNet resource group (see azure_loadbalancer.go), and keeps
+// callers from building resource IDs with an empty resource group segment.
+func (c *Config) VNetResourceGroupOrDefault() string {
+	if c.VNetResourceGroup != "" {
+		return c.VNetResourceGroup
+	}
+	return c.ResourceGroup
 }
 
 // Validate checks if the configuration has all required fields

--- a/pkg/provider/servicegateway/difftracker/config_test.go
+++ b/pkg/provider/servicegateway/difftracker/config_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package difftracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVNetResourceGroupOrDefault(t *testing.T) {
+	tests := []struct {
+		name              string
+		resourceGroup     string
+		vnetResourceGroup string
+		expected          string
+	}{
+		{
+			name:              "returns the VNet resource group when set",
+			resourceGroup:     "cluster-rg",
+			vnetResourceGroup: "vnet-rg",
+			expected:          "vnet-rg",
+		},
+		{
+			name:          "falls back to the cluster resource group when unset",
+			resourceGroup: "cluster-rg",
+			expected:      "cluster-rg",
+		},
+		{
+			name:              "prefers the VNet resource group even when both match",
+			resourceGroup:     "cluster-rg",
+			vnetResourceGroup: "cluster-rg",
+			expected:          "cluster-rg",
+		},
+		{
+			name:     "returns empty when neither is set",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := Config{
+				ResourceGroup:     tt.resourceGroup,
+				VNetResourceGroup: tt.vnetResourceGroup,
+			}
+			assert.Equal(t, tt.expected, config.VNetResourceGroupOrDefault())
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`difftracker.Config` carries `VNetResourceGroup`, which is optional: it is only set for BYO-VNet
clusters whose Virtual Network lives outside the cluster resource group. When it is empty the VNet
is in `ResourceGroup`, so every consumer has to remember to fall back. Anyone who forgets builds an
ARM ID with an empty resource group segment:

    /subscriptions/<sub>/resourceGroups//providers/Microsoft.Network/virtualNetworks/<vnet>

This adds a single accessor so the fallback lives with the config instead of being repeated at each
call site, and documents the field.

The rest of the provider already resolves the VNet resource group this way:

- `getVnetResourceID` in `pkg/provider/azure_loadbalancer_backendpool.go`
- `pkg/provider/azure_privatelinkservice.go`

so this keeps the ServiceGateway config consistent with existing behaviour.

No existing behaviour changes: the method is additive and nothing calls it yet.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Small, self-contained piece of the in-progress ServiceGateway work, split out so the follow-up PR
that adds the Azure operations (which builds subnet and backend pool resource IDs) stays focused.
`config_test.go` is new because `config.go` had no test file yet; it covers the set, unset, equal
and both-empty cases.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```release-note
NONE
```