### PR TITLE
test: assert ExtendedLocation is propagated on VMSS update

### DIFF
--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -2627,6 +2627,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 		setIPv6Config         bool
 		useMultipleSLBs       bool
 		getInstanceIDErr      error
+		extendedLocation      *armcompute.ExtendedLocation
 		expectedErr           error
 	}{
 		{
@@ -2862,6 +2863,23 @@ func TestEnsureVMSSInPool(t *testing.T) {
 			getInstanceIDErr:      errors.New("error"),
 			expectedErr:           errors.New("error"),
 		},
+		{
+			description: "ensureVMSSInPool should propagate ExtendedLocation onto the update request when the source VMSS has one",
+			nodes: []*v1.Node{
+				{
+					Spec: v1.NodeSpec{
+						ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss/virtualMachines/0",
+					},
+				},
+			},
+			isBasicLB:       false,
+			backendPoolID:   testLBBackendpoolID1,
+			expectedPutVMSS: true,
+			extendedLocation: &armcompute.ExtendedLocation{
+				Name: ptr.To("microsoftlosangeles1"),
+				Type: to.Ptr(armcompute.ExtendedLocationTypesEdgeZone),
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -2880,6 +2898,7 @@ func TestEnsureVMSSInPool(t *testing.T) {
 			if test.isVMSSNilNICConfig {
 				expectedVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
 			}
+			expectedVMSS.ExtendedLocation = test.extendedLocation
 			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
 			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
 			vmssPutTimes := 0
@@ -2887,7 +2906,13 @@ func TestEnsureVMSSInPool(t *testing.T) {
 				vmssPutTimes = 1
 				mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil)
 			}
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).Return(nil, nil).Times(vmssPutTimes)
+			var capturedVMSS armcompute.VirtualMachineScaleSet
+			mockVMSSClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _, _ string, v armcompute.VirtualMachineScaleSet) (*armcompute.VirtualMachineScaleSet, error) {
+					capturedVMSS = v
+					return nil, nil
+				}).Times(vmssPutTimes)
 
 			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", test.setIPv6Config)
 			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
@@ -2901,10 +2926,65 @@ func TestEnsureVMSSInPool(t *testing.T) {
 
 			err = ss.ensureVMSSInPool(context.TODO(), &v1.Service{Spec: v1.ServiceSpec{ClusterIP: test.clusterIP}}, test.nodes, test.backendPoolID, test.vmSetName)
 			assert.Equal(t, test.expectedErr, err, test.description+errMsgSuffix)
+			assert.Equal(t, test.extendedLocation, capturedVMSS.ExtendedLocation, test.description+errMsgSuffix)
 		})
 	}
 }
 
+func TestEnsureBackendPoolDeletedFromVMSetsExtendedLocation(t *testing.T) {
+	cases := []struct {
+		description      string
+		extendedLocation *armcompute.ExtendedLocation
+	}{
+		{
+			description: "propagates ExtendedLocation onto the update request when the source VMSS has one",
+			extendedLocation: &armcompute.ExtendedLocation{
+				Name: ptr.To("microsoftlosangeles1"),
+				Type: to.Ptr(armcompute.ExtendedLocationTypesEdgeZone),
+			},
+		},
+		{
+			description:      "leaves ExtendedLocation nil on the update request when the source VMSS has none",
+			extendedLocation: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ss, err := NewTestScaleSet(ctrl)
+			assert.NoError(t, err)
+			ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+
+			expectedVMSS := buildTestVMSSWithLB(testVMSSName, "vmss-vm-", []string{testLBBackendpoolID0}, false)
+			expectedVMSS.ExtendedLocation = tc.extendedLocation
+
+			mockVMSSClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
+			mockVMSSClient.EXPECT().List(gomock.Any(), ss.ResourceGroup).Return([]*armcompute.VirtualMachineScaleSet{expectedVMSS}, nil).AnyTimes()
+			mockVMSSClient.EXPECT().Get(gomock.Any(), ss.ResourceGroup, testVMSSName, nil).Return(expectedVMSS, nil).AnyTimes()
+
+			var capturedVMSS armcompute.VirtualMachineScaleSet
+			mockVMSSClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), ss.ResourceGroup, testVMSSName, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _, _ string, v armcompute.VirtualMachineScaleSet) (*armcompute.VirtualMachineScaleSet, error) {
+					capturedVMSS = v
+					return nil, nil
+				}).Times(1)
+
+			expectedVMSSVMs, _, _ := buildTestVirtualMachineEnv(ss.Cloud, testVMSSName, "", 0, []string{"vmss-vm-000000"}, "", false)
+			mockVMSSVMClient := ss.ComputeClientFactory.GetVirtualMachineScaleSetVMClient().(*mock_virtualmachinescalesetvmclient.MockInterface)
+			mockVMSSVMClient.EXPECT().List(gomock.Any(), ss.ResourceGroup, testVMSSName).Return(expectedVMSSVMs, nil).AnyTimes()
+
+			err = ss.EnsureBackendPoolDeletedFromVMSets(context.TODO(), map[string]bool{testVMSSName: true}, []string{testLBBackendpoolID0})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.extendedLocation, capturedVMSS.ExtendedLocation)
+		})
+	}
+}
+
+// TestEnsureHostsInPool
 func TestEnsureHostsInPool(t *testing.T) {
 
 	testCases := []struct {

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -2984,7 +2984,6 @@ func TestEnsureBackendPoolDeletedFromVMSetsExtendedLocation(t *testing.T) {
 	}
 }
 
-// TestEnsureHostsInPool
 func TestEnsureHostsInPool(t *testing.T) {
 
 	testCases := []struct {

--- a/pkg/provider/azure_vmssflex_test.go
+++ b/pkg/provider/azure_vmssflex_test.go
@@ -1260,6 +1260,7 @@ func TestEnsureVMSSFlexInPool(t *testing.T) {
 		testVMListWithOnlyInstanceView []*armcompute.VirtualMachine
 		vmListErr                      error
 		vmssPutErr                     error
+		extendedLocation               *armcompute.ExtendedLocation
 		expectedErr                    error
 	}{
 		{
@@ -1358,6 +1359,27 @@ func TestEnsureVMSSFlexInPool(t *testing.T) {
 			vmListErr:                      nil,
 			expectedErr:                    nil,
 		},
+		{
+			description: "ensureVMSSFlexInPool should propagate ExtendedLocation onto the update request when the source VMSS Flex has one",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmssflex1000001",
+					},
+				},
+			},
+			service:                        &v1.Service{},
+			vmSetNameOfLB:                  "",
+			backendPoolID:                  "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb-internal/backendAddressPools/backendpool-1",
+			isStandardLB:                   true,
+			hasDefaultVMProfile:            true,
+			testVMListWithoutInstanceView:  testVMListWithoutInstanceView,
+			testVMListWithOnlyInstanceView: testVMListWithOnlyInstanceView,
+			extendedLocation: &armcompute.ExtendedLocation{
+				Name: ptr.To("microsoftlosangeles1"),
+				Type: to.Ptr(armcompute.ExtendedLocationTypesEdgeZone),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1375,12 +1397,19 @@ func TestEnsureVMSSFlexInPool(t *testing.T) {
 		if !tc.hasDefaultVMProfile {
 			testVmssFlex.Properties.VirtualMachineProfile = nil
 		}
+		testVmssFlex.ExtendedLocation = tc.extendedLocation
 		expectedestVmssFlexList := []*armcompute.VirtualMachineScaleSet{testVmssFlex}
 
 		mockVMSSClient := fs.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
 		mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(expectedestVmssFlexList, nil).AnyTimes()
 		mockVMSSClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testVmssFlex1, nil).AnyTimes()
-		mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tc.vmssPutErr).AnyTimes()
+		var capturedVMSS armcompute.VirtualMachineScaleSet
+		mockVMSSClient.EXPECT().
+			CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _, _ string, v armcompute.VirtualMachineScaleSet) (*armcompute.VirtualMachineScaleSet, error) {
+				capturedVMSS = v
+				return nil, tc.vmssPutErr
+			}).AnyTimes()
 
 		mockVMClient := fs.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
 		mockVMClient.EXPECT().ListVmssFlexVMsWithOutInstanceView(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.testVMListWithoutInstanceView, tc.vmListErr).AnyTimes()
@@ -1391,6 +1420,7 @@ func TestEnsureVMSSFlexInPool(t *testing.T) {
 		if tc.expectedErr != nil {
 			assert.EqualError(t, err, tc.expectedErr.Error(), tc.description)
 		}
+	    assert.Equal(t, tc.extendedLocation, capturedVMSS.ExtendedLocation, tc.description)
 	}
 
 }
@@ -1520,6 +1550,7 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 		isIPConfigEmpty      bool
 		vmssListCallingTimes int
 		vmssPutErr           error
+		extendedLocation     *armcompute.ExtendedLocation
 		expectedErr          error
 	}{
 		{
@@ -1610,6 +1641,19 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 			vmssListCallingTimes: 2,
 			expectedErr:          fmt.Errorf("failed to update nic"),
 		},
+		{
+			description: "EnsureBackendPoolDeletedFromVMSets should propagate ExtendedLocation onto the update request when the source VMSS Flex has one",
+			vmssNamesMap: map[string]bool{
+				"vmssflex1": true,
+			},
+			backendPoolID:        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/backendAddressPools/backendpool-0",
+			hasDefaultVMProfile:  true,
+			vmssListCallingTimes: 2,
+			extendedLocation: &armcompute.ExtendedLocation{
+				Name: ptr.To("microsoftlosangeles1"),
+				Type: to.Ptr(armcompute.ExtendedLocationTypesEdgeZone),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1631,13 +1675,20 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 			if tc.isIPConfigEmpty {
 				(testVmssFlex.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations)[0].Properties.IPConfigurations = []*armcompute.VirtualMachineScaleSetIPConfiguration{}
 			}
+			testVmssFlex.ExtendedLocation = tc.extendedLocation
 
 			vmssFlexList := []*armcompute.VirtualMachineScaleSet{testVmssFlex}
 
 			mockVMSSClient := fs.ComputeClientFactory.GetVirtualMachineScaleSetClient().(*mock_virtualmachinescalesetclient.MockInterface)
 			mockVMSSClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(vmssFlexList, nil).Times(tc.vmssListCallingTimes)
 			mockVMSSClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testVmssFlex1, nil).AnyTimes()
-			mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tc.vmssPutErr).AnyTimes()
+			var capturedVMSS armcompute.VirtualMachineScaleSet
+			mockVMSSClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _, _ string, v armcompute.VirtualMachineScaleSet) (*armcompute.VirtualMachineScaleSet, error) {
+					capturedVMSS = v
+					return nil, tc.vmssPutErr
+				}).AnyTimes()
 
 			err = fs.EnsureBackendPoolDeletedFromVMSets(context.TODO(), tc.vmssNamesMap, []string{tc.backendPoolID})
 			_, _ = fs.getVmssFlexByName(context.TODO(), "vmssflex1")
@@ -1647,6 +1698,7 @@ func TestEnsureBackendPoolDeletedFromVMSetsVmssFlex(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			assert.Equal(t, tc.extendedLocation, capturedVMSS.ExtendedLocation, tc.description)
 		})
 	}
 }

--- a/pkg/provider/azure_vmssflex_test.go
+++ b/pkg/provider/azure_vmssflex_test.go
@@ -1420,7 +1420,7 @@ func TestEnsureVMSSFlexInPool(t *testing.T) {
 		if tc.expectedErr != nil {
 			assert.EqualError(t, err, tc.expectedErr.Error(), tc.description)
 		}
-	    assert.Equal(t, tc.extendedLocation, capturedVMSS.ExtendedLocation, tc.description)
+		assert.Equal(t, tc.extendedLocation, capturedVMSS.ExtendedLocation, tc.description)
 	}
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind test

#### What this PR does / why we need it:
Follow-up adding unit tests for #10816 (\"fix: Included ExtendedLocation when update VMSS\"). 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

```docs

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
