### PR TITLE
fix: fall back to an IP-derived name for backend addresses with no cached node name

### DIFF
--- a/pkg/provider/azure_loadbalancer_backendpool.go
+++ b/pkg/provider/azure_loadbalancer_backendpool.go
@@ -707,6 +707,13 @@ func (az *Cloud) addNodeIPAddressesToBackendPool(backendPool *armnetwork.Backend
 	for _, ipAddress := range nodeIPAddresses {
 		if !hasIPAddressInBackendPool(backendPool, ipAddress) {
 			name := az.nodePrivateIPToNodeNameMap[ipAddress]
+			if name == "" {
+				// The node name in cache could be empty for unknown reasons. Fall back to a name
+				// derived from the IP address, prefixed to avoid colliding with a real node name,
+				// so the backend address is not created with an empty name.
+				name = "ip-" + strings.NewReplacer(".", "-", ":", "-").Replace(ipAddress)
+				logger.V(2).Info("Node name not found in cache for IP address, generated a name for the backend address", "ip", ipAddress, "generatedName", name)
+			}
 			logger.V(4).Info("adding node to the backend pool", "ip", ipAddress, "backendPoolName", ptr.Deref(backendPool.Name, ""))
 			addresses = append(addresses, &armnetwork.LoadBalancerBackendAddress{
 				Name: ptr.To(name),

--- a/pkg/provider/azure_loadbalancer_backendpool_test.go
+++ b/pkg/provider/azure_loadbalancer_backendpool_test.go
@@ -958,6 +958,24 @@ func TestAddNodeIPAddressesToBackendPoolDeduplicates(t *testing.T) {
 	}
 }
 
+func TestAddNodeIPAddressesToBackendPoolGeneratesNameWhenNodeNameMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := GetTestCloud(ctrl)
+	cloud.nodePrivateIPToNodeNameMap = map[string]string{}
+
+	bp := buildTestLoadBalancerBackendPoolWithIPs("test-pool", nil)
+	changed := cloud.addNodeIPAddressesToBackendPool(bp, []string{"10.0.0.1"})
+	assert.True(t, changed)
+
+	if assert.Len(t, bp.Properties.LoadBalancerBackendAddresses, 1) {
+		addr := bp.Properties.LoadBalancerBackendAddresses[0]
+		assert.Equal(t, "10.0.0.1", ptr.Deref(addr.Properties.IPAddress, ""))
+		assert.Equal(t, "ip-10-0-0-1", ptr.Deref(addr.Name, ""))
+	}
+}
+
 func TestGetBackendPrivateIPsNodeIPConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/provider/azure_local_services_test.go
+++ b/pkg/provider/azure_local_services_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -522,8 +523,10 @@ func getTestBackendAddressPoolWithIPs(lbName, bpName string, ips []string) *armn
 	}
 	for _, ip := range ips {
 		if len(ip) > 0 {
+			// The local service reconciliation path never populates nodePrivateIPToNodeNameMap,
+			// so addNodeIPAddressesToBackendPool falls back to a name derived from the IP address.
 			bp.Properties.LoadBalancerBackendAddresses = append(bp.Properties.LoadBalancerBackendAddresses, &armnetwork.LoadBalancerBackendAddress{
-				Name: ptr.To(""),
+				Name: ptr.To("ip-" + strings.NewReplacer(".", "-", ":", "-").Replace(ip)),
 				Properties: &armnetwork.LoadBalancerBackendAddressPropertiesFormat{
 					IPAddress: ptr.To(ip),
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `addNodeIPAddressesToBackendPool` builds a new `armnetwork.LoadBalancerBackendAddress`
for a node IP, it looks up the node name from `az.nodePrivateIPToNodeNameMap` and uses it
as the address `Name`. If that lookup misses, `Name` is set to a pointer to an empty
string.

This is reachable today: the local-service backend-pool-updater test suite
(`pkg/provider/azure_local_services_test.go`, exercising
`pkg/provider/azure_local_services.go`) seeds `nodePrivateIPs` directly without going
through `updateNodeCaches`, so `nodePrivateIPToNodeNameMap` stays empty and every backend
address built on that path previously got `Name: ""`. In production, both maps are
populated together by the same node-informer callback (`pkg/provider/azure.go`,
`updateNodeCaches`), so a persistently empty name there would only happen for a node whose
private-IP cache entry exists ahead of/without its name-map entry (e.g. a timing/race gap
during cache population), matching the "for unknown reason" note in the linked issue. This
PR does not claim to have reproduced that race live; the fix protects the code path (used by
both production and this test suite) that hits the empty-name case, and is validated by a
unit test that reproduces "cache miss -> empty name" directly.

An empty-named backend address risks being rejected, or colliding with other empty-named
addresses, when the pool is sent to the Azure API. This PR falls back to a name derived
from the IP address (e.g. `10.0.0.1` -> `ip-10-0-0-1`) whenever the cached node name is
empty, so the address always gets a non-empty, distinguishable name. The `ip-` prefix
avoids colliding with a real node whose name happens to already look IP-derived.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

- This is a defensive fallback, not a fix for the root cause of why the cache entry could
  be missing in production (that root cause is not confirmed — see discussion above).
- Also updated `pkg/provider/azure_local_services_test.go`'s
  `getTestBackendAddressPoolWithIPs` helper, which previously hardcoded
  `Name: ptr.To("")` for every synthesized backend address, to generate the same
  fallback name production code now generates, since that test path never populates
  `nodePrivateIPToNodeNameMap`.
- Validation: `go build ./...` passes. `go test ./pkg/provider/...` passes (full
  package, no regressions). Added
  `TestAddNodeIPAddressesToBackendPoolGeneratesNameWhenNodeNameMissing`, confirmed it
  fails with `expected "ip-10-0-0-1", actual ""` when the fix is reverted and passes
  with the fix applied. `golangci-lint run ./pkg/provider/...` shows no new findings on
  the changed lines (pre-existing goconst/gosec/govet findings elsewhere in the package
  are unrelated to this diff).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a potential issue where a load balancer backend address could be created with an empty name when the node name was missing from the internal node-IP cache, by falling back to a name derived from the node's IP address.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

Fixes #9803