### PR TITLE
[release-1.35] feat: support AllowCrossTenantReplication in AccountOptions

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -77,6 +77,7 @@ type AccountOptions struct {
 	AllowBlobPublicAccess                   *bool
 	RequireInfrastructureEncryption         *bool
 	AllowSharedKeyAccess                    *bool
+	AllowCrossTenantReplication             *bool
 	IsMultichannelEnabled                   *bool
 	IsSmbOAuthEnabled                       *bool
 	KeyName                                 *string
@@ -156,7 +157,7 @@ func (az *AccountRepo) getStorageAccounts(ctx context.Context, storageAccountCli
 	accounts := []accountWithLocation{}
 	for _, acct := range result {
 		if acct.Name != nil && acct.Location != nil && acct.SKU != nil {
-			if !isStorageTypeEqual(acct, accountOptions) || !isAccountKindEqual(acct, accountOptions) || !isLocationEqual(acct, accountOptions) || !isLargeFileSharesPropertyEqual(acct, accountOptions) || !isTagsEqual(acct, accountOptions) || !isTaggedWithSkip(acct) || !isHnsPropertyEqual(acct, accountOptions) || !isEnableNfsV3PropertyEqual(acct, accountOptions) || !isEnableHTTPSTrafficOnlyEqual(acct, accountOptions) || !isAllowBlobPublicAccessEqual(acct, accountOptions) || !isRequireInfrastructureEncryptionEqual(acct, accountOptions) || !isAllowSharedKeyAccessEqual(acct, accountOptions) || !isAccessTierEqual(acct, accountOptions) || !AreVNetRulesEqual(acct, accountOptions) || !isPrivateEndpointAsExpected(acct, accountOptions) || !isSmbOAuthEnabledEqual(acct, accountOptions) {
+			if !isStorageTypeEqual(acct, accountOptions) || !isAccountKindEqual(acct, accountOptions) || !isLocationEqual(acct, accountOptions) || !isLargeFileSharesPropertyEqual(acct, accountOptions) || !isTagsEqual(acct, accountOptions) || !isTaggedWithSkip(acct) || !isHnsPropertyEqual(acct, accountOptions) || !isEnableNfsV3PropertyEqual(acct, accountOptions) || !isEnableHTTPSTrafficOnlyEqual(acct, accountOptions) || !isAllowBlobPublicAccessEqual(acct, accountOptions) || !isRequireInfrastructureEncryptionEqual(acct, accountOptions) || !isAllowSharedKeyAccessEqual(acct, accountOptions) || !isAllowCrossTenantReplicationEqual(acct, accountOptions) || !isAccessTierEqual(acct, accountOptions) || !AreVNetRulesEqual(acct, accountOptions) || !isPrivateEndpointAsExpected(acct, accountOptions) || !isSmbOAuthEnabledEqual(acct, accountOptions) {
 				continue
 			}
 
@@ -569,6 +570,10 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.AllowBlobPublicAccess != nil {
 			logger.V(2).Info("set AllowBlobPublicAccess for storage account", "AllowBlobPublicAccess", *accountOptions.AllowBlobPublicAccess, "account", accountName)
 			cp.Properties.AllowBlobPublicAccess = accountOptions.AllowBlobPublicAccess
+		}
+		if accountOptions.AllowCrossTenantReplication != nil {
+			logger.V(2).Info("set AllowCrossTenantReplication for storage account", "AllowCrossTenantReplication", *accountOptions.AllowCrossTenantReplication, "account", accountName)
+			cp.Properties.AllowCrossTenantReplication = accountOptions.AllowCrossTenantReplication
 		}
 		if accountOptions.RequireInfrastructureEncryption != nil {
 			logger.V(2).Info("set RequireInfrastructureEncryption for storage account", "RequireInfrastructureEncryption", *accountOptions.RequireInfrastructureEncryption, "account", accountName)
@@ -1053,6 +1058,13 @@ func isRequireInfrastructureEncryptionEqual(account *armstorage.Account, account
 
 func isAllowSharedKeyAccessEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {
 	return ptr.Deref(accountOptions.AllowSharedKeyAccess, true) == ptr.Deref(account.Properties.AllowSharedKeyAccess, true)
+}
+
+func isAllowCrossTenantReplicationEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {
+	if accountOptions.AllowCrossTenantReplication == nil {
+		return true
+	}
+	return *accountOptions.AllowCrossTenantReplication == ptr.Deref(account.Properties.AllowCrossTenantReplication, false)
 }
 
 func isAccessTierEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -1368,6 +1368,82 @@ func TestIsAllowSharedKeyAccessEqual(t *testing.T) {
 	}
 }
 
+func TestIsAllowCrossTenantReplicationEqual(t *testing.T) {
+	tests := []struct {
+		account        *armstorage.Account
+		accountOptions *AccountOptions
+		expectedResult bool
+	}{
+		{
+			// options nil (don't care), always match regardless of account value
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			// options nil (don't care), match even when account is false
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(false),
+				},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			// options nil (don't care), match even when account is true
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(true),
+				},
+			},
+			accountOptions: &AccountOptions{},
+			expectedResult: true,
+		},
+		{
+			// both explicitly true
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(true),
+				},
+			},
+			accountOptions: &AccountOptions{
+				AllowCrossTenantReplication: ptr.To(true),
+			},
+			expectedResult: true,
+		},
+		{
+			// options false, account true -> mismatch
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					AllowCrossTenantReplication: ptr.To(true),
+				},
+			},
+			accountOptions: &AccountOptions{
+				AllowCrossTenantReplication: ptr.To(false),
+			},
+			expectedResult: false,
+		},
+		{
+			// options true, account nil (defaults to false) -> mismatch
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{},
+			},
+			accountOptions: &AccountOptions{
+				AllowCrossTenantReplication: ptr.To(true),
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := isAllowCrossTenantReplicationEqual(test.account, test.accountOptions)
+		assert.Equal(t, test.expectedResult, result)
+	}
+}
+
 func TestIsRequireInfrastructureEncryptionEqual(t *testing.T) {
 	tests := []struct {
 		account        *armstorage.Account


### PR DESCRIPTION
## What type of PR is this?

/kind feature

Cherry-pick of #10148 to `release-1.35`.

## What this PR does / why we need it

Backports `AllowCrossTenantReplication` support in `AccountOptions` to the 1.35 release branch.

### Changes (from #10148)
- Add `AllowCrossTenantReplication *bool` field to `AccountOptions`
- Set `cp.Properties.AllowCrossTenantReplication` during account creation when specified
- Add `isAllowCrossTenantReplicationEqual` for account matching
- Wire the new check into the account filtering logic

### Conflict resolution
One minor merge conflict in `getStorageAccounts` — the release-1.35 branch includes `isSmbOAuthEnabledEqual` (not present in master at the time of the original PR). Resolved by keeping both checks in the boolean chain.

```release-note
feat: support AllowCrossTenantReplication in AccountOptions
```
