### PR TITLE
[release-1.35] feat: support separate resource group for private DNS zone

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -99,6 +99,8 @@ type AccountOptions struct {
 	SourceAccountName string
 	// default is "privatelink"
 	PrivateDNSZoneName string
+	// resource group for private DNS zone, default is vnetResourceGroup
+	PrivateDNSZoneResourceGroup string
 	// default is vnetName + "-vnetlink"
 	VNetLinkName        string
 	PublicNetworkAccess string
@@ -460,20 +462,27 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		}
 	}
 
+	// Use a separate resource group for private DNS zone if specified,
+	// otherwise default to vnetResourceGroup for backward compatibility.
+	privateDNSResourceGroup := vnetResourceGroup
+	if accountOptions.PrivateDNSZoneResourceGroup != "" {
+		privateDNSResourceGroup = accountOptions.PrivateDNSZoneResourceGroup
+	}
+
 	if ptr.Deref(accountOptions.CreatePrivateEndpoint, false) {
 		clientFactory := az.NetworkClientFactory
 		if clientFactory == nil {
 			// multi-tenant support
 			clientFactory = az.ComputeClientFactory
 		}
-		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, vnetResourceGroup, privateDNSZoneName); err != nil {
+		if _, err := clientFactory.GetPrivateZoneClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				// Create DNS zone first, this could make sure driver has write permission on vnetResourceGroup
-				if err := az.createPrivateDNSZone(ctx, vnetResourceGroup, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create private DNS zone(%s) in resourceGroup(%s): %w", privateDNSZoneName, vnetResourceGroup, err)
+				// Create DNS zone first, this could make sure driver has write permission on privateDNSResourceGroup
+				if err := az.createPrivateDNSZone(ctx, privateDNSResourceGroup, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get private dns zone %s returned with %v", privateDNSZoneName, err.Error())
+				return "", "", fmt.Errorf("get private DNS zone(%s) in privateDNSResourceGroup(%s): %w", privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 
@@ -482,13 +491,13 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.VNetLinkName != "" {
 			vNetLinkName = accountOptions.VNetLinkName
 		}
-		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, vnetResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
+		if _, err := clientFactory.GetVirtualNetworkLinkClient().Get(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName); err != nil {
 			if strings.Contains(err.Error(), consts.ResourceNotFoundMessageCode) {
-				if err := az.createVNetLink(ctx, vNetLinkName, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
-					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s): %w", vnetName, privateDNSZoneName, vnetResourceGroup, err)
+				if err := az.createVNetLink(ctx, vNetLinkName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+					return "", "", fmt.Errorf("create virtual link for vnet(%s) and DNS Zone(%s) in privateDNSResourceGroup(%s): %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 				}
 			} else {
-				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in resourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, vnetResourceGroup, err)
+				return "", "", fmt.Errorf("get virtual link for vnet(%s) and DNS Zone(%s) in privateDNSResourceGroup(%s) returned with %w", vnetName, privateDNSZoneName, privateDNSResourceGroup, err)
 			}
 		}
 	}
@@ -719,8 +728,8 @@ func (az *AccountRepo) EnsureStorageAccount(ctx context.Context, accountOptions 
 		if accountOptions.StorageType == StorageTypeBlob {
 			dnsZoneGroupName = dnsZoneGroupName + blobNameSuffix
 		}
-		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, vnetName, privateDNSZoneName); err != nil {
-			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), resourceGroup(%s): %w", privateEndpointName, vnetName, vnetResourceGroup, err)
+		if err := az.createPrivateDNSZoneGroup(ctx, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName); err != nil {
+			return "", "", fmt.Errorf("create private DNS zone group - privateEndpoint(%s), vNetName(%s), privateEndpointResourceGroup(%s), privateDNSZoneResourceGroup(%s): %w", privateEndpointName, vnetName, vnetResourceGroup, privateDNSResourceGroup, err)
 		}
 	}
 
@@ -783,9 +792,9 @@ func (az *AccountRepo) createPrivateEndpoint(ctx context.Context, accountName st
 	return err
 }
 
-func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGroup, privateDNSZoneName string) error {
+func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, privateDNSResourceGroup, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZone")
-	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating private DNS zone", "privateDNSZone", privateDNSZoneName, "resourceGroup", privateDNSResourceGroup)
 	location := LocationGlobal
 	privateDNSZone := privatedns.PrivateZone{Location: &location}
 	clientFactory := az.NetworkClientFactory
@@ -795,9 +804,9 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGro
 	}
 	privatednsclient := clientFactory.GetPrivateZoneClient()
 
-	if _, err := privatednsclient.CreateOrUpdate(ctx, vnetResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
+	if _, err := privatednsclient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, privateDNSZone); err != nil {
 		if strings.Contains(err.Error(), "exists already") {
-			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+			logger.V(2).Info("private dns zone in resourceGroup already exists", "privateDNSZone", privateDNSZoneName, "resourceGroup", privateDNSResourceGroup)
 			return nil
 		}
 		return err
@@ -805,9 +814,9 @@ func (az *AccountRepo) createPrivateDNSZone(ctx context.Context, vnetResourceGro
 	return nil
 }
 
-func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetResourceGroup, vnetName, privateDNSZoneName string) error {
+func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createVNetLink")
-	logger.V(2).Info("Creating virtual network link", "vNetLinkName", vNetLinkName, "privateDNSZone", privateDNSZoneName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating virtual network link", "vNetLinkName", vNetLinkName, "privateDNSZone", privateDNSZoneName, "vnetResourceGroup", vnetResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 	clientFactory := az.NetworkClientFactory
 	if clientFactory == nil {
 		// multi-tenant support
@@ -823,20 +832,20 @@ func (az *AccountRepo) createVNetLink(ctx context.Context, vNetLinkName, vnetRes
 			VirtualNetwork:      &privatedns.SubResource{ID: &vnetID},
 			RegistrationEnabled: ptr.To(false)},
 	}
-	_, err := vnetLinkClient.CreateOrUpdate(ctx, vnetResourceGroup, privateDNSZoneName, vNetLinkName, parameters)
+	_, err := vnetLinkClient.CreateOrUpdate(ctx, privateDNSResourceGroup, privateDNSZoneName, vNetLinkName, parameters)
 	return err
 }
 
-func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGroupName, privateEndpointName, vnetResourceGroup, vnetName, privateDNSZoneName string) error {
+func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGroupName, privateEndpointName, privateEndpointResourceGroup, privateDNSResourceGroup, vnetName, privateDNSZoneName string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("createPrivateDNSZoneGroup")
-	logger.V(2).Info("Creating private DNS zone group", "dnsZoneGroup", dnsZoneGroupName, "privateEndpoint", privateEndpointName, "vnetName", vnetName, "ResourceGroup", vnetResourceGroup)
+	logger.V(2).Info("Creating private DNS zone group", "dnsZoneGroup", dnsZoneGroupName, "privateEndpoint", privateEndpointName, "vnetName", vnetName, "privateEndpointResourceGroup", privateEndpointResourceGroup, "privateDNSResourceGroup", privateDNSResourceGroup)
 	privateDNSZoneGroup := &armnetwork.PrivateDNSZoneGroup{
 		Properties: &armnetwork.PrivateDNSZoneGroupPropertiesFormat{
 			PrivateDNSZoneConfigs: []*armnetwork.PrivateDNSZoneConfig{
 				{
 					Name: &privateDNSZoneName,
 					Properties: &armnetwork.PrivateDNSZonePropertiesFormat{
-						PrivateDNSZoneID: to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s", az.SubscriptionID, vnetResourceGroup, privateDNSZoneName)),
+						PrivateDNSZoneID: to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s", az.SubscriptionID, privateDNSResourceGroup, privateDNSZoneName)),
 					},
 				},
 			},
@@ -847,7 +856,7 @@ func (az *AccountRepo) createPrivateDNSZoneGroup(ctx context.Context, dnsZoneGro
 		clientFactory = az.ComputeClientFactory
 	}
 	privatednsgroupClient := clientFactory.GetPrivateDNSZoneGroupClient()
-	_, err := privatednsgroupClient.CreateOrUpdate(ctx, vnetResourceGroup, privateEndpointName, dnsZoneGroupName, *privateDNSZoneGroup)
+	_, err := privatednsgroupClient.CreateOrUpdate(ctx, privateEndpointResourceGroup, privateEndpointName, dnsZoneGroupName, *privateDNSZoneGroup)
 	return err
 }
 

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -460,6 +460,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 		name                            string
 		createAccount                   bool
 		createPrivateEndpoint           *bool
+		privateDNSZoneResourceGroup     string
 		vNetLinkName                    string
 		publicNetworkAccess             string
 		SubnetPropertiesFormatNil       bool
@@ -504,6 +505,19 @@ func TestEnsureStorageAccount(t *testing.T) {
 			setAccountOptions:               true,
 			requireInfrastructureEncryption: ptr.To(true),
 			keyVaultURL:                     ptr.To("keyVaultURL"),
+			resourceGroup:                   "rg",
+			accessTier:                      "AccessTierHot",
+			accountName:                     "",
+			expectedErr:                     "",
+		},
+		{
+			name:                            "[Success] EnsureStorageAccount with createPrivateEndpoint and separate privateDNSZoneResourceGroup",
+			createAccount:                   true,
+			createPrivateEndpoint:           ptr.To(true),
+			privateDNSZoneResourceGroup:     "dns-rg",
+			mockStorageAccountsClient:       true,
+			setAccountOptions:               true,
+			requireInfrastructureEncryption: ptr.To(true),
 			resourceGroup:                   "rg",
 			accessTier:                      "AccessTierHot",
 			accountName:                     "",
@@ -594,21 +608,37 @@ func TestEnsureStorageAccount(t *testing.T) {
 					createOrUpdateCall.Times(1)
 				}
 
+				// DNS operations use privateDNSZoneResourceGroup when set, otherwise vnetResourceGroup
+				dnsRG := vnetResourceGroup
+				if test.privateDNSZoneResourceGroup != "" {
+					dnsRG = test.privateDNSZoneResourceGroup
+				}
+
 				mockPrivateDNSClient := mock_privatezoneclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateZoneClient().Return(mockPrivateDNSClient).AnyTimes()
-				mockPrivateDNSClient.EXPECT().Get(gomock.Any(), vnetResourceGroup, gomock.Any()).Return(&privatedns.PrivateZone{}, errors.New("ResourceNotFound")).Times(1)
-				mockPrivateDNSClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockPrivateDNSClient.EXPECT().Get(gomock.Any(), dnsRG, gomock.Any()).Return(&privatedns.PrivateZone{}, errors.New("ResourceNotFound")).Times(1)
+				mockPrivateDNSClient.EXPECT().CreateOrUpdate(gomock.Any(), dnsRG, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 
 				mockPrivateDNSZoneGroup := mock_privatednszonegroupclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateDNSZoneGroupClient().Return(mockPrivateDNSZoneGroup).AnyTimes()
-				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockPrivateDNSZoneGroup.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Cond(func(x any) bool {
+					group, ok := x.(armnetwork.PrivateDNSZoneGroup)
+					if !ok {
+						return false
+					}
+					if group.Properties == nil || len(group.Properties.PrivateDNSZoneConfigs) == 0 {
+						return false
+					}
+					zoneID := *group.Properties.PrivateDNSZoneConfigs[0].Properties.PrivateDNSZoneID
+					return strings.Contains(zoneID, "/resourceGroups/"+dnsRG+"/")
+				})).Return(nil, nil).Times(1)
 				mockPrivateEndpointClient := mock_privateendpointclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetPrivateEndpointClient().Return(mockPrivateEndpointClient).AnyTimes()
 				mockPrivateEndpointClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 				mockVirtualNetworkLinksClient := mock_virtualnetworklinkclient.NewMockInterface(ctrl)
 				StorageAccountRepo.NetworkClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetVirtualNetworkLinkClient().Return(mockVirtualNetworkLinksClient).AnyTimes()
-				mockVirtualNetworkLinksClient.EXPECT().Get(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any()).Return(&privatedns.VirtualNetworkLink{}, errors.New("ResourceNotFound")).Times(1)
-				mockVirtualNetworkLinksClient.EXPECT().CreateOrUpdate(gomock.Any(), vnetResourceGroup, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockVirtualNetworkLinksClient.EXPECT().Get(gomock.Any(), dnsRG, gomock.Any(), gomock.Any()).Return(&privatedns.VirtualNetworkLink{}, errors.New("ResourceNotFound")).Times(1)
+				mockVirtualNetworkLinksClient.EXPECT().CreateOrUpdate(gomock.Any(), dnsRG, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			}
 
 			if test.sourceAccountName != "" {
@@ -620,6 +650,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 				testAccountOptions = &AccountOptions{
 					ResourceGroup:                   test.resourceGroup,
 					CreatePrivateEndpoint:           test.createPrivateEndpoint,
+					PrivateDNSZoneResourceGroup:     test.privateDNSZoneResourceGroup,
 					VNetLinkName:                    test.vNetLinkName,
 					PublicNetworkAccess:             test.publicNetworkAccess,
 					Name:                            test.accountName,


### PR DESCRIPTION
## What type of PR is this?

/kind feature

Cherry-pick of #10189 to `release-1.35`.

## What this PR does / why we need it

Backports `PrivateDNSZoneResourceGroup` support in `AccountOptions` to the 1.35 release branch.

### Changes (from #10189)
- Add `PrivateDNSZoneResourceGroup` field to `AccountOptions`
- All Private DNS zone operations (create/get Private DNS zone, VNet link, DNS zone group) use this resource group when set
- Defaults to `vnetResourceGroup` when not set — fully backward compatible

### Conflict resolution
None — clean cherry-pick.

Ref: kubernetes-sigs/azurefile-csi-driver#2845

```release-note
feat: support separate resource group for private DNS zone via `PrivateDNSZoneResourceGroup` in AccountOptions
```
