### PR TITLE
fix: include priority 4096 in managed security rule allocation range

### DIFF
--- a/pkg/provider/securitygroup/securitygroup.go
+++ b/pkg/provider/securitygroup/securitygroup.go
@@ -110,22 +110,24 @@ const (
 
 // nextRulePriority returns the next available priority for a new rule.
 // It takes a preference for whether to start from the beginning or end of the priority range.
+// The priority range is inclusive of both consts.LoadBalancerMinimumPriority and
+// consts.LoadBalancerMaximumPriority, matching the range considered managed by IsManagedSecurityRule.
 func (helper *RuleHelper) nextRulePriority(prefer rulePriorityPrefer) (int32, error) {
 	var (
-		init, end = consts.LoadBalancerMinimumPriority, consts.LoadBalancerMaximumPriority
-		delta     = 1
+		init, end = int32(consts.LoadBalancerMinimumPriority), int32(consts.LoadBalancerMaximumPriority)
+		delta     = int32(1)
 	)
 	if prefer == rulePriorityPreferFromEnd {
-		init, end, delta = end-1, init-1, -1
+		init, end, delta = end, init, -1
 	}
 
-	for init != end {
-		p := int32(init)
-		if _, found := helper.priorities[p]; found {
-			init += delta
-			continue
+	for p := init; ; p += delta {
+		if _, found := helper.priorities[p]; !found {
+			return p, nil
 		}
-		return p, nil
+		if p == end {
+			break
+		}
 	}
 
 	return 0, ErrSecurityRulePriorityExhausted

--- a/pkg/provider/securitygroup/securitygroup_test.go
+++ b/pkg/provider/securitygroup/securitygroup_test.go
@@ -863,7 +863,7 @@ func TestSecurityGroupHelper_AddRuleForDenyAll(t *testing.T) {
 						SourcePortRange:            ptr.To("*"),
 						DestinationAddressPrefixes: fnutil.Map(func(v netip.Addr) *string { return to.Ptr(v.String()) }, dstAddresses),
 						DestinationPortRange:       ptr.To("*"),
-						Priority:                   ptr.To(int32(4095)),
+						Priority:                   ptr.To(int32(4096)),
 					},
 				},
 			}, "[`%s`] 1 allow rule should be created", c.TestName)

--- a/pkg/provider/securitygroup/securityrule_test.go
+++ b/pkg/provider/securitygroup/securityrule_test.go
@@ -22,7 +22,39 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 )
+
+func TestRuleHelper_NextRulePriority_IncludesMaximumPriority(t *testing.T) {
+	t.Parallel()
+
+	// Fill every priority except the maximum one, so the only slot left to find is
+	// consts.LoadBalancerMaximumPriority. IsManagedSecurityRule treats this priority as
+	// managed, so nextRulePriority must be able to allocate it too.
+	priorities := make(map[int32]string, consts.LoadBalancerMaximumPriority-consts.LoadBalancerMinimumPriority)
+	for p := int32(consts.LoadBalancerMinimumPriority); p < int32(consts.LoadBalancerMaximumPriority); p++ {
+		priorities[p] = "existing-rule"
+	}
+
+	t.Run("from start", func(t *testing.T) {
+		t.Parallel()
+		helper := &RuleHelper{priorities: priorities}
+
+		p, err := helper.nextRulePriority(rulePriorityPreferFromStart)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(consts.LoadBalancerMaximumPriority), p)
+	})
+
+	t.Run("from end", func(t *testing.T) {
+		t.Parallel()
+		helper := &RuleHelper{priorities: priorities}
+
+		p, err := helper.nextRulePriority(rulePriorityPreferFromEnd)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(consts.LoadBalancerMaximumPriority), p)
+	})
+}
 
 func TestSetDestinationPortRanges(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`IsManagedSecurityRule` (pkg/provider/securitygroup/securityrule.go) treats the
managed security rule priority range as `[500, 4096]`, inclusive of the maximum
priority 4096. However, `RuleHelper.nextRulePriority`
(pkg/provider/securitygroup/securitygroup.go), which allocates priorities for
rules the cloud-provider creates, used an exclusive upper bound and could only
ever assign priorities in `[500, 4095]` in both allocation directions (from
start and from end). Azure's valid NSG rule priority range is 100-4096, so
priority 4096 is a legitimate allocatable value; excluding it from allocation
while still treating it as "managed" was an inconsistency between the two
functions.

This PR rewrites `nextRulePriority`'s loop to use inclusive bounds on both
ends, so it can now allocate priority 4096, matching `IsManagedSecurityRule`'s
range in both allocation directions.

This is a narrow allocation off-by-one affecting only the single boundary
priority 4096; it does not change behavior for any existing rule or any
priority below 4096, and is not a crash or data-loss issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Validation performed locally:
- `go build ./...` passes.
- Added `TestRuleHelper_NextRulePriority_IncludesMaximumPriority` in
  pkg/provider/securitygroup/securityrule_test.go, which fills every priority
  except 4096 and asserts `nextRulePriority` can still find it in both
  directions. This test fails on the pre-fix code (returns "security rule
  priority exhausted") and passes after the fix.
- `go test ./pkg/provider/securitygroup/...` passes, including the updated
  `TestSecurityGroupHelper_AddRuleForDenyAll`, whose expected priority for a
  deny-all rule allocated into an otherwise-empty managed range changes from
  the old (buggy) 4095 to the correct 4096.
- `golangci-lint run ./pkg/provider/securitygroup/...` shows only
  pre-existing `goconst` warnings in the test file, unchanged from master
  (verified via `git stash`).

Note: `pkg/provider/azure_standard.go` has a `getNextAvailablePriority`
function with the same exclusive-upper-bound pattern, but it appears to be
unreferenced outside its own unit test (dead code), so it was left out of
this narrowly-scoped fix.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an inconsistency where the cloud-provider's security rule priority allocator could never assign the maximum valid priority (4096) to a new managed rule, even though that priority is considered part of the managed range for cleanup purposes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Fixes #9906