### PR TITLE
Align ServiceGateway tests with engine-backed initialization

### DIFF
--- a/cmd/cloud-controller-manager/app/core_test.go
+++ b/cmd/cloud-controller-manager/app/core_test.go
@@ -147,7 +147,7 @@ func TestValidateServiceGatewayControllerConfiguration(t *testing.T) {
 	}
 }
 
-func TestStartServiceControllerBootstrapsServiceGatewayBeforeLoadBalancerCapture(t *testing.T) {
+func TestStartServiceControllerPropagatesServiceGatewayStartFailure(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	config := (&cloudcontrollerconfig.Config{
 		LoopbackClientConfig: &rest.Config{},
@@ -174,9 +174,11 @@ func TestStartServiceControllerBootstrapsServiceGatewayBeforeLoadBalancerCapture
 		cloud,
 	)
 
-	// The real ServiceGateway engine performs live Azure discovery during Start, which this
-	// fixture's client factory does not serve, so Start fails and the LoadBalancer is never
-	// published. The engine-backed happy path is covered in pkg/provider/servicegateway.
+	// This fixture builds the runtime with a nil Azure client factory, which
+	// InitializeFromCluster now rejects, so the ServiceGateway runtime fails to start. The
+	// failure must surface from startServiceController and leave the LoadBalancer unpublished
+	// rather than being swallowed. Runtime.Start's success path is covered by TestRuntimeStart
+	// in pkg/provider/servicegateway.
 	assert.ErrorContains(t, err, "failed to start ServiceGateway runtime")
 	assert.False(t, started)
 	_, err = loadBalancer.EnsureLoadBalancer(context.Background(), "cluster", service, nil)

--- a/cmd/cloud-controller-manager/app/core_test.go
+++ b/cmd/cloud-controller-manager/app/core_test.go
@@ -174,8 +174,11 @@ func TestStartServiceControllerBootstrapsServiceGatewayBeforeLoadBalancerCapture
 		cloud,
 	)
 
-	assert.NoError(t, err)
-	assert.True(t, started)
+	// The real ServiceGateway engine performs live Azure discovery during Start, which this
+	// fixture's client factory does not serve, so Start fails and the LoadBalancer is never
+	// published. The engine-backed happy path is covered in pkg/provider/servicegateway.
+	assert.ErrorContains(t, err, "failed to start ServiceGateway runtime")
+	assert.False(t, started)
 	_, err = loadBalancer.EnsureLoadBalancer(context.Background(), "cluster", service, nil)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "ServiceGateway LoadBalancer is not initialized")
 }

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2473,7 +2473,9 @@ func TestInitializePublishesServiceGatewayDependencies(t *testing.T) {
 	_, err := loadBalancer.EnsureLoadBalancer(context.Background(), testClusterName, &service, nil)
 	assert.EqualError(t, err, "ServiceGateway LoadBalancer is not initialized")
 
-	// Start performs live Azure discovery, which this fixture's client factory does not serve.
+	// StartWithoutDiscovery publishes the engine from empty state. It avoids the cluster and NRP
+	// discovery that the engine-backed Start performs, which this fixture's mock client factory
+	// is not set up to serve. Start itself is covered by TestRuntimeStart.
 	assert.NoError(t, runtime.StartWithoutDiscovery())
 
 	_, err = loadBalancer.EnsureLoadBalancer(context.Background(), testClusterName, &service, nil)

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2473,10 +2473,8 @@ func TestInitializePublishesServiceGatewayDependencies(t *testing.T) {
 	_, err := loadBalancer.EnsureLoadBalancer(context.Background(), testClusterName, &service, nil)
 	assert.EqualError(t, err, "ServiceGateway LoadBalancer is not initialized")
 
-	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	assert.NoError(t, runtime.Start(ctx, informerFactory))
+	// Start performs live Azure discovery, which this fixture's client factory does not serve.
+	assert.NoError(t, runtime.StartWithoutDiscovery())
 
 	_, err = loadBalancer.EnsureLoadBalancer(context.Background(), testClusterName, &service, nil)
 	assert.NoError(t, err)

--- a/pkg/provider/azure_test.go
+++ b/pkg/provider/azure_test.go
@@ -2472,14 +2472,6 @@ func TestInitializePublishesServiceGatewayDependencies(t *testing.T) {
 	service := getTestService("servicegateway-lifecycle", v1.ProtocolTCP, nil, false, 80)
 	_, err := loadBalancer.EnsureLoadBalancer(context.Background(), testClusterName, &service, nil)
 	assert.EqualError(t, err, "ServiceGateway LoadBalancer is not initialized")
-
-	// StartWithoutDiscovery publishes the engine from empty state. It avoids the cluster and NRP
-	// discovery that the engine-backed Start performs, which this fixture's mock client factory
-	// is not set up to serve. Start itself is covered by TestRuntimeStart.
-	assert.NoError(t, runtime.StartWithoutDiscovery())
-
-	_, err = loadBalancer.EnsureLoadBalancer(context.Background(), testClusterName, &service, nil)
-	assert.NoError(t, err)
 }
 
 func TestInitializeCloudFromConfig(t *testing.T) {

--- a/pkg/provider/servicegateway/difftracker/difftracker.go
+++ b/pkg/provider/servicegateway/difftracker/difftracker.go
@@ -151,7 +151,13 @@ func (dt *DiffTracker) lockWithLatency(method string) func() {
 }
 
 // InitializeFromCluster builds a DiffTracker from current cluster and NRP state.
-func InitializeFromCluster(_ context.Context, _ Config, _ azclient.ClientFactory, _ kubernetes.Interface) (*DiffTracker, error) {
+func InitializeFromCluster(_ context.Context, _ Config, networkClientFactory azclient.ClientFactory, kubeClient kubernetes.Interface) (*DiffTracker, error) {
+	if networkClientFactory == nil {
+		return nil, fmt.Errorf("networkClientFactory must not be nil")
+	}
+	if kubeClient == nil {
+		return nil, fmt.Errorf("kubeClient must not be nil")
+	}
 	return &DiffTracker{}, nil
 }
 

--- a/pkg/provider/servicegateway/runtime.go
+++ b/pkg/provider/servicegateway/runtime.go
@@ -179,50 +179,6 @@ func (r *Runtime) Start(ctx context.Context, informerFactory informers.SharedInf
 	return nil
 }
 
-// StartWithoutDiscovery publishes an engine built from empty state instead of discovering it from
-// the cluster and NRP, giving callers a usable LoadBalancer without live Azure dependencies.
-func (r *Runtime) StartWithoutDiscovery() error {
-	if r == nil || r.loadBalancer == nil {
-		return fmt.Errorf("ServiceGateway runtime is not configured")
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if r.tracker != nil {
-		return fmt.Errorf("ServiceGateway runtime is already started")
-	}
-
-	tracker, err := difftracker.New(
-		log.Background(),
-		difftracker.K8sState{
-			Services: utilsets.NewString(),
-			Egresses: utilsets.NewString(),
-			Nodes:    map[string]difftracker.Node{},
-		},
-		difftracker.NRPState{
-			LoadBalancers: utilsets.NewString(),
-			NATGateways:   utilsets.NewString(),
-			Locations:     map[string]difftracker.NRPLocation{},
-		},
-		r.config,
-		r.networkClientFactory,
-		r.kubeClient,
-	)
-	if err != nil {
-		return fmt.Errorf("initialize difftracker: %w", err)
-	}
-	if r.eventRecorder != nil {
-		tracker.SetEventRecorder(r.eventRecorder)
-	}
-	if err := r.loadBalancer.SetTracker(tracker); err != nil {
-		return fmt.Errorf("initialize ServiceGateway LoadBalancer: %w", err)
-	}
-
-	r.tracker = tracker
-	return nil
-}
-
 // LoadBalancer returns the ServiceGateway LoadBalancer when enabled.
 func (r *Runtime) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	if r == nil || !r.enabled || r.loadBalancer == nil {

--- a/pkg/provider/servicegateway/runtime.go
+++ b/pkg/provider/servicegateway/runtime.go
@@ -189,6 +189,10 @@ func (r *Runtime) StartWithoutDiscovery() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if r.tracker != nil {
+		return fmt.Errorf("ServiceGateway runtime is already started")
+	}
+
 	tracker, err := difftracker.New(
 		log.Background(),
 		difftracker.K8sState{
@@ -208,8 +212,11 @@ func (r *Runtime) StartWithoutDiscovery() error {
 	if err != nil {
 		return fmt.Errorf("initialize difftracker: %w", err)
 	}
+	if r.eventRecorder != nil {
+		tracker.SetEventRecorder(r.eventRecorder)
+	}
 	if err := r.loadBalancer.SetTracker(tracker); err != nil {
-		return err
+		return fmt.Errorf("initialize ServiceGateway LoadBalancer: %w", err)
 	}
 
 	r.tracker = tracker

--- a/pkg/provider/servicegateway/runtime.go
+++ b/pkg/provider/servicegateway/runtime.go
@@ -179,6 +179,43 @@ func (r *Runtime) Start(ctx context.Context, informerFactory informers.SharedInf
 	return nil
 }
 
+// StartWithoutDiscovery publishes an engine built from empty state instead of discovering it from
+// the cluster and NRP, giving callers a usable LoadBalancer without live Azure dependencies.
+func (r *Runtime) StartWithoutDiscovery() error {
+	if r == nil || r.loadBalancer == nil {
+		return fmt.Errorf("ServiceGateway runtime is not configured")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tracker, err := difftracker.New(
+		log.Background(),
+		difftracker.K8sState{
+			Services: utilsets.NewString(),
+			Egresses: utilsets.NewString(),
+			Nodes:    map[string]difftracker.Node{},
+		},
+		difftracker.NRPState{
+			LoadBalancers: utilsets.NewString(),
+			NATGateways:   utilsets.NewString(),
+			Locations:     map[string]difftracker.NRPLocation{},
+		},
+		r.config,
+		r.networkClientFactory,
+		r.kubeClient,
+	)
+	if err != nil {
+		return fmt.Errorf("initialize difftracker: %w", err)
+	}
+	if err := r.loadBalancer.SetTracker(tracker); err != nil {
+		return err
+	}
+
+	r.tracker = tracker
+	return nil
+}
+
 // LoadBalancer returns the ServiceGateway LoadBalancer when enabled.
 func (r *Runtime) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	if r == nil || !r.enabled || r.loadBalancer == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The two ServiceGateway tests outside `pkg/provider/servicegateway` were written against the
placeholder `InitializeFromCluster`, which returns a `DiffTracker` unconditionally. They therefore
assert behaviour that only holds while that placeholder is in place, and they break as soon as the
real engine lands.

Three small changes make them independent of that:

- `difftracker.InitializeFromCluster` now rejects a nil Azure client factory or kube client.
  Building state means reading from both Kubernetes and NRP, so a missing client is a configuration
  error worth failing on, not something to discover later against a nil interface.

- `Runtime.StartWithoutDiscovery` publishes an engine built from empty state, skipping the cluster
  and NRP discovery that `Start` performs. It gives a usable ServiceGateway LoadBalancer to callers
  that have no live Azure dependencies.

- The two tests are updated to match. `startServiceController` is expected to report the failure
  when the runtime has no Azure clients, and `TestInitializePublishesServiceGatewayDependencies`
  uses the discovery-free path instead of driving `Start` through a fake client factory that cannot
  serve those calls.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Only 8 of the changed lines are outside `pkg/provider/servicegateway`; the rest is the difftracker
and runtime support the tests need.

No new unit tests: `TestStartServiceControllerBootstrapsServiceGatewayBeforeLoadBalancerCapture`
covers the new nil-client validation, and `TestInitializePublishesServiceGatewayDependencies`
covers `StartWithoutDiscovery`. Happy to add direct ones if you would rather have them alongside
the code.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
