### PR TITLE
fix: add SkipHTTPSTrafficOnlyMatch option to opt out of matching for NFS

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -65,6 +65,12 @@ type AccountOptions struct {
 	SubscriptionID                            string
 	Name, Type, Kind, ResourceGroup, Location string
 	EnableHTTPSTrafficOnly                    bool
+	// SkipHTTPSTrafficOnlyMatch skips EnableHTTPSTrafficOnly account matching
+	// during account reuse lookup. Useful for NFS file share callers where
+	// EnableHTTPSTrafficOnly only governs the REST plane and has no effect
+	// on the NFS mount, so existing accounts should be reused regardless of
+	// their EnableHTTPSTrafficOnly value. Has no effect on account creation.
+	SkipHTTPSTrafficOnlyMatch bool
 	// indicate whether create new account when Name is empty or when account does not exists
 	CreateAccount                           bool
 	CreatePrivateEndpoint                   *bool
@@ -1057,6 +1063,15 @@ func isEnableNfsV3PropertyEqual(account *armstorage.Account, accountOptions *Acc
 }
 
 func isEnableHTTPSTrafficOnlyEqual(account *armstorage.Account, accountOptions *AccountOptions) bool {
+	// Callers can opt out of EnableHTTPSTrafficOnly matching for scenarios
+	// where the setting is irrelevant to the mount protocol (e.g. NFS file
+	// shares, where EnableHTTPSTrafficOnly only affects REST traffic). This
+	// preserves account reuse across driver-side cleanups such as
+	// kubernetes-sigs/azurefile-csi-driver#3335 that stop explicitly setting
+	// EnableHTTPSTrafficOnly=false for NFS accounts.
+	if accountOptions.SkipHTTPSTrafficOnlyMatch {
+		return true
+	}
 	return accountOptions.EnableHTTPSTrafficOnly == ptr.Deref(account.Properties.EnableHTTPSTrafficOnly, true)
 }
 

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -1265,6 +1265,34 @@ func TestIsEnableHTTPSTrafficOnly(t *testing.T) {
 			},
 			expectedResult: false,
 		},
+		{
+			// SkipHTTPSTrafficOnlyMatch=true → accept any account regardless of
+			// its EnableHTTPSTrafficOnly value, even when options require true.
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					EnableHTTPSTrafficOnly: ptr.To(false),
+				},
+			},
+			accountOptions: &AccountOptions{
+				EnableHTTPSTrafficOnly:    true,
+				SkipHTTPSTrafficOnlyMatch: true,
+			},
+			expectedResult: true,
+		},
+		{
+			// SkipHTTPSTrafficOnlyMatch=true with the same value on both sides
+			// also matches (skip supersedes equality check).
+			account: &armstorage.Account{
+				Properties: &armstorage.AccountProperties{
+					EnableHTTPSTrafficOnly: ptr.To(true),
+				},
+			},
+			accountOptions: &AccountOptions{
+				EnableHTTPSTrafficOnly:    true,
+				SkipHTTPSTrafficOnlyMatch: true,
+			},
+			expectedResult: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`isEnableHTTPSTrafficOnlyEqual` currently does a **strict equality** check between the account's `EnableHTTPSTrafficOnly` value and the value on `AccountOptions`. This creates a subtle account-matching regression for NFS callers.

### Background

Azure Files NFS shares are unaffected by `EnableHTTPSTrafficOnly` — that setting only governs the REST plane. Historically the [azurefile-csi-driver](https://github.com/kubernetes-sigs/azurefile-csi-driver) explicitly forced `AccountOptions.EnableHTTPSTrafficOnly=false` for NFS to work around older platform limitations. As part of upcoming cleanups (e.g. [azurefile-csi-driver#3335](https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3335)) that explicit `false` is being removed, so NFS requests will start passing `EnableHTTPSTrafficOnly=true`.

Without this fix, once the driver stops setting `EnableHTTPSTrafficOnly=false`:

1. Every new NFS PVC request comes in with `EnableHTTPSTrafficOnly=true`
2. All pre-existing NFS accounts have `EnableHTTPSTrafficOnly=false`
3. `isEnableHTTPSTrafficOnlyEqual` returns `false` → no match
4. A brand-new storage account is created for every NFS PVC → hits the 250-per-subscription cap fast

### Change

Add a new `SkipHTTPSTrafficOnlyMatch bool` on `AccountOptions`. When set, `isEnableHTTPSTrafficOnlyEqual` returns `true` regardless of the account property value or the caller's `EnableHTTPSTrafficOnly` value. NFS-style callers (where the setting is irrelevant to the mount protocol) can opt out of matching without affecting account creation.

| Caller sets | Account has `true` | Account has `false` |
|-------------|-------------------|--------------------|
| `EnableHTTPSTrafficOnly=true`, `SkipHTTPSTrafficOnlyMatch=false` | ✅ match (unchanged) | ❌ mismatch (unchanged) |
| `EnableHTTPSTrafficOnly=false`, `SkipHTTPSTrafficOnlyMatch=false` | ❌ mismatch (unchanged) | ✅ match (unchanged) |
| `SkipHTTPSTrafficOnlyMatch=true` (any `EnableHTTPSTrafficOnly`) | ✅ match (**new**) | ✅ match (**new**) |

### Why not a tri-state / `*bool`?

`AccountOptions.EnableHTTPSTrafficOnly` is a plain `bool` today and is written to the account on create. Flipping it to `*bool` is a source-breaking change for every downstream caller. A dedicated additive flag keeps the API surface backwards compatible and cleanly separates the *matching* concern from the *creation* concern.

## Which issue(s) this PR fixes

Related to https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3335

## Follow-up in azurefile-csi-driver

Once this PR is merged and vendored, the driver-side change lands in a follow-up PR against [kubernetes-sigs/azurefile-csi-driver](https://github.com/kubernetes-sigs/azurefile-csi-driver):

1. **Set `SkipHTTPSTrafficOnlyMatch = true` unconditionally on the NFS path** in `pkg/azurefile/controllerserver.go` (next to where `enableHTTPSTrafficOnly = false` is set today, around line 448 — *outside* the `if encryptInTransit { … }` block), so **every** NFS request (both `encryptInTransit=false` and `encryptInTransit=true`) opts out of `EnableHTTPSTrafficOnly` matching.
   - This matters because after [azurefile-csi-driver#3335](https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3335), NFS + `encryptInTransit=true` now sets `EnableHTTPSTrafficOnly=true` on account creation, while all NFS accounts created by earlier driver versions have `EnableHTTPSTrafficOnly=false` (the previous NFS code path forced `false` regardless of `encryptInTransit`). Setting `SkipHTTPSTrafficOnlyMatch=true` only on the `encryptInTransit=false` branch would leave legacy `encryptInTransit=true` accounts unmatchable and force new account creation. Because `EnableHTTPSTrafficOnly` only governs the REST plane and has no effect on NFS mounts or NFS encryption-in-transit (which is negotiated at the NFS protocol layer), skipping the match for the entire NFS path is semantically safe.
2. **Do the same in `pkg/azurefile/azurefile_mgmt_client.go`** where NFS overrides `az.accountOptions.EnableHTTPSTrafficOnly` — again, unconditional on the NFS branch, not gated on `encryptInTransit`.
3. Rebase / redo the cleanup from [azurefile-csi-driver#3335](https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3335) on top: once the skip flag is in place, the explicit NFS `EnableHTTPSTrafficOnly=false` overrides can be dropped without regressing account reuse. NFS requests then flow through with the default `EnableHTTPSTrafficOnly=true` and still match pre-existing NFS accounts (which have `EnableHTTPSTrafficOnly=false`).
4. Cherry-pick to active release branches (release-1.35 / release-1.34) alongside the corresponding cloud-provider-azure cherry-picks so out-of-tree AKS builds get the fix in the same release window.

Rollout order:

| Step | Repo | Change |
|------|------|--------|
| 1 | cloud-provider-azure (this PR) | Add `SkipHTTPSTrafficOnlyMatch`; no behavior change to existing callers |
| 2 | cloud-provider-azure | Cherry-pick to `release-1.35` / `release-1.34` |
| 3 | azurefile-csi-driver | Vendor cloud-provider-azure bump + set `SkipHTTPSTrafficOnlyMatch=true` on NFS path |
| 4 | azurefile-csi-driver | Rebase / re-land [#3335](https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3335) cleanup on top |
| 5 | azurefile-csi-driver | Cherry-pick to release branches |

## Special notes for your reviewer

- Additive change: no existing callers affected. Existing behavior is preserved unless `SkipHTTPSTrafficOnlyMatch` is explicitly set to `true`.
- Account creation is not affected; `AccountOptions.EnableHTTPSTrafficOnly` is still what's written to the storage account on create.
- Unit tests in `TestIsEnableHTTPSTrafficOnly` extended with two new cases covering the `SkipHTTPSTrafficOnlyMatch=true` path (mismatched account property and matched account property, both should return `true`).

## Release note

```release-note
Added `AccountOptions.SkipHTTPSTrafficOnlyMatch` to opt out of `EnableHTTPSTrafficOnly` equality when reusing an existing storage account. Useful for callers such as NFS file share requests where the setting has no effect on the mount protocol and existing accounts should be reused regardless of their `EnableHTTPSTrafficOnly` value.
```

