### PR TITLE
Fix retryrepectthrottled typo in azclient policy package

### DIFF
--- a/pkg/azclient/metrics/metrics.go
+++ b/pkg/azclient/metrics/metrics.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/ratelimit"
-	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrespectthrottled"
 )
 
 var (
@@ -77,7 +77,7 @@ func (c *ARMContext) Observe(ctx context.Context, err error) {
 		return
 	}
 
-	if errors.Is(err, retryrepectthrottled.ErrTooManyRequest) {
+	if errors.Is(err, retryrespectthrottled.ErrTooManyRequest) {
 		c.Throttled(ctx)
 		return
 	}

--- a/pkg/azclient/policy/retryrespectthrottled/retryrespectthrottled_suite_test.go
+++ b/pkg/azclient/policy/retryrespectthrottled/retryrespectthrottled_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package retryrepectthrottled_test
+package retryrespectthrottled_test
 
 import (
 	"testing"

--- a/pkg/azclient/policy/retryrespectthrottled/throttle.go
+++ b/pkg/azclient/policy/retryrespectthrottled/throttle.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package retryrepectthrottled
+package retryrespectthrottled
 
 import (
 	"errors"

--- a/pkg/azclient/policy/retryrespectthrottled/throttle_test.go
+++ b/pkg/azclient/policy/retryrespectthrottled/throttle_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package retryrepectthrottled_test
+package retryrespectthrottled_test
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrespectthrottled"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
 )
 
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("Throttle", func() {
 	ginkgo.Describe("Throttle", func() {
 		ginkgo.It("should respect retry-after", func() {
 			once := sync.Once{}
-			throttlePolicy := &retryrepectthrottled.ThrottlingPolicy{}
+			throttlePolicy := &retryrespectthrottled.ThrottlingPolicy{}
 			pipeline := runtime.NewPipeline("testmodule", "v0.1.0", runtime.PipelineOptions{}, &policy.ClientOptions{
 				PerCallPolicies: []policy.Policy{
 					throttlePolicy,
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe("Throttle", func() {
 
 		ginkgo.DescribeTable("should populate RetryAfter correctly",
 			func(initialTimer *time.Time, responseStatus int, retryAfterValue string, check func(time.Time)) {
-				throttlePolicy := &retryrepectthrottled.ThrottlingPolicy{}
+				throttlePolicy := &retryrespectthrottled.ThrottlingPolicy{}
 				if initialTimer != nil {
 					throttlePolicy.RetryAfterWriter = *initialTimer
 				}
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("Throttle", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				_, err = pipeline.Do(req)
 				gomega.Expect(err).To(gomega.HaveOccurred())
-				var throttleErr *retryrepectthrottled.ThrottleError
+				var throttleErr *retryrespectthrottled.ThrottleError
 				gomega.Expect(errors.As(err, &throttleErr)).To(gomega.BeTrue())
 				check(throttleErr.RetryAfter)
 			},
@@ -148,21 +148,21 @@ var _ = ginkgo.Describe("Throttle", func() {
 		)
 
 		ginkgo.It("should satisfy errors.Is(err, ErrTooManyRequest) for ThrottleError", func() {
-			err := &retryrepectthrottled.ThrottleError{RetryAfter: time.Now()}
-			gomega.Expect(errors.Is(err, retryrepectthrottled.ErrTooManyRequest)).To(gomega.BeTrue())
+			err := &retryrespectthrottled.ThrottleError{RetryAfter: time.Now()}
+			gomega.Expect(errors.Is(err, retryrespectthrottled.ErrTooManyRequest)).To(gomega.BeTrue())
 		})
 
 		ginkgo.It("should allow errors.As to extract ThrottleError with correct RetryAfter", func() {
 			expected := time.Now().Add(42 * time.Second)
-			var err error = &retryrepectthrottled.ThrottleError{RetryAfter: expected}
-			var throttleErr *retryrepectthrottled.ThrottleError
+			var err error = &retryrespectthrottled.ThrottleError{RetryAfter: expected}
+			var throttleErr *retryrespectthrottled.ThrottleError
 			gomega.Expect(errors.As(err, &throttleErr)).To(gomega.BeTrue())
 			gomega.Expect(throttleErr.RetryAfter).To(gomega.BeTemporally("~", expected, time.Millisecond))
 		})
 
 		ginkgo.It("should return the same error string as ErrTooManyRequest", func() {
-			err := &retryrepectthrottled.ThrottleError{RetryAfter: time.Now()}
-			gomega.Expect(err.Error()).To(gomega.Equal(retryrepectthrottled.ErrTooManyRequest.Error()))
+			err := &retryrespectthrottled.ThrottleError{RetryAfter: time.Now()}
+			gomega.Expect(err.Error()).To(gomega.Equal(retryrespectthrottled.ErrTooManyRequest.Error()))
 		})
 	})
 })

--- a/pkg/azclient/utils/options.go
+++ b/pkg/azclient/utils/options.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 
-	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrepectthrottled"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/policy/retryrespectthrottled"
 )
 
 var TracingProvider tracing.Provider
@@ -48,10 +48,10 @@ func GetDefaultAzCoreClientOption() policy.ClientOptions {
 			RetryDelay:    DefaultRetryDelay,
 			MaxRetryDelay: DefaultMaxRetryDelay,
 			MaxRetries:    DefaultMaxRetries,
-			StatusCodes:   retryrepectthrottled.GetRetriableStatusCode(),
+			StatusCodes:   retryrespectthrottled.GetRetriableStatusCode(),
 		},
 		PerRetryPolicies: []policy.Policy{
-			retryrepectthrottled.NewThrottlingPolicy(),
+			retryrespectthrottled.NewThrottlingPolicy(),
 		},
 		Transport: &http.Client{
 			Transport: DefaultTransport,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The throttling policy package under `pkg/azclient/policy` was named `retryrepectthrottled`, which misspells "respect". This renames the package and its directory to `retryrespectthrottled` and updates the two importers (`metrics` and `utils`) to match.

It is a pure rename with no behavior change. The policy, its exported types, and its logic stay exactly the same.

#### Which issue(s) this PR fixes:

Fixes #10558

#### Special notes for your reviewer:

Only the azclient module is touched here. The root module still vendors azclient at its published tag, so the vendored copy keeps the old name until the next azclient version bump picks this up.

Ran `go build ./...`, `go vet`, and the package tests in `pkg/azclient` after the rename and they all pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
