### PR TITLE
Fix case-insensitive duplicate tags

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3628,7 +3628,7 @@ func shouldReleaseExistingOwnedPublicIP(
 func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAddress) bool {
 	configTags, err := parseTags(az.Tags, az.TagsMap)
 	if err != nil {
-		klog.Warningf("ensurePIPTagged: %v", err)
+		log.Background().WithName("ensurePIPTagged").Error(err, "Found duplicate tag keys in cloud configuration")
 	}
 	annotationTags := make(map[string]*string)
 	if _, ok := service.Annotations[consts.ServiceAnnotationAzurePIPTags]; ok {
@@ -3636,7 +3636,7 @@ func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAd
 		annotationTags, annErr = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags], map[string]string{})
 		if annErr != nil {
 			az.Event(service, v1.EventTypeWarning, "DuplicatePIPTags", annErr.Error())
-			klog.Warningf("ensurePIPTagged: %v", annErr)
+			log.Background().WithName("ensurePIPTagged").Error(annErr, "Found duplicate tag keys in service annotation", "service", getServiceName(service))
 		}
 	}
 
@@ -4385,7 +4385,7 @@ func (az *Cloud) ensureLoadBalancerTagged(lb *armnetwork.LoadBalancer) bool {
 	}
 	tags, err := parseTags(az.Tags, az.TagsMap)
 	if err != nil {
-		klog.Warningf("ensureLoadBalancerTagged: %v", err)
+		log.Background().WithName("ensureLoadBalancerTagged").Error(err, "Found duplicate tag keys in cloud configuration")
 	}
 	if lb.Tags == nil {
 		lb.Tags = make(map[string]*string)
@@ -4404,7 +4404,7 @@ func (az *Cloud) ensureSecurityGroupTagged(sg *armnetwork.SecurityGroup) bool {
 	}
 	tags, err := parseTags(az.Tags, az.TagsMap)
 	if err != nil {
-		klog.Warningf("ensureSecurityGroupTagged: %v", err)
+		log.Background().WithName("ensureSecurityGroupTagged").Error(err, "Found duplicate tag keys in cloud configuration")
 	}
 	if sg.Tags == nil {
 		sg.Tags = make(map[string]*string)

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3626,10 +3626,18 @@ func shouldReleaseExistingOwnedPublicIP(
 
 // ensurePIPTagged ensures the public IP of the service is tagged as configured
 func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAddress) bool {
-	configTags := parseTags(az.Tags, az.TagsMap)
+	configTags, err := parseTags(az.Tags, az.TagsMap)
+	if err != nil {
+		klog.Warningf("ensurePIPTagged: %v", err)
+	}
 	annotationTags := make(map[string]*string)
 	if _, ok := service.Annotations[consts.ServiceAnnotationAzurePIPTags]; ok {
-		annotationTags = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags], map[string]string{})
+		var annErr error
+		annotationTags, annErr = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags], map[string]string{})
+		if annErr != nil {
+			az.Event(service, v1.EventTypeWarning, "DuplicatePIPTags", annErr.Error())
+			klog.Warningf("ensurePIPTagged: %v", annErr)
+		}
 	}
 
 	var ignoredReservedKeys bool
@@ -4375,7 +4383,10 @@ func (az *Cloud) ensureLoadBalancerTagged(lb *armnetwork.LoadBalancer) bool {
 	if az.Tags == "" && len(az.TagsMap) == 0 {
 		return false
 	}
-	tags := parseTags(az.Tags, az.TagsMap)
+	tags, err := parseTags(az.Tags, az.TagsMap)
+	if err != nil {
+		klog.Warningf("ensureLoadBalancerTagged: %v", err)
+	}
 	if lb.Tags == nil {
 		lb.Tags = make(map[string]*string)
 	}
@@ -4391,7 +4402,10 @@ func (az *Cloud) ensureSecurityGroupTagged(sg *armnetwork.SecurityGroup) bool {
 	if az.Tags == "" && (len(az.TagsMap) == 0) {
 		return false
 	}
-	tags := parseTags(az.Tags, az.TagsMap)
+	tags, err := parseTags(az.Tags, az.TagsMap)
+	if err != nil {
+		klog.Warningf("ensureSecurityGroupTagged: %v", err)
+	}
 	if sg.Tags == nil {
 		sg.Tags = make(map[string]*string)
 	}

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3626,17 +3626,18 @@ func shouldReleaseExistingOwnedPublicIP(
 
 // ensurePIPTagged ensures the public IP of the service is tagged as configured
 func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAddress) bool {
-	configTags, err := parseTags(az.Tags, az.TagsMap)
-	if err != nil {
-		log.Background().WithName("ensurePIPTagged").Error(err, "Found duplicate tag keys in cloud configuration")
+	configTags, droppedConfigKeys := parseTags(az.Tags, az.TagsMap)
+	if len(droppedConfigKeys) > 0 {
+		log.Background().WithName("ensurePIPTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedConfigKeys)
 	}
 	annotationTags := make(map[string]*string)
 	if _, ok := service.Annotations[consts.ServiceAnnotationAzurePIPTags]; ok {
-		var annErr error
-		annotationTags, annErr = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags], map[string]string{})
-		if annErr != nil {
-			az.Event(service, v1.EventTypeWarning, "DuplicatePIPTags", annErr.Error())
-			log.Background().WithName("ensurePIPTagged").Error(annErr, "Found duplicate tag keys in service annotation", "service", getServiceName(service))
+		var droppedAnnotationKeys []string
+		annotationTags, droppedAnnotationKeys = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags], nil)
+		if len(droppedAnnotationKeys) > 0 {
+			az.Event(service, v1.EventTypeWarning, "DuplicatePIPTags", fmt.Sprintf(
+				"Ignoring duplicate tag keys (case-insensitive) in the %s annotation; keeping the first occurrence: %s",
+				consts.ServiceAnnotationAzurePIPTags, strings.Join(droppedAnnotationKeys, ", ")))
 		}
 	}
 
@@ -4383,9 +4384,9 @@ func (az *Cloud) ensureLoadBalancerTagged(lb *armnetwork.LoadBalancer) bool {
 	if az.Tags == "" && len(az.TagsMap) == 0 {
 		return false
 	}
-	tags, err := parseTags(az.Tags, az.TagsMap)
-	if err != nil {
-		log.Background().WithName("ensureLoadBalancerTagged").Error(err, "Found duplicate tag keys in cloud configuration")
+	tags, droppedKeys := parseTags(az.Tags, az.TagsMap)
+	if len(droppedKeys) > 0 {
+		log.Background().WithName("ensureLoadBalancerTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
 	}
 	if lb.Tags == nil {
 		lb.Tags = make(map[string]*string)
@@ -4402,9 +4403,9 @@ func (az *Cloud) ensureSecurityGroupTagged(sg *armnetwork.SecurityGroup) bool {
 	if az.Tags == "" && (len(az.TagsMap) == 0) {
 		return false
 	}
-	tags, err := parseTags(az.Tags, az.TagsMap)
-	if err != nil {
-		log.Background().WithName("ensureSecurityGroupTagged").Error(err, "Found duplicate tag keys in cloud configuration")
+	tags, droppedKeys := parseTags(az.Tags, az.TagsMap)
+	if len(droppedKeys) > 0 {
+		log.Background().WithName("ensureSecurityGroupTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
 	}
 	if sg.Tags == nil {
 		sg.Tags = make(map[string]*string)

--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3628,7 +3628,7 @@ func shouldReleaseExistingOwnedPublicIP(
 func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAddress) bool {
 	configTags, droppedConfigKeys := parseTags(az.Tags, az.TagsMap)
 	if len(droppedConfigKeys) > 0 {
-		log.Background().WithName("ensurePIPTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedConfigKeys)
+		log.Background().WithName("ensurePIPTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "droppedKeys", droppedConfigKeys)
 	}
 	annotationTags := make(map[string]*string)
 	if _, ok := service.Annotations[consts.ServiceAnnotationAzurePIPTags]; ok {
@@ -3636,7 +3636,7 @@ func (az *Cloud) ensurePIPTagged(service *v1.Service, pip *armnetwork.PublicIPAd
 		annotationTags, droppedAnnotationKeys = parseTags(service.Annotations[consts.ServiceAnnotationAzurePIPTags], nil)
 		if len(droppedAnnotationKeys) > 0 {
 			az.Event(service, v1.EventTypeWarning, "DuplicatePIPTags", fmt.Sprintf(
-				"Ignoring duplicate tag keys (case-insensitive) in the %s annotation; keeping the first occurrence: %s",
+				"Ignoring duplicate tag keys (case-insensitive) in the %s annotation; keeping the first occurrence, dropped duplicate keys: %s",
 				consts.ServiceAnnotationAzurePIPTags, strings.Join(droppedAnnotationKeys, ", ")))
 		}
 	}
@@ -4386,7 +4386,7 @@ func (az *Cloud) ensureLoadBalancerTagged(lb *armnetwork.LoadBalancer) bool {
 	}
 	tags, droppedKeys := parseTags(az.Tags, az.TagsMap)
 	if len(droppedKeys) > 0 {
-		log.Background().WithName("ensureLoadBalancerTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
+		log.Background().WithName("ensureLoadBalancerTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "droppedKeys", droppedKeys)
 	}
 	if lb.Tags == nil {
 		lb.Tags = make(map[string]*string)
@@ -4405,7 +4405,7 @@ func (az *Cloud) ensureSecurityGroupTagged(sg *armnetwork.SecurityGroup) bool {
 	}
 	tags, droppedKeys := parseTags(az.Tags, az.TagsMap)
 	if len(droppedKeys) > 0 {
-		log.Background().WithName("ensureSecurityGroupTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
+		log.Background().WithName("ensureSecurityGroupTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "droppedKeys", droppedKeys)
 	}
 	if sg.Tags == nil {
 		sg.Tags = make(map[string]*string)

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -9405,6 +9405,39 @@ func TestEnsurePIPTagged(t *testing.T) {
 		assert.True(t, changed)
 		assert.Equal(t, expectedPIP, pip)
 	})
+
+	t.Run("ensurePIPTagged should retain first tag value and emit DuplicatePIPTags warning event on duplicate annotation keys", func(t *testing.T) {
+		recorder := record.NewFakeRecorder(10)
+		cloud.eventRecorder = recorder
+		cloud.Tags = ""
+		cloud.TagsMap = nil
+		cloud.SystemTags = ""
+
+		serviceWithDups := v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					consts.ServiceAnnotationAzurePIPTags: "key1=val1,KEY1=val2,key2=val3",
+				},
+			},
+		}
+		targetPIP := armnetwork.PublicIPAddress{
+			Tags: map[string]*string{},
+		}
+		changed := cloud.ensurePIPTagged(&serviceWithDups, &targetPIP)
+		assert.True(t, changed)
+		assert.Equal(t, map[string]*string{
+			"key1": ptr.To("val1"),
+			"key2": ptr.To("val3"),
+		}, targetPIP.Tags)
+
+		var events []string
+		for len(recorder.Events) > 0 {
+			events = append(events, <-recorder.Events)
+		}
+		if assert.Len(t, events, 1) {
+			assert.Contains(t, events[0], "Warning DuplicatePIPTags")
+		}
+	})
 }
 
 func TestEnsurePIPTaggedShouldIgnoreReservedTagKeysFromAnnotation(t *testing.T) {

--- a/pkg/provider/azure_loadbalancer_test.go
+++ b/pkg/provider/azure_loadbalancer_test.go
@@ -9436,6 +9436,8 @@ func TestEnsurePIPTagged(t *testing.T) {
 		}
 		if assert.Len(t, events, 1) {
 			assert.Contains(t, events[0], "Warning DuplicatePIPTags")
+			assert.Contains(t, events[0], consts.ServiceAnnotationAzurePIPTags)
+			assert.Contains(t, events[0], "KEY1")
 		}
 	})
 }

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -594,7 +595,10 @@ func (az *Cloud) reconcilePLSTags(
 	clusterName *string,
 	service *v1.Service,
 ) bool {
-	configTags := parseTags(az.Tags, az.TagsMap)
+	configTags, err := parseTags(az.Tags, az.TagsMap)
+	if err != nil {
+		klog.Warningf("reconcilePLSTags: %v", err)
+	}
 	serviceName := getServiceName(service)
 
 	if existingPLS.Tags == nil {

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -29,7 +29,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
@@ -597,7 +596,7 @@ func (az *Cloud) reconcilePLSTags(
 ) bool {
 	configTags, err := parseTags(az.Tags, az.TagsMap)
 	if err != nil {
-		klog.Warningf("reconcilePLSTags: %v", err)
+		log.Background().WithName("reconcilePLSTags").Error(err, "Found duplicate tag keys in cloud configuration")
 	}
 	serviceName := getServiceName(service)
 

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -29,10 +29,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -594,9 +594,9 @@ func (az *Cloud) reconcilePLSTags(
 	clusterName *string,
 	service *v1.Service,
 ) bool {
-	configTags, err := parseTags(az.Tags, az.TagsMap)
-	if err != nil {
-		log.Background().WithName("reconcilePLSTags").Error(err, "Found duplicate tag keys in cloud configuration")
+	configTags, droppedKeys := parseTags(az.Tags, az.TagsMap)
+	if len(droppedKeys) > 0 {
+		log.Background().WithName("reconcilePLSTags").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
 	}
 	serviceName := getServiceName(service)
 

--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -596,7 +596,7 @@ func (az *Cloud) reconcilePLSTags(
 ) bool {
 	configTags, droppedKeys := parseTags(az.Tags, az.TagsMap)
 	if len(droppedKeys) > 0 {
-		log.Background().WithName("reconcilePLSTags").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
+		log.Background().WithName("reconcilePLSTags").V(2).Info("Found duplicate tag keys in cloud configuration", "droppedKeys", droppedKeys)
 	}
 	serviceName := getServiceName(service)
 

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
@@ -580,7 +579,7 @@ func (az *Cloud) ensureRouteTableTagged(rt *armnetwork.RouteTable) (map[string]*
 	}
 	tags, err := parseTags(az.Tags, az.TagsMap)
 	if err != nil {
-		klog.Warningf("reconcileRouteTableTags: %v", err)
+		log.Background().WithName("ensureRouteTableTagged").Error(err, "Found duplicate tag keys in cloud configuration")
 	}
 	if rt.Tags == nil {
 		rt.Tags = make(map[string]*string)

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -27,11 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -577,9 +577,9 @@ func (az *Cloud) ensureRouteTableTagged(rt *armnetwork.RouteTable) (map[string]*
 	if az.Tags == "" && (len(az.TagsMap) == 0) {
 		return nil, false
 	}
-	tags, err := parseTags(az.Tags, az.TagsMap)
-	if err != nil {
-		log.Background().WithName("ensureRouteTableTagged").Error(err, "Found duplicate tag keys in cloud configuration")
+	tags, droppedKeys := parseTags(az.Tags, az.TagsMap)
+	if len(droppedKeys) > 0 {
+		log.Background().WithName("ensureRouteTableTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
 	}
 	if rt.Tags == nil {
 		rt.Tags = make(map[string]*string)

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	"sigs.k8s.io/cloud-provider-azure/pkg/log"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -577,7 +578,10 @@ func (az *Cloud) ensureRouteTableTagged(rt *armnetwork.RouteTable) (map[string]*
 	if az.Tags == "" && (len(az.TagsMap) == 0) {
 		return nil, false
 	}
-	tags := parseTags(az.Tags, az.TagsMap)
+	tags, err := parseTags(az.Tags, az.TagsMap)
+	if err != nil {
+		klog.Warningf("reconcileRouteTableTags: %v", err)
+	}
 	if rt.Tags == nil {
 		rt.Tags = make(map[string]*string)
 	}

--- a/pkg/provider/azure_routes.go
+++ b/pkg/provider/azure_routes.go
@@ -579,7 +579,7 @@ func (az *Cloud) ensureRouteTableTagged(rt *armnetwork.RouteTable) (map[string]*
 	}
 	tags, droppedKeys := parseTags(az.Tags, az.TagsMap)
 	if len(droppedKeys) > 0 {
-		log.Background().WithName("ensureRouteTableTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "duplicateKeys", droppedKeys)
+		log.Background().WithName("ensureRouteTableTagged").V(2).Info("Found duplicate tag keys in cloud configuration", "droppedKeys", droppedKeys)
 	}
 	if rt.Tags == nil {
 		rt.Tags = make(map[string]*string)

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 
@@ -62,9 +63,10 @@ func getContextWithCancel() (context.Context, context.CancelFunc) {
 // It logs warnings for parsing errors and empty keys, and info messages for case-insensitive key replacements.
 //
 // XXX: return error instead of logging; decouple tag parsing and tag application
-func parseTags(tags string, tagsMap map[string]string) map[string]*string {
+func parseTags(tags string, tagsMap map[string]string) (map[string]*string, error) {
 	logger := log.Background().WithName("parseTags")
 	formatted := make(map[string]*string)
+	var errs []error
 
 	if tags != "" {
 		kvs := strings.Split(tags, consts.TagsDelimiter)
@@ -85,13 +87,25 @@ func parseTags(tags string, tagsMap map[string]string) map[string]*string {
 				klog.Warning("parseTags: empty key, ignoring this key-value pair")
 				continue
 			}
+			if found, kExisting := findKeyInMapCaseInsensitive(formatted, k); found {
+				errs = append(errs, fmt.Errorf("found duplicate tag key %q (case-insensitive) in tags, ignoring this key-value pair and keeping the first occurrence %q", k, kExisting))
+				continue
+			}
 			formatted[k] = ptr.To(v)
 		}
 	}
 
 	if len(tagsMap) > 0 {
-		for k, v := range tagsMap {
-			key, value := strings.TrimSpace(k), strings.TrimSpace(v)
+		var keys []string
+		for k := range tagsMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		tagsMapKeys := make(map[string]bool)
+		for _, key := range keys {
+			v := tagsMap[key]
+			key, value := strings.TrimSpace(key), strings.TrimSpace(v)
 			if strings.EqualFold(value, "null") {
 				value = v
 			}
@@ -100,15 +114,29 @@ func parseTags(tags string, tagsMap map[string]string) map[string]*string {
 				continue
 			}
 
-			if found, k := findKeyInMapCaseInsensitive(formatted, key); found && k != key {
-				logger.V(4).Info("found identical keys from tags and tagsMap (case-insensitive), will replace", "identical keys", k, "keyFromTagsMap", key)
-				delete(formatted, k)
+			if found, kExisting := findKeyInMapCaseInsensitive(formatted, key); found {
+				if tagsMapKeys[strings.ToLower(key)] {
+					errs = append(errs, fmt.Errorf("found duplicate tag key %q (case-insensitive) in tagsMap, keeping the first occurrence %q", key, kExisting))
+					continue
+				}
+				if kExisting != key {
+					logger.V(4).Info("found identical keys from tags and tagsMap (case-insensitive), will replace", "identical keys", kExisting, "keyFromTagsMap", key)
+					delete(formatted, kExisting)
+				}
 			}
 			formatted[key] = ptr.To(value)
+			tagsMapKeys[strings.ToLower(key)] = true
 		}
 	}
 
-	return formatted
+	if len(errs) > 0 {
+		var errStrs []string
+		for _, err := range errs {
+			errStrs = append(errStrs, err.Error())
+		}
+		return formatted, fmt.Errorf("%s", strings.Join(errStrs, "; "))
+	}
+	return formatted, nil
 }
 
 func findKeyInMapCaseInsensitive(targetMap map[string]*string, key string) (bool, string) {

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -58,17 +58,15 @@ func getContextWithCancel() (context.Context, context.CancelFunc) {
 //
 // Returns:
 //   - A map[string]*string where keys are tag names and values are pointers to tag values
-//   - An error if duplicate keys (case-insensitive) are found. Duplicate keys produce a non-fatal error
-//     alongside a usable result, keeping the first occurrence.
+//   - A slice of strings containing duplicate tag keys (case-insensitive) that were dropped, if any
 //
 // The function prioritizes tags from tagsMap over those from the tags string in case of conflicts.
 // It logs warnings for parsing errors and empty keys, and info messages for case-insensitive key replacements.
-//
-// XXX: return error instead of logging; decouple tag parsing and tag application
-func parseTags(tags string, tagsMap map[string]string) (map[string]*string, error) {
+func parseTags(tags string, tagsMap map[string]string) (map[string]*string, []string) {
 	logger := log.Background().WithName("parseTags")
 	formatted := make(map[string]*string)
-	var errs []error
+	normalizedKeys := make(map[string]string)
+	var duplicateKeys []string
 
 	if tags != "" {
 		kvs := strings.Split(tags, consts.TagsDelimiter)
@@ -89,22 +87,24 @@ func parseTags(tags string, tagsMap map[string]string) (map[string]*string, erro
 				klog.Warning("parseTags: empty key, ignoring this key-value pair")
 				continue
 			}
-			if found, kExisting := findKeyInMapCaseInsensitive(formatted, k); found {
-				errs = append(errs, fmt.Errorf("found duplicate tag key %q (case-insensitive) in tags, ignoring this key-value pair and keeping the first occurrence %q", k, kExisting))
+			kLower := strings.ToLower(k)
+			if _, exists := normalizedKeys[kLower]; exists {
+				duplicateKeys = append(duplicateKeys, k)
 				continue
 			}
+			normalizedKeys[kLower] = k
 			formatted[k] = ptr.To(v)
 		}
 	}
 
 	if len(tagsMap) > 0 {
-		var keys []string
+		keys := make([]string, 0, len(tagsMap))
 		for k := range tagsMap {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 
-		var tagsMapKeys []string
+		tagsMapNormalized := make(map[string]string, len(keys))
 		for _, key := range keys {
 			v := tagsMap[key]
 			key, value := strings.TrimSpace(key), strings.TrimSpace(v)
@@ -116,40 +116,25 @@ func parseTags(tags string, tagsMap map[string]string) (map[string]*string, erro
 				continue
 			}
 
-			var alreadyInTagsMap bool
-			var existingTagsMapKey string
-			for _, k := range tagsMapKeys {
-				if strings.EqualFold(k, key) {
-					alreadyInTagsMap = true
-					existingTagsMapKey = k
-					break
-				}
-			}
-
-			if alreadyInTagsMap {
-				errs = append(errs, fmt.Errorf("found duplicate tag key %q (case-insensitive) in tagsMap, keeping the first occurrence %q", key, existingTagsMapKey))
+			keyLower := strings.ToLower(key)
+			if _, exists := tagsMapNormalized[keyLower]; exists {
+				duplicateKeys = append(duplicateKeys, key)
 				continue
 			}
+			tagsMapNormalized[keyLower] = key
 
-			if found, kExisting := findKeyInMapCaseInsensitive(formatted, key); found {
+			if kExisting, found := normalizedKeys[keyLower]; found {
 				if kExisting != key {
 					logger.V(4).Info("found identical keys from tags and tagsMap (case-insensitive), will replace", "identical keys", kExisting, "keyFromTagsMap", key)
 					delete(formatted, kExisting)
 				}
 			}
+			normalizedKeys[keyLower] = key
 			formatted[key] = ptr.To(value)
-			tagsMapKeys = append(tagsMapKeys, key)
 		}
 	}
 
-	if len(errs) > 0 {
-		var errStrs []string
-		for _, err := range errs {
-			errStrs = append(errStrs, err.Error())
-		}
-		return formatted, fmt.Errorf("%s", strings.Join(errStrs, "; "))
-	}
-	return formatted, nil
+	return formatted, duplicateKeys
 }
 
 func findKeyInMapCaseInsensitive(targetMap map[string]*string, key string) (bool, string) {

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -58,6 +58,8 @@ func getContextWithCancel() (context.Context, context.CancelFunc) {
 //
 // Returns:
 //   - A map[string]*string where keys are tag names and values are pointers to tag values
+//   - An error if duplicate keys (case-insensitive) are found. Duplicate keys produce a non-fatal error
+//     alongside a usable result, keeping the first occurrence.
 //
 // The function prioritizes tags from tagsMap over those from the tags string in case of conflicts.
 // It logs warnings for parsing errors and empty keys, and info messages for case-insensitive key replacements.
@@ -102,7 +104,7 @@ func parseTags(tags string, tagsMap map[string]string) (map[string]*string, erro
 		}
 		sort.Strings(keys)
 
-		tagsMapKeys := make(map[string]bool)
+		var tagsMapKeys []string
 		for _, key := range keys {
 			v := tagsMap[key]
 			key, value := strings.TrimSpace(key), strings.TrimSpace(v)
@@ -114,18 +116,29 @@ func parseTags(tags string, tagsMap map[string]string) (map[string]*string, erro
 				continue
 			}
 
-			if found, kExisting := findKeyInMapCaseInsensitive(formatted, key); found {
-				if tagsMapKeys[strings.ToLower(key)] {
-					errs = append(errs, fmt.Errorf("found duplicate tag key %q (case-insensitive) in tagsMap, keeping the first occurrence %q", key, kExisting))
-					continue
+			var alreadyInTagsMap bool
+			var existingTagsMapKey string
+			for _, k := range tagsMapKeys {
+				if strings.EqualFold(k, key) {
+					alreadyInTagsMap = true
+					existingTagsMapKey = k
+					break
 				}
+			}
+
+			if alreadyInTagsMap {
+				errs = append(errs, fmt.Errorf("found duplicate tag key %q (case-insensitive) in tagsMap, keeping the first occurrence %q", key, existingTagsMapKey))
+				continue
+			}
+
+			if found, kExisting := findKeyInMapCaseInsensitive(formatted, key); found {
 				if kExisting != key {
 					logger.V(4).Info("found identical keys from tags and tagsMap (case-insensitive), will replace", "identical keys", kExisting, "keyFromTagsMap", key)
 					delete(formatted, kExisting)
 				}
 			}
 			formatted[key] = ptr.To(value)
-			tagsMapKeys[strings.ToLower(key)] = true
+			tagsMapKeys = append(tagsMapKeys, key)
 		}
 	}
 

--- a/pkg/provider/azure_utils.go
+++ b/pkg/provider/azure_utils.go
@@ -138,8 +138,9 @@ func parseTags(tags string, tagsMap map[string]string) (map[string]*string, []st
 }
 
 func findKeyInMapCaseInsensitive(targetMap map[string]*string, key string) (bool, string) {
+	keyLower := strings.ToLower(key)
 	for k := range targetMap {
-		if strings.EqualFold(k, key) {
+		if strings.ToLower(k) == keyLower {
 			return true, k
 		}
 	}

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -197,6 +197,7 @@ func TestParseTags(t *testing.T) {
 		description, tags string
 		tagsMap           map[string]string
 		expectedTags      map[string]*string
+		expectedErr       bool
 	}{
 		{
 			description: "parseTags should return a map of tags",
@@ -280,10 +281,58 @@ func TestParseTags(t *testing.T) {
 				"z": ptr.To("z"),
 			},
 		},
+		{
+			description: "parseTags should keep first occurrence when duplicate case-insensitive keys are in tags",
+			tags:        "foo=bar, FOO=baz, FOO=qux, bar=1",
+			expectedTags: map[string]*string{
+				"foo": ptr.To("bar"),
+				"bar": ptr.To("1"),
+			},
+			expectedErr: true,
+		},
+		{
+			description: "parseTags should keep first occurrence when duplicate case-insensitive keys are in tagsMap",
+			tagsMap: map[string]string{
+				"foo": "bar",
+				"FOO": "baz",
+			},
+			expectedTags: map[string]*string{
+				"FOO": ptr.To("baz"),
+			},
+			expectedErr: true,
+		},
+		{
+			description: "parseTags should handle Unicode case-folded duplicate keys in tagsMap",
+			tagsMap: map[string]string{
+				"S": "first",
+				"ſ": "second",
+			},
+			expectedTags: map[string]*string{
+				"S": ptr.To("first"),
+			},
+			expectedErr: true,
+		},
+		{
+			description: "parseTags should let tagsMap override tags while discarding duplicates in both",
+			tags:        "foo=1, FOO=2",
+			tagsMap: map[string]string{
+				"Foo": "3",
+				"fOO": "4",
+			},
+			expectedTags: map[string]*string{
+				"Foo": ptr.To("3"),
+			},
+			expectedErr: true,
+		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
-			tags, _ := parseTags(testCase.tags, testCase.tagsMap)
+			tags, err := parseTags(testCase.tags, testCase.tagsMap)
 			assert.Equal(t, testCase.expectedTags, tags)
+			if testCase.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -194,10 +194,10 @@ func TestReconcileTags(t *testing.T) {
 
 func TestParseTags(t *testing.T) {
 	for _, testCase := range []struct {
-		description, tags string
-		tagsMap           map[string]string
-		expectedTags      map[string]*string
-		expectedErr       bool
+		description, tags   string
+		tagsMap             map[string]string
+		expectedTags        map[string]*string
+		expectedDroppedKeys []string
 	}{
 		{
 			description: "parseTags should return a map of tags",
@@ -288,7 +288,7 @@ func TestParseTags(t *testing.T) {
 				"foo": ptr.To("bar"),
 				"bar": ptr.To("1"),
 			},
-			expectedErr: true,
+			expectedDroppedKeys: []string{"FOO", "FOO"},
 		},
 		{
 			description: "parseTags should keep first occurrence when duplicate case-insensitive keys are in tagsMap",
@@ -299,18 +299,7 @@ func TestParseTags(t *testing.T) {
 			expectedTags: map[string]*string{
 				"FOO": ptr.To("baz"),
 			},
-			expectedErr: true,
-		},
-		{
-			description: "parseTags should handle Unicode case-folded duplicate keys in tagsMap",
-			tagsMap: map[string]string{
-				"S": "first",
-				"ſ": "second",
-			},
-			expectedTags: map[string]*string{
-				"S": ptr.To("first"),
-			},
-			expectedErr: true,
+			expectedDroppedKeys: []string{"foo"},
 		},
 		{
 			description: "parseTags should let tagsMap override tags while discarding duplicates in both",
@@ -322,17 +311,13 @@ func TestParseTags(t *testing.T) {
 			expectedTags: map[string]*string{
 				"Foo": ptr.To("3"),
 			},
-			expectedErr: true,
+			expectedDroppedKeys: []string{"FOO", "fOO"},
 		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
-			tags, err := parseTags(testCase.tags, testCase.tagsMap)
+			tags, droppedKeys := parseTags(testCase.tags, testCase.tagsMap)
 			assert.Equal(t, testCase.expectedTags, tags)
-			if testCase.expectedErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			assert.Equal(t, testCase.expectedDroppedKeys, droppedKeys)
 		})
 	}
 }

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -282,7 +282,7 @@ func TestParseTags(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
-			tags := parseTags(testCase.tags, testCase.tagsMap)
+			tags, _ := parseTags(testCase.tags, testCase.tagsMap)
 			assert.Equal(t, testCase.expectedTags, tags)
 		})
 	}

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -302,6 +302,17 @@ func TestParseTags(t *testing.T) {
 			expectedDroppedKeys: []string{"foo"},
 		},
 		{
+			description: "parseTags should handle Unicode characters in tagsMap",
+			tagsMap: map[string]string{
+				"S": "first",
+				"ſ": "second",
+			},
+			expectedTags: map[string]*string{
+				"S": ptr.To("first"),
+				"ſ": ptr.To("second"),
+			},
+		},
+		{
 			description: "parseTags should let tagsMap override tags while discarding duplicates in both",
 			tags:        "foo=1, FOO=2",
 			tagsMap: map[string]string{

--- a/pkg/provider/azure_utils_test.go
+++ b/pkg/provider/azure_utils_test.go
@@ -178,6 +178,20 @@ func TestReconcileTags(t *testing.T) {
 			},
 			expectedChanged: false,
 		},
+		{
+			description: "reconcileTags should preserve distinct Unicode characters",
+			currentTagsOnResource: map[string]*string{
+				"S": ptr.To("first"),
+			},
+			newTags: map[string]*string{
+				"ſ": ptr.To("second"),
+			},
+			expectedTags: map[string]*string{
+				"S": ptr.To("first"),
+				"ſ": ptr.To("second"),
+			},
+			expectedChanged: true,
+		},
 	} {
 		t.Run(testCase.description, func(t *testing.T) {
 			cloud := &Cloud{}
@@ -331,6 +345,33 @@ func TestParseTags(t *testing.T) {
 			assert.Equal(t, testCase.expectedDroppedKeys, droppedKeys)
 		})
 	}
+}
+
+func TestFindKeyInMapCaseInsensitive(t *testing.T) {
+	targetMap := map[string]*string{
+		"Foo": ptr.To("1"),
+		"S":   ptr.To("2"),
+	}
+
+	found, k := findKeyInMapCaseInsensitive(targetMap, "foo")
+	assert.True(t, found)
+	assert.Equal(t, "Foo", k)
+
+	found, k = findKeyInMapCaseInsensitive(targetMap, "FOO")
+	assert.True(t, found)
+	assert.Equal(t, "Foo", k)
+
+	found, k = findKeyInMapCaseInsensitive(targetMap, "s")
+	assert.True(t, found)
+	assert.Equal(t, "S", k)
+
+	found, k = findKeyInMapCaseInsensitive(targetMap, "ſ")
+	assert.False(t, found)
+	assert.Equal(t, "", k)
+
+	found, k = findKeyInMapCaseInsensitive(targetMap, "bar")
+	assert.False(t, found)
+	assert.Equal(t, "", k)
 }
 
 func TestGetNodePrivateIPAddress(t *testing.T) {

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -502,7 +502,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 			// The controller does not own this key, so it proves the annotation was applied at all.
 			expectedTagValue := "b"
-			tagsAnnotation := "a=" + expectedTagValue
+			tagsAnnotation := "a=" + expectedTagValue + ",A=should-be-dropped"
 			if setOnCreate {
 				tagsAnnotation += "," + reservedPairs
 			}
@@ -546,7 +546,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 					if err != nil {
 						return err
 					}
-					service.Annotations[consts.ServiceAnnotationAzurePIPTags] = "a=" + expectedTagValue + "," + reservedPairs
+					service.Annotations[consts.ServiceAnnotationAzurePIPTags] = "a=" + expectedTagValue + ",A=should-be-dropped," + reservedPairs
 					_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 					return err
 				})
@@ -581,9 +581,12 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 				Expect(ptr.Deref(pip.Tags["a"], "")).To(Equal(expectedTagValue))
 			}
 
-			By("Checking the warning event on the service")
+			By("Checking the warning events on the service")
 			err = utils.WaitForServiceEventAfter(cs, ns.Name, serviceName, v1.EventTypeWarning,
 				"IgnoredPIPTagKeys", consts.ServiceAnnotationAzurePIPTags, since)
+			Expect(err).NotTo(HaveOccurred())
+			err = utils.WaitForServiceEventAfter(cs, ns.Name, serviceName, v1.EventTypeWarning,
+				"DuplicatePIPTags", consts.ServiceAnnotationAzurePIPTags, since)
 			Expect(err).NotTo(HaveOccurred())
 		},
 		Entry("when set at service creation", true),

--- a/tests/e2e/network/service_annotations.go
+++ b/tests/e2e/network/service_annotations.go
@@ -502,7 +502,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 
 			// The controller does not own this key, so it proves the annotation was applied at all.
 			expectedTagValue := "b"
-			tagsAnnotation := "a=" + expectedTagValue + ",A=should-be-dropped"
+			tagsAnnotation := "a=" + expectedTagValue + ",A=should-be-dropped,S=first,ſ=second"
 			if setOnCreate {
 				tagsAnnotation += "," + reservedPairs
 			}
@@ -546,7 +546,7 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 					if err != nil {
 						return err
 					}
-					service.Annotations[consts.ServiceAnnotationAzurePIPTags] = "a=" + expectedTagValue + ",A=should-be-dropped," + reservedPairs
+					service.Annotations[consts.ServiceAnnotationAzurePIPTags] = "a=" + expectedTagValue + ",A=should-be-dropped,S=first,ſ=second," + reservedPairs
 					_, err = cs.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 					return err
 				})
@@ -579,6 +579,8 @@ var _ = Describe("Service with annotation", Label(utils.TestSuiteLabelServiceAnn
 				}
 				Expect(ptr.Deref(pip.Tags[consts.ServiceTagKey], "")).To(Equal(ns.Name + "/" + serviceName))
 				Expect(ptr.Deref(pip.Tags["a"], "")).To(Equal(expectedTagValue))
+				Expect(ptr.Deref(pip.Tags["S"], "")).To(Equal("first"))
+				Expect(ptr.Deref(pip.Tags["ſ"], "")).To(Equal("second"))
 			}
 
 			By("Checking the warning events on the service")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Azure resource tag names are case-insensitive. The duplicate entries were resolved case-insensitively while ranging over a Go map, so which value ended up on the resource depended on map iteration order and could differ between reconciles. This caused the controller to issue an update even when nothing should change.
This PR fixes the issue by keeping only the first case-insensitive tag occurrence and discarding duplicates. It also logs a warning or issues an event when duplicates are found.

#### Which issue(s) this PR fixes:

Fixes #10902

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix Azure resource tags duplication due to case-insensitivity in cloud config `tags`/`tagsMap` and the `service.beta.kubernetes.io/azure-pip-tags` service annotation by preserving the first occurrence and ignoring duplicates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
