### PR TITLE
feat: support NFS encryption in transit for new storage accounts

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -80,6 +80,7 @@ type AccountOptions struct {
 	AllowCrossTenantReplication             *bool
 	IsMultichannelEnabled                   *bool
 	IsSmbOAuthEnabled                       *bool
+	IsNFSEncryptionInTransitEnabled         *bool
 	KeyName                                 *string
 	KeyVersion                              *string
 	KeyVaultURI                             *string
@@ -172,6 +173,13 @@ func (az *AccountRepo) getStorageAccounts(ctx context.Context, storageAccountCli
 			}
 
 			if equal, err = az.isDisableFileServiceDeleteRetentionPolicyEqual(ctx, acct, accountOptions); err != nil {
+				return nil, err
+			}
+			if !equal {
+				continue
+			}
+
+			if equal, err = az.isNFSEncryptionInTransitEnabledEqual(ctx, acct, accountOptions); err != nil {
 				return nil, err
 			}
 			if !equal {
@@ -671,7 +679,7 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 			}
 		}
 
-		if accountOptions.DisableFileServiceDeleteRetentionPolicy != nil || accountOptions.IsMultichannelEnabled != nil {
+		if accountOptions.DisableFileServiceDeleteRetentionPolicy != nil || accountOptions.IsMultichannelEnabled != nil || ptr.Deref(accountOptions.IsNFSEncryptionInTransitEnabled, false) {
 			prop, err := az.fileServiceRepo.Get(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, accountName)
 			if err != nil {
 				return "", "", err
@@ -693,7 +701,21 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 			if accountOptions.IsMultichannelEnabled != nil {
 				logger.V(2).Info("enable SMB Multichannel setting on account", "account", accountName, "subscription", subsID, "resourceGroup", resourceGroup)
 				enabled := *accountOptions.IsMultichannelEnabled
-				prop.FileServiceProperties.ProtocolSettings = &armstorage.ProtocolSettings{Smb: &armstorage.SmbSetting{Multichannel: &armstorage.Multichannel{Enabled: &enabled}}}
+				if prop.FileServiceProperties.ProtocolSettings == nil {
+					prop.FileServiceProperties.ProtocolSettings = &armstorage.ProtocolSettings{}
+				}
+				prop.FileServiceProperties.ProtocolSettings.Smb = &armstorage.SmbSetting{Multichannel: &armstorage.Multichannel{Enabled: &enabled}}
+			}
+			if ptr.Deref(accountOptions.IsNFSEncryptionInTransitEnabled, false) {
+				logger.V(2).Info("set NFS EncryptionInTransit setting on account",
+					"required", true,
+					"account", accountName,
+					"subscription", subsID,
+					"resourceGroup", resourceGroup)
+				if prop.FileServiceProperties.ProtocolSettings == nil {
+					prop.FileServiceProperties.ProtocolSettings = &armstorage.ProtocolSettings{}
+				}
+				prop.FileServiceProperties.ProtocolSettings.Nfs = &armstorage.NfsSetting{EncryptionInTransit: &armstorage.EncryptionInTransit{Required: ptr.To(true)}}
 			}
 
 			if err := az.fileServiceRepo.Set(ctx, subsID, resourceGroup, accountName, prop); err != nil {
@@ -1118,6 +1140,31 @@ func (az *AccountRepo) isMultichannelEnabledEqual(ctx context.Context, account *
 	}
 
 	return *accountOptions.IsMultichannelEnabled == ptr.Deref(prop.FileServiceProperties.ProtocolSettings.Smb.Multichannel.Enabled, false), nil
+}
+
+func (az *AccountRepo) isNFSEncryptionInTransitEnabledEqual(ctx context.Context, account *armstorage.Account, accountOptions *AccountOptions) (bool, error) {
+	if accountOptions.IsNFSEncryptionInTransitEnabled == nil {
+		return true, nil
+	}
+
+	if account.Name == nil {
+		klog.Warningf("account.Name under resource group(%s) is nil", accountOptions.ResourceGroup)
+		return false, nil
+	}
+
+	prop, err := az.fileServiceRepo.Get(ctx, accountOptions.SubscriptionID, accountOptions.ResourceGroup, ptr.Deref(account.Name, ""))
+	if err != nil {
+		return false, err
+	}
+
+	if prop.FileServiceProperties == nil ||
+		prop.FileServiceProperties.ProtocolSettings == nil ||
+		prop.FileServiceProperties.ProtocolSettings.Nfs == nil ||
+		prop.FileServiceProperties.ProtocolSettings.Nfs.EncryptionInTransit == nil {
+		return !*accountOptions.IsNFSEncryptionInTransitEnabled, nil
+	}
+
+	return *accountOptions.IsNFSEncryptionInTransitEnabled == ptr.Deref(prop.FileServiceProperties.ProtocolSettings.Nfs.EncryptionInTransit.Required, false), nil
 }
 
 func (az *AccountRepo) isDisableFileServiceDeleteRetentionPolicyEqual(ctx context.Context, account *armstorage.Account, accountOptions *AccountOptions) (bool, error) {

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -1921,6 +1921,152 @@ func TestIsMultichannelEnabledEqual(t *testing.T) {
 	}
 }
 
+func TestIsNFSEncryptionInTransitEnabledEqual(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	accountName := "account2"
+
+	StorageAccountRepo := &AccountRepo{
+		fileServiceRepo: mock_fileservice.NewMockRepository(ctrl),
+	}
+
+	nfsEiTRequired := armstorage.FileServiceProperties{
+		FileServiceProperties: &armstorage.FileServicePropertiesProperties{
+			ProtocolSettings: &armstorage.ProtocolSettings{
+				Nfs: &armstorage.NfsSetting{EncryptionInTransit: &armstorage.EncryptionInTransit{Required: ptr.To(true)}},
+			},
+		},
+	}
+
+	nfsEiTNotRequired := armstorage.FileServiceProperties{
+		FileServiceProperties: &armstorage.FileServicePropertiesProperties{
+			ProtocolSettings: &armstorage.ProtocolSettings{
+				Nfs: &armstorage.NfsSetting{EncryptionInTransit: &armstorage.EncryptionInTransit{Required: ptr.To(false)}},
+			},
+		},
+	}
+
+	incompleteServiceProperties := armstorage.FileServiceProperties{
+		FileServiceProperties: &armstorage.FileServicePropertiesProperties{
+			ProtocolSettings: &armstorage.ProtocolSettings{},
+		},
+	}
+
+	tests := []struct {
+		desc                      string
+		account                   *armstorage.Account
+		accountOptions            *AccountOptions
+		serviceProperties         *armstorage.FileServiceProperties
+		servicePropertiesRetError error
+		expectedResult            bool
+	}{
+		{
+			desc: "IsNFSEncryptionInTransitEnabled is nil",
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			desc: "account.Name is nil",
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsNFSEncryptionInTransitEnabled: ptr.To(false),
+			},
+			expectedResult: false,
+		},
+		{
+			desc: "IsNFSEncryptionInTransitEnabled not equal #1",
+			account: &armstorage.Account{
+				Name:       &accountName,
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsNFSEncryptionInTransitEnabled: ptr.To(false),
+			},
+			serviceProperties: &nfsEiTRequired,
+			expectedResult:    false,
+		},
+		{
+			desc: "GetServiceProperties return error",
+			account: &armstorage.Account{
+				Name:       &accountName,
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsNFSEncryptionInTransitEnabled: ptr.To(false),
+			},
+			serviceProperties:         &nfsEiTRequired,
+			servicePropertiesRetError: fmt.Errorf("GetServiceProperties return error"),
+			expectedResult:            false,
+		},
+		{
+			desc: "IsNFSEncryptionInTransitEnabled not equal #2",
+			account: &armstorage.Account{
+				Name:       &accountName,
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsNFSEncryptionInTransitEnabled: ptr.To(true),
+			},
+			serviceProperties: &nfsEiTNotRequired,
+			expectedResult:    false,
+		},
+		{
+			desc: "IsNFSEncryptionInTransitEnabled is equal #1",
+			account: &armstorage.Account{
+				Name:       &accountName,
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsNFSEncryptionInTransitEnabled: ptr.To(true),
+			},
+			serviceProperties: &nfsEiTRequired,
+			expectedResult:    true,
+		},
+		{
+			desc: "IsNFSEncryptionInTransitEnabled is equal #2",
+			account: &armstorage.Account{
+				Name:       &accountName,
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsNFSEncryptionInTransitEnabled: ptr.To(false),
+			},
+			serviceProperties: &nfsEiTNotRequired,
+			expectedResult:    true,
+		},
+		{
+			desc: "incompleteServiceProperties should be regarded as NFS EncryptionInTransit not required",
+			account: &armstorage.Account{
+				Name:       &accountName,
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				IsNFSEncryptionInTransitEnabled: ptr.To(false),
+			},
+			serviceProperties: &incompleteServiceProperties,
+			expectedResult:    true,
+		},
+	}
+
+	for _, test := range tests {
+		if test.serviceProperties != nil {
+			StorageAccountRepo.fileServiceRepo.(*mock_fileservice.MockRepository).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.serviceProperties, test.servicePropertiesRetError).Times(1)
+		}
+
+		result, _ := StorageAccountRepo.isNFSEncryptionInTransitEnabledEqual(ctx, test.account, test.accountOptions)
+		assert.Equal(t, test.expectedResult, result, test.desc)
+	}
+}
+
 func TestIsDisableFileServiceDeleteRetentionPolicyEqual(t *testing.T) {
 
 	accountName := "account"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Azure Files now supports per-protocol encryption in transit (EiT) for NFS.  Enforcement is service side at the storage account file service level. The AzureFile CSI Driver needs to be able to enable this on accounts for storageclasses that request it, at create time only for safety.

Changes:
- Add `AccountOptions.IsNFSEncryptionInTransitEnabled` to configure per-protocol encryption in transit for NFS on a storage account's file service (`ProtocolSettings.Nfs.EncryptionInTransit.Required`).
- Updates account matching (`getStorageAccounts`) with `isNFSEncryptionInTransitEnabledEqual` so an account with NFS encryption in transit enabled is not reused for a request that does not require it (and vice versa), preventing plaintext NFS mounts from landing on an encryption-required account.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `AccountOptions.IsNFSEncryptionInTransitEnabled` to enable per-protocol NFS encryption in transit on newly created storage accounts.  The field is optional, leaving it as nil preserves the existing behavior.
```