### PR TITLE
fix: skip public ip check for azure stack

### DIFF
--- a/pkg/provider/azure_publicip_repo.go
+++ b/pkg/provider/azure_publicip_repo.go
@@ -177,7 +177,7 @@ func (az *Cloud) listPIP(ctx context.Context, pipResourceGroup string, crt azcac
 }
 
 func (az *Cloud) findMatchedPIP(ctx context.Context, loadBalancerIP, pipName, pipResourceGroup string) (pip *armnetwork.PublicIPAddress, err error) {
-	if loadBalancerIP != "" {
+	if loadBalancerIP != "" && !az.IsStackCloud() {
 		if err := validatePublicIPCandidate(loadBalancerIP); err != nil {
 			return nil, err
 		}

--- a/pkg/provider/azure_publicip_repo_test.go
+++ b/pkg/provider/azure_publicip_repo_test.go
@@ -425,7 +425,7 @@ func TestFindMatchedPIPAllowsPrivateIPOnAzureStackHub(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			az := GetTestCloud(ctrl)
-			az.Config.Cloud = consts.AzureStackCloudName
+			az.Cloud = consts.AzureStackCloudName
 			mockPIPsClient := az.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
 			mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return([]*armnetwork.PublicIPAddress{}, nil).Times(2)
 

--- a/pkg/provider/azure_publicip_repo_test.go
+++ b/pkg/provider/azure_publicip_repo_test.go
@@ -403,6 +403,39 @@ func TestFindMatchedPIPSkipsListForInvalidOrNonPublicLoadBalancerIP(t *testing.T
 	}
 }
 
+func TestFindMatchedPIPAllowsPrivateIPOnAzureStackHub(t *testing.T) {
+	for _, tc := range []struct {
+		description    string
+		loadBalancerIP string
+	}{
+		{
+			description:    "RFC1918 10/8 on Azure Stack Hub",
+			loadBalancerIP: "10.255.96.63",
+		},
+		{
+			description:    "RFC1918 172.16/12 on Azure Stack Hub",
+			loadBalancerIP: "172.16.0.5",
+		},
+		{
+			description:    "RFC1918 192.168/16 on Azure Stack Hub",
+			loadBalancerIP: "192.168.0.5",
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			az := GetTestCloud(ctrl)
+			az.Config.Cloud = consts.AzureStackCloudName
+			mockPIPsClient := az.NetworkClientFactory.GetPublicIPAddressClient().(*mock_publicipaddressclient.MockInterface)
+			mockPIPsClient.EXPECT().List(gomock.Any(), "rg").Return([]*armnetwork.PublicIPAddress{}, nil).Times(2)
+
+			_, err := az.findMatchedPIP(context.TODO(), tc.loadBalancerIP, "", "rg")
+
+			assert.NotErrorIs(t, err, providererrors.ErrNonPublicLoadBalancerIP)
+		})
+	}
+}
+
 func TestIsAzureReservedIP(t *testing.T) {
 	for _, tc := range []struct {
 		description string


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression


#### What this PR does / why we need it:

Azure Stack does not have a concept of public or private IP addresses, just IP addresses. Skip the function to find matched public IP addresses when running on azure stack. After #10507, provisioning LBs on Azure Stack fails with: 

```
(SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balancer: external Service "openshift-ingress/router-default" cannot use non-public LoadBalancer IP "10.255.96.63"; use an internal LoadBalancer annotation or a valid Azure Public IP address
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
