### PR TITLE
fix: ignore controller-owned tag keys in pip tags annotation

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -1529,6 +1529,25 @@ func getClusterFromPIPClusterTags(tags map[string]*string) string {
 	return ""
 }
 
+// Public IP tag keys whose values the controller owns.
+var reservedPIPTagKeys = []string{
+	consts.ClusterNameKey, consts.LegacyClusterNameKey,
+	consts.ServiceTagKey, consts.LegacyServiceTagKey,
+	consts.ServiceUsingDNSKey, consts.LegacyServiceUsingDNSKey,
+}
+
+// isPIPReservedTagKey reports whether key names a Public IP tag whose value the controller owns.
+// Matching ignores case: Azure resource tag names are case-insensitive.
+// https://learn.microsoft.com/azure/azure-resource-manager/management/tag-resources
+func isPIPReservedTagKey(key string) bool {
+	for _, reserved := range reservedPIPTagKeys {
+		if strings.EqualFold(key, reserved) {
+			return true
+		}
+	}
+	return false
+}
+
 type serviceIPTagRequest struct {
 	IPTagsRequestedByAnnotation bool
 	IPTags                      []*armnetwork.IPTag
@@ -3613,13 +3632,23 @@ func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAd
 		annotationTags = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags], map[string]string{})
 	}
 
+	var ignoredReservedKeys bool
 	for k, v := range annotationTags {
+		if isPIPReservedTagKey(k) {
+			ignoredReservedKeys = true
+			continue // the controller owns these values; an annotation must not set them
+		}
 		found, key := findKeyInMapCaseInsensitive(configTags, k)
 		if !found {
 			configTags[k] = v
 		} else if !strings.EqualFold(ptr.Deref(v, ""), ptr.Deref(configTags[key], "")) {
 			configTags[key] = v
 		}
+	}
+	if ignoredReservedKeys {
+		az.Event(service, v1.EventTypeWarning, "IgnoredPIPTagKeys", fmt.Sprintf(
+			"Ignoring reserved tag keys in the %s annotation; the controller owns the values of: %s",
+			consts.ServiceAnnotationAzurePIPTags, strings.Join(reservedPIPTagKeys, ", ")))
 	}
 
 	// include the cluster name and service names tags when comparing

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/backendaddresspoolclient/mock_backendaddresspoolclient"
@@ -7917,8 +7918,18 @@ func compareStrings(s0, s1 []string) bool {
 }
 
 func TestEnsurePublicIPExistsCommon(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	// Builds a pip tags annotation that tries to set every controller-owned tag key.
+	reservedTagKeysAnnotation := func(transform func(string) string) string {
+		var pairs []string
+		for _, key := range []string{
+			consts.ClusterNameKey, consts.LegacyClusterNameKey,
+			consts.ServiceTagKey, consts.LegacyServiceTagKey,
+			consts.ServiceUsingDNSKey, consts.LegacyServiceUsingDNSKey,
+		} {
+			pairs = append(pairs, transform(key)+"=annotation-value")
+		}
+		return strings.Join(pairs, ",")
+	}
 
 	testCases := []struct {
 		desc                    string
@@ -7936,6 +7947,7 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 		assertPutPIPCalled      bool
 		putErr                  error
 		expectedError           bool
+		expectedWarningReasons  []string
 	}{
 		{
 			desc:    "shall return existed IPv4 PIP if there is any",
@@ -8244,6 +8256,71 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			desc:    "shall not apply reserved tag keys from the pip tags annotation",
+			pipName: "pip1",
+			additionalAnnotations: map[string]string{
+				consts.ServiceAnnotationAzurePIPTags: reservedTagKeysAnnotation(func(key string) string { return key }),
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{{
+				Name: ptr.To("pip1"),
+				ID:   ptr.To(expectedPIPID),
+				Tags: map[string]*string{
+					consts.ClusterNameKey: ptr.To("testCluster"),
+					consts.ServiceTagKey:  ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+				},
+			}},
+			expectedPIP: &armnetwork.PublicIPAddress{
+				Name: ptr.To("pip1"),
+				ID:   ptr.To(expectedPIPID),
+				Tags: map[string]*string{
+					consts.ClusterNameKey: ptr.To("testCluster"),
+					consts.ServiceTagKey:  ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+				},
+			},
+			expectedWarningReasons: []string{"IgnoredPIPTagKeys"},
+		},
+		{
+			// Azure resource tag names are case-insensitive.
+			desc:    "shall not apply reserved tag keys from the pip tags annotation regardless of their case",
+			pipName: "pip1",
+			additionalAnnotations: map[string]string{
+				consts.ServiceAnnotationAzurePIPTags: reservedTagKeysAnnotation(strings.ToUpper),
+			},
+			existingPIPs: []*armnetwork.PublicIPAddress{{
+				Name: ptr.To("pip1"),
+				ID:   ptr.To(expectedPIPID),
+				Tags: map[string]*string{
+					consts.ClusterNameKey: ptr.To("testCluster"),
+					consts.ServiceTagKey:  ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+				},
+			}},
+			expectedPIP: &armnetwork.PublicIPAddress{
+				Name: ptr.To("pip1"),
+				ID:   ptr.To(expectedPIPID),
+				Tags: map[string]*string{
+					consts.ClusterNameKey: ptr.To("testCluster"),
+					consts.ServiceTagKey:  ptr.To("default/test1"),
+				},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+				},
+			},
+			expectedWarningReasons: []string{"IgnoredPIPTagKeys"},
+		},
+		{
 			desc:          "shall return the pip without calling PUT API if the tags are good",
 			pipName:       "pip1",
 			inputDNSLabel: "test",
@@ -8430,20 +8507,26 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 			additionalAnnotations: map[string]string{
 				consts.ServiceAnnotationIPTagsForPublicIP: "RoutingPreference=Invalid",
 			},
-			shouldPutPIP:       true,
-			assertPutPIPCalled: true,
-			putErr:             errors.New("azure rejected iptags mutation"),
-			expectedError:      true,
+			shouldPutPIP:           true,
+			assertPutPIPCalled:     true,
+			putErr:                 errors.New("azure rejected iptags mutation"),
+			expectedError:          true,
+			expectedWarningReasons: []string{"CreateOrUpdatePublicIPAddress"},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
 			az := GetTestCloud(ctrl)
 			if test.useSLB {
 				az.LoadBalancerSKU = consts.LoadBalancerSKUStandard
 			}
 			az.EnableIPTagMutationForExistingPublicIP = test.enableIPTagMutation
+			recorder := record.NewFakeRecorder(10)
+			az.eventRecorder = recorder
 
 			service := getTestService("test1", v1.ProtocolTCP, nil, test.isIPv6, 80)
 			service.Annotations = test.additionalAnnotations
@@ -8499,6 +8582,16 @@ func TestEnsurePublicIPExistsCommon(t *testing.T) {
 				assert.Equal(t, test.expectedID, ptr.Deref(pip.ID, ""))
 			} else {
 				assert.Equal(t, test.expectedPIP, pip)
+			}
+
+			var events []string
+			for len(recorder.Events) > 0 {
+				events = append(events, <-recorder.Events)
+			}
+			if assert.Len(t, events, len(test.expectedWarningReasons), events) {
+				for i, reason := range test.expectedWarningReasons {
+					assert.Contains(t, events[i], v1.EventTypeWarning+" "+reason)
+				}
 			}
 		})
 	}
@@ -9234,7 +9327,7 @@ func TestEnsurePIPTagged(t *testing.T) {
 	service := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				consts.ServiceAnnotationAzurePIPTags: "A=b,c=d,e=,=f,ghi",
+				consts.ServiceAnnotationAzurePIPTags: "A=b,c=d,e=,=f,ghi,k8s-azure-service-suffix=b,prefix-k8s-azure-service=b",
 			},
 		},
 	}
@@ -9252,15 +9345,17 @@ func TestEnsurePIPTagged(t *testing.T) {
 	t.Run("ensurePIPTagged should ensure the pip is tagged as configured", func(t *testing.T) {
 		expectedPIP := armnetwork.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey:     ptr.To("testCluster"),
-				consts.ServiceTagKey:      ptr.To("default/svc1,default/svc2"),
-				consts.ServiceUsingDNSKey: ptr.To("default/svc1"),
-				"foo":                     ptr.To("bar"),
-				"a":                       ptr.To("b"),
-				"c":                       ptr.To("d"),
-				"y":                       ptr.To("z"),
-				"m":                       ptr.To("n"),
-				"e":                       ptr.To(""),
+				consts.ClusterNameKey:      ptr.To("testCluster"),
+				consts.ServiceTagKey:       ptr.To("default/svc1,default/svc2"),
+				consts.ServiceUsingDNSKey:  ptr.To("default/svc1"),
+				"foo":                      ptr.To("bar"),
+				"a":                        ptr.To("b"),
+				"c":                        ptr.To("d"),
+				"y":                        ptr.To("z"),
+				"m":                        ptr.To("n"),
+				"e":                        ptr.To(""),
+				"k8s-azure-service-suffix": ptr.To("b"),
+				"prefix-k8s-azure-service": ptr.To("b"),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -9272,14 +9367,16 @@ func TestEnsurePIPTagged(t *testing.T) {
 		cloud.SystemTags = "a,foo"
 		expectedPIP := armnetwork.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey:     ptr.To("testCluster"),
-				consts.ServiceTagKey:      ptr.To("default/svc1,default/svc2"),
-				consts.ServiceUsingDNSKey: ptr.To("default/svc1"),
-				"foo":                     ptr.To("bar"),
-				"a":                       ptr.To("b"),
-				"c":                       ptr.To("d"),
-				"y":                       ptr.To("z"),
-				"e":                       ptr.To(""),
+				consts.ClusterNameKey:      ptr.To("testCluster"),
+				consts.ServiceTagKey:       ptr.To("default/svc1,default/svc2"),
+				consts.ServiceUsingDNSKey:  ptr.To("default/svc1"),
+				"foo":                      ptr.To("bar"),
+				"a":                        ptr.To("b"),
+				"c":                        ptr.To("d"),
+				"y":                        ptr.To("z"),
+				"e":                        ptr.To(""),
+				"k8s-azure-service-suffix": ptr.To("b"),
+				"prefix-k8s-azure-service": ptr.To("b"),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
@@ -9292,20 +9389,94 @@ func TestEnsurePIPTagged(t *testing.T) {
 		cloud.TagsMap = map[string]string{"a": "c", "a=b": "c=d", "Y": "zz"}
 		expectedPIP := armnetwork.PublicIPAddress{
 			Tags: map[string]*string{
-				consts.ClusterNameKey:     ptr.To("testCluster"),
-				consts.ServiceTagKey:      ptr.To("default/svc1,default/svc2"),
-				consts.ServiceUsingDNSKey: ptr.To("default/svc1"),
-				"foo":                     ptr.To("bar"),
-				"a":                       ptr.To("b"),
-				"c":                       ptr.To("d"),
-				"a=b":                     ptr.To("c=d"),
-				"e":                       ptr.To(""),
+				consts.ClusterNameKey:      ptr.To("testCluster"),
+				consts.ServiceTagKey:       ptr.To("default/svc1,default/svc2"),
+				consts.ServiceUsingDNSKey:  ptr.To("default/svc1"),
+				"foo":                      ptr.To("bar"),
+				"a":                        ptr.To("b"),
+				"c":                        ptr.To("d"),
+				"a=b":                      ptr.To("c=d"),
+				"e":                        ptr.To(""),
+				"k8s-azure-service-suffix": ptr.To("b"),
+				"prefix-k8s-azure-service": ptr.To("b"),
 			},
 		}
 		changed := cloud.ensurePIPTagged(&service, &pip)
 		assert.True(t, changed)
 		assert.Equal(t, expectedPIP, pip)
 	})
+}
+
+func TestEnsurePIPTaggedShouldIgnoreReservedTagKeysFromAnnotation(t *testing.T) {
+	const (
+		existingValue   = "existing-value"
+		annotationValue = "annotation-value"
+	)
+
+	// Tag keys whose values the controller owns.
+	reservedKeys := []string{
+		consts.ClusterNameKey,
+		consts.LegacyClusterNameKey,
+		consts.ServiceTagKey,
+		consts.LegacyServiceTagKey,
+		consts.ServiceUsingDNSKey,
+		consts.LegacyServiceUsingDNSKey,
+	}
+
+	newService := func(annotationKey string) v1.Service {
+		return v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					consts.ServiceAnnotationAzurePIPTags: annotationKey + "=" + annotationValue,
+				},
+			},
+		}
+	}
+
+	for _, reservedKey := range reservedKeys {
+		// Azure resource tag names are case-insensitive, so any spelling must be treated as reserved.
+		for _, annotationKey := range []string{reservedKey, strings.ToUpper(reservedKey)} {
+			t.Run(fmt.Sprintf("annotation key %s, tag already set on the PIP", annotationKey), func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+
+				cloud := GetTestCloud(ctrl)
+				service := newService(annotationKey)
+				pip := armnetwork.PublicIPAddress{
+					Tags: map[string]*string{
+						reservedKey: ptr.To(existingValue),
+						"foo":       ptr.To("bar"),
+					},
+				}
+
+				cloud.ensurePIPTagged(&service, &pip)
+
+				assert.Equal(t, existingValue, ptr.Deref(pip.Tags[reservedKey], ""),
+					"the controller-owned value must be preserved")
+				for k, v := range pip.Tags {
+					assert.NotEqual(t, annotationValue, ptr.Deref(v, ""),
+						"tag key %q must not carry a value supplied by the annotation", k)
+				}
+			})
+
+			t.Run(fmt.Sprintf("annotation key %s, tag not set on the PIP", annotationKey), func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+
+				cloud := GetTestCloud(ctrl)
+				service := newService(annotationKey)
+				pip := armnetwork.PublicIPAddress{
+					Tags: map[string]*string{"foo": ptr.To("bar")},
+				}
+
+				changed := cloud.ensurePIPTagged(&service, &pip)
+
+				assert.False(t, changed)
+				assert.Equal(t, map[string]*string{"foo": ptr.To("bar")}, pip.Tags,
+					"the annotation must not change the PIP tags")
+			})
+		}
+	}
 }
 
 func TestEnsurePIPIPTagged(t *testing.T) {

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -487,6 +487,109 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 		testPIPTagAnnotationWithTags(cs, tc, ns, serviceName, labels, ports, expectedTags)
 	})
 
+	DescribeTable("should ignore controller-owned tag keys in service annotation `service.beta.kubernetes.io/azure-pip-tags`",
+		func(setOnCreate bool) {
+			const sentinel = "annotation-value"
+			// Alternating case, because Azure resource tag names are case-insensitive.
+			reservedPairs := strings.Join([]string{
+				consts.ClusterNameKey + "=" + sentinel,
+				strings.ToUpper(consts.LegacyClusterNameKey) + "=" + sentinel,
+				consts.ServiceTagKey + "=" + sentinel,
+				strings.ToUpper(consts.LegacyServiceTagKey) + "=" + sentinel,
+				consts.ServiceUsingDNSKey + "=" + sentinel,
+				strings.ToUpper(consts.LegacyServiceUsingDNSKey) + "=" + sentinel,
+			}, ",")
+
+			// The controller does not own this key, so it proves the annotation was applied at all.
+			expectedTagValue := "b"
+			tagsAnnotation := "a=" + expectedTagValue
+			if setOnCreate {
+				tagsAnnotation += "," + reservedPairs
+			}
+
+			since := time.Now()
+			By("Creating a service with the pip tags annotation")
+			annotation := map[string]string{consts.ServiceAnnotationAzurePIPTags: tagsAnnotation}
+			service := utils.CreateLoadBalancerServiceManifest(serviceName, annotation, labels, ns.Name, ports)
+			_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			defer func() {
+				By("Cleaning up test service")
+				err := utils.DeleteService(cs, ns.Name, serviceName)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			By("Waiting for the service to expose")
+			ips, err := utils.WaitServiceExposureAndValidateConnectivity(cs, tc.IPFamily, ns.Name, serviceName, []*string{})
+			Expect(err).NotTo(HaveOccurred())
+
+			pips, err := tc.ListPublicIPs(tc.GetResourceGroup())
+			Expect(err).NotTo(HaveOccurred())
+			var targetPIPNames []string
+			for _, pip := range pips {
+				for _, ip := range ips {
+					if strings.EqualFold(ptr.Deref(pip.Properties.IPAddress, ""), ptr.Deref(ip, "")) {
+						targetPIPNames = append(targetPIPNames, ptr.Deref(pip.Name, ""))
+						break
+					}
+				}
+			}
+			Expect(targetPIPNames).NotTo(BeEmpty())
+
+			if !setOnCreate {
+				By("Adding the controller-owned tag keys to the annotation of the running service")
+				since = time.Now()
+				expectedTagValue = "c"
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					service, err := cs.CoreV1().Services(ns.Name).Get(context.TODO(), serviceName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					service.Annotations[consts.ServiceAnnotationAzurePIPTags] = "a=" + expectedTagValue + "," + reservedPairs
+					_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+					return err
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Wait for the new annotation to land, otherwise the checks below pass before it is applied.
+				By("Waiting for the updated annotation to be applied")
+				err = wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
+					for _, pipName := range targetPIPNames {
+						pip, err := utils.WaitGetPIP(tc, pipName)
+						if err != nil {
+							return false, err
+						}
+						if ptr.Deref(pip.Tags["a"], "") != expectedTagValue {
+							return false, nil
+						}
+					}
+					return true, nil
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("Checking the tags on the corresponding public IP")
+			for _, pipName := range targetPIPNames {
+				pip, err := utils.WaitGetPIP(tc, pipName)
+				Expect(err).NotTo(HaveOccurred())
+
+				for k, v := range pip.Tags {
+					Expect(ptr.Deref(v, "")).NotTo(Equal(sentinel), "tag %q carries a value supplied by the annotation", k)
+				}
+				Expect(ptr.Deref(pip.Tags[consts.ServiceTagKey], "")).To(Equal(ns.Name + "/" + serviceName))
+				Expect(ptr.Deref(pip.Tags["a"], "")).To(Equal(expectedTagValue))
+			}
+
+			By("Checking the warning event on the service")
+			err = utils.WaitForServiceEventAfter(cs, ns.Name, serviceName, v1.EventTypeWarning,
+				"IgnoredPIPTagKeys", consts.ServiceAnnotationAzurePIPTags, since)
+			Expect(err).NotTo(HaveOccurred())
+		},
+		Entry("when set at service creation", true),
+		Entry("when added to a running service", false),
+	)
+
 	It("should support service annotation `service.beta.kubernetes.io/azure-pip-name`", func() {
 		By("Creating two test pips or more if DualStack")
 		v4Enabled, v6Enabled := utils.IfIPFamiliesEnabled(tc.IPFamily)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The `service.beta.kubernetes.io/azure-pip-tags` annotation was applied to the Public IP without filtering, so it could set the tag keys the controller owns (`k8s-azure-cluster-name`, `k8s-azure-service`, `k8s-azure-dns-label-service`, and their legacy spellings).

`ensurePIPTagged` now skips those keys when merging the annotation and emits a `Warning` event with reason `IgnoredPIPTagKeys` on the Service. Matching is case-insensitive because [Azure resource tag names are case-insensitive](https://learn.microsoft.com/azure/azure-resource-manager/management/tag-resources).
All other annotation keys behave as before.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `service.beta.kubernetes.io/azure-pip-tags` annotation no longer sets the Public IP tag keys managed by the controller (`k8s-azure-cluster-name`, `k8s-azure-service`, `k8s-azure-dns-label-service`, and their legacy names). Such keys in the annotation are now ignored, in any letter case, and a `Warning` event with reason `IgnoredPIPTagKeys` is emitted on the Service.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
