### PR TITLE
fix: emit access control warning events on ensure and never block deletion

### DIFF
--- a/internal/testutil/fixture/kubernetes.go
+++ b/internal/testutil/fixture/kubernetes.go
@@ -116,6 +116,11 @@ func (f *KubernetesServiceFixture) WithLoadBalancerSourceRanges(parts ...string)
 	return f
 }
 
+func (f *KubernetesServiceFixture) WithIPFamilies(families ...v1.IPFamily) *KubernetesServiceFixture {
+	f.svc.Spec.IPFamilies = families
+	return f
+}
+
 func (f *KubernetesServiceFixture) TCPPorts() []int32 {
 	var rv []int32
 	for _, p := range f.svc.Spec.Ports {

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3429,6 +3429,8 @@ func (az *Cloud) reconcileSecurityGroup(
 		var opts []loadbalancer.AccessControlOption
 		if !wantLb {
 			// When deleting LB, we don't need to validate the annotation
+			opts = append(opts, loadbalancer.SkipAnnotationValidation())
+		} else {
 			opts = append(opts, loadbalancer.WithEventEmitter(az.Event))
 		}
 		accessControl, err = loadbalancer.NewAccessControl(logger, service, sg, opts...)

--- a/pkg/provider/azure_loadbalancer_accesscontrol_test.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/internal/testutil"
@@ -2752,6 +2753,248 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 
 		_, err := az.reconcileSecurityGroup(ctx, ClusterName, &svc, *loadBalancer.Name, azureFx.LoadBalancer().Addresses(), false) // deleting
 		assert.NoError(t, err)
+	})
+
+	t.Run("validation events", func(t *testing.T) {
+		reconcile := func(
+			t *testing.T, svc *v1.Service, lbIPs []string, wantLb bool,
+			staleRules ...*armnetwork.SecurityRule,
+		) (*armnetwork.SecurityGroup, []string, error) {
+			t.Helper()
+			var (
+				ctrl                    = gomock.NewController(t)
+				az                      = GetTestCloud(ctrl)
+				securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+				loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+				loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+				securityGroup           = azureFx.SecurityGroup().WithRules(append(azureFx.NoiseSecurityRules(), staleRules...)).Build()
+				loadBalancer            = azureFx.LoadBalancer().Build()
+			)
+			defer ctrl.Finish()
+
+			// GetTestCloud's zero-value FakeRecorder has a nil channel that discards events.
+			recorder := record.NewFakeRecorder(10)
+			az.eventRecorder = recorder
+
+			securityGroupClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+				Return(securityGroup, nil).
+				AnyTimes()
+			securityGroupClient.EXPECT().
+				CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+				Return(nil, nil).
+				AnyTimes()
+			loadBalancerClient.EXPECT().
+				Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+				Return(loadBalancer, nil).
+				AnyTimes()
+			loadBalancerBackendPool.EXPECT().
+				GetBackendPrivateIPs(gomock.Any(), ClusterName, svc, loadBalancer).
+				Return(
+					azureFx.LoadBalancer().BackendPoolIPv4Addresses(),
+					azureFx.LoadBalancer().BackendPoolIPv6Addresses(),
+				).
+				AnyTimes()
+
+			rv, err := az.reconcileSecurityGroup(ctx, ClusterName, svc, *loadBalancer.Name, lbIPs, wantLb)
+
+			var events []string
+			for len(recorder.Events) > 0 {
+				events = append(events, <-recorder.Events)
+			}
+			return rv, events, err
+		}
+
+		for _, tt := range []struct {
+			name           string
+			families       []v1.IPFamily
+			ipRanges       []string
+			sourceRanges   []string
+			serviceTags    []string
+			expectedReason string
+			expectedRules  []*armnetwork.SecurityRule
+		}{
+			{
+				name:           "it should emit IPRangeFamilyMismatch and leave the frontend with no allow rule when ensuring an IPv4 Service with IPv6-only azure-allowed-ip-ranges",
+				families:       []v1.IPFamily{v1.IPv4Protocol},
+				ipRanges:       []string{"2001:db8:85a3::/64"},
+				expectedReason: "IPRangeFamilyMismatch",
+			},
+			{
+				name:           "it should emit IPRangeFamilyMismatch and leave the frontend with no allow rule when ensuring an IPv6 Service with IPv4-only azure-allowed-ip-ranges",
+				families:       []v1.IPFamily{v1.IPv6Protocol},
+				ipRanges:       []string{"10.0.0.0/24"},
+				expectedReason: "IPRangeFamilyMismatch",
+			},
+			{
+				name:           "it should emit IPRangeFamilyMismatch and not open the frontend to the Internet when ensuring an IPv4 Service with an allow-all IPv6 range in azure-allowed-ip-ranges",
+				families:       []v1.IPFamily{v1.IPv4Protocol},
+				ipRanges:       []string{"::/0"},
+				expectedReason: "IPRangeFamilyMismatch",
+			},
+			{
+				name:           "it should emit IPRangeFamilyMismatch and not open the frontend to the Internet when ensuring an IPv6 Service with an allow-all IPv4 range in azure-allowed-ip-ranges",
+				families:       []v1.IPFamily{v1.IPv6Protocol},
+				ipRanges:       []string{"0.0.0.0/0"},
+				expectedReason: "IPRangeFamilyMismatch",
+			},
+			{
+				name:           "it should emit IPRangeFamilyMismatch and still add the service tag rules when ensuring an IPv4 Service with IPv6-only azure-allowed-ip-ranges and a service tag",
+				families:       []v1.IPFamily{v1.IPv4Protocol},
+				ipRanges:       []string{"2001:db8:85a3::/64"},
+				serviceTags:    []string{"AzureCloud"},
+				expectedReason: "IPRangeFamilyMismatch",
+				expectedRules: []*armnetwork.SecurityRule{
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"AzureCloud"}, k8sFx.Service().TCPPorts()).
+						WithPriority(500).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"AzureCloud"}, k8sFx.Service().UDPPorts()).
+						WithPriority(501).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+				},
+			},
+			{
+				name:           "it should emit IPRangeFamilyMismatch and still add the service tag rules when ensuring an IPv6 Service with IPv4-only azure-allowed-ip-ranges and a service tag",
+				families:       []v1.IPFamily{v1.IPv6Protocol},
+				ipRanges:       []string{"10.0.0.0/24"},
+				serviceTags:    []string{"AzureCloud"},
+				expectedReason: "IPRangeFamilyMismatch",
+				expectedRules: []*armnetwork.SecurityRule{
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, []string{"AzureCloud"}, k8sFx.Service().TCPPorts()).
+						WithPriority(500).WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, []string{"AzureCloud"}, k8sFx.Service().UDPPorts()).
+						WithPriority(501).WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).Build(),
+				},
+			},
+			{
+				name:     "it should not emit any event and add rules for both families when ensuring a dual-stack Service with both IPv4 and IPv6 azure-allowed-ip-ranges",
+				families: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				ipRanges: []string{"10.0.0.0/24", "2001:db8:85a3::/64"},
+				expectedRules: []*armnetwork.SecurityRule{
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"10.0.0.0/24"}, k8sFx.Service().TCPPorts()).
+						WithPriority(500).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, []string{"2001:db8:85a3::/64"}, k8sFx.Service().TCPPorts()).
+						WithPriority(501).WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"10.0.0.0/24"}, k8sFx.Service().UDPPorts()).
+						WithPriority(502).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, []string{"2001:db8:85a3::/64"}, k8sFx.Service().UDPPorts()).
+						WithPriority(503).WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).Build(),
+				},
+			},
+			{
+				name:           "it should emit InvalidAllowedIPRanges and add DenyAll rules when ensuring a Service with an invalid range in azure-allowed-ip-ranges",
+				ipRanges:       []string{"foo", "10.0.0.0/24"},
+				expectedReason: "InvalidAllowedIPRanges",
+				expectedRules: []*armnetwork.SecurityRule{
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"10.0.0.0/24"}, k8sFx.Service().TCPPorts()).
+						WithPriority(500).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"10.0.0.0/24"}, k8sFx.Service().UDPPorts()).
+						WithPriority(501).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.DenyAllSecurityRule(iputil.IPv6).
+						WithPriority(4094).WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).Build(),
+					azureFx.DenyAllSecurityRule(iputil.IPv4).
+						WithPriority(4095).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+				},
+			},
+			{
+				name:           "it should emit ConflictConfiguration and add rules for both the spec ranges and the service tag when ensuring a Service with spec.loadBalancerSourceRanges and service tags",
+				sourceRanges:   []string{"20.0.0.1/32"},
+				serviceTags:    []string{"AKS"},
+				expectedReason: "ConflictConfiguration",
+				expectedRules: []*armnetwork.SecurityRule{
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"AKS"}, k8sFx.Service().TCPPorts()).
+						WithPriority(500).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"20.0.0.1/32"}, k8sFx.Service().TCPPorts()).
+						WithPriority(501).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv6, []string{"AKS"}, k8sFx.Service().TCPPorts()).
+						WithPriority(502).WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"AKS"}, k8sFx.Service().UDPPorts()).
+						WithPriority(503).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"20.0.0.1/32"}, k8sFx.Service().UDPPorts()).
+						WithPriority(504).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv6, []string{"AKS"}, k8sFx.Service().UDPPorts()).
+						WithPriority(505).WithDestination(azureFx.LoadBalancer().IPv6Addresses()...).Build(),
+				},
+			},
+			{
+				name:     "it should not emit any event and add the allow rules when ensuring a Service with a valid range in azure-allowed-ip-ranges",
+				ipRanges: []string{"10.0.0.0/24"},
+				expectedRules: []*armnetwork.SecurityRule{
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"10.0.0.0/24"}, k8sFx.Service().TCPPorts()).
+						WithPriority(500).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+					azureFx.AllowSecurityRule(armnetwork.SecurityRuleProtocolUDP, iputil.IPv4, []string{"10.0.0.0/24"}, k8sFx.Service().UDPPorts()).
+						WithPriority(501).WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).Build(),
+				},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				builder := k8sFx.Service().WithIPFamilies(tt.families...)
+				if len(tt.ipRanges) > 0 {
+					builder = builder.WithAllowedIPRanges(tt.ipRanges...)
+				}
+				if len(tt.sourceRanges) > 0 {
+					builder = builder.WithLoadBalancerSourceRanges(tt.sourceRanges...)
+				}
+				if len(tt.serviceTags) > 0 {
+					builder = builder.WithAllowedServiceTags(tt.serviceTags...)
+				}
+				svc := builder.Build()
+
+				// A single-stack Service has an LB frontend of only its own family.
+				lbIPs := azureFx.LoadBalancer().Addresses()
+				switch {
+				case len(tt.families) == 1 && tt.families[0] == v1.IPv4Protocol:
+					lbIPs = azureFx.LoadBalancer().IPv4Addresses()
+				case len(tt.families) == 1 && tt.families[0] == v1.IPv6Protocol:
+					lbIPs = azureFx.LoadBalancer().IPv6Addresses()
+				}
+
+				sg, events, err := reconcile(t, &svc, lbIPs, EnsureLB)
+				assert.NoError(t, err, "a rejected configuration must not block reconcile")
+				if tt.expectedReason != "" {
+					assert.Contains(t, strings.Join(events, "\n"), tt.expectedReason)
+				} else {
+					assert.Empty(t, events)
+				}
+				testutil.ExpectExactSecurityRules(t, sg, append(azureFx.NoiseSecurityRules(), tt.expectedRules...))
+			})
+		}
+
+		for _, tt := range []struct {
+			name string
+			svc  v1.Service
+		}{
+			{
+				name: "it should skip validation and clean up when deleting a Service with an invalid range in azure-allowed-ip-ranges",
+				svc:  k8sFx.Service().WithAllowedIPRanges("foo", "10.0.0.0/24").Build(),
+			},
+			{
+				name: "it should skip validation and clean up when deleting a Service with spec.loadBalancerSourceRanges and service tags",
+				svc:  k8sFx.Service().WithLoadBalancerSourceRanges("20.0.0.1/32").WithAllowedServiceTags("AKS").Build(),
+			},
+			{
+				name: "it should skip validation and clean up when deleting a Service with an IP family mismatch in azure-allowed-ip-ranges",
+				svc:  k8sFx.Service().WithIPFamilies(v1.IPv4Protocol).WithAllowedIPRanges("2001:db8:85a3::/64").Build(),
+			},
+			{
+				name: "it should skip validation and clean up when deleting a Service with both spec.loadBalancerSourceRanges and azure-allowed-ip-ranges",
+				svc:  k8sFx.Service().WithLoadBalancerSourceRanges("20.0.0.1/32").WithAllowedIPRanges("10.0.0.1/32").Build(),
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				svc := tt.svc
+
+				// Without a rule to clean up, the assertion below cannot fail.
+				staleRule := azureFx.
+					AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, iputil.IPv4, []string{"10.0.0.0/24"}, k8sFx.Service().TCPPorts()).
+					WithPriority(507).
+					WithDestination(azureFx.LoadBalancer().IPv4Addresses()...).
+					Build()
+
+				sg, events, err := reconcile(t, &svc, azureFx.LoadBalancer().IPv4Addresses(), false, staleRule)
+				assert.NoError(t, err, "configuration validation must not block deletion")
+				assert.Empty(t, events)
+				testutil.ExpectExactSecurityRules(t, sg, azureFx.NoiseSecurityRules())
+			})
+		}
 	})
 
 	t.Run("negative cases", func(t *testing.T) {

--- a/pkg/provider/loadbalancer/accesscontrol.go
+++ b/pkg/provider/loadbalancer/accesscontrol.go
@@ -52,7 +52,8 @@ type AccessControl struct {
 }
 
 type accessControlOptions struct {
-	EventEmitter K8sEventEmitter
+	EventEmitter             K8sEventEmitter
+	SkipAnnotationValidation bool
 }
 
 var defaultAccessControlOptions = accessControlOptions{
@@ -64,6 +65,13 @@ type AccessControlOption func(*accessControlOptions)
 func WithEventEmitter(emitter K8sEventEmitter) AccessControlOption {
 	return func(o *accessControlOptions) {
 		o.EventEmitter = emitter
+	}
+}
+
+// SkipAnnotationValidation keeps a rejected annotation configuration from aborting the caller.
+func SkipAnnotationValidation() AccessControlOption {
+	return func(o *accessControlOptions) {
+		o.SkipAnnotationValidation = true
 	}
 }
 
@@ -81,32 +89,34 @@ func NewAccessControl(logger logr.Logger, svc *v1.Service, sg *armnetwork.Securi
 		logger.Error(err, "Failed to initialize RuleHelper")
 		return nil, err
 	}
-	sourceRanges, invalidSourceRanges, err := SourceRanges(svc)
-	if err != nil {
-		logger.Error(err, "Failed to parse SourceRange configuration")
-
-		// Backward compatibility: no error but emit a warning event.
-		eventEmitter(svc, v1.EventTypeWarning, "InvalidSourceRanges", EventMessageOfInvalidSourceRanges(invalidSourceRanges))
-	}
-	allowedIPRanges, invalidAllowedIPRanges, err := AllowedIPRanges(svc)
-	if err != nil {
-		logger.Error(err, "Failed to parse AllowedIPRanges configuration")
-
-		// Backward compatibility: no error but emit a warning event.
-		eventEmitter(svc, v1.EventTypeWarning, "InvalidAllowedIPRanges", EventMessageOfInvalidAllowedIPRanges(invalidAllowedIPRanges))
-	}
+	sourceRanges, invalidSourceRanges, sourceRangesErr := SourceRanges(svc)
+	allowedIPRanges, invalidAllowedIPRanges, allowedIPRangesErr := AllowedIPRanges(svc)
 	allowedServiceTags := AllowedServiceTags(svc)
 	securityRuleDestinationPortsByProtocol, err := SecurityRuleDestinationPortsByProtocol(svc)
 	if err != nil {
 		logger.Error(err, "Failed to parse service Spec.Ports")
 		return nil, err
 	}
-	if len(sourceRanges) > 0 && len(allowedIPRanges) > 0 {
+	if !options.SkipAnnotationValidation && len(sourceRanges) > 0 && len(allowedIPRanges) > 0 {
 		logger.Error(ErrSetBothLoadBalancerSourceRangesAndAllowedIPRanges, "Forbidden configuration")
 		return nil, ErrSetBothLoadBalancerSourceRangesAndAllowedIPRanges
 	}
 
-	if len(sourceRanges) > 0 && len(allowedServiceTags) > 0 {
+	// Emitted after the fatal checks so no event describes a security group change that an error prevents.
+	if sourceRangesErr != nil && !options.SkipAnnotationValidation {
+		logger.Error(sourceRangesErr, "Failed to parse SourceRange configuration")
+
+		// Backward compatibility: no error but emit a warning event.
+		eventEmitter(svc, v1.EventTypeWarning, "InvalidSourceRanges", EventMessageOfInvalidSourceRanges(invalidSourceRanges))
+	}
+	if allowedIPRangesErr != nil && !options.SkipAnnotationValidation {
+		logger.Error(allowedIPRangesErr, "Failed to parse AllowedIPRanges configuration")
+
+		// Backward compatibility: no error but emit a warning event.
+		eventEmitter(svc, v1.EventTypeWarning, "InvalidAllowedIPRanges", EventMessageOfInvalidAllowedIPRanges(invalidAllowedIPRanges))
+	}
+
+	if !options.SkipAnnotationValidation && len(sourceRanges) > 0 && len(allowedServiceTags) > 0 {
 		logger.Info(
 			"Service is using both of spec.loadBalancerSourceRanges and annotation service.beta.kubernetes.io/azure-allowed-service-tags",
 		)
@@ -115,7 +125,7 @@ func NewAccessControl(logger logr.Logger, svc *v1.Service, sg *armnetwork.Securi
 		eventEmitter(svc, v1.EventTypeWarning, "ConflictConfiguration", EventMessageOfConflictLoadBalancerSourceRangesAndAllowedIPRanges())
 	}
 
-	return &AccessControl{
+	ac := &AccessControl{
 		logger:                                 logger,
 		svc:                                    svc,
 		sgHelper:                               sgHelper,
@@ -124,7 +134,47 @@ func NewAccessControl(logger logr.Logger, svc *v1.Service, sg *armnetwork.Securi
 		AllowedServiceTags:                     allowedServiceTags,
 		invalidRanges:                          append(invalidSourceRanges, invalidAllowedIPRanges...),
 		securityRuleDestinationPortsByProtocol: securityRuleDestinationPortsByProtocol,
-	}, nil
+	}
+
+	if !options.SkipAnnotationValidation {
+		if mismatched := ac.mismatchedIPFamilyRanges(); len(mismatched) > 0 {
+			ranges := fnutil.Map(func(p netip.Prefix) string { return p.String() }, mismatched)
+			logger.V(2).Info("Found IP ranges that do not match the Service's IP families, no traffic from them can reach the Service",
+				"ip-ranges", ranges, "service-ip-families", ac.svc.Spec.IPFamilies)
+			eventEmitter(svc, v1.EventTypeWarning, "IPRangeFamilyMismatch", EventMessageOfIPRangeFamilyMismatch(ranges))
+		}
+	}
+
+	return ac, nil
+}
+
+// mismatchedIPFamilyRanges returns the configured ranges that do not match any of the Service's IP families.
+// Such a range can still appear in a security rule, targeting an additional public IP or a backend node IP
+// when the floating IP is disabled. kube-proxy programs rules only for the Service's own families, so no
+// traffic from the range can reach the Service.
+func (ac *AccessControl) mismatchedIPFamilyRanges() []netip.Prefix {
+	if len(ac.svc.Spec.IPFamilies) == 0 {
+		return nil
+	}
+
+	var hasIPv4, hasIPv6 bool
+	for _, family := range ac.svc.Spec.IPFamilies {
+		switch family {
+		case v1.IPv4Protocol:
+			hasIPv4 = true
+		case v1.IPv6Protocol:
+			hasIPv6 = true
+		}
+	}
+
+	var rv []netip.Prefix
+	if !hasIPv4 {
+		rv = append(rv, ac.AllowedIPv4Ranges()...)
+	}
+	if !hasIPv6 {
+		rv = append(rv, ac.AllowedIPv6Ranges()...)
+	}
+	return rv
 }
 
 // IsAllowFromInternet returns true if the given service is allowed to be accessed from internet.

--- a/pkg/provider/loadbalancer/accesscontrol_test.go
+++ b/pkg/provider/loadbalancer/accesscontrol_test.go
@@ -18,6 +18,7 @@ package loadbalancer
 
 import (
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -203,6 +204,206 @@ func TestNewAccessControl(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, called)
 	})
+
+	t.Run("it should not emit any event if azure-allowed-ip-ranges is valid", func(t *testing.T) {
+		svc := k8sFx.Service().
+			WithAllowedIPRanges("10.0.0.0/24").
+			Build()
+
+		called := 0
+		eventEmitter := func(_ runtime.Object, _, reason, _ string) {
+			called++
+			t.Errorf("unexpected event with reason %q", reason)
+		}
+
+		_, err := NewAccessControl(log.Noop(), &svc, sg, WithEventEmitter(eventEmitter))
+		assert.NoError(t, err)
+		assert.Equal(t, 0, called)
+	})
+
+	t.Run("it should not report a rejected configuration if annotation validation is skipped", func(t *testing.T) {
+		svc := k8sFx.Service().
+			WithLoadBalancerSourceRanges("20.0.0.1/32").
+			WithAllowedIPRanges("10.0.0.1/32").
+			Build()
+
+		called := 0
+		eventEmitter := func(_ runtime.Object, _, reason, _ string) {
+			called++
+			t.Errorf("unexpected event with reason %q", reason)
+		}
+
+		_, err := NewAccessControl(log.Noop(), &svc, sg, WithEventEmitter(eventEmitter), SkipAnnotationValidation())
+		assert.NoError(t, err, "setting both ranges must not be a hard error when validation is skipped")
+		assert.Equal(t, 0, called)
+	})
+
+	for _, tt := range []struct {
+		name              string
+		families          []v1.IPFamily
+		ipRanges          []string
+		sourceRanges      []string
+		legacyRanges      []string
+		serviceTags       []string
+		disableFloatingIP bool
+		expectedErr       error
+		expectedReasons   []string
+	}{
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv4 Service with IPv6-only azure-allowed-ip-ranges",
+			families:        []v1.IPFamily{v1.IPv4Protocol},
+			ipRanges:        []string{"2001:db8:85a3::/64"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv4 Service with IPv6-only spec.loadBalancerSourceRanges",
+			families:        []v1.IPFamily{v1.IPv4Protocol},
+			sourceRanges:    []string{"2001:db8:85a3::/64"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv4 Service with IPv6-only load-balancer-source-ranges",
+			families:        []v1.IPFamily{v1.IPv4Protocol},
+			legacyRanges:    []string{"2001:db8:85a3::/64"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv6 Service with IPv4-only azure-allowed-ip-ranges",
+			families:        []v1.IPFamily{v1.IPv6Protocol},
+			ipRanges:        []string{"10.0.0.0/24"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv6 Service with IPv4-only spec.loadBalancerSourceRanges",
+			families:        []v1.IPFamily{v1.IPv6Protocol},
+			sourceRanges:    []string{"10.0.0.0/24"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv6 Service with IPv4-only load-balancer-source-ranges",
+			families:        []v1.IPFamily{v1.IPv6Protocol},
+			legacyRanges:    []string{"10.0.0.0/24"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv4 Service with both IPv4 and IPv6 azure-allowed-ip-ranges, even though the IPv4 range applies",
+			families:        []v1.IPFamily{v1.IPv4Protocol},
+			ipRanges:        []string{"10.0.0.0/24", "2001:db8:85a3::/64"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv6 Service with both IPv4 and IPv6 azure-allowed-ip-ranges, even though the IPv6 range applies",
+			families:        []v1.IPFamily{v1.IPv6Protocol},
+			ipRanges:        []string{"10.0.0.0/24", "2001:db8:85a3::/64"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv4 Service with IPv6-only azure-allowed-ip-ranges and a service tag",
+			families:        []v1.IPFamily{v1.IPv4Protocol},
+			ipRanges:        []string{"2001:db8:85a3::/64"},
+			serviceTags:     []string{"AzureCloud"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:            "it should emit IPRangeFamilyMismatch if IPv6 Service with IPv4-only azure-allowed-ip-ranges and a service tag",
+			families:        []v1.IPFamily{v1.IPv6Protocol},
+			ipRanges:        []string{"10.0.0.0/24"},
+			serviceTags:     []string{"AzureCloud"},
+			expectedReasons: []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			// spec.loadBalancerSourceRanges is the only range source that also conflicts with
+			// service tags, so it reports both problems.
+			name:            "it should emit ConflictConfiguration and IPRangeFamilyMismatch if IPv4 Service with IPv6-only spec.loadBalancerSourceRanges and a service tag",
+			families:        []v1.IPFamily{v1.IPv4Protocol},
+			sourceRanges:    []string{"2001:db8:85a3::/64"},
+			serviceTags:     []string{"AzureCloud"},
+			expectedReasons: []string{"ConflictConfiguration", "IPRangeFamilyMismatch"},
+		},
+		{
+			name:     "it should not emit any event if dual-stack Service with both IPv4 and IPv6 azure-allowed-ip-ranges",
+			families: []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+			ipRanges: []string{"10.0.0.0/24", "2001:db8:85a3::/64"},
+		},
+		{
+			// Disabling the floating IP retargets the rule at a node IP of the range's own family,
+			// but the Service still answers only on its families, so the range remains unreachable.
+			name:              "it should emit IPRangeFamilyMismatch if IPv4 Service with IPv6-only azure-allowed-ip-ranges and the floating IP disabled",
+			families:          []v1.IPFamily{v1.IPv4Protocol},
+			ipRanges:          []string{"2001:db8:85a3::/64"},
+			disableFloatingIP: true,
+			expectedReasons:   []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			name:              "it should emit IPRangeFamilyMismatch if IPv6 Service with IPv4-only azure-allowed-ip-ranges and the floating IP disabled",
+			families:          []v1.IPFamily{v1.IPv6Protocol},
+			ipRanges:          []string{"10.0.0.0/24"},
+			disableFloatingIP: true,
+			expectedReasons:   []string{"IPRangeFamilyMismatch"},
+		},
+		{
+			// Warning events should not be emitted after fatal checks error.
+			name:         "it should not emit InvalidAllowedIPRanges if setting both spec.loadBalancerSourceRanges and azure-allowed-ip-ranges is rejected",
+			sourceRanges: []string{"20.0.0.1/32"},
+			ipRanges:     []string{"10.0.0.0/24", "bad"},
+			expectedErr:  ErrSetBothLoadBalancerSourceRangesAndAllowedIPRanges,
+		},
+		{
+			name:         "it should not emit InvalidSourceRanges if setting both spec.loadBalancerSourceRanges and azure-allowed-ip-ranges is rejected",
+			sourceRanges: []string{"20.0.0.1/32", "bad"},
+			ipRanges:     []string{"10.0.0.0/24"},
+			expectedErr:  ErrSetBothLoadBalancerSourceRangesAndAllowedIPRanges,
+		},
+		{
+			name:         "it should not emit ConflictConfiguration if setting both spec.loadBalancerSourceRanges and azure-allowed-ip-ranges is rejected",
+			sourceRanges: []string{"20.0.0.1/32"},
+			ipRanges:     []string{"10.0.0.0/24"},
+			serviceTags:  []string{"AzureCloud"},
+			expectedErr:  ErrSetBothLoadBalancerSourceRangesAndAllowedIPRanges,
+		},
+		{
+			name:         "it should not emit IPRangeFamilyMismatch if setting both spec.loadBalancerSourceRanges and azure-allowed-ip-ranges is rejected",
+			families:     []v1.IPFamily{v1.IPv4Protocol},
+			sourceRanges: []string{"2001:db8:85a3::/64"},
+			ipRanges:     []string{"10.0.0.0/24"},
+			expectedErr:  ErrSetBothLoadBalancerSourceRangesAndAllowedIPRanges,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := k8sFx.Service().WithIPFamilies(tt.families...)
+			if len(tt.ipRanges) > 0 {
+				builder = builder.WithAllowedIPRanges(tt.ipRanges...)
+			}
+			if len(tt.sourceRanges) > 0 {
+				builder = builder.WithLoadBalancerSourceRanges(tt.sourceRanges...)
+			}
+			if len(tt.serviceTags) > 0 {
+				builder = builder.WithAllowedServiceTags(tt.serviceTags...)
+			}
+			if tt.disableFloatingIP {
+				builder = builder.WithDisableFloatingIP()
+			}
+			svc := builder.Build()
+			if len(tt.legacyRanges) > 0 {
+				svc.Annotations[v1.AnnotationLoadBalancerSourceRangesKey] = strings.Join(tt.legacyRanges, ",")
+			}
+
+			var reasons []string
+			eventEmitter := func(obj runtime.Object, eventType, reason, _ string) {
+				assert.Equal(t, &svc, obj)
+				assert.Equal(t, v1.EventTypeWarning, eventType)
+				reasons = append(reasons, reason)
+			}
+
+			_, err := NewAccessControl(log.Noop(), &svc, sg, WithEventEmitter(eventEmitter))
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err, "this configuration must not be a hard error")
+			}
+			assert.ElementsMatch(t, tt.expectedReasons, reasons)
+		})
+	}
 }
 
 func TestAccessControl_DenyAllExceptSourceRanges(t *testing.T) {

--- a/pkg/provider/loadbalancer/configuration_test.go
+++ b/pkg/provider/loadbalancer/configuration_test.go
@@ -221,6 +221,24 @@ func TestAllowedIPRanges(t *testing.T) {
 		assert.ErrorAs(t, err, &e)
 		assert.Equal(t, []string{"foobar", "10.0.0.1/24", "barfoo", "2002:db8::1/32"}, invalid)
 	})
+	t.Run("with empty value in allowed ip ranges", func(t *testing.T) {
+		actual, invalid, err := AllowedIPRanges(&v1.Service{
+			Spec: v1.ServiceSpec{
+				Type: v1.ServiceTypeLoadBalancer,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					consts.ServiceAnnotationAllowedIPRanges: "",
+				},
+			},
+		})
+		assert.Error(t, err)
+
+		var e *ErrAnnotationValue
+		assert.ErrorAs(t, err, &e)
+		assert.Empty(t, actual)
+		assert.Equal(t, []string{""}, invalid)
+	})
 }
 
 func TestSourceRanges(t *testing.T) {

--- a/pkg/provider/loadbalancer/k8sevent.go
+++ b/pkg/provider/loadbalancer/k8sevent.go
@@ -21,6 +21,7 @@ import (
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -47,5 +48,14 @@ func EventMessageOfConflictLoadBalancerSourceRangesAndAllowedIPRanges() string {
 		"Please use annotation %s instead of spec.loadBalancerSourceRanges while using %s annotation at the same time.",
 		consts.ServiceAnnotationAllowedIPRanges,
 		consts.ServiceAnnotationAllowedServiceTags,
+	)
+}
+
+func EventMessageOfIPRangeFamilyMismatch(ipRanges []string) string {
+	return fmt.Sprintf(
+		"Found IP ranges %q that do not match the Service's IP families, so no traffic from them can reach the Service. Check spec.loadBalancerSourceRanges, %s and %s.",
+		ipRanges,
+		consts.ServiceAnnotationAllowedIPRanges,
+		v1.AnnotationLoadBalancerSourceRangesKey,
 	)
 }

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -22,6 +22,7 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	. "github.com/onsi/ginkgo/v2"
@@ -225,8 +226,8 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		})
 	})
 
-	When("creating a LoadBalancer service with `spec.LoadBalancerSourceRanges`", func() {
-		It("should add a rule to allow traffic from allowed-IPs only", func() {
+	DescribeTable("creating a LoadBalancer service with load balancer source ranges",
+		func(viaAnnotation bool) {
 			var (
 				serviceIPv4s      []netip.Addr
 				serviceIPv6s      []netip.Addr
@@ -258,21 +259,31 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 					labels = map[string]string{
 						"app": ServiceName,
 					}
-					annotations = map[string]string{
-						v1.AnnotationLoadBalancerSourceRangesKey: strings.Join(
-							append(
-								append(allowedIPv4Ranges, overlappingIPv4Ranges...),
-								append(allowedIPv6Ranges, overlappingIPv6Ranges...)...,
-							),
-							",",
-						),
-					}
-					ports = []v1.ServicePort{{
+					annotations = map[string]string{}
+					ports       = []v1.ServicePort{{
 						Port:       serverPort,
 						TargetPort: intstr.FromInt32(serverPort),
 					}}
+					sourceRanges = append(
+						append(allowedIPv4Ranges, overlappingIPv4Ranges...),
+						append(allowedIPv6Ranges, overlappingIPv6Ranges...)...,
+					)
 				)
-				rv := createAndExposeDefaultServiceWithAnnotation(k8sClient, azureClient.IPFamily, ServiceName, namespace.Name, labels, annotations, ports)
+				service := utils.CreateLoadBalancerServiceManifest(ServiceName, annotations, labels, namespace.Name, ports)
+				if viaAnnotation {
+					service.Annotations[v1.AnnotationLoadBalancerSourceRangesKey] = strings.Join(sourceRanges, ",")
+				} else {
+					service.Spec.LoadBalancerSourceRanges = sourceRanges
+				}
+				_, err := k8sClient.CoreV1().Services(namespace.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				utils.PrintCreateSVCSuccessfully(ServiceName, namespace.Name)
+
+				// Skip service connectivity validation because kube-proxy enforces
+				// spec.loadBalancerSourceRanges and these test ranges exclude the IP
+				// used by the connectivity test.
+				rv, err := utils.WaitServiceExposureAndGetIPs(k8sClient, namespace.Name, ServiceName)
+				Expect(err).NotTo(HaveOccurred())
 				serviceIPv4s, serviceIPv6s = groupIPsByFamily(mustParseIPs(derefSliceOfStringPtr(rv)))
 			})
 			logger.Info("Created a LoadBalancer service", "v4-IPs", serviceIPv4s, "v6-IPs", serviceIPv6s)
@@ -314,8 +325,10 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 					).To(BeFalse(), "Should not have a rule for denying all traffic")
 				}
 			})
-		})
-	})
+		},
+		Entry("via `spec.loadBalancerSourceRanges` should add a rule to allow traffic from allowed-IPs only", false),
+		Entry("via annotation `service.beta.kubernetes.io/load-balancer-source-ranges` should add a rule to allow traffic from allowed-IPs only", true),
+	)
 
 	When("creating a LoadBalancer service with annotation `service.beta.kubernetes.io/azure-deny-all-except-load-balancer-source-ranges`", func() {
 		It("should add a rule to allow traffic from allowed-IPs only", func() {
@@ -686,8 +699,8 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 		})
 	})
 
-	When("creating a LoadBalancer service with annotation `service.beta.kubernetes.io/azure-allowed-ip-ranges`", func() {
-		It("should add a rule to allow traffic from allowed-IPs only", func() {
+	DescribeTable("creating a LoadBalancer service with annotation `service.beta.kubernetes.io/azure-allowed-ip-ranges`",
+		func(internal bool) {
 			var (
 				serviceIPv4s      []netip.Addr
 				serviceIPv6s      []netip.Addr
@@ -733,6 +746,9 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 						TargetPort: intstr.FromInt32(serverPort),
 					}}
 				)
+				if internal {
+					annotations[consts.ServiceAnnotationLoadBalancerInternal] = "true"
+				}
 				rv := createAndExposeDefaultServiceWithAnnotation(k8sClient, azureClient.IPFamily, ServiceName, namespace.Name, labels, annotations, ports)
 				serviceIPv4s, serviceIPv6s = groupIPsByFamily(mustParseIPs(derefSliceOfStringPtr(rv)))
 			})
@@ -774,6 +790,133 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 						validator.HasDenyAllRuleForDestination(serviceIPv6s),
 					).To(BeFalse(), "Should not have a rule for denying all traffic")
 				}
+			})
+		},
+		Entry("should add a rule to allow traffic from allowed-IPs only", false),
+		Entry("should add a rule to allow traffic from allowed-IPs only on an internal load balancer", true),
+	)
+
+	When("creating a LoadBalancer service with an invalid `service.beta.kubernetes.io/azure-allowed-ip-ranges`", func() {
+		It("should keep the valid ranges, deny all other traffic and emit a warning event", func() {
+			var (
+				serviceIPv4s     []netip.Addr
+				serviceIPv6s     []netip.Addr
+				allowedIPv4Range = "10.20.0.0/16"
+				allowedIPv6Range = "2c0f:fe40:8000::/48"
+				invalidRange     = "notacidr"
+				createdAt        time.Time
+			)
+
+			By("Creating a LoadBalancer service", func() {
+				var (
+					labels = map[string]string{
+						"app": ServiceName,
+					}
+					annotations = map[string]string{
+						consts.ServiceAnnotationAllowedIPRanges: strings.Join(
+							[]string{allowedIPv4Range, allowedIPv6Range, invalidRange}, ",",
+						),
+					}
+					ports = []v1.ServicePort{{
+						Port:       serverPort,
+						TargetPort: intstr.FromInt32(serverPort),
+					}}
+				)
+				createdAt = time.Now()
+				rv := createAndExposeDefaultServiceWithAnnotation(k8sClient, azureClient.IPFamily, ServiceName, namespace.Name, labels, annotations, ports)
+				serviceIPv4s, serviceIPv6s = groupIPsByFamily(mustParseIPs(derefSliceOfStringPtr(rv)))
+			})
+			logger.Info("Created a LoadBalancer service", "v4-IPs", serviceIPv4s, "v6-IPs", serviceIPv6s)
+
+			By("Checking if the warning event for the invalid range is emitted", func() {
+				Expect(
+					utils.WaitForServiceWarningEventAfter(k8sClient, namespace.Name, ServiceName, "InvalidAllowedIPRanges", invalidRange, createdAt),
+				).NotTo(HaveOccurred(), "Should emit an InvalidAllowedIPRanges event naming the invalid range")
+			})
+
+			var validator *SecurityGroupValidator
+			By("Getting the cluster security groups", func() {
+				rv, err := azureClient.GetClusterSecurityGroups()
+				Expect(err).NotTo(HaveOccurred())
+
+				validator = NewSecurityGroupValidator(rv)
+			})
+
+			By("Checking if the valid ranges are allowed and all other traffic is denied", func() {
+				var (
+					expectedProtocol = armnetwork.SecurityRuleProtocolTCP
+					expectedDstPorts = []string{strconv.FormatInt(int64(serverPort), 10)}
+				)
+
+				if len(serviceIPv4s) > 0 {
+					Expect(
+						validator.HasExactAllowRule(expectedProtocol, []string{allowedIPv4Range}, serviceIPv4s, expectedDstPorts),
+					).To(BeTrue(), "Should have a rule for allowing IPv4 traffic from the valid range")
+					Expect(
+						validator.HasExactAllowRule(expectedProtocol, []string{"Internet"}, serviceIPv4s, expectedDstPorts),
+					).To(BeFalse(), "Should not have a rule for allowing IPv4 traffic from Internet")
+					Expect(
+						validator.HasDenyAllRuleForDestination(serviceIPv4s),
+					).To(BeTrue(), "Should have a rule for denying all other IPv4 traffic")
+				}
+				if len(serviceIPv6s) > 0 {
+					Expect(
+						validator.HasExactAllowRule(expectedProtocol, []string{allowedIPv6Range}, serviceIPv6s, expectedDstPorts),
+					).To(BeTrue(), "Should have a rule for allowing IPv6 traffic from the valid range")
+					Expect(
+						validator.HasExactAllowRule(expectedProtocol, []string{"Internet"}, serviceIPv6s, expectedDstPorts),
+					).To(BeFalse(), "Should not have a rule for allowing IPv6 traffic from Internet")
+					Expect(
+						validator.HasDenyAllRuleForDestination(serviceIPv6s),
+					).To(BeTrue(), "Should have a rule for denying all other IPv6 traffic")
+				}
+			})
+		})
+	})
+
+	When("creating a LoadBalancer service with both `spec.loadBalancerSourceRanges` and annotation `service.beta.kubernetes.io/azure-allowed-ip-ranges`", func() {
+		It("should refuse to reconcile and emit a warning event", func() {
+			var createdAt time.Time
+			By("Creating a LoadBalancer service", func() {
+				var (
+					labels = map[string]string{
+						"app": ServiceName,
+					}
+					annotations = map[string]string{
+						consts.ServiceAnnotationAllowedIPRanges: "10.20.0.0/16",
+					}
+					ports = []v1.ServicePort{{
+						Port:       serverPort,
+						TargetPort: intstr.FromInt32(serverPort),
+					}}
+				)
+				svc := utils.CreateLoadBalancerServiceManifest(ServiceName, annotations, labels, namespace.Name, ports)
+				svc.Spec.LoadBalancerSourceRanges = []string{"192.168.0.1/32"}
+
+				createdAt = time.Now()
+				_, err := k8sClient.CoreV1().Services(namespace.Name).Create(context.Background(), svc, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			defer func() {
+				err := utils.DeleteService(k8sClient, namespace.Name, ServiceName)
+				Expect(err).NotTo(HaveOccurred(), "Should not be blocked by the rejected configuration")
+			}()
+
+			By("Checking if the reconcile failure is reported", func() {
+				err := utils.WaitForServiceWarningEventAfter(k8sClient, namespace.Name, ServiceName, "SyncLoadBalancerFailed", "cannot set both", createdAt)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("Checking that the service is never exposed", func() {
+				svc, err := k8sClient.CoreV1().Services(namespace.Name).Get(context.Background(), ServiceName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svc.Status.LoadBalancer.Ingress).To(BeEmpty(), "Should not assign an ingress IP to a rejected service")
+			})
+
+			By("Deleting the service", func() {
+				err := utils.DeleteService(k8sClient, namespace.Name, ServiceName)
+				Expect(err).NotTo(HaveOccurred(), "Should not be blocked by the rejected configuration")
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- **Warning events were not emitted on create/update.** `reconcileSecurityGroup` wired the event emitter only on the delete path, so a rejected configuration produced no Kubernetes event on apply. Introduced by #7178, which swapped `SkipAnnotationValidation()` for `WithEventEmitter()` inside the existing `if !wantLb` branch, so events were only emitted when deleting. `InvalidAllowedIPRanges` and `ConflictConfiguration` are now visible to users.
- **Deletion could be blocked by configuration validation.** Setting both `spec.loadBalancerSourceRanges` and `azure-allowed-ip-ranges` returned `ErrSetBoth` on the delete path, so `EnsureLoadBalancerDeleted` failed and the cleanup finalizer was never
  removed. Follows the intended `When deleting LB, we don't need to validate the annotation`.
- **New `IPRangeFamilyMismatch` warning.** No traffic from an IP range whose IP family the Service does not have can reach the Service, because kube-proxy only programs rules for the Service's own families. The wrong-family proxier [drops the Service outright](https://github.com/kubernetes/kubernetes/blob/96cb9ab4201d88ce5e549fde047a686171838fdb/pkg/proxy/servicechangetracker.go#L145-L148), and the right-family one [filters `status.loadBalancer.ingress`](https://github.com/kubernetes/kubernetes/blob/96cb9ab4201d88ce5e549fde047a686171838fdb/pkg/proxy/serviceport.go#L216-L229). A security rule may still be created for such a range. This was silent; it now emits a warning event naming the ranges.
- **Warning events could describe a security group change that never happened.** `InvalidSourceRanges` and `InvalidAllowedIPRanges` were emitted during parsing, before the `ErrSetBoth` check. With both `spec.loadBalancerSourceRanges` and a partly-valid `azure-allowed-ip-ranges` set, the user saw "ignoring and adding a default DenyAll rule in security group" followed by `SyncLoadBalancerFailed`, and no rule was added at all. All fatal checks now run before any event is emitted.

Adds unit, integration and E2E coverage.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #6492. This unblocks deletion for a Service with both `spec.loadBalancerSourceRanges` and the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation. The hard error on create/update is unchanged.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: `InvalidSourceRanges`, `InvalidAllowedIPRanges` and `ConflictConfiguration` warning events are now emitted when a Service is created or updated instead of only during delete, and are no longer emitted when the configuration is rejected and no security group change is made. Deleting a Service is no longer blocked when both `spec.loadBalancerSourceRanges` and the `service.beta.kubernetes.io/azure-allowed-ip-ranges` annotation are set.
feat: a new `IPRangeFamilyMismatch` warning event reports IP ranges from `spec.loadBalancerSourceRanges`, `service.beta.kubernetes.io/load-balancer-source-ranges`, and `service.beta.kubernetes.io/azure-allowed-ip-ranges` whose IP family the Service does not have.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
