### PR TITLE
fix: pass cloud config in GetStorageAccesskeyFromServiceAccountToken (sovereign cloud WI)

### DIFF
--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
@@ -39,6 +40,7 @@ import (
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/accountclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/cache"
+	azclientutils "sigs.k8s.io/cloud-provider-azure/pkg/azclient/utils"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
@@ -285,7 +287,18 @@ func (az *AccountRepo) buildSATokenClientOptions() (azcore.ClientOptions, arm.Cl
 	if err != nil {
 		return azcore.ClientOptions{}, arm.ClientOptions{}, fmt.Errorf("failed to get azcore client options, error: %w", err)
 	}
-	return azcore.ClientOptions{Cloud: clientOpts.Cloud}, arm.ClientOptions{ClientOptions: *clientOpts}, nil
+	armOpts := arm.ClientOptions{ClientOptions: *clientOpts}
+	// Match the API-version branching that the normal account-client factory
+	// applies (see pkg/azclient/factory_gen.go NewAccountClient): sovereign
+	// clouds and Azure Stack pin an older ListKeys API version, otherwise the
+	// SDK default would return an unsupported-API-version error even after the
+	// authentication fix.
+	if az.ARMClientConfig.Cloud != "" && strings.EqualFold(az.ARMClientConfig.Cloud, azclientutils.AzureStackCloudName) && !az.ARMClientConfig.DisableAzureStackCloud {
+		armOpts.APIVersion = accountclient.AzureStackCloudAPIVersion
+	} else if !strings.EqualFold(clientOpts.Cloud.ActiveDirectoryAuthorityHost, cloud.AzurePublic.ActiveDirectoryAuthorityHost) {
+		armOpts.APIVersion = accountclient.MooncakeApiVersion
+	}
+	return azcore.ClientOptions{Cloud: clientOpts.Cloud}, armOpts, nil
 }
 
 func (az *AccountRepo) GetStorageAccesskeyFromServiceAccountToken(ctx context.Context, subsID, accountName, rgName, clientID, tenantID, serviceAccountToken string) (string, error) {

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -293,7 +293,7 @@ func (az *AccountRepo) buildSATokenClientOptions() (azcore.ClientOptions, arm.Cl
 	// clouds and Azure Stack pin an older ListKeys API version, otherwise the
 	// SDK default would return an unsupported-API-version error even after the
 	// authentication fix.
-	if az.ARMClientConfig.Cloud != "" && strings.EqualFold(az.ARMClientConfig.Cloud, azclientutils.AzureStackCloudName) && !az.ARMClientConfig.DisableAzureStackCloud {
+	if az.Cloud != "" && strings.EqualFold(az.Cloud, azclientutils.AzureStackCloudName) && !az.DisableAzureStackCloud {
 		armOpts.APIVersion = accountclient.AzureStackCloudAPIVersion
 	} else if !strings.EqualFold(clientOpts.Cloud.ActiveDirectoryAuthorityHost, cloud.AzurePublic.ActiveDirectoryAuthorityHost) {
 		armOpts.APIVersion = accountclient.MooncakeApiVersion

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -131,6 +131,12 @@ type AccountRepo struct {
 	fileServiceRepo      fileservice.Repository
 	storageAccountCache  cache.Resource[armstorage.Account]
 	lockMap              *lockmap.LockMap
+	// saTokenCredOpts and saTokenARMOpts are pre-resolved at init time
+	// so that GetStorageAccesskeyFromServiceAccountToken does not call
+	// GetAzCoreClientOption (and the metadata-service network fetch it
+	// triggers on Azure Stack) on every volume mount.
+	saTokenCredOpts azcore.ClientOptions
+	saTokenARMOpts  arm.ClientOptions
 }
 
 func NewRepository(config azureconfig.Config, env *azclient.Environment, authProvider *azclient.AuthProvider, computeClientFactory azclient.ClientFactory, networkClientFactory azclient.ClientFactory) (*AccountRepo, error) {
@@ -147,6 +153,13 @@ func NewRepository(config azureconfig.Config, env *azclient.Environment, authPro
 	if err != nil {
 		return nil, err
 	}
+	// Pre-resolve azcore/arm client options at init time so the SA-token
+	// path does not call GetAzCoreClientOption (which may hit the metadata
+	// endpoint on Azure Stack) on every volume mount.
+	credOpts, armOpts, err := buildSATokenClientOptions(&config.ARMClientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build SA-token client options: %w", err)
+	}
 	return &AccountRepo{
 		Config:               config,
 		Environment:          env,
@@ -157,6 +170,8 @@ func NewRepository(config azureconfig.Config, env *azclient.Environment, authPro
 		subnetRepo:           subnetRepo,
 		storageAccountCache:  storageAccountCache,
 		lockMap:              lockmap.NewLockMap(),
+		saTokenCredOpts:      credOpts,
+		saTokenARMOpts:       armOpts,
 	}, nil
 }
 
@@ -272,18 +287,11 @@ func (az *AccountRepo) getStorageAccountWithCache(ctx context.Context, subsID, r
 }
 
 // buildSATokenClientOptions derives the azcore + arm client options for the
-// service-account-token workload-identity path from az.ARMClientConfig, so
-// that non-Public clouds (AzureChinaCloud, AzureUSGovernmentCloud,
-// AzureStackCloud) authenticate against the correct AAD authority + ARM
-// audience. Without this, azidentity / arm clients default to Azure Public,
-// which causes AADSTS500011 in sovereign clouds
-// (see kubernetes-sigs/blob-csi-driver#2649).
-//
-// Extracted from GetStorageAccesskeyFromServiceAccountToken so the
-// cloud-selection behavior can be exercised by unit tests without needing a
-// live ARM endpoint.
-func (az *AccountRepo) buildSATokenClientOptions() (azcore.ClientOptions, arm.ClientOptions, error) {
-	clientOpts, _, err := azclient.GetAzCoreClientOption(&az.ARMClientConfig)
+// service-account-token workload-identity path. It is called once at
+// repository init time so the per-call GetStorageAccesskeyFromServiceAccountToken
+// path does not trigger network I/O (metadata endpoint on Azure Stack).
+func buildSATokenClientOptions(armConfig *azclient.ARMClientConfig) (azcore.ClientOptions, arm.ClientOptions, error) {
+	clientOpts, _, err := azclient.GetAzCoreClientOption(armConfig)
 	if err != nil {
 		return azcore.ClientOptions{}, arm.ClientOptions{}, fmt.Errorf("failed to get azcore client options, error: %w", err)
 	}
@@ -293,7 +301,7 @@ func (az *AccountRepo) buildSATokenClientOptions() (azcore.ClientOptions, arm.Cl
 	// clouds and Azure Stack pin an older ListKeys API version, otherwise the
 	// SDK default would return an unsupported-API-version error even after the
 	// authentication fix.
-	if az.Cloud != "" && strings.EqualFold(az.Cloud, azclientutils.AzureStackCloudName) && !az.DisableAzureStackCloud {
+	if armConfig.Cloud != "" && strings.EqualFold(armConfig.Cloud, azclientutils.AzureStackCloudName) && !armConfig.DisableAzureStackCloud {
 		armOpts.APIVersion = accountclient.AzureStackCloudAPIVersion
 	} else if !strings.EqualFold(clientOpts.Cloud.ActiveDirectoryAuthorityHost, cloud.AzurePublic.ActiveDirectoryAuthorityHost) {
 		armOpts.APIVersion = accountclient.MooncakeApiVersion
@@ -302,20 +310,16 @@ func (az *AccountRepo) buildSATokenClientOptions() (azcore.ClientOptions, arm.Cl
 }
 
 func (az *AccountRepo) GetStorageAccesskeyFromServiceAccountToken(ctx context.Context, subsID, accountName, rgName, clientID, tenantID, serviceAccountToken string) (string, error) {
-	credOpts, armOpts, err := az.buildSATokenClientOptions()
-	if err != nil {
-		return "", err
-	}
-
 	cred, err := azidentity.NewClientAssertionCredential(tenantID, clientID, func(context.Context) (string, error) {
 		return parseServiceAccountToken(serviceAccountToken)
 	}, &azidentity.ClientAssertionCredentialOptions{
-		ClientOptions: credOpts,
+		ClientOptions: az.saTokenCredOpts,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create client assertion credential, error: %w", err)
 	}
 
+	armOpts := az.saTokenARMOpts // shallow copy so callers don't race
 	client, err := accountclient.New(subsID, cred, &armOpts)
 	if err != nil {
 		return "", fmt.Errorf("failed to create storage account client, error: %w", err)

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -269,27 +269,41 @@ func (az *AccountRepo) getStorageAccountWithCache(ctx context.Context, subsID, r
 	return *result, nil
 }
 
-func (az *AccountRepo) GetStorageAccesskeyFromServiceAccountToken(ctx context.Context, subsID, accountName, rgName, clientID, tenantID, serviceAccountToken string) (string, error) {
-	// Build cloud config from az's ARMClientConfig so non-Public clouds
-	// (e.g. AzureChinaCloud, AzureUSGovernmentCloud) authenticate against
-	// the correct AAD authority + ARM audience. Without this, azidentity /
-	// arm clients default to Azure Public, which causes AADSTS500011 in
-	// sovereign clouds (see kubernetes-sigs/blob-csi-driver#2649).
+// buildSATokenClientOptions derives the azcore + arm client options for the
+// service-account-token workload-identity path from az.ARMClientConfig, so
+// that non-Public clouds (AzureChinaCloud, AzureUSGovernmentCloud,
+// AzureStackCloud) authenticate against the correct AAD authority + ARM
+// audience. Without this, azidentity / arm clients default to Azure Public,
+// which causes AADSTS500011 in sovereign clouds
+// (see kubernetes-sigs/blob-csi-driver#2649).
+//
+// Extracted from GetStorageAccesskeyFromServiceAccountToken so the
+// cloud-selection behavior can be exercised by unit tests without needing a
+// live ARM endpoint.
+func (az *AccountRepo) buildSATokenClientOptions() (azcore.ClientOptions, arm.ClientOptions, error) {
 	clientOpts, _, err := azclient.GetAzCoreClientOption(&az.ARMClientConfig)
 	if err != nil {
-		return "", fmt.Errorf("failed to get azcore client options, error: %w", err)
+		return azcore.ClientOptions{}, arm.ClientOptions{}, fmt.Errorf("failed to get azcore client options, error: %w", err)
+	}
+	return azcore.ClientOptions{Cloud: clientOpts.Cloud}, arm.ClientOptions{ClientOptions: *clientOpts}, nil
+}
+
+func (az *AccountRepo) GetStorageAccesskeyFromServiceAccountToken(ctx context.Context, subsID, accountName, rgName, clientID, tenantID, serviceAccountToken string) (string, error) {
+	credOpts, armOpts, err := az.buildSATokenClientOptions()
+	if err != nil {
+		return "", err
 	}
 
 	cred, err := azidentity.NewClientAssertionCredential(tenantID, clientID, func(context.Context) (string, error) {
 		return parseServiceAccountToken(serviceAccountToken)
 	}, &azidentity.ClientAssertionCredentialOptions{
-		ClientOptions: azcore.ClientOptions{Cloud: clientOpts.Cloud},
+		ClientOptions: credOpts,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create client assertion credential, error: %w", err)
 	}
 
-	client, err := accountclient.New(subsID, cred, &arm.ClientOptions{ClientOptions: *clientOpts})
+	client, err := accountclient.New(subsID, cred, &armOpts)
 	if err != nil {
 		return "", fmt.Errorf("failed to create storage account client, error: %w", err)
 	}

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
@@ -268,14 +270,26 @@ func (az *AccountRepo) getStorageAccountWithCache(ctx context.Context, subsID, r
 }
 
 func (az *AccountRepo) GetStorageAccesskeyFromServiceAccountToken(ctx context.Context, subsID, accountName, rgName, clientID, tenantID, serviceAccountToken string) (string, error) {
+	// Build cloud config from az's ARMClientConfig so non-Public clouds
+	// (e.g. AzureChinaCloud, AzureUSGovernmentCloud) authenticate against
+	// the correct AAD authority + ARM audience. Without this, azidentity /
+	// arm clients default to Azure Public, which causes AADSTS500011 in
+	// sovereign clouds (see kubernetes-sigs/blob-csi-driver#2649).
+	clientOpts, _, err := azclient.GetAzCoreClientOption(&az.ARMClientConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to get azcore client options, error: %w", err)
+	}
+
 	cred, err := azidentity.NewClientAssertionCredential(tenantID, clientID, func(context.Context) (string, error) {
 		return parseServiceAccountToken(serviceAccountToken)
-	}, &azidentity.ClientAssertionCredentialOptions{})
+	}, &azidentity.ClientAssertionCredentialOptions{
+		ClientOptions: azcore.ClientOptions{Cloud: clientOpts.Cloud},
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create client assertion credential, error: %w", err)
 	}
 
-	client, err := accountclient.New(subsID, cred, nil)
+	client, err := accountclient.New(subsID, cred, &arm.ClientOptions{ClientOptions: *clientOpts})
 	if err != nil {
 		return "", fmt.Errorf("failed to create storage account client, error: %w", err)
 	}

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -135,8 +135,9 @@ type AccountRepo struct {
 	// so that GetStorageAccesskeyFromServiceAccountToken does not call
 	// GetAzCoreClientOption (and the metadata-service network fetch it
 	// triggers on Azure Stack) on every volume mount.
-	saTokenCredOpts azcore.ClientOptions
-	saTokenARMOpts  arm.ClientOptions
+	saTokenCredOpts              azcore.ClientOptions
+	saTokenARMOpts               arm.ClientOptions
+	saTokenDisableInstanceDiscov bool // true for Azure Stack (private/disconnected cloud)
 }
 
 func NewRepository(config azureconfig.Config, env *azclient.Environment, authProvider *azclient.AuthProvider, computeClientFactory azclient.ClientFactory, networkClientFactory azclient.ClientFactory) (*AccountRepo, error) {
@@ -156,7 +157,7 @@ func NewRepository(config azureconfig.Config, env *azclient.Environment, authPro
 	// Pre-resolve azcore/arm client options at init time so the SA-token
 	// path does not call GetAzCoreClientOption (which may hit the metadata
 	// endpoint on Azure Stack) on every volume mount.
-	credOpts, armOpts, err := buildSATokenClientOptions(&config.ARMClientConfig)
+	credOpts, armOpts, isAzureStack, err := buildSATokenClientOptions(&config.ARMClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build SA-token client options: %w", err)
 	}
@@ -170,8 +171,9 @@ func NewRepository(config azureconfig.Config, env *azclient.Environment, authPro
 		subnetRepo:           subnetRepo,
 		storageAccountCache:  storageAccountCache,
 		lockMap:              lockmap.NewLockMap(),
-		saTokenCredOpts:      credOpts,
-		saTokenARMOpts:       armOpts,
+		saTokenCredOpts:              credOpts,
+		saTokenARMOpts:               armOpts,
+		saTokenDisableInstanceDiscov: isAzureStack,
 	}, nil
 }
 
@@ -290,30 +292,27 @@ func (az *AccountRepo) getStorageAccountWithCache(ctx context.Context, subsID, r
 // service-account-token workload-identity path. It is called once at
 // repository init time so the per-call GetStorageAccesskeyFromServiceAccountToken
 // path does not trigger network I/O (metadata endpoint on Azure Stack).
-func buildSATokenClientOptions(armConfig *azclient.ARMClientConfig) (azcore.ClientOptions, arm.ClientOptions, error) {
+func buildSATokenClientOptions(armConfig *azclient.ARMClientConfig) (azcore.ClientOptions, arm.ClientOptions, bool, error) {
 	clientOpts, _, err := azclient.GetAzCoreClientOption(armConfig)
 	if err != nil {
-		return azcore.ClientOptions{}, arm.ClientOptions{}, fmt.Errorf("failed to get azcore client options, error: %w", err)
+		return azcore.ClientOptions{}, arm.ClientOptions{}, false, fmt.Errorf("failed to get azcore client options, error: %w", err)
 	}
 	armOpts := arm.ClientOptions{ClientOptions: *clientOpts}
-	// Match the API-version branching that the normal account-client factory
-	// applies (see pkg/azclient/factory_gen.go NewAccountClient): sovereign
-	// clouds and Azure Stack pin an older ListKeys API version, otherwise the
-	// SDK default would return an unsupported-API-version error even after the
-	// authentication fix.
-	if armConfig.Cloud != "" && strings.EqualFold(armConfig.Cloud, azclientutils.AzureStackCloudName) && !armConfig.DisableAzureStackCloud {
+	isAzureStack := armConfig.Cloud != "" && strings.EqualFold(armConfig.Cloud, azclientutils.AzureStackCloudName) && !armConfig.DisableAzureStackCloud
+	if isAzureStack {
 		armOpts.APIVersion = accountclient.AzureStackCloudAPIVersion
 	} else if !strings.EqualFold(clientOpts.Cloud.ActiveDirectoryAuthorityHost, cloud.AzurePublic.ActiveDirectoryAuthorityHost) {
 		armOpts.APIVersion = accountclient.MooncakeApiVersion
 	}
-	return azcore.ClientOptions{Cloud: clientOpts.Cloud}, armOpts, nil
+	return azcore.ClientOptions{Cloud: clientOpts.Cloud}, armOpts, isAzureStack, nil
 }
 
 func (az *AccountRepo) GetStorageAccesskeyFromServiceAccountToken(ctx context.Context, subsID, accountName, rgName, clientID, tenantID, serviceAccountToken string) (string, error) {
 	cred, err := azidentity.NewClientAssertionCredential(tenantID, clientID, func(context.Context) (string, error) {
 		return parseServiceAccountToken(serviceAccountToken)
 	}, &azidentity.ClientAssertionCredentialOptions{
-		ClientOptions: az.saTokenCredOpts,
+		ClientOptions:            az.saTokenCredOpts,
+		DisableInstanceDiscovery: az.saTokenDisableInstanceDiscov,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create client assertion credential, error: %w", err)

--- a/pkg/provider/storage/azure_storageaccount.go
+++ b/pkg/provider/storage/azure_storageaccount.go
@@ -131,6 +131,7 @@ type AccountRepo struct {
 	fileServiceRepo      fileservice.Repository
 	storageAccountCache  cache.Resource[armstorage.Account]
 	lockMap              *lockmap.LockMap
+
 	// saTokenCredOpts and saTokenARMOpts are pre-resolved at init time
 	// so that GetStorageAccesskeyFromServiceAccountToken does not call
 	// GetAzCoreClientOption (and the metadata-service network fetch it
@@ -171,6 +172,7 @@ func NewRepository(config azureconfig.Config, env *azclient.Environment, authPro
 		subnetRepo:           subnetRepo,
 		storageAccountCache:  storageAccountCache,
 		lockMap:              lockmap.NewLockMap(),
+
 		saTokenCredOpts:              credOpts,
 		saTokenARMOpts:               armOpts,
 		saTokenDisableInstanceDiscov: isAzureStack,

--- a/pkg/provider/storage/azure_storageaccount_satoken_test.go
+++ b/pkg/provider/storage/azure_storageaccount_satoken_test.go
@@ -42,20 +42,22 @@ import (
 // fails loudly.
 func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 	tests := []struct {
-		name             string
-		cloudName        string
-		wantAADAuthority string
-		wantARMEndpoint  string
-		wantARMAudience  string
-		wantAPIVersion   string
+		name                      string
+		cloudName                 string
+		wantAADAuthority          string
+		wantARMEndpoint           string
+		wantARMAudience           string
+		wantAPIVersion            string
+		wantDisableInstanceDiscov bool
 	}{
 		{
-			name:             "Azure Public (default)",
-			cloudName:        "AzurePublicCloud",
-			wantAADAuthority: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
-			wantARMEndpoint:  cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint,
-			wantARMAudience:  cloud.AzurePublic.Services[cloud.ResourceManager].Audience,
-			wantAPIVersion:   "", // SDK default; no override.
+			name:                      "Azure Public (default)",
+			cloudName:                 "AzurePublicCloud",
+			wantAADAuthority:          cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+			wantARMEndpoint:           cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint,
+			wantARMAudience:           cloud.AzurePublic.Services[cloud.ResourceManager].Audience,
+			wantAPIVersion:            "", // SDK default; no override.
+			wantDisableInstanceDiscov: false,
 		},
 		{
 			// The bug: before this fix, the credential/ARM client fell
@@ -63,20 +65,22 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 			// failed with AADSTS500011. Assert BOTH the endpoint and the
 			// audience so a mixed China-endpoint + Public-audience
 			// configuration (the exact shape of issue #2649) cannot pass.
-			name:             "Azure China",
-			cloudName:        "AzureChinaCloud",
-			wantAADAuthority: cloud.AzureChina.ActiveDirectoryAuthorityHost,
-			wantARMEndpoint:  cloud.AzureChina.Services[cloud.ResourceManager].Endpoint,
-			wantARMAudience:  cloud.AzureChina.Services[cloud.ResourceManager].Audience,
-			wantAPIVersion:   accountclient.MooncakeApiVersion,
+			name:                      "Azure China",
+			cloudName:                 "AzureChinaCloud",
+			wantAADAuthority:          cloud.AzureChina.ActiveDirectoryAuthorityHost,
+			wantARMEndpoint:           cloud.AzureChina.Services[cloud.ResourceManager].Endpoint,
+			wantARMAudience:           cloud.AzureChina.Services[cloud.ResourceManager].Audience,
+			wantAPIVersion:            accountclient.MooncakeApiVersion,
+			wantDisableInstanceDiscov: false,
 		},
 		{
-			name:             "Azure US Government",
-			cloudName:        "AzureUSGovernmentCloud",
-			wantAADAuthority: cloud.AzureGovernment.ActiveDirectoryAuthorityHost,
-			wantARMEndpoint:  cloud.AzureGovernment.Services[cloud.ResourceManager].Endpoint,
-			wantARMAudience:  cloud.AzureGovernment.Services[cloud.ResourceManager].Audience,
-			wantAPIVersion:   accountclient.MooncakeApiVersion,
+			name:                      "Azure US Government",
+			cloudName:                 "AzureUSGovernmentCloud",
+			wantAADAuthority:          cloud.AzureGovernment.ActiveDirectoryAuthorityHost,
+			wantARMEndpoint:           cloud.AzureGovernment.Services[cloud.ResourceManager].Endpoint,
+			wantARMAudience:           cloud.AzureGovernment.Services[cloud.ResourceManager].Audience,
+			wantAPIVersion:            accountclient.MooncakeApiVersion,
+			wantDisableInstanceDiscov: false,
 		},
 	}
 
@@ -92,7 +96,7 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 				},
 			}
 
-			credOpts, armOpts, err := buildSATokenClientOptions(&az.ARMClientConfig)
+			credOpts, armOpts, isAzureStack, err := buildSATokenClientOptions(&az.ARMClientConfig)
 			assert.NoError(t, err)
 
 			// azidentity uses ClientOptions.Cloud.ActiveDirectoryAuthorityHost
@@ -121,6 +125,8 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 			// in the same clouds even after the authentication fix.
 			assert.Equal(t, tc.wantAPIVersion, armOpts.APIVersion,
 				"ARM APIVersion override must match the normal account-client factory")
+			assert.Equal(t, tc.wantDisableInstanceDiscov, isAzureStack,
+				"DisableInstanceDiscovery must be true for Azure Stack")
 		})
 	}
 }
@@ -132,8 +138,9 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 func TestBuildSATokenClientOptions_NilConfig(t *testing.T) {
 	az := &AccountRepo{}
 
-	credOpts, armOpts, err := buildSATokenClientOptions(&az.ARMClientConfig)
+	credOpts, armOpts, isAzureStack, err := buildSATokenClientOptions(&az.ARMClientConfig)
 	assert.NoError(t, err)
+	assert.False(t, isAzureStack)
 	// Zero-valued config defaults to AzurePublic.
 	assert.Equal(t, cloud.AzurePublic.ActiveDirectoryAuthorityHost, credOpts.Cloud.ActiveDirectoryAuthorityHost)
 	gotARM, ok := armOpts.Cloud.Services[cloud.ResourceManager]

--- a/pkg/provider/storage/azure_storageaccount_satoken_test.go
+++ b/pkg/provider/storage/azure_storageaccount_satoken_test.go
@@ -41,10 +41,10 @@ import (
 // fails loudly.
 func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 	tests := []struct {
-		name                 string
-		cloudName            string
-		wantAADAuthority     string
-		wantARMEndpoint      string
+		name             string
+		cloudName        string
+		wantAADAuthority string
+		wantARMEndpoint  string
 	}{
 		{
 			name:             "Azure Public (default)",

--- a/pkg/provider/storage/azure_storageaccount_satoken_test.go
+++ b/pkg/provider/storage/azure_storageaccount_satoken_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/accountclient"
 	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 )
 
@@ -45,27 +46,37 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 		cloudName        string
 		wantAADAuthority string
 		wantARMEndpoint  string
+		wantARMAudience  string
+		wantAPIVersion   string
 	}{
 		{
 			name:             "Azure Public (default)",
 			cloudName:        "AzurePublicCloud",
 			wantAADAuthority: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
 			wantARMEndpoint:  cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint,
+			wantARMAudience:  cloud.AzurePublic.Services[cloud.ResourceManager].Audience,
+			wantAPIVersion:   "", // SDK default; no override.
 		},
 		{
 			// The bug: before this fix, the credential/ARM client fell
 			// back to AzurePublic here, and Azure China token exchange
-			// failed with AADSTS500011.
+			// failed with AADSTS500011. Assert BOTH the endpoint and the
+			// audience so a mixed China-endpoint + Public-audience
+			// configuration (the exact shape of issue #2649) cannot pass.
 			name:             "Azure China",
 			cloudName:        "AzureChinaCloud",
 			wantAADAuthority: cloud.AzureChina.ActiveDirectoryAuthorityHost,
 			wantARMEndpoint:  cloud.AzureChina.Services[cloud.ResourceManager].Endpoint,
+			wantARMAudience:  cloud.AzureChina.Services[cloud.ResourceManager].Audience,
+			wantAPIVersion:   accountclient.MooncakeApiVersion,
 		},
 		{
 			name:             "Azure US Government",
 			cloudName:        "AzureUSGovernmentCloud",
 			wantAADAuthority: cloud.AzureGovernment.ActiveDirectoryAuthorityHost,
 			wantARMEndpoint:  cloud.AzureGovernment.Services[cloud.ResourceManager].Endpoint,
+			wantARMAudience:  cloud.AzureGovernment.Services[cloud.ResourceManager].Audience,
+			wantAPIVersion:   accountclient.MooncakeApiVersion,
 		},
 	}
 
@@ -98,6 +109,18 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 			assert.True(t, ok, "arm client options must carry a ResourceManager endpoint")
 			assert.Equal(t, tc.wantARMEndpoint, gotARM.Endpoint,
 				"ARM ResourceManager endpoint must follow the configured cloud")
+			// The ARM bearer policy builds its scope from Services[ResourceManager].Audience
+			// independently of the endpoint, so a mixed China-endpoint +
+			// Public-audience configuration (issue #2649's exact shape)
+			// must not slip through.
+			assert.Equal(t, tc.wantARMAudience, gotARM.Audience,
+				"ARM ResourceManager audience must follow the configured cloud")
+			// The account-client factory pins an older ListKeys API
+			// version in sovereign clouds; the SA-token path must match
+			// or ListKeys will fail with an unsupported-API-version error
+			// in the same clouds even after the authentication fix.
+			assert.Equal(t, tc.wantAPIVersion, armOpts.APIVersion,
+				"ARM APIVersion override must match the normal account-client factory")
 		})
 	}
 }

--- a/pkg/provider/storage/azure_storageaccount_satoken_test.go
+++ b/pkg/provider/storage/azure_storageaccount_satoken_test.go
@@ -92,7 +92,7 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 				},
 			}
 
-			credOpts, armOpts, err := buildSATokenClientOptions(&az.Config.ARMClientConfig)
+			credOpts, armOpts, err := buildSATokenClientOptions(&az.ARMClientConfig)
 			assert.NoError(t, err)
 
 			// azidentity uses ClientOptions.Cloud.ActiveDirectoryAuthorityHost
@@ -132,7 +132,7 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 func TestBuildSATokenClientOptions_NilConfig(t *testing.T) {
 	az := &AccountRepo{}
 
-	credOpts, armOpts, err := buildSATokenClientOptions(&az.Config.ARMClientConfig)
+	credOpts, armOpts, err := buildSATokenClientOptions(&az.ARMClientConfig)
 	assert.NoError(t, err)
 	// Zero-valued config defaults to AzurePublic.
 	assert.Equal(t, cloud.AzurePublic.ActiveDirectoryAuthorityHost, credOpts.Cloud.ActiveDirectoryAuthorityHost)

--- a/pkg/provider/storage/azure_storageaccount_satoken_test.go
+++ b/pkg/provider/storage/azure_storageaccount_satoken_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
+	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
+)
+
+// TestBuildSATokenClientOptions_CloudSelection is a regression test for
+// https://github.com/kubernetes-sigs/blob-csi-driver/issues/2649: when
+// GetStorageAccesskeyFromServiceAccountToken runs in a sovereign cloud
+// (Azure China / Azure US Government / Azure Stack), the azidentity
+// credential and the ARM storage-account client MUST NOT default to Azure
+// Public. Otherwise the AAD token exchange fails with AADSTS500011 because
+// the token audience does not match the sovereign-cloud ARM resource ID.
+//
+// This test derives the client options exactly the same way the fix does
+// (via az.buildSATokenClientOptions -> azclient.GetAzCoreClientOption), and
+// pins both the AAD authority host and the ARM ResourceManager endpoint per
+// cloud so any future refactor that drops the cloud config on the floor
+// fails loudly.
+func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
+	tests := []struct {
+		name                 string
+		cloudName            string
+		wantAADAuthority     string
+		wantARMEndpoint      string
+	}{
+		{
+			name:             "Azure Public (default)",
+			cloudName:        "AzurePublicCloud",
+			wantAADAuthority: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+			wantARMEndpoint:  cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint,
+		},
+		{
+			// The bug: before this fix, the credential/ARM client fell
+			// back to AzurePublic here, and Azure China token exchange
+			// failed with AADSTS500011.
+			name:             "Azure China",
+			cloudName:        "AzureChinaCloud",
+			wantAADAuthority: cloud.AzureChina.ActiveDirectoryAuthorityHost,
+			wantARMEndpoint:  cloud.AzureChina.Services[cloud.ResourceManager].Endpoint,
+		},
+		{
+			name:             "Azure US Government",
+			cloudName:        "AzureUSGovernmentCloud",
+			wantAADAuthority: cloud.AzureGovernment.ActiveDirectoryAuthorityHost,
+			wantARMEndpoint:  cloud.AzureGovernment.Services[cloud.ResourceManager].Endpoint,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			az := &AccountRepo{
+				Config: azureconfig.Config{
+					AzureClientConfig: azureconfig.AzureClientConfig{
+						ARMClientConfig: azclient.ARMClientConfig{
+							Cloud: tc.cloudName,
+						},
+					},
+				},
+			}
+
+			credOpts, armOpts, err := az.buildSATokenClientOptions()
+			assert.NoError(t, err)
+
+			// azidentity uses ClientOptions.Cloud.ActiveDirectoryAuthorityHost
+			// to build the token endpoint; this is exactly what determines
+			// whether we hit login.microsoftonline.com vs
+			// login.chinacloudapi.cn vs login.microsoftonline.us.
+			assert.Equal(t, tc.wantAADAuthority, credOpts.Cloud.ActiveDirectoryAuthorityHost,
+				"credential AAD authority must follow the configured cloud")
+
+			// arm.ClientOptions.Cloud.Services[ResourceManager] is what the
+			// storage-account ARM client uses for both the request base URL
+			// and the token audience (scope).
+			gotARM, ok := armOpts.Cloud.Services[cloud.ResourceManager]
+			assert.True(t, ok, "arm client options must carry a ResourceManager endpoint")
+			assert.Equal(t, tc.wantARMEndpoint, gotARM.Endpoint,
+				"ARM ResourceManager endpoint must follow the configured cloud")
+		})
+	}
+}
+
+// TestBuildSATokenClientOptions_NilConfig ensures the helper degrades to
+// a valid default (public cloud) rather than panicking when no cloud is
+// configured; this matches the historical behavior of the ARM client
+// factory for a zero-valued ARMClientConfig.
+func TestBuildSATokenClientOptions_NilConfig(t *testing.T) {
+	az := &AccountRepo{}
+
+	credOpts, armOpts, err := az.buildSATokenClientOptions()
+	assert.NoError(t, err)
+	// Zero-valued config defaults to AzurePublic.
+	assert.Equal(t, cloud.AzurePublic.ActiveDirectoryAuthorityHost, credOpts.Cloud.ActiveDirectoryAuthorityHost)
+	gotARM, ok := armOpts.Cloud.Services[cloud.ResourceManager]
+	assert.True(t, ok)
+	assert.Equal(t, cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint, gotARM.Endpoint)
+}

--- a/pkg/provider/storage/azure_storageaccount_satoken_test.go
+++ b/pkg/provider/storage/azure_storageaccount_satoken_test.go
@@ -36,7 +36,7 @@ import (
 // the token audience does not match the sovereign-cloud ARM resource ID.
 //
 // This test derives the client options exactly the same way the fix does
-// (via az.buildSATokenClientOptions -> azclient.GetAzCoreClientOption), and
+// (via buildSATokenClientOptions -> azclient.GetAzCoreClientOption), and
 // pins both the AAD authority host and the ARM ResourceManager endpoint per
 // cloud so any future refactor that drops the cloud config on the floor
 // fails loudly.
@@ -92,7 +92,7 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 				},
 			}
 
-			credOpts, armOpts, err := az.buildSATokenClientOptions()
+			credOpts, armOpts, err := buildSATokenClientOptions(&az.Config.ARMClientConfig)
 			assert.NoError(t, err)
 
 			// azidentity uses ClientOptions.Cloud.ActiveDirectoryAuthorityHost
@@ -132,7 +132,7 @@ func TestBuildSATokenClientOptions_CloudSelection(t *testing.T) {
 func TestBuildSATokenClientOptions_NilConfig(t *testing.T) {
 	az := &AccountRepo{}
 
-	credOpts, armOpts, err := az.buildSATokenClientOptions()
+	credOpts, armOpts, err := buildSATokenClientOptions(&az.Config.ARMClientConfig)
 	assert.NoError(t, err)
 	// Zero-valued config defaults to AzurePublic.
 	assert.Equal(t, cloud.AzurePublic.ActiveDirectoryAuthorityHost, credOpts.Cloud.ActiveDirectoryAuthorityHost)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`GetStorageAccesskeyFromServiceAccountToken` currently constructs both the `azidentity.ClientAssertionCredential` and the ARM `accountclient` with default (Azure Public) cloud settings:

```go
cred, _ := azidentity.NewClientAssertionCredential(..., &azidentity.ClientAssertionCredentialOptions{})
client, _ := accountclient.New(subsID, cred, nil)
```

In sovereign clouds (AzureChinaCloud, AzureUSGovernmentCloud, AzureStackCloud) this causes AAD to reject the federated token exchange with `AADSTS500011: The resource principal named https://management.core.windows.net was not found in the tenant` because the requested audience does not match the sovereign ARM endpoint.

This PR derives the azcore `ClientOptions` from the repo's own `ARMClientConfig` via `azclient.GetAzCoreClientOption` and threads it into both the credential (via `ClientOptions.Cloud`) and the ARM client. Now blob-csi-driver / azurefile-csi-driver workload-identity storage-account-key retrieval works in non-Public clouds.

**Which issue(s) this PR fixes**:

Fixes kubernetes-sigs/blob-csi-driver#2649

**Special notes for your reviewer**:
- Only touches the workload-identity path (`GetStorageAccesskeyFromServiceAccountToken`); no behavior change for the other credential paths.
- Uses the same `azclient.GetAzCoreClientOption` helper the rest of the codebase already uses to bridge `ARMClientConfig` \u2192 azcore cloud config.
- Build passes locally (`go build ./pkg/provider/storage/...`).

**Release note**:
```release-note
Fix workload-identity storage account key retrieval failing with AADSTS500011 in sovereign clouds (Azure China / US Gov / AzureStack) by threading the cloud config into the client assertion credential and the ARM client.
```