### PR TITLE
fix: one-directional NFS EiT account matching for account reuse

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -1162,6 +1162,15 @@ func (az *AccountRepo) isNFSEncryptionInTransitEnabledEqual(ctx context.Context,
 		return true, nil
 	}
 
+	// An EiT request can reuse any existing account. Enforcement handled by
+	// ProtocolSettings.Nfs.EncryptionInTransit.Required (stamped at account
+	// creation) and client-side TLS. Short circuit prevents EiT requests from
+	// always creating a new account per PVC (Required property is new, no
+	// pre-existing account has it).
+	if *accountOptions.IsNFSEncryptionInTransitEnabled {
+		return true, nil
+	}
+
 	if account.Name == nil {
 		klog.Warningf("account.Name under resource group(%s) is nil", accountOptions.ResourceGroup)
 		return false, nil
@@ -1176,10 +1185,12 @@ func (az *AccountRepo) isNFSEncryptionInTransitEnabledEqual(ctx context.Context,
 		prop.FileServiceProperties.ProtocolSettings == nil ||
 		prop.FileServiceProperties.ProtocolSettings.Nfs == nil ||
 		prop.FileServiceProperties.ProtocolSettings.Nfs.EncryptionInTransit == nil {
-		return !*accountOptions.IsNFSEncryptionInTransitEnabled, nil
+		// Account has no NFS EiT requirement, non EiT request may reuse it.
+		return true, nil
 	}
 
-	return *accountOptions.IsNFSEncryptionInTransitEnabled == ptr.Deref(prop.FileServiceProperties.ProtocolSettings.Nfs.EncryptionInTransit.Required, false), nil
+	// Non-EiT request must not reuse an account requiring EiT.
+	return !ptr.Deref(prop.FileServiceProperties.ProtocolSettings.Nfs.EncryptionInTransit.Required, false), nil
 }
 
 func (az *AccountRepo) isDisableFileServiceDeleteRetentionPolicyEqual(ctx context.Context, account *armstorage.Account, accountOptions *AccountOptions) (bool, error) {

--- a/pkg/provider/storage/azure_storageaccount_test.go
+++ b/pkg/provider/storage/azure_storageaccount_test.go
@@ -2036,7 +2036,7 @@ func TestIsNFSEncryptionInTransitEnabledEqual(t *testing.T) {
 			expectedResult:            false,
 		},
 		{
-			desc: "IsNFSEncryptionInTransitEnabled not equal #2",
+			desc: "EiT request matches a non-EiT account without a file-service Get (one-directional)",
 			account: &armstorage.Account{
 				Name:       &accountName,
 				Properties: &armstorage.AccountProperties{},
@@ -2044,11 +2044,10 @@ func TestIsNFSEncryptionInTransitEnabledEqual(t *testing.T) {
 			accountOptions: &AccountOptions{
 				IsNFSEncryptionInTransitEnabled: ptr.To(true),
 			},
-			serviceProperties: &nfsEiTNotRequired,
-			expectedResult:    false,
+			expectedResult: true,
 		},
 		{
-			desc: "IsNFSEncryptionInTransitEnabled is equal #1",
+			desc: "EiT request matches an EiT-required account without a file-service Get (one-directional)",
 			account: &armstorage.Account{
 				Name:       &accountName,
 				Properties: &armstorage.AccountProperties{},
@@ -2056,8 +2055,7 @@ func TestIsNFSEncryptionInTransitEnabledEqual(t *testing.T) {
 			accountOptions: &AccountOptions{
 				IsNFSEncryptionInTransitEnabled: ptr.To(true),
 			},
-			serviceProperties: &nfsEiTRequired,
-			expectedResult:    true,
+			expectedResult: true,
 		},
 		{
 			desc: "IsNFSEncryptionInTransitEnabled is equal #2",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 

The isNFSEncryptionInTransitEnabledEqual logic would lead to not matching existing EiT accounts (without the flag having been set), so new EiT PVCs would always create a new account after this change.  This adds a one-directional match (via the isNFSEncryptionInTransitEnabledLogic) to skip the check for EiT requests (match any existing account) and only check for non-EiT requests s.t. non EiT requests don't get matched to accounts with Required=true.

https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3335#pullrequestreview-4933645188 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
