### PR TITLE
fix: guard nodePrivateIPs cache reads with nodeCachesLock

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -886,6 +886,19 @@ func (az *Cloud) updateNodeCaches(prevNode, newNode *v1.Node) {
 	}
 }
 
+// getNodePrivateIPsForNode returns the cached private IPs of the given node, and
+// whether the node is present in the cache. It is safe for concurrent use with
+// updateNodeCaches. The list is extracted while holding the lock because the
+// cached set is mutated in place by updateNodeCaches, so returning the set
+// itself would let callers race with it.
+func (az *Cloud) getNodePrivateIPsForNode(nodeName string) ([]string, bool) {
+	az.nodeCachesLock.RLock()
+	defer az.nodeCachesLock.RUnlock()
+
+	ips, found := az.nodePrivateIPs[strings.ToLower(nodeName)]
+	return ips.UnsortedList(), found
+}
+
 // updateNodeTaint updates node out-of-service taint
 func (az *Cloud) updateNodeTaint(node *v1.Node) {
 	logger := log.Background().WithName("updateNodeTaint")

--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -278,12 +278,11 @@ func (bc *backendPoolTypeNodeIPConfig) GetBackendPrivateIPs(ctx context.Context,
 						logger.Error(err, "failed: GetNodeNameByIPConfigurationID", "service", serviceName)
 						continue
 					}
-					privateIPsSet, ok := bc.nodePrivateIPs[strings.ToLower(nodeName)]
+					privateIPs, ok := bc.getNodePrivateIPsForNode(nodeName)
 					if !ok {
 						klog.Warningf("bc.GetBackendPrivateIPs for service (%s): failed to get private IPs of node %s", serviceName, nodeName)
 						continue
 					}
-					privateIPs := privateIPsSet.UnsortedList()
 					for _, ip := range privateIPs {
 						logger.V(2).Info("lb backendpool - found private IPs of node", "serviceName", serviceName, "ip", ip, "nodeName", nodeName)
 						if utilnet.IsIPv4String(ip) {
@@ -534,7 +533,8 @@ func (bi *backendPoolTypeNodeIP) ReconcileBackendPools(ctx context.Context, clus
 			bp := newBackendPools[i]
 			var nodeIPAddressesToBeDeleted []string
 			for _, nodeName := range bi.excludeLoadBalancerNodes.UnsortedList() {
-				for _, ip := range bi.nodePrivateIPs[strings.ToLower(nodeName)].UnsortedList() {
+				ips, _ := bi.getNodePrivateIPsForNode(nodeName)
+				for _, ip := range ips {
 					logger.V(2).Info("found unwanted node private IP, decouple it from the LB", "serviceName", serviceName, "ip", ip, "lbName", lbName)
 					nodeIPAddressesToBeDeleted = append(nodeIPAddressesToBeDeleted, ip)
 				}

--- a/pkg/provider/azure_local_services.go
+++ b/pkg/provider/azure_local_services.go
@@ -404,12 +404,12 @@ func (az *Cloud) setUpEndpointSlicesInformer(informerFactory informers.SharedInf
 					}
 				}
 				for _, previousNodeName := range previousNodeNameSet.UnsortedList() {
-					nodeIPsSet := az.nodePrivateIPs[strings.ToLower(previousNodeName)]
-					previousIPs = append(previousIPs, nodeIPsSet.UnsortedList()...)
+					ips, _ := az.getNodePrivateIPsForNode(previousNodeName)
+					previousIPs = append(previousIPs, ips...)
 				}
 				for _, currentNodeName := range currentNodeNameSet.UnsortedList() {
-					nodeIPsSet := az.nodePrivateIPs[strings.ToLower(currentNodeName)]
-					currentIPs = append(currentIPs, nodeIPsSet.UnsortedList()...)
+					ips, _ := az.getNodePrivateIPsForNode(currentNodeName)
+					currentIPs = append(currentIPs, ips...)
 				}
 
 				if az.backendPoolUpdater != nil {
@@ -618,8 +618,8 @@ func (az *Cloud) checkAndApplyLocalServiceBackendPoolUpdates(lb armnetwork.LoadB
 
 	var expectedIPs []string
 	for _, nodeName := range endpointsNodeNames.UnsortedList() {
-		ips := az.nodePrivateIPs[strings.ToLower(nodeName)]
-		expectedIPs = append(expectedIPs, ips.UnsortedList()...)
+		ips, _ := az.getNodePrivateIPsForNode(nodeName)
+		expectedIPs = append(expectedIPs, ips...)
 	}
 	currentIPsInBackendPools := make(map[string][]string)
 	for _, bp := range lb.Properties.BackendAddressPools {

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -1380,3 +1380,92 @@ func TestLoadBalancerBackendPoolUpdaterRemoveOperationCancelsOperationsBeforeDra
 	assert.Equal(t, 0, len(u.operations))
 	u.lock.Unlock()
 }
+
+// TestNodeAndEndpointSliceInformersConcurrentAccess reproduces a data race between the node
+// informer, which writes az.nodePrivateIPs under nodeCachesLock in updateNodeCaches, and the
+// EndpointSlice informer, which used to read az.nodePrivateIPs without holding the lock. Run
+// with -race to verify.
+func TestNodeAndEndpointSliceInformersConcurrentAccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.localServiceNameToServiceInfoMap = sync.Map{}
+	cloud.localServiceNameToServiceInfoMap.Store("test/svc1", newServiceInfo(consts.IPVersionIPv4String, "lb1"))
+	cloud.LoadBalancerBackendPoolUpdateIntervalInSeconds = 1
+	cloud.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+	cloud.MultipleStandardLoadBalancerConfigurations = []config.MultipleStandardLoadBalancerConfiguration{
+		{Name: "lb1"},
+	}
+
+	for i := 0; i < 10; i++ {
+		cloud.nodePrivateIPs[fmt.Sprintf("node-%d", i)] = utilsets.NewString(fmt.Sprintf("10.0.0.%d", i))
+	}
+
+	existingEPS := getTestEndpointSlice("eps1", "test", "svc1", "node-0")
+	svc := getTestService("svc1", v1.ProtocolTCP, nil, false)
+	svc.Namespace = "test"
+
+	initialNodes := make([]runtime.Object, 10)
+	for i := 0; i < 10; i++ {
+		initialNodes[i] = &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("node-%d", i),
+			},
+			Status: v1.NodeStatus{
+				Addresses: []v1.NodeAddress{
+					{Type: v1.NodeInternalIP, Address: fmt.Sprintf("10.0.0.%d", i)},
+				},
+			},
+		}
+	}
+	clientObjs := append([]runtime.Object{&svc, existingEPS}, initialNodes...)
+	client := fake.NewSimpleClientset(clientObjs...)
+	cloud.KubeClient = client
+
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	mockVMSet := NewMockVMSet(ctrl)
+	mockVMSet.EXPECT().DeleteCacheForNode(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	cloud.VMSet = mockVMSet
+
+	cloud.SetInformers(informerFactory)
+
+	stopChan := make(chan struct{})
+	informerFactory.Start(stopChan)
+	informerFactory.WaitForCacheSync(stopChan)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			node := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("node-%d", i%10),
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeInternalIP, Address: fmt.Sprintf("10.0.%d.%d", i/256, i%256)},
+					},
+				},
+			}
+			_, _ = client.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			eps := getTestEndpointSlice("eps1", "test", "svc1", fmt.Sprintf("node-%d", i%10))
+			eps.ResourceVersion = fmt.Sprintf("%d", i+2)
+			_, _ = client.DiscoveryV1().EndpointSlices("test").Update(context.Background(), eps, metav1.UpdateOptions{})
+		}
+	}()
+
+	wg.Wait()
+	time.Sleep(500 * time.Millisecond)
+	close(stopChan)
+}


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:

Cloud.nodePrivateIPs is written under nodeCachesLock inside
updateNodeCaches, which runs on the node informer's AddFunc/UpdateFunc/
DeleteFunc handlers. Several other code paths read it without holding
the lock: the EndpointSlice informer's UpdateFunc,
checkAndApplyLocalServiceBackendPoolUpdates,
backendPoolTypeNodeIPConfig.GetBackendPrivateIPs, and
backendPoolTypeNodeIP.ReconcileBackendPools. When a node update and an
EndpointSlice update (or a service reconciliation) land at the same
time, the writer and an unlocked reader can access the same
*utilsets.IgnoreCaseSet concurrently, which the Go race detector
reports and which can surface in production as a fatal, unrecoverable
"concurrent map read and map write" crash of the process, since
updateNodeCaches mutates the set in place via Delete/SafeInsert rather
than replacing it.

Approach: add Cloud.getNodePrivateIPsForNode, which takes
nodeCachesLock.RLock() and extracts the IP list (via UnsortedList())
while still holding the lock, returning a plain []string plus a bool
mirroring the original map-presence check. Extracting the list inside
the critical section is required: returning the cached
*IgnoreCaseSet pointer itself and calling UnsortedList() on it after
releasing the lock still races, because the writer mutates that same
object in place rather than replacing it wholesale. All four unlocked
read sites now go through this helper instead of indexing
az.nodePrivateIPs directly.

Special notes for your reviewer:

Validation: added TestNodeAndEndpointSliceInformersConcurrentAccess to
pkg/provider/azure_local_services_test.go (from the issue's
reproduction recipe), which wires up both the node and EndpointSlice
informers via Cloud.SetInformers against a fake clientset and drives
concurrent node/EndpointSlice updates from two goroutines.

  go test -race -run TestNodeAndEndpointSliceInformersConcurrentAccess -count=10 ./pkg/provider/

Before this change, this reproduces the reported race:
"WARNING: DATA RACE ... Write at ... by
sigs.k8s.io/cloud-provider-azure/pkg/provider.(*Cloud).updateNodeCaches()
... Previous read at ... by
sigs.k8s.io/cloud-provider-azure/pkg/provider.(*Cloud).setUpEndpointSlicesInformer.func2()
... --- FAIL: TestNodeAndEndpointSliceInformersConcurrentAccess ...
race detected during execution of test". With this change, the same
command passes 10/10 with no race reported. Also ran the full affected
package tree with the race detector:

  go test -race ./pkg/provider/...

All packages pass. Also ran go build ./pkg/provider/..., go vet
./pkg/provider/..., and gofmt -l on the changed files; all clean.

Fixes #10729

Does this PR introduce a user-facing change?
```release-note
Fixed a data race on the internal node-private-IP cache that could crash cloud-controller-manager with a fatal "concurrent map read and map write" error when a node update and an EndpointSlice update (or service reconciliation) for a local-traffic-policy Service occurred concurrently.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>