### PR TITLE
Adopt NodeLifecycleControllerOptions for k8s.io/cloud-provider v0.37.0

### DIFF
--- a/cmd/cloud-controller-manager/app/core.go
+++ b/cmd/cloud-controller-manager/app/core.go
@@ -72,7 +72,8 @@ func startCloudNodeLifecycleController(ctx context.Context, controllerContext ge
 		// cloud node lifecycle controller uses existing cluster role from node-controller
 		completedConfig.ClientBuilder.ClientOrDie("node-controller"),
 		cloud,
-		completedConfig.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
+		completedConfig.ComponentConfig.NodeLifecycleController.NodeMonitorPeriod.Duration,
+		int(completedConfig.ComponentConfig.NodeLifecycleController.ConcurrentNodeLifecycleSyncs),
 	)
 	if err != nil {
 		klog.Warningf("failed to start cloud node lifecycle controller: %s", err)

--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -65,10 +65,11 @@ const (
 
 // CloudControllerManagerOptions is the main context object for the controller manager.
 type CloudControllerManagerOptions struct {
-	Generic            *cmoptions.GenericControllerManagerConfigurationOptions
-	KubeCloudShared    *cpoptions.KubeCloudSharedOptions
-	ServiceController  *cpoptions.ServiceControllerOptions
-	NodeIPAMController *NodeIPAMControllerOptions
+	Generic                 *cmoptions.GenericControllerManagerConfigurationOptions
+	KubeCloudShared         *cpoptions.KubeCloudSharedOptions
+	NodeLifecycleController *cpoptions.NodeLifecycleControllerOptions
+	ServiceController       *cpoptions.ServiceControllerOptions
+	NodeIPAMController      *NodeIPAMControllerOptions
 
 	SecureServing  *apiserveroptions.SecureServingOptionsWithLoopback
 	Authentication *apiserveroptions.DelegatingAuthenticationOptions
@@ -96,6 +97,9 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 	s := CloudControllerManagerOptions{
 		Generic:         cmoptions.NewGenericControllerManagerConfigurationOptions(&componentConfig.Generic),
 		KubeCloudShared: cpoptions.NewKubeCloudSharedOptions(&componentConfig.KubeCloudShared),
+		NodeLifecycleController: &cpoptions.NodeLifecycleControllerOptions{
+			NodeLifecycleControllerConfiguration: &componentConfig.NodeLifecycleController,
+		},
 		ServiceController: &cpoptions.ServiceControllerOptions{
 			ServiceControllerConfiguration: &componentConfig.ServiceController,
 		},
@@ -141,6 +145,7 @@ func (o *CloudControllerManagerOptions) Flags(allControllers, disabledByDefaultC
 	fss := cliflag.NamedFlagSets{}
 	o.Generic.AddFlags(&fss, allControllers, disabledByDefaultControllers, names.CCMControllerAliases())
 	o.KubeCloudShared.AddFlags(fss.FlagSet("generic"))
+	o.NodeLifecycleController.AddFlags(fss.FlagSet("node lifecycle controller"))
 	o.ServiceController.AddFlags(fss.FlagSet("service controller"))
 	o.NodeIPAMController.AddFlags(fss.FlagSet("node ipam controller"))
 
@@ -175,6 +180,9 @@ func (o *CloudControllerManagerOptions) ApplyTo(
 		return err
 	}
 	if err = o.KubeCloudShared.ApplyTo(&c.ComponentConfig.KubeCloudShared); err != nil {
+		return err
+	}
+	if err = o.NodeLifecycleController.ApplyTo(&c.ComponentConfig.NodeLifecycleController); err != nil {
 		return err
 	}
 	if err = o.ServiceController.ApplyTo(&c.ComponentConfig.ServiceController); err != nil {
@@ -254,6 +262,7 @@ func (o *CloudControllerManagerOptions) Validate(allControllers, disabledByDefau
 
 	errors = append(errors, o.Generic.Validate(allControllers, disabledByDefaultControllers, controllerAliases)...)
 	errors = append(errors, o.KubeCloudShared.Validate()...)
+	errors = append(errors, o.NodeLifecycleController.Validate()...)
 	errors = append(errors, o.ServiceController.Validate()...)
 	errors = append(errors, o.NodeIPAMController.Validate()...)
 	errors = append(errors, o.SecureServing.Validate()...)

--- a/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/cmd/cloud-controller-manager/app/options/options_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	cpconfig "k8s.io/cloud-provider/config"
+	nodelifecycleconfig "k8s.io/cloud-provider/controllers/nodelifecycle/config"
 	serviceconfig "k8s.io/cloud-provider/controllers/service/config"
 	"k8s.io/cloud-provider/names"
 	cpoptions "k8s.io/cloud-provider/options"
@@ -83,7 +84,6 @@ func TestDefaultFlags(t *testing.T) {
 		KubeCloudShared: &cpoptions.KubeCloudSharedOptions{
 			KubeCloudSharedConfiguration: &cpconfig.KubeCloudSharedConfiguration{
 				RouteReconciliationPeriod: metav1.Duration{Duration: 10 * time.Second},
-				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
 				ClusterName:               "kubernetes",
 				ClusterCIDR:               "",
 				AllocateNodeCIDRs:         false,
@@ -95,6 +95,12 @@ func TestDefaultFlags(t *testing.T) {
 					Name:            "azure",
 					CloudConfigFile: "",
 				},
+			},
+		},
+		NodeLifecycleController: &cpoptions.NodeLifecycleControllerOptions{
+			NodeLifecycleControllerConfiguration: &nodelifecycleconfig.NodeLifecycleControllerConfiguration{
+				NodeMonitorPeriod:            metav1.Duration{Duration: 5 * time.Second},
+				ConcurrentNodeLifecycleSyncs: 1,
 			},
 		},
 		ServiceController: &cpoptions.ServiceControllerOptions{
@@ -230,7 +236,6 @@ func TestAddFlags(t *testing.T) {
 		KubeCloudShared: &cpoptions.KubeCloudSharedOptions{
 			KubeCloudSharedConfiguration: &cpconfig.KubeCloudSharedConfiguration{
 				RouteReconciliationPeriod: metav1.Duration{Duration: 30 * time.Second},
-				NodeMonitorPeriod:         metav1.Duration{Duration: 5 * time.Second},
 				ClusterName:               "k8s",
 				ClusterCIDR:               "1.2.3.4/24",
 				AllocateNodeCIDRs:         true,
@@ -242,6 +247,12 @@ func TestAddFlags(t *testing.T) {
 					Name:            "azure",
 					CloudConfigFile: "/cloud-config",
 				},
+			},
+		},
+		NodeLifecycleController: &cpoptions.NodeLifecycleControllerOptions{
+			NodeLifecycleControllerConfiguration: &nodelifecycleconfig.NodeLifecycleControllerConfiguration{
+				NodeMonitorPeriod:            metav1.Duration{Duration: 5 * time.Second},
+				ConcurrentNodeLifecycleSyncs: 1,
 			},
 		},
 		ServiceController: &cpoptions.ServiceControllerOptions{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Prepares this repo for the k8s.io/* v0.37.0 dependency bump. kubernetes/kubernetes#137964
moved NodeMonitorPeriod from KubeCloudSharedConfiguration to a new
NodeLifecycleControllerConfiguration and added a concurrentNodeLifecycleSyncs parameter
to NewCloudNodeLifecycleController. This updates both call sites: the standard CCM node
lifecycle controller starter and the GKE tenant controller manager. Compile fix only;
no behavioral change at default flag values.

**Which issue(s) this PR fixes:**
Fixes #1254

**Special notes for your reviewer:**
CI is expected to fail until the dependency bump to k8s.io/* v0.37.0 lands — this change
is source-compatible with v0.37.0 only. Note the staging pins live in the replace blocks
of both go.mod and go.work; this PR intentionally touches neither and contains only the
two source fixes, to compose with the bump PR. Verified against
k8s.io/cloud-provider@master (`go build ./cmd/...` passes with the vendor tree synced).
Opened per elmiko's suggestion so the provider team can sequence it with the bump.
Happy to rebase or fold into the bump PR as preferred.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```
