### PR TITLE
fix: Included ExtendedLocation when update VMSS

### DIFF
--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1347,7 +1347,7 @@ func (ss *ScaleSet) ensureVMSSInPool(ctx context.Context, _ *v1.Service, nodes [
 			})
 		primaryIPConfig.Properties.LoadBalancerBackendAddressPools = loadBalancerBackendAddressPools
 		newVMSS := armcompute.VirtualMachineScaleSet{
-			Location: vmss.Location,
+			Location:         vmss.Location,
 			ExtendedLocation: vmss.ExtendedLocation,
 			Properties: &armcompute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
@@ -2286,7 +2286,7 @@ func (ss *ScaleSet) EnsureBackendPoolDeletedFromVMSets(ctx context.Context, vmss
 		vmssUpdaters = append(vmssUpdaters, func() error {
 			// Compose a new vmss with added backendPoolID.
 			newVMSS := armcompute.VirtualMachineScaleSet{
-				Location: vmss.Location,
+				Location:         vmss.Location,
 				ExtendedLocation: vmss.ExtendedLocation,
 				Properties: &armcompute.VirtualMachineScaleSetProperties{
 					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{

--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1348,6 +1348,7 @@ func (ss *ScaleSet) ensureVMSSInPool(ctx context.Context, _ *v1.Service, nodes [
 		primaryIPConfig.Properties.LoadBalancerBackendAddressPools = loadBalancerBackendAddressPools
 		newVMSS := armcompute.VirtualMachineScaleSet{
 			Location: vmss.Location,
+			ExtendedLocation: vmss.ExtendedLocation,
 			Properties: &armcompute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
 					NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
@@ -2286,6 +2287,7 @@ func (ss *ScaleSet) EnsureBackendPoolDeletedFromVMSets(ctx context.Context, vmss
 			// Compose a new vmss with added backendPoolID.
 			newVMSS := armcompute.VirtualMachineScaleSet{
 				Location: vmss.Location,
+				ExtendedLocation: vmss.ExtendedLocation,
 				Properties: &armcompute.VirtualMachineScaleSetProperties{
 					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
 						NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{

--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -695,7 +695,7 @@ func (fs *FlexScaleSet) ensureVMSSFlexInPool(ctx context.Context, _ *v1.Service,
 			})
 		primaryIPConfig.Properties.LoadBalancerBackendAddressPools = loadBalancerBackendAddressPools
 		newVMSS := armcompute.VirtualMachineScaleSet{
-			Location: vmssFlex.Location,
+			Location:         vmssFlex.Location,
 			ExtendedLocation: vmssFlex.ExtendedLocation,
 			Properties: &armcompute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
@@ -843,7 +843,7 @@ func (fs *FlexScaleSet) EnsureBackendPoolDeletedFromVMSets(ctx context.Context, 
 		vmssUpdaters = append(vmssUpdaters, func() error {
 			// Compose a new vmss with added backendPoolID.
 			newVMSS := armcompute.VirtualMachineScaleSet{
-				Location: vmss.Location,
+				Location:         vmss.Location,
 				ExtendedLocation: vmss.ExtendedLocation,
 				Properties: &armcompute.VirtualMachineScaleSetProperties{
 					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{

--- a/pkg/provider/azure_vmssflex.go
+++ b/pkg/provider/azure_vmssflex.go
@@ -696,6 +696,7 @@ func (fs *FlexScaleSet) ensureVMSSFlexInPool(ctx context.Context, _ *v1.Service,
 		primaryIPConfig.Properties.LoadBalancerBackendAddressPools = loadBalancerBackendAddressPools
 		newVMSS := armcompute.VirtualMachineScaleSet{
 			Location: vmssFlex.Location,
+			ExtendedLocation: vmssFlex.ExtendedLocation,
 			Properties: &armcompute.VirtualMachineScaleSetProperties{
 				VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
 					NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
@@ -843,6 +844,7 @@ func (fs *FlexScaleSet) EnsureBackendPoolDeletedFromVMSets(ctx context.Context, 
 			// Compose a new vmss with added backendPoolID.
 			newVMSS := armcompute.VirtualMachineScaleSet{
 				Location: vmss.Location,
+				ExtendedLocation: vmss.ExtendedLocation,
 				Properties: &armcompute.VirtualMachineScaleSetProperties{
 					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
 						NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
VMSS requires extended location when update the vmss.

This is error 
```
The resource 'aks-xxxxxxxx-vmss' already exists in extended location 'EdgeZone': 'xxxxxx' of location 'eastus'. A resource with the same name cannot be created in location 'eastus'. Please select a new resource name."
```
The VMSS team showed me the code, basically, when extendedLocaiton is set when the vmss is created, it will expect extendedLocaiton in subsequence update requests. The code was there since 2020, long before the first PR of extendedLocaiton in Cloud provider. My guess is the feature was half baked and never verified.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bug fix: sends extended location when update vmss.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

