### PR TITLE
fix: register e2e Service cleanup defer before it can be skipped

### DIFF
--- a/tests/e2e/network/ensureloadbalancer.go
+++ b/tests/e2e/network/ensureloadbalancer.go
@@ -1012,14 +1012,14 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 		}
 
 		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, testServiceName, ns.Name, labels, annotation, ports)
-		Expect(len(ips)).NotTo(BeZero())
-		ip := ips[0]
-		service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		defer func() {
 			By("Cleaning up")
 			err := utils.DeleteService(cs, ns.Name, testServiceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
+		service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Update the service and without significant changes and compare etags")
@@ -1074,16 +1074,16 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 		}
 		service.Spec.SessionAffinity = "ClientIP"
 		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, targetIPs)
-		Expect(err).NotTo(HaveOccurred())
-
-		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		defer func() {
 			By("Cleaning up")
 			err := utils.DeleteService(cs, ns.Name, testServiceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, targetIPs)
+		Expect(err).NotTo(HaveOccurred())
+
+		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Update the service and without significant changes and compare etags")
@@ -1135,6 +1135,11 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 		service := utils.CreateLoadBalancerServiceManifest(testServiceName, annotation, labels, ns.Name, ports)
 		service.Spec.ExternalTrafficPolicy = "Local"
 		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+		defer func() {
+			By("Cleaning up")
+			err := utils.DeleteService(cs, ns.Name, testServiceName)
+			Expect(err).NotTo(HaveOccurred())
+		}()
 		Expect(err).NotTo(HaveOccurred())
 		ips, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, testServiceName, []*string{})
 		Expect(err).NotTo(HaveOccurred())
@@ -1142,11 +1147,6 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 		ip := ips[0]
 
 		service, err = cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
-		defer func() {
-			By("Cleaning up")
-			err := utils.DeleteService(cs, ns.Name, testServiceName)
-			Expect(err).NotTo(HaveOccurred())
-		}()
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Update the service and without significant changes and compare etags")
@@ -1175,12 +1175,12 @@ var _ = Describe("EnsureLoadBalancer should not update any resources when servic
 			consts.ServiceAnnotationLoadBalancerEnableHighAvailabilityPorts: "true",
 		}
 		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, testServiceName, ns.Name, labels, annotation, ports)
-		service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		defer func() {
 			By("Cleaning up")
 			err := utils.DeleteService(cs, ns.Name, testServiceName)
 			Expect(err).NotTo(HaveOccurred())
 		}()
+		service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), testServiceName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(ips)).NotTo(BeZero())
 		ip := ips[0]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In `tests/e2e/network/ensureloadbalancer.go`, four specs create/expose a
Service and only register the cleanup `defer DeleteService(...)` after a
later `Get(...)` call, with one or more `Expect(...)` assertions running
between successful service creation and that defer registration. In
Ginkgo v2 + Gomega, a failing `Expect(...)` unwinds the current goroutine
via `runtime.Goexit()`; any defer not yet registered at that point is
skipped. If the Service already exists by then and one of those
intervening assertions fails, the cleanup never runs and the Service is
left behind in the cluster.

This PR moves each `defer` to be registered immediately after the point
where the Service is first known to exist (right after `Create(...)`
succeeds, or right after the `createAndExposeDefaultServiceWithAnnotation(...)`
helper returns), before any subsequent `Expect(...)` calls. This mirrors
the fix suggested in the issue report. `utils.DeleteService` already
treats a NotFound error as success, so registering the deferred delete
this early is safe even on the path where creation itself failed.

#### Which issue(s) this PR fixes:
Fixes #10126

#### Special notes for your reviewer:

- This is a test-only change; `tests/e2e/network/ensureloadbalancer.go` is
  the only file touched (4 hunks, 14 insertions / 14 deletions).
- Validation performed: `go build ./e2e/network/...`, `go vet ./e2e/network/...`,
  `gofmt -l`, and `golangci-lint run` against the `tests` module — all pass,
  and golangci-lint reports the same 33 pre-existing issues before and after
  this change, confirming no new lint issues were introduced.
- These specs are Ginkgo e2e tests that require a live Azure/AKS cluster to
  execute; that isn't available in this environment, so the fix was not
  exercised against a live cluster. The correctness argument rests on Go's
  documented defer/Goexit semantics and static review of the reordered
  control flow, not a live reproduction.
- CI on this repo requires a maintainer to add `ok-to-test` — happy to
  address anything it surfaces.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```