### PR TITLE
feat: add transient image build retries

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -56,7 +56,7 @@ level small:
   matching errors against known failure patterns
 - `build-images`: build cloud-provider-azure CCM, CNM, health-probe-proxy,
   CCM e2e, or root CCM/CNM aggregate images with explicit tag/registry inputs
-  and optional make flag overrides
+  plus optional make flag overrides and bounded Docker or Podman retries
 
 ## How To Use
 

--- a/.agents/skills/build-images/SKILL.md
+++ b/.agents/skills/build-images/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-images
-description: Build cloud-provider-azure container images through the repo Makefile with explicit IMAGE_TAG and IMAGE_REGISTRY inputs plus optional make flag overrides. Use when the user wants to build CCM, CNM, health-probe-proxy, CCM e2e, or root CCM/CNM aggregate images, or mentions build-ccm-image, build-node-image-linux, build images, image registry, or image tag.
+description: Build cloud-provider-azure container images through the repo Makefile with explicit IMAGE_TAG and IMAGE_REGISTRY inputs, optional make flag overrides, and opt-in bounded Docker or Podman retries. Use when the user wants to build CCM, CNM, health-probe-proxy, CCM e2e, or root CCM/CNM aggregate images, or mentions build-ccm-image, build-node-image-linux, build images, image registry, or image tag.
 ---
 
 # Build Images
@@ -128,11 +128,46 @@ reserved. Do not pass `MAKEFLAGS`, `MFLAGS`, `GNUMAKEFLAGS`, `MAKEOVERRIDES`,
 or `MAKEFILES` with `--set`; the helper rejects those keys and removes inherited
 values before running `make`.
 
+## Transient Runtime Retries
+
+Use `--retry-transient-runtime-errors` only when the caller wants the helper to
+retry one recognized transient runtime failure. This option requires an
+explicit `--set CONTAINER_CLI=<path-to-docker-or-podman>` so classification and
+the retry use the same selected runtime:
+
+```bash
+python3 <SKILL_DIR>/scripts/build_image.py \
+  --image ccm \
+  --tag <tag> \
+  --registry <registry> \
+  --set CONTAINER_CLI=/absolute/path/to/podman \
+  --retry-transient-runtime-errors
+```
+
+The helper streams build output while retaining only the last 50 stderr lines
+for classification. It waits five seconds, then retries the identical working
+directory, command, and environment once in these cases:
+
+- Docker Buildx setup failed because concurrent builder creation raced.
+- Podman failed during registry access or image transfer with a temporary DNS
+  error, connection timeout or reset, TLS handshake timeout, or registry HTTP
+  429 or 5xx response. Before retrying, the helper requires the same Podman
+  executable's `info` check to succeed within ten seconds.
+
+The helper does not retry authentication or authorization, missing manifests
+or digests, disk-capacity, compilation, Dockerfile or Makefile,
+builder-configuration, interruption, or unclassified failures. A failed retry
+is returned directly; there is no third attempt. `--dry-run` never builds,
+checks runtime health, sleeps, or includes the retry option in the resolved
+Make command.
+
 ## Validation
 
 Use `--dry-run` when the user asks for the command, when checking flag changes,
 or before running an expensive build. The script prints the resolved working
 directory and shell-quoted command. When the helper removes a default or
 sanitizes inherited managed environment, dry-runs show that as `env -u KEY`.
-Without `--dry-run`, it prints the same resolved working directory and command,
-then runs `make` via `subprocess.run` without `shell=True`.
+Without `--dry-run`, it prints the same resolved working directory and command.
+The default path runs `make` once via `subprocess.run` without `shell=True`; the
+opt-in retry path streams stderr via `subprocess.Popen` without `shell=True` so
+it can classify and replay bounded failure evidence.

--- a/.agents/skills/build-images/scripts/build_image.py
+++ b/.agents/skills/build-images/scripts/build_image.py
@@ -21,6 +21,8 @@ import re
 import shlex
 import subprocess
 import sys
+import time
+from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +40,36 @@ MAKE_CONTROL_ENV = {
 }
 GOEXPERIMENT_DEFAULT = "nosystemcrypto"
 ENABLE_GIT_COMMAND_DEFAULT = "false"
+RETRY_DELAY_SECONDS = 5
+PODMAN_INFO_TIMEOUT_SECONDS = 10
+FAILURE_TAIL_LINES = 50
+PODMAN_REGISTRY_CONTEXT_MARKERS = (
+    "initializing source docker://",
+    "pinging container registry",
+    "reading manifest",
+    "copying system image",
+    "copying blob",
+    "fetching blob",
+    "pulling image",
+    "trying to pull",
+)
+PODMAN_TRANSIENT_ERROR_MARKERS = (
+    "temporary failure in name resolution",
+    "i/o timeout",
+    "connection timed out",
+    "connection timeout",
+    "connection reset by peer",
+    "tls handshake timeout",
+)
+PODMAN_TRANSIENT_HTTP_STATUS_RE = re.compile(
+    r"(?:http(?:\s+response)?\s+status|status(?:\s+code)?|"
+    r"unexpected\s+(?:http\s+)?status)[^\n]{0,80}\b(?:429|5\d{2})\b",
+    re.IGNORECASE,
+)
+DOCKER_BUILDX_RACE_MARKER_GROUPS = (
+    ("existing instance for", "no append mode"),
+    ("builder instance with the name", "already exists"),
+)
 
 
 @dataclass(frozen=True)
@@ -54,6 +86,12 @@ class BuildPlan:
     cmd: list[str]
     env: dict[str, str]
     unset_env: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class BuildAttempt:
+    returncode: int
+    stderr_tail: str
 
 
 IMAGE_TARGETS = {
@@ -193,6 +231,103 @@ def format_dry_run(plan: BuildPlan) -> str:
     return f"cwd: {plan.cwd}\ncommand: {format_command(plan)}"
 
 
+def is_transient_podman_registry_failure(output: str) -> bool:
+    lines = output.splitlines()[-FAILURE_TAIL_LINES:]
+    for index, line in enumerate(lines):
+        lowered = line.lower()
+        is_transient = any(
+            marker in lowered for marker in PODMAN_TRANSIENT_ERROR_MARKERS
+        ) or PODMAN_TRANSIENT_HTTP_STATUS_RE.search(line)
+        if not is_transient:
+            continue
+
+        adjacent = "\n".join(lines[max(0, index - 1) : index + 2]).lower()
+        if any(marker in adjacent for marker in PODMAN_REGISTRY_CONTEXT_MARKERS):
+            return True
+    return False
+
+
+def is_docker_buildx_setup_race(output: str) -> bool:
+    lowered = "\n".join(output.splitlines()[-FAILURE_TAIL_LINES:]).lower()
+    return any(
+        all(marker in lowered for marker in group)
+        for group in DOCKER_BUILDX_RACE_MARKER_GROUPS
+    )
+
+
+def explicit_container_runtime(plan: BuildPlan) -> str | None:
+    container_cli = plan.env.get("CONTAINER_CLI")
+    if not container_cli:
+        return None
+    runtime = Path(container_cli).name.lower()
+    return runtime if runtime in {"docker", "podman"} else None
+
+
+def retryable_failure_reason(runtime: str, output: str) -> str | None:
+    if runtime == "docker" and is_docker_buildx_setup_race(output):
+        return "Docker Buildx setup race"
+    if runtime == "podman" and is_transient_podman_registry_failure(output):
+        return "transient Podman registry access or image transfer"
+    return None
+
+
+def is_interrupted_returncode(returncode: int) -> bool:
+    return returncode < 0 or 128 <= returncode <= 159
+
+
+def run_plan_capturing_stderr(plan: BuildPlan, env: Mapping[str, str]) -> BuildAttempt:
+    process = subprocess.Popen(
+        plan.cmd,
+        cwd=plan.cwd,
+        env=env,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    if process.stderr is None:
+        raise RuntimeError("failed to capture build stderr")
+
+    stderr_tail: deque[str] = deque(maxlen=FAILURE_TAIL_LINES)
+    for line in process.stderr:
+        stderr_tail.append(line)
+        sys.stderr.write(line)
+        sys.stderr.flush()
+    return BuildAttempt(process.wait(), "".join(stderr_tail))
+
+
+def podman_is_available(plan: BuildPlan, env: Mapping[str, str]) -> bool:
+    container_cli = plan.env["CONTAINER_CLI"]
+    try:
+        completed = subprocess.run(
+            [container_cli, "info"],
+            cwd=plan.cwd,
+            env=env,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=PODMAN_INFO_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            "[ERROR] Podman availability check timed out; not retrying the build",
+            file=sys.stderr,
+        )
+        return False
+
+    if completed.returncode != 0:
+        print(
+            "[ERROR] Podman is unavailable after the transient build failure; "
+            "not retrying",
+            file=sys.stderr,
+        )
+        if completed.stderr:
+            sys.stderr.write(completed.stderr)
+            sys.stderr.flush()
+        return False
+    return True
+
+
 def find_repo_root(start: Path) -> Path:
     _ = start
     return script_repo_root()
@@ -231,10 +366,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="print the resolved working directory and command without building",
     )
+    parser.add_argument(
+        "--retry-transient-runtime-errors",
+        action="store_true",
+        help="retry one recognized transient Docker or Podman build failure",
+    )
     return parser.parse_args(argv)
 
 
-def run_plan(plan: BuildPlan) -> int:
+def run_plan(plan: BuildPlan, *, retry_transient_runtime_errors: bool = False) -> int:
     env = os.environ.copy()
     for key in MAKE_CONTROL_ENV:
         env.pop(key, None)
@@ -242,7 +382,44 @@ def run_plan(plan: BuildPlan) -> int:
         env.pop(key, None)
     env.update(plan.env)
     print(format_dry_run(plan))
-    return subprocess.run(plan.cmd, cwd=plan.cwd, env=env, check=False).returncode
+    if not retry_transient_runtime_errors:
+        return subprocess.run(plan.cmd, cwd=plan.cwd, env=env, check=False).returncode
+
+    runtime = explicit_container_runtime(plan)
+    if runtime is None:
+        raise ValueError(
+            "--retry-transient-runtime-errors requires an explicit "
+            "CONTAINER_CLI ending in docker or podman"
+        )
+
+    first = run_plan_capturing_stderr(plan, env)
+    if first.returncode == 0:
+        return 0
+    if is_interrupted_returncode(first.returncode):
+        return first.returncode
+    reason = retryable_failure_reason(runtime, first.stderr_tail)
+    if reason is None:
+        return first.returncode
+
+    print(
+        f"[WARN] Build failed with a retryable {reason} (exit code "
+        f"{first.returncode}); retrying once after {RETRY_DELAY_SECONDS} seconds",
+        file=sys.stderr,
+    )
+    time.sleep(RETRY_DELAY_SECONDS)
+    if runtime == "podman" and not podman_is_available(plan, env):
+        return first.returncode
+
+    second = run_plan_capturing_stderr(plan, env)
+    if second.returncode == 0:
+        print(f"[INFO] {runtime.capitalize()} build retry succeeded", file=sys.stderr)
+    else:
+        print(
+            f"[ERROR] {runtime.capitalize()} build retry failed with exit code "
+            f"{second.returncode}",
+            file=sys.stderr,
+        )
+    return second.returncode
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -263,6 +440,14 @@ def main(argv: list[str] | None = None) -> int:
             unset_values=args.unset_values,
             inherited_env=os.environ,
         )
+        if (
+            args.retry_transient_runtime_errors
+            and explicit_container_runtime(plan) is None
+        ):
+            raise ValueError(
+                "--retry-transient-runtime-errors requires --set "
+                "CONTAINER_CLI=<path-to-docker-or-podman>"
+            )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -270,7 +455,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.dry_run:
         print(format_dry_run(plan))
         return 0
-    return run_plan(plan)
+    return run_plan(
+        plan,
+        retry_transient_runtime_errors=args.retry_transient_runtime_errors,
+    )
 
 
 if __name__ == "__main__":

--- a/.agents/skills/build-images/scripts/test_build_image.py
+++ b/.agents/skills/build-images/scripts/test_build_image.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 import os
 import subprocess
@@ -30,6 +30,15 @@ import build_image
 class BuildImageTest(unittest.TestCase):
     def setUp(self) -> None:
         self.repo = Path("/repo")
+
+    def podman_plan(self) -> build_image.BuildPlan:
+        return build_image.build_plan(
+            image="ccm",
+            tag="dev",
+            registry="local",
+            repo_root=self.repo,
+            set_values=["CONTAINER_CLI=/opt/podman/bin/podman"],
+        )
 
     def test_ccm_uses_default_command(self) -> None:
         plan = build_image.build_plan(
@@ -216,7 +225,9 @@ class BuildImageTest(unittest.TestCase):
 
         with mock.patch.object(
             build_image, "find_repo_root", return_value=self.repo
-        ), mock.patch.object(build_image.subprocess, "run") as run_mock, redirect_stdout(
+        ), mock.patch.object(
+            build_image.subprocess, "run"
+        ) as run_mock, redirect_stdout(
             stdout
         ):
             self.assertEqual(
@@ -243,6 +254,46 @@ class BuildImageTest(unittest.TestCase):
             "make build-ccm-image\n",
         )
 
+    def test_main_dry_run_with_retry_does_not_run_or_change_command(self) -> None:
+        stdout = StringIO()
+
+        with mock.patch.object(
+            build_image, "find_repo_root", return_value=self.repo
+        ), mock.patch.object(
+            build_image.subprocess, "run"
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ) as sleep_mock, redirect_stdout(
+            stdout
+        ):
+            self.assertEqual(
+                build_image.main(
+                    [
+                        "--image",
+                        "ccm",
+                        "--tag",
+                        "dev",
+                        "--registry",
+                        "local",
+                        "--set",
+                        "CONTAINER_CLI=/opt/podman/bin/podman",
+                        "--retry-transient-runtime-errors",
+                        "--dry-run",
+                    ]
+                ),
+                0,
+            )
+
+        run_mock.assert_not_called()
+        sleep_mock.assert_not_called()
+        self.assertEqual(
+            stdout.getvalue(),
+            "cwd: /repo\n"
+            "command: IMAGE_TAG=dev IMAGE_REGISTRY=local "
+            "GOEXPERIMENT=nosystemcrypto ENABLE_GIT_COMMAND=false "
+            "CONTAINER_CLI=/opt/podman/bin/podman make build-ccm-image\n",
+        )
+
     def test_dry_run_shows_inherited_make_control_cleanup(self) -> None:
         plan = build_image.build_plan(
             image="ccm",
@@ -266,7 +317,9 @@ class BuildImageTest(unittest.TestCase):
             build_image, "find_repo_root"
         ) as find_repo_root, mock.patch.object(
             build_image.subprocess, "run"
-        ) as run_mock, redirect_stdout(stdout):
+        ) as run_mock, redirect_stdout(
+            stdout
+        ):
             self.assertEqual(
                 build_image.main(
                     [
@@ -305,7 +358,9 @@ class BuildImageTest(unittest.TestCase):
             clear=True,
         ), mock.patch.object(
             build_image.subprocess, "run", return_value=completed
-        ) as run_mock, redirect_stdout(stdout):
+        ) as run_mock, redirect_stdout(
+            stdout
+        ):
             self.assertEqual(build_image.run_plan(plan), 7)
 
         run_mock.assert_called_once()
@@ -327,6 +382,391 @@ class BuildImageTest(unittest.TestCase):
         self.assertNotIn("ENABLE_GIT_COMMAND", kwargs["env"])
         self.assertEqual(kwargs["env"]["IMAGE_TAG"], "dev")
         self.assertEqual(kwargs["env"]["IMAGE_REGISTRY"], "example.azurecr.io/cpa")
+
+    def test_classifies_only_transient_podman_registry_failures(self) -> None:
+        positive_cases = [
+            "pinging container registry gcr.io: Temporary failure in name resolution",
+            "pulling image quay.io/example: i/o timeout",
+            "reading manifest latest in registry: connection timed out",
+            "fetching blob sha256:abc: connection reset by peer",
+            "initializing source docker://example/image: TLS handshake timeout",
+            "copying system image: unexpected HTTP status: 429 Too Many Requests",
+            "pinging container registry: status code 503 Service Unavailable",
+        ]
+        negative_cases = [
+            "compile: connection reset by peer",
+            "RUN go mod download: i/o timeout",
+            "pinging container registry: status code 401 Unauthorized",
+            "reading manifest: status code 404 Not Found",
+            "copying blob: no space left on device",
+            "initializing source docker://example/image: manifest unknown",
+            "context deadline exceeded",
+            "pinging container registry: i/o timeout\n"
+            + "\n".join(["go build: compilation failed"] * 51),
+        ]
+
+        for output in positive_cases:
+            with self.subTest(output=output):
+                self.assertTrue(
+                    build_image.is_transient_podman_registry_failure(output)
+                )
+        for output in negative_cases:
+            with self.subTest(output=output):
+                self.assertFalse(
+                    build_image.is_transient_podman_registry_failure(output)
+                )
+
+    def test_run_plan_captures_only_failure_tail_and_replays_stderr(self) -> None:
+        plan = self.podman_plan()
+        lines = [f"stderr line {index}\n" for index in range(55)]
+        process = mock.Mock()
+        process.stderr = iter(lines)
+        process.wait.return_value = 7
+        stderr = StringIO()
+
+        with mock.patch.object(
+            build_image.subprocess, "Popen", return_value=process
+        ) as popen_mock, redirect_stderr(stderr):
+            result = build_image.run_plan_capturing_stderr(plan, {"PATH": "/bin"})
+
+        self.assertEqual(result.returncode, 7)
+        self.assertEqual(
+            result.stderr_tail,
+            "".join(lines[-build_image.FAILURE_TAIL_LINES :]),
+        )
+        self.assertEqual(stderr.getvalue(), "".join(lines))
+        _, kwargs = popen_mock.call_args
+        self.assertNotIn("stdout", kwargs)
+        self.assertEqual(kwargs["stderr"], subprocess.PIPE)
+        self.assertTrue(kwargs["text"])
+
+    def test_podman_transient_failure_retries_identical_build_once(self) -> None:
+        plan = self.podman_plan()
+        first = build_image.BuildAttempt(
+            returncode=125,
+            stderr_tail=(
+                "pinging container registry gcr.io: "
+                "Temporary failure in name resolution\n"
+            ),
+        )
+        health = subprocess.CompletedProcess(
+            args=["/opt/podman/bin/podman", "info"],
+            returncode=0,
+            stderr="",
+        )
+        second = build_image.BuildAttempt(returncode=0, stderr_tail="")
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", side_effect=[first, second]
+        ) as build_mock, mock.patch.object(
+            build_image.subprocess, "run", return_value=health
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ) as sleep_mock, redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 0
+            )
+
+        self.assertEqual(build_mock.call_count, 2)
+        run_mock.assert_called_once()
+        sleep_mock.assert_called_once_with(build_image.RETRY_DELAY_SECONDS)
+        first_call, second_call = build_mock.call_args_list
+        self.assertEqual(first_call.args, second_call.args)
+        self.assertEqual(first_call.kwargs, second_call.kwargs)
+        self.assertEqual(run_mock.call_args.args[0], ["/opt/podman/bin/podman", "info"])
+
+    def test_podman_failed_retry_returns_second_failure_without_third_attempt(
+        self,
+    ) -> None:
+        plan = self.podman_plan()
+        transient = (
+            "initializing source docker://gcr.io/example: " "connection reset by peer\n"
+        )
+        first = build_image.BuildAttempt(returncode=125, stderr_tail=transient)
+        health = subprocess.CompletedProcess(
+            args=["/opt/podman/bin/podman", "info"], returncode=0, stderr=""
+        )
+        second = build_image.BuildAttempt(returncode=2, stderr_tail=transient)
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", side_effect=[first, second]
+        ) as build_mock, mock.patch.object(
+            build_image.subprocess, "run", return_value=health
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ), redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 2
+            )
+
+        self.assertEqual(build_mock.call_count, 2)
+        run_mock.assert_called_once()
+
+    def test_podman_nontransient_failure_is_not_retried(self) -> None:
+        plan = self.podman_plan()
+        failed = build_image.BuildAttempt(
+            returncode=2,
+            stderr_tail="go build: compilation failed\n",
+        )
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", return_value=failed
+        ) as build_mock, mock.patch.object(
+            build_image.subprocess, "run"
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ) as sleep_mock, redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 2
+            )
+
+        build_mock.assert_called_once()
+        run_mock.assert_not_called()
+        sleep_mock.assert_not_called()
+
+    def test_interrupted_podman_build_is_not_retried(self) -> None:
+        plan = self.podman_plan()
+
+        for returncode in (-2, 130, 137, 143):
+            with self.subTest(returncode=returncode):
+                interrupted = build_image.BuildAttempt(
+                    returncode=returncode,
+                    stderr_tail="pulling image: TLS handshake timeout\n",
+                )
+                with mock.patch.object(
+                    build_image,
+                    "run_plan_capturing_stderr",
+                    return_value=interrupted,
+                ) as build_mock, mock.patch.object(
+                    build_image.subprocess, "run"
+                ) as run_mock, mock.patch.object(
+                    build_image.time, "sleep"
+                ) as sleep_mock, redirect_stdout(
+                    StringIO()
+                ), redirect_stderr(
+                    StringIO()
+                ):
+                    self.assertEqual(
+                        build_image.run_plan(plan, retry_transient_runtime_errors=True),
+                        returncode,
+                    )
+
+                build_mock.assert_called_once()
+                run_mock.assert_not_called()
+                sleep_mock.assert_not_called()
+
+    def test_podman_success_with_transient_warning_is_not_retried(self) -> None:
+        plan = self.podman_plan()
+        succeeded = build_image.BuildAttempt(
+            returncode=0,
+            stderr_tail=(
+                "pulling image recovered after "
+                "Temporary failure in name resolution\n"
+            ),
+        )
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", return_value=succeeded
+        ) as build_mock, mock.patch.object(
+            build_image.subprocess, "run"
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ) as sleep_mock, redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 0
+            )
+
+        build_mock.assert_called_once()
+        run_mock.assert_not_called()
+        sleep_mock.assert_not_called()
+
+    def test_podman_health_check_failure_prevents_retry(self) -> None:
+        plan = self.podman_plan()
+        first = build_image.BuildAttempt(
+            returncode=125,
+            stderr_tail="pulling image: TLS handshake timeout\n",
+        )
+        health = subprocess.CompletedProcess(
+            args=["/opt/podman/bin/podman", "info"],
+            returncode=1,
+            stderr="machine unavailable\n",
+        )
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", return_value=first
+        ) as build_mock, mock.patch.object(
+            build_image.subprocess, "run", return_value=health
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ), redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 125
+            )
+
+        build_mock.assert_called_once()
+        run_mock.assert_called_once()
+
+    def test_podman_health_check_timeout_prevents_retry(self) -> None:
+        plan = self.podman_plan()
+        first = build_image.BuildAttempt(
+            returncode=125,
+            stderr_tail="pulling image: TLS handshake timeout\n",
+        )
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", return_value=first
+        ) as build_mock, mock.patch.object(
+            build_image.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("podman info", 10),
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ), redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 125
+            )
+
+        build_mock.assert_called_once()
+        run_mock.assert_called_once()
+
+    def test_transient_podman_failure_without_retry_option_runs_once(self) -> None:
+        plan = self.podman_plan()
+        failed = subprocess.CompletedProcess(args=plan.cmd, returncode=125)
+
+        with mock.patch.object(
+            build_image.subprocess, "run", return_value=failed
+        ) as run_mock, mock.patch.object(
+            build_image, "run_plan_capturing_stderr"
+        ) as build_mock, redirect_stdout(
+            StringIO()
+        ):
+            self.assertEqual(build_image.run_plan(plan), 125)
+
+        run_mock.assert_called_once()
+        build_mock.assert_not_called()
+
+    def test_retry_option_requires_explicit_supported_runtime(self) -> None:
+        cases = [[], ["CONTAINER_CLI=/usr/local/bin/nerdctl"]]
+
+        for set_values in cases:
+            with self.subTest(set_values=set_values):
+                stderr = StringIO()
+                argv = [
+                    "--image",
+                    "ccm",
+                    "--tag",
+                    "dev",
+                    "--registry",
+                    "local",
+                    "--retry-transient-runtime-errors",
+                    "--dry-run",
+                ]
+                for value in set_values:
+                    argv.extend(["--set", value])
+
+                with mock.patch.object(
+                    build_image, "find_repo_root", return_value=self.repo
+                ), mock.patch.object(
+                    build_image.subprocess, "run"
+                ) as run_mock, redirect_stderr(
+                    stderr
+                ):
+                    self.assertEqual(build_image.main(argv), 2)
+
+                run_mock.assert_not_called()
+                self.assertIn("requires --set CONTAINER_CLI", stderr.getvalue())
+
+    def test_docker_buildx_setup_race_retries_once(self) -> None:
+        plan = build_image.build_plan(
+            image="ccm",
+            tag="dev",
+            registry="local",
+            repo_root=self.repo,
+            set_values=["CONTAINER_CLI=/usr/local/bin/docker"],
+        )
+        first = build_image.BuildAttempt(
+            returncode=1,
+            stderr_tail=(
+                'ERROR: existing instance for "img-builder" but no append mode, '
+                "specify the node name to make changes\n"
+            ),
+        )
+        second = build_image.BuildAttempt(returncode=0, stderr_tail="")
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", side_effect=[first, second]
+        ) as build_mock, mock.patch.object(
+            build_image.subprocess, "run"
+        ) as run_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ) as sleep_mock, redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 0
+            )
+
+        self.assertEqual(build_mock.call_count, 2)
+        run_mock.assert_not_called()
+        sleep_mock.assert_called_once_with(build_image.RETRY_DELAY_SECONDS)
+
+    def test_docker_non_buildx_failure_is_not_retried(self) -> None:
+        plan = build_image.build_plan(
+            image="ccm",
+            tag="dev",
+            registry="local",
+            repo_root=self.repo,
+            set_values=["CONTAINER_CLI=/usr/local/bin/docker"],
+        )
+        failed = build_image.BuildAttempt(
+            returncode=1,
+            stderr_tail=(
+                "pinging container registry gcr.io: "
+                "Temporary failure in name resolution\n"
+            ),
+        )
+
+        with mock.patch.object(
+            build_image, "run_plan_capturing_stderr", return_value=failed
+        ) as build_mock, mock.patch.object(
+            build_image.time, "sleep"
+        ) as sleep_mock, redirect_stdout(
+            StringIO()
+        ), redirect_stderr(
+            StringIO()
+        ):
+            self.assertEqual(
+                build_image.run_plan(plan, retry_transient_runtime_errors=True), 1
+            )
+
+        build_mock.assert_called_once()
+        sleep_mock.assert_not_called()
 
     def test_run_plan_scrubs_inherited_make_control_environment(self) -> None:
         plan = build_image.build_plan(
@@ -350,7 +790,9 @@ class BuildImageTest(unittest.TestCase):
             clear=True,
         ), mock.patch.object(
             build_image.subprocess, "run", return_value=completed
-        ) as run_mock, redirect_stdout(StringIO()):
+        ) as run_mock, redirect_stdout(
+            StringIO()
+        ):
             self.assertEqual(build_image.run_plan(plan), 0)
 
         _, kwargs = run_mock.call_args

--- a/.agents/skills/remediate-image-cves/SKILL.md
+++ b/.agents/skills/remediate-image-cves/SKILL.md
@@ -103,9 +103,12 @@ Use this order and identity in every phase:
 | health-probe-proxy | `hpp` | `local/health-probe-proxy:<tag>` | `health-probe-proxy` | `health-probe-proxy/Dockerfile` |
 
 For every build, allow concurrent builds from other worktrees. Docker builds
-share a host-level Buildx builder; Podman uses its native builder. For Docker
-only, if a build fails specifically because Buildx setup raced, retry the exact
-build once; otherwise do not retry it.
+share a host-level Buildx builder; Podman uses its native builder. Pass the
+build helper's `--retry-transient-runtime-errors` option on every build. The
+build skill owns runtime-specific failure classification, health checks,
+bounded delay, exact retry execution, and the two-attempt limit. Do not run an
+additional outer retry. If the helper still returns a failure, preserve both
+attempts in the run summary and stop.
 
 ### Baseline Phase
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Moves bounded runtime retry execution into the shared `build-images` helper so retries are deterministic and testable instead of agent-dependent orchestration prose.

- Adds opt-in `--retry-transient-runtime-errors` handling that requires an explicit Docker or Podman executable.
- Retries Docker only for the existing Buildx builder-creation race.
- Retries Podman only for recognized transient registry or image-transfer failures, after a bounded delay and successful `podman info` health check.
- Streams stderr while retaining a bounded failure tail, reuses the identical build plan once, and fails closed for interruptions, authentication, missing manifests, disk, source/build, and unclassified failures.
- Makes `remediate-image-cves` opt into the helper policy on every build and forbids an additional outer retry.

Validation:

- 30 `build-images` helper tests
- 25 `fix-image-cves` helper tests
- Python syntax compilation and Black formatting check
- Shared-skill frontmatter validation
- Boilerplate validation
- `git diff --check`
- Independent adversarial review with no remaining material findings

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

The retry option is disabled by default, requires an explicit supported runtime, and permits at most two total build attempts. The bundled Python skill validator could not start because PyYAML is unavailable in the local environment; equivalent Ruby frontmatter validation passed without installing dependencies.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
