### PR TITLE
Build health-probe-proxy binary inside its image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -384,6 +384,30 @@ updates:
         - "minor"
         - "major"
   - package-ecosystem: "docker"
+    directory: "/health-probe-proxy"
+    schedule:
+      interval: "weekly"
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    target-branch: "release-1.36"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "lgtm"
+      - "approved"
+      - "release-1.36"
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+        - "minor"
+        - "major"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -465,6 +489,30 @@ updates:
         - "minor"
         - "major"
   - package-ecosystem: "docker"
+    directory: "/health-probe-proxy"
+    schedule:
+      interval: "weekly"
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    target-branch: "release-1.35"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "lgtm"
+      - "approved"
+      - "release-1.35"
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+        - "minor"
+        - "major"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -546,6 +594,30 @@ updates:
         - "minor"
         - "major"
   - package-ecosystem: "docker"
+    directory: "/health-probe-proxy"
+    schedule:
+      interval: "weekly"
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    target-branch: "release-1.34"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "lgtm"
+      - "approved"
+      - "release-1.34"
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+        - "minor"
+        - "major"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -613,6 +685,30 @@ updates:
       - "release-note-none"
       - "ok-to-test"
       - "kind/testing"
+      - "lgtm"
+      - "approved"
+      - "release-1.33"
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+        - "*"
+        update-types:
+        - "patch"
+        - "minor"
+        - "major"
+  - package-ecosystem: "docker"
+    directory: "/health-probe-proxy"
+    schedule:
+      interval: "weekly"
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    target-branch: "release-1.33"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+      - "kind/cleanup"
       - "lgtm"
       - "approved"
       - "release-1.33"

--- a/health-probe-proxy/Dockerfile
+++ b/health-probe-proxy/Dockerfile
@@ -14,6 +14,17 @@
 
 # syntax=docker/dockerfile:1
 
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.5-2-bookworm@sha256:ea712a1aaf80306c19ff842ba0bfcb9ad360afd8143e70044e0d0bd6d6899887 AS builder
+
+ARG ARCH=amd64
+
+WORKDIR /go/src/health-probe-proxy
+COPY . .
+
+# Cache the go build into the Go compiler cache folder so we benefit from compiler caching across docker build calls
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    make bin/health-probe-proxy ARCH=${ARCH}
+
 FROM gcr.io/distroless/base:latest@sha256:9ef50bca108839d5986e4d84b7f7b2d79024c9293b7c35b162c6c55485bd5868
-COPY bin/health-probe-proxy /usr/local/bin/health-probe-proxy
+COPY --from=builder /go/src/health-probe-proxy/bin/health-probe-proxy /usr/local/bin/health-probe-proxy
 ENTRYPOINT [ "/usr/local/bin/health-probe-proxy" ]

--- a/health-probe-proxy/Makefile
+++ b/health-probe-proxy/Makefile
@@ -59,7 +59,7 @@ else
 endif
 
 .PHONY: build-health-probe-proxy-image
-build-health-probe-proxy-image: buildx-setup  $(BIN_DIR)/health-probe-proxy ## Build health-probe-proxy image for Linux.
+build-health-probe-proxy-image: buildx-setup ## Build health-probe-proxy image for Linux.
 	$(CONTAINER_BUILDX) build --pull \
 		$(OUTPUT_FLAG) \
 		--platform linux/$(ARCH) \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `health-probe-proxy` image copies a binary that is compiled on the host, so the Go toolchain baked into the binary depends on whoever built it. That makes stdlib CVE fixes awkward: there is no builder image to bump, you have to chase the version on the build machine.

This adds a proper builder stage to `health-probe-proxy/Dockerfile`, using the same pinned `mcr.microsoft.com/oss/go/microsoft/golang` image as the cloud-controller-manager and cloud-node-manager Dockerfiles. The binary is now compiled inside the container, so a stdlib CVE fix is just a builder digest bump.

A few related changes come along with it:

* The Makefile no longer builds the binary on the host before the image build, since the Dockerfile handles that now.
* Dependabot gets `health-probe-proxy` docker entries on the community-supported release branches, so the builder digest is bumped automatically the same way it already is for CCM and CNM.

#### Which issue(s) this PR fixes:

Fixes #10632

#### Special notes for your reviewer:

The Windows image is left as is. It cross-compiles the `.exe` on the host and there is no Go builder stage for nanoserver, so it is out of scope here.

Verified the image builds and the binary runs from the builder stage.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
