### PR TITLE
fix: use PATCH when refreshing failed VMs

### DIFF
--- a/pkg/provider/azure_controller_common.go
+++ b/pkg/provider/azure_controller_common.go
@@ -28,6 +28,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
+	azclientutils "sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachineclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 )
 
@@ -52,6 +54,21 @@ type ExtendedLocation struct {
 	Name string `json:"name,omitempty"`
 	// Type - The type of the extended location.
 	Type string `json:"type,omitempty"`
+}
+
+func updateVirtualMachine(
+	ctx context.Context,
+	client virtualmachineclient.Interface,
+	resourceGroupName,
+	vmName string,
+) (*armcompute.VirtualMachine, error) {
+	resp, err := azclientutils.NewPollerWrapper(
+		client.BeginUpdate(ctx, resourceGroupName, vmName, armcompute.VirtualMachineUpdate{}, nil),
+	).WaitforPollerResp(ctx)
+	if err != nil || resp == nil {
+		return nil, err
+	}
+	return &resp.VirtualMachine, nil
 }
 
 func FilterNonExistingDisks(ctx context.Context, clientFactory azclient.ClientFactory, unfilteredDisks []*armcompute.DataDisk) []*armcompute.DataDisk {

--- a/pkg/provider/azure_controller_standard.go
+++ b/pkg/provider/azure_controller_standard.go
@@ -227,7 +227,7 @@ func (as *availabilitySet) UpdateVM(ctx context.Context, nodeName types.NodeName
 		return err
 	}
 
-	result, rerr := as.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, vmName, armcompute.VirtualMachine{})
+	result, rerr := updateVirtualMachine(ctx, as.ComputeClientFactory.GetVirtualMachineClient(), nodeResourceGroup, vmName)
 	if rerr != nil {
 		if exists, err := errutils.CheckResourceExistsFromAzcoreError(rerr); !exists && err == nil {
 			// if the VM does not exist, we should not update the cache

--- a/pkg/provider/azure_controller_standard_test.go
+++ b/pkg/provider/azure_controller_standard_test.go
@@ -267,10 +267,10 @@ func TestStandardUpdateVM(t *testing.T) {
 		mockVMsClient.EXPECT().Get(gomock.Any(), testCloud.ResourceGroup, "vm2", gomock.Any()).Return(&armcompute.VirtualMachine{}, runtime.NewResponseErrorWithErrorCode(&http.Response{StatusCode: http.StatusNotFound}, cloudprovider.InstanceNotFound.Error())).AnyTimes()
 
 		if test.isDetachFail {
-			mockVMsClient.EXPECT().CreateOrUpdate(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any()).Return(nil, &azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: cloudprovider.InstanceNotFound.Error()}).AnyTimes()
+			mockVMsClient.EXPECT().BeginUpdate(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), armcompute.VirtualMachineUpdate{}, nil).Return(nil, &azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: cloudprovider.InstanceNotFound.Error()}).Times(1)
 
 		} else {
-			mockVMsClient.EXPECT().CreateOrUpdate(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), gomock.Any()).Return(nil, &azcore.ResponseError{StatusCode: http.StatusNotFound, ErrorCode: cloudprovider.InstanceNotFound.Error()}).AnyTimes()
+			mockVMsClient.EXPECT().BeginUpdate(gomock.Any(), testCloud.ResourceGroup, gomock.Any(), armcompute.VirtualMachineUpdate{}, nil).Return(nil, &azcore.ResponseError{StatusCode: http.StatusNotFound, ErrorCode: cloudprovider.InstanceNotFound.Error()}).Times(1)
 		}
 		err := vmSet.UpdateVM(ctx, test.nodeName)
 		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
@@ -279,6 +279,38 @@ func TestStandardUpdateVM(t *testing.T) {
 			assert.Equal(t, true, len(dataDisks) == 3, "TestCase[%d]: %s, err: %v", i, test.desc, err)
 		}
 	}
+}
+
+func TestStandardUpdateVMCachesSuccessfulResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
+	testCloud := GetTestCloud(ctrl)
+	updatedVM := &armcompute.VirtualMachine{
+		Name: ptr.To("vm1"),
+		Properties: &armcompute.VirtualMachineProperties{
+			StorageProfile: &armcompute.StorageProfile{
+				DataDisks: []*armcompute.DataDisk{
+					{Name: ptr.To("updated-disk")},
+				},
+			},
+		},
+	}
+	mockVMsClient := testCloud.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
+	mockVMsClient.EXPECT().
+		BeginUpdate(gomock.Any(), testCloud.ResourceGroup, "vm1", armcompute.VirtualMachineUpdate{}, nil).
+		Return(newVirtualMachineUpdatePoller(t, *updatedVM), nil).
+		Times(1)
+
+	err := testCloud.VMSet.UpdateVM(ctx, "vm1")
+	assert.NoError(t, err)
+
+	cachedVM, err := testCloud.vmCache.Get(ctx, "vm1", azcache.CacheReadTypeDefault)
+	assert.NoError(t, err)
+	assert.Equal(t, updatedVM, cachedVM)
 }
 
 func TestGetDataDisks(t *testing.T) {

--- a/pkg/provider/azure_controller_vmssflex.go
+++ b/pkg/provider/azure_controller_vmssflex.go
@@ -233,7 +233,7 @@ func (fs *FlexScaleSet) UpdateVM(ctx context.Context, nodeName types.NodeName) e
 		return err
 	}
 
-	_, err = fs.ComputeClientFactory.GetVirtualMachineClient().CreateOrUpdate(ctx, nodeResourceGroup, *vm.Name, armcompute.VirtualMachine{})
+	_, err = updateVirtualMachine(ctx, fs.ComputeClientFactory.GetVirtualMachineClient(), nodeResourceGroup, *vm.Name)
 	return err
 }
 

--- a/pkg/provider/azure_controller_vmssflex_test.go
+++ b/pkg/provider/azure_controller_vmssflex_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/stretchr/testify/assert"
 
@@ -36,6 +37,36 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/virtualmachinescalesetclient/mock_virtualmachinescalesetclient"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 )
+
+type virtualMachineUpdatePollerHandler struct{}
+
+func (*virtualMachineUpdatePollerHandler) Done() bool {
+	return true
+}
+
+func (*virtualMachineUpdatePollerHandler) Poll(context.Context) (*http.Response, error) {
+	return &http.Response{StatusCode: http.StatusOK}, nil
+}
+
+func (*virtualMachineUpdatePollerHandler) Result(_ context.Context, _ *armcompute.VirtualMachinesClientUpdateResponse) error {
+	return nil
+}
+
+func newVirtualMachineUpdatePoller(t *testing.T, vm armcompute.VirtualMachine) *runtime.Poller[armcompute.VirtualMachinesClientUpdateResponse] {
+	t.Helper()
+	poller, err := runtime.NewPoller(
+		&http.Response{StatusCode: http.StatusOK},
+		runtime.Pipeline{},
+		&runtime.NewPollerOptions[armcompute.VirtualMachinesClientUpdateResponse]{
+			Handler: &virtualMachineUpdatePollerHandler{},
+			Response: &armcompute.VirtualMachinesClientUpdateResponse{
+				VirtualMachine: vm,
+			},
+		},
+	)
+	assert.NoError(t, err)
+	return poller
+}
 
 func TestAttachDiskWithVmssFlex(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -279,8 +310,11 @@ func TestUpdateVMWithVmssFlex(t *testing.T) {
 		mockVMClient.EXPECT().ListVmssFlexVMsWithOutInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
 		mockVMClient.EXPECT().ListVmssFlexVMsWithOnlyInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.testVMListWithOnlyInstanceView, tc.vmListErr).AnyTimes()
 
-		mockVMClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), tc.vmName, gomock.Any()).Return(nil, tc.vmssFlexVMUpdateError).AnyTimes()
-		mockVMClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), tc.vmName, gomock.Any()).Return(nil, tc.vmssFlexVMUpdateError).AnyTimes()
+		var poller *runtime.Poller[armcompute.VirtualMachinesClientUpdateResponse]
+		if tc.vmssFlexVMUpdateError == nil {
+			poller = newVirtualMachineUpdatePoller(t, armcompute.VirtualMachine{})
+		}
+		mockVMClient.EXPECT().BeginUpdate(gomock.Any(), gomock.Any(), tc.vmName, armcompute.VirtualMachineUpdate{}, nil).Return(poller, tc.vmssFlexVMUpdateError).AnyTimes()
 
 		err = fs.UpdateVM(ctx, tc.nodeName)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When disk recovery asks the cloud provider to refresh a VM in a `Failed` provisioning state, both the standard and Flex `UpdateVM` paths send an empty `VirtualMachine` through `CreateOrUpdate`. The Track 2 SDK maps that call to PUT, and Azure rejects the incomplete body with `LocationRequired`.

Use `BeginUpdate` with an empty `VirtualMachineUpdate` instead, wait for the PATCH operation to complete, and preserve the existing cache behavior.

#### Which issue(s) this PR fixes:

Related: [OCPBUGS-100185](https://redhat.atlassian.net/browse/OCPBUGS-100185)

#### Special notes for your reviewer:

This restores the PATCH behavior that existed before the Track 2 SDK migration in #7833. The equivalent downstream fix is being tested in [openshift/cloud-provider-azure#199](https://github.com/openshift/cloud-provider-azure/pull/199).

Validation:

- `go test -v ./pkg/provider/...`
- `go vet ./pkg/provider`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
Fix Azure failed-VM refresh operations to use PATCH so recovery is not rejected with LocationRequired.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
