### PR TITLE
docs: harden CVE remediation Git locking

### DIFF
--- a/.agents/skills/authoring.md
+++ b/.agents/skills/authoring.md
@@ -46,6 +46,10 @@ agents that support the shared `.agents` convention.
   skill itself unless they are part of the agent workflow.
 - Make scripts accept explicit inputs rather than assuming a specific local
   agent path.
+- Scope `GIT_OPTIONAL_LOCKS=0` to read-only Git subprocesses in bundled
+  scripts so status-style inspections cannot refresh the index. Keep normal
+  required locking enabled for checkout, staging, commits, pushes, and ref
+  updates.
 - If you need an exception to the Python-only convention, explain it in
   `SKILL.md` so later contributors do not reintroduce mixed runtimes casually.
 

--- a/.agents/skills/fix-image-cves/SKILL.md
+++ b/.agents/skills/fix-image-cves/SKILL.md
@@ -130,6 +130,10 @@ python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
 - The state file is resolved with
   `git rev-parse --git-path fix-image-cves.json` so it stays untracked and each
   linked worktree gets isolated scan, plan, apply, and verification state.
+- Helper-owned Git commands are read-only and run with
+  `GIT_OPTIONAL_LOCKS=0`. This prevents `git status` from refreshing the index
+  as an optional side effect without weakening required locking for later
+  checkout, staging, commit, push, or ref-update operations.
 - `verify --rescan` expects the agent to rebuild the image first. The skill
   does not build or push images.
 - `clean` removes the state file and cleans up any temporary helper artifacts

--- a/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
@@ -97,6 +97,20 @@ def run_result(
     return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, env=env)
 
 
+def read_only_git_env() -> dict[str, str]:
+    """Disable optional index refresh locks for read-only Git commands."""
+    return {**os.environ, "GIT_OPTIONAL_LOCKS": "0"}
+
+
+def read_only_git(repo_root: Path, args: list[str], *, capture: bool = True) -> str:
+    return run(
+        ["git", "-C", str(repo_root), *args],
+        cwd=repo_root,
+        capture=capture,
+        env=read_only_git_env(),
+    )
+
+
 def _go_env() -> dict[str, str]:
     """Return env dict with GOTOOLCHAIN=local to match CI (actions/setup-go)."""
     return {**os.environ, "GOTOOLCHAIN": "local"}
@@ -154,21 +168,21 @@ def ensure_command(name: str) -> None:
 
 def ensure_repo_root(repo_arg: str) -> Path:
     repo = Path(repo_arg).resolve()
-    proc = subprocess.run(
-        ["git", "-C", str(repo), "rev-parse", "--show-toplevel"],
-        text=True,
-        capture_output=True,
-    )
-    if proc.returncode != 0 or not proc.stdout.strip():
+    if not repo.is_dir():
         raise CommandError(f"{repo} is not a git checkout")
-    return Path(proc.stdout.strip())
+    try:
+        root = read_only_git(repo, ["rev-parse", "--show-toplevel"])
+    except CommandError as exc:
+        raise CommandError(f"{repo} is not a git checkout") from exc
+    if not root:
+        raise CommandError(f"{repo} is not a git checkout")
+    return Path(root)
 
 
 def git_path(repo_root: Path) -> Path:
-    raw_path = run(
-        ["git", "rev-parse", "--git-path", STATE_FILE_NAME],
-        cwd=repo_root,
-        capture=True,
+    raw_path = read_only_git(
+        repo_root,
+        ["rev-parse", "--git-path", STATE_FILE_NAME],
     ).strip()
     if not raw_path:
         raise CommandError("git rev-parse returned an empty CVE state path")
@@ -677,7 +691,7 @@ def summarize_plan(plan: dict[str, Any]) -> None:
 
 
 def git_status_paths(repo_root: Path) -> set[str]:
-    output = run(["git", "-C", str(repo_root), "status", "--porcelain"], cwd=repo_root, capture=True)
+    output = read_only_git(repo_root, ["status", "--porcelain"])
     paths: set[str] = set()
     for line in output.splitlines():
         if len(line) < 4:
@@ -696,7 +710,7 @@ def path_is_under(path: str, prefix: str) -> bool:
 
 
 def discover_go_modules(repo_root: Path) -> list[str]:
-    output = run(["git", "-C", str(repo_root), "ls-files", "go.mod", "**/go.mod"], cwd=repo_root, capture=True)
+    output = read_only_git(repo_root, ["ls-files", "go.mod", "**/go.mod"])
     modules = []
     for mod_path in output.splitlines():
         directory = str(Path(mod_path).parent)

--- a/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
@@ -43,22 +43,79 @@ def module_info(
 
 
 class FixImageCVEsTest(unittest.TestCase):
+    def test_read_only_git_disables_optional_locks_without_mutating_parent_env(self) -> None:
+        repo_root = Path("/repo")
+        with mock.patch.dict(
+            os.environ,
+            {"GIT_OPTIONAL_LOCKS": "1", "KEEP_ME": "yes"},
+            clear=True,
+        ):
+            with mock.patch.object(
+                fix_image_cves,
+                "run",
+                return_value="ok",
+            ) as run:
+                self.assertEqual(
+                    fix_image_cves.read_only_git(repo_root, ["status", "--short"]),
+                    "ok",
+                )
+
+            child_env = run.call_args.kwargs["env"]
+            self.assertEqual(child_env["GIT_OPTIONAL_LOCKS"], "0")
+            self.assertEqual(child_env["KEEP_ME"], "yes")
+            self.assertEqual(os.environ["GIT_OPTIONAL_LOCKS"], "1")
+
+        run.assert_called_once_with(
+            ["git", "-C", str(repo_root), "status", "--short"],
+            cwd=repo_root,
+            capture=True,
+            env=child_env,
+        )
+
+    def test_ensure_repo_root_uses_read_only_git(self) -> None:
+        repo = Path("/repo")
+        with mock.patch.object(Path, "is_dir", return_value=True):
+            with mock.patch.object(
+                fix_image_cves,
+                "read_only_git",
+                return_value=str(repo),
+            ) as read_only_git:
+                self.assertEqual(fix_image_cves.ensure_repo_root(str(repo)), repo)
+
+        read_only_git.assert_called_once_with(
+            repo,
+            ["rev-parse", "--show-toplevel"],
+        )
+
+    def test_ensure_repo_root_rejects_missing_path_before_running_git(self) -> None:
+        missing_repo = Path("/definitely-missing-fix-image-cves-repo")
+        with mock.patch.object(
+            fix_image_cves,
+            "read_only_git",
+        ) as read_only_git:
+            with self.assertRaisesRegex(
+                fix_image_cves.CommandError,
+                "is not a git checkout",
+            ):
+                fix_image_cves.ensure_repo_root(str(missing_repo))
+
+        read_only_git.assert_not_called()
+
     def test_git_path_resolves_main_checkout_state(self) -> None:
         repo_root = Path("/repo")
         with mock.patch.object(
             fix_image_cves,
-            "run",
+            "read_only_git",
             return_value=".git/fix-image-cves.json",
-        ) as run:
+        ) as read_only_git:
             self.assertEqual(
                 fix_image_cves.git_path(repo_root),
                 Path("/repo/.git/fix-image-cves.json"),
             )
 
-        run.assert_called_once_with(
-            ["git", "rev-parse", "--git-path", "fix-image-cves.json"],
-            cwd=repo_root,
-            capture=True,
+        read_only_git.assert_called_once_with(
+            repo_root,
+            ["rev-parse", "--git-path", "fix-image-cves.json"],
         )
 
     def test_git_path_preserves_linked_worktree_state(self) -> None:
@@ -67,7 +124,7 @@ class FixImageCVEsTest(unittest.TestCase):
         )
         with mock.patch.object(
             fix_image_cves,
-            "run",
+            "read_only_git",
             return_value=str(worktree_path),
         ):
             self.assertEqual(
@@ -76,12 +133,36 @@ class FixImageCVEsTest(unittest.TestCase):
             )
 
     def test_git_path_rejects_empty_output(self) -> None:
-        with mock.patch.object(fix_image_cves, "run", return_value=""):
+        with mock.patch.object(fix_image_cves, "read_only_git", return_value=""):
             with self.assertRaisesRegex(
                 fix_image_cves.CommandError,
                 "empty CVE state path",
             ):
                 fix_image_cves.git_path(Path("/repo"))
+
+    def test_status_and_module_discovery_use_read_only_git(self) -> None:
+        repo_root = Path("/repo")
+        with mock.patch.object(
+            fix_image_cves,
+            "read_only_git",
+            side_effect=[" M tracked.txt\n?? untracked.txt", "go.mod\nnested/go.mod"],
+        ) as read_only_git:
+            self.assertEqual(
+                fix_image_cves.git_status_paths(repo_root),
+                {"tracked.txt", "untracked.txt"},
+            )
+            self.assertEqual(
+                fix_image_cves.discover_go_modules(repo_root),
+                [".", "nested"],
+            )
+
+        self.assertEqual(
+            read_only_git.call_args_list,
+            [
+                mock.call(repo_root, ["status", "--porcelain"]),
+                mock.call(repo_root, ["ls-files", "go.mod", "**/go.mod"]),
+            ],
+        )
 
     def test_classify_result_treats_go_runtime_packages_as_toolchain(self) -> None:
         result = {"Class": "lang-pkgs", "Type": "gobinary"}

--- a/.agents/skills/remediate-image-cves/SKILL.md
+++ b/.agents/skills/remediate-image-cves/SKILL.md
@@ -36,6 +36,21 @@ Invoke both image helpers and the module-sync helper with their explicit
 `--repo` input pointing at the current worktree. Remove the temporary tooling
 snapshot during final cleanup.
 
+## Git Lock Discipline
+
+Run every orchestration-owned read-only Git inspection with command-scoped
+`GIT_OPTIONAL_LOCKS=0`. This includes status, diff, log, show, rev-parse,
+ls-files, ls-tree, and ref checks. The image-CVE and module-sync helpers enforce
+the same rule internally for their read-only Git subprocesses.
+
+Do not export this setting across the workflow or pass it to mutating Git
+commands. Fetch, checkout, branch or ref updates, staging, commits, and pushes
+must run serially with normal required locking. Before each mutation and after
+each long-running helper exits, inspect the current worktree Git directory for
+lock files. If an unexpected lock exists, stop and report its path, owner,
+size, modification time, and holder check when available. Never delete,
+rename, bypass, or work around it as part of this skill.
+
 ## Preconditions
 
 1. Require a clean worktree before changing branches. Preserve all pre-existing

--- a/.agents/skills/sync-go-modules/SKILL.md
+++ b/.agents/skills/sync-go-modules/SKILL.md
@@ -20,7 +20,7 @@ Replace `<SKILL_DIR>` with the path to this skill directory.
 1. Check for unrelated local work before mutating files:
 
 ```bash
-git status --short
+GIT_OPTIONAL_LOCKS=0 git status --short
 ```
 
 If there are unrelated uncommitted changes, stop and report the conflict. If the
@@ -42,7 +42,7 @@ python3 <SKILL_DIR>/scripts/sync_go_modules.py --repo . --allow-dirty
 The helper discovers modules with the same tracked-file pathspec as CI:
 
 ```bash
-git ls-files 'go.mod' '**/go.mod'
+GIT_OPTIONAL_LOCKS=0 git ls-files 'go.mod' '**/go.mod'
 ```
 
 It then runs `go mod tidy` and `go mod verify` in every discovered module, with
@@ -61,7 +61,7 @@ without touching root vendored dependencies.
 4. Inspect the generated diff:
 
 ```bash
-git diff --stat
+GIT_OPTIONAL_LOCKS=0 git diff --stat
 ```
 
 Expected changes are scoped to tracked module files (`go.mod` / `go.sum`) and,
@@ -81,12 +81,17 @@ python3 <SKILL_DIR>/scripts/sync_go_modules.py --repo . --check-clean
 `--check-clean` fails if the sync produces any repository diff, matching the CI
 "Fail on uncommitted changes" step.
 
+Helper-owned Git commands are read-only and run with
+`GIT_OPTIONAL_LOCKS=0`. This suppresses optional index refresh writes without
+weakening required locking for checkout, staging, commit, push, or ref-update
+operations performed outside this helper.
+
 ## Manual Fallback
 
 If the helper cannot be used, run the CI-equivalent loop manually:
 
 ```bash
-mapfile -t go_mods < <(git ls-files 'go.mod' '**/go.mod')
+mapfile -t go_mods < <(GIT_OPTIONAL_LOCKS=0 git ls-files 'go.mod' '**/go.mod')
 mapfile -t modules < <(for mod in "${go_mods[@]}"; do dirname "$mod"; done | sort -u)
 for m in "${modules[@]}"; do
   echo ">> go mod tidy (${m})"
@@ -95,7 +100,7 @@ for m in "${modules[@]}"; do
   (cd "${m}" && GOTOOLCHAIN=local go mod verify)
 done
 GOTOOLCHAIN=local go mod vendor
-git diff --stat
+GIT_OPTIONAL_LOCKS=0 git diff --stat
 ```
 
 Do not use `find . -name go.mod` for this repo. Hidden local worktrees and other

--- a/.agents/skills/sync-go-modules/scripts/sync_go_modules.py
+++ b/.agents/skills/sync-go-modules/scripts/sync_go_modules.py
@@ -69,25 +69,31 @@ def run_logged(
     run(cmd, cwd=cwd, env=env)
 
 
-def git(repo: Path, args: list[str], *, capture: bool = True) -> str:
-    return run(["git", "-C", str(repo), *args], cwd=repo, capture=capture)
+def read_only_git_env() -> dict[str, str]:
+    """Disable optional index refresh locks for read-only Git commands."""
+    return {**os.environ, "GIT_OPTIONAL_LOCKS": "0"}
+
+
+def read_only_git(repo: Path, args: list[str], *, capture: bool = True) -> str:
+    return run(
+        ["git", "-C", str(repo), *args],
+        cwd=repo,
+        env=read_only_git_env(),
+        capture=capture,
+    )
 
 
 def resolve_repo_root(path: Path) -> Path:
-    root = run(
-        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
-        cwd=path,
-        capture=True,
-    )
+    root = read_only_git(path, ["rev-parse", "--show-toplevel"])
     return Path(root).resolve()
 
 
 def status_short(repo: Path) -> str:
-    return git(repo, ["status", "--short"])
+    return read_only_git(repo, ["status", "--short"])
 
 
 def discover_go_modules(repo: Path) -> list[str]:
-    out = git(repo, ["ls-files", "go.mod", "**/go.mod"])
+    out = read_only_git(repo, ["ls-files", "go.mod", "**/go.mod"])
     go_mods = [line for line in out.splitlines() if line]
     if not go_mods:
         raise CommandError("No tracked go.mod files were found")
@@ -154,7 +160,7 @@ def check_go_version(
 
 
 def print_diff_stat(repo: Path) -> None:
-    stat = git(repo, ["diff", "--stat"])
+    stat = read_only_git(repo, ["diff", "--stat"])
     if not stat:
         print("[INFO] No repository diff after sync", file=sys.stderr)
         return
@@ -163,7 +169,11 @@ def print_diff_stat(repo: Path) -> None:
 
 
 def check_clean(repo: Path) -> None:
-    proc = subprocess.run(["git", "-C", str(repo), "diff", "--quiet"], cwd=repo)
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--quiet"],
+        cwd=repo,
+        env=read_only_git_env(),
+    )
     if proc.returncode == 0:
         return
     if proc.returncode == 1:

--- a/.agents/skills/sync-go-modules/scripts/test_sync_go_modules.py
+++ b/.agents/skills/sync-go-modules/scripts/test_sync_go_modules.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import sync_go_modules
+
+
+class SyncGoModulesTest(unittest.TestCase):
+    def test_read_only_git_disables_optional_locks_without_mutating_parent_env(self) -> None:
+        repo = Path("/repo")
+        with mock.patch.dict(
+            os.environ,
+            {"GIT_OPTIONAL_LOCKS": "1", "KEEP_ME": "yes"},
+            clear=True,
+        ):
+            with mock.patch.object(
+                sync_go_modules,
+                "run",
+                return_value="ok",
+            ) as run:
+                self.assertEqual(
+                    sync_go_modules.read_only_git(repo, ["status", "--short"]),
+                    "ok",
+                )
+
+            child_env = run.call_args.kwargs["env"]
+            self.assertEqual(child_env["GIT_OPTIONAL_LOCKS"], "0")
+            self.assertEqual(child_env["KEEP_ME"], "yes")
+            self.assertEqual(os.environ["GIT_OPTIONAL_LOCKS"], "1")
+
+        run.assert_called_once_with(
+            ["git", "-C", str(repo), "status", "--short"],
+            cwd=repo,
+            env=child_env,
+            capture=True,
+        )
+
+    def test_repo_queries_use_read_only_git(self) -> None:
+        repo = Path("/repo")
+        with mock.patch.object(
+            sync_go_modules,
+            "read_only_git",
+            side_effect=[
+                str(repo),
+                " M go.mod",
+                "go.mod\nnested/go.mod",
+                " go.mod | 2 +-",
+            ],
+        ) as read_only_git:
+            self.assertEqual(sync_go_modules.resolve_repo_root(repo), repo)
+            self.assertEqual(sync_go_modules.status_short(repo), " M go.mod")
+            self.assertEqual(
+                sync_go_modules.discover_go_modules(repo),
+                [".", "nested"],
+            )
+            with mock.patch("sys.stderr", new=io.StringIO()) as stderr:
+                sync_go_modules.print_diff_stat(repo)
+                self.assertIn("go.mod | 2 +-", stderr.getvalue())
+
+        self.assertEqual(
+            read_only_git.call_args_list,
+            [
+                mock.call(repo, ["rev-parse", "--show-toplevel"]),
+                mock.call(repo, ["status", "--short"]),
+                mock.call(repo, ["ls-files", "go.mod", "**/go.mod"]),
+                mock.call(repo, ["diff", "--stat"]),
+            ],
+        )
+
+    def test_check_clean_disables_optional_git_locks(self) -> None:
+        repo = Path("/repo")
+        with mock.patch.dict(
+            os.environ,
+            {"GIT_OPTIONAL_LOCKS": "1", "KEEP_ME": "yes"},
+            clear=True,
+        ):
+            with mock.patch.object(
+                sync_go_modules.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess([], 0),
+            ) as subprocess_run:
+                sync_go_modules.check_clean(repo)
+
+            child_env = subprocess_run.call_args.kwargs["env"]
+            self.assertEqual(child_env["GIT_OPTIONAL_LOCKS"], "0")
+            self.assertEqual(child_env["KEEP_ME"], "yes")
+            self.assertEqual(os.environ["GIT_OPTIONAL_LOCKS"], "1")
+
+        subprocess_run.assert_called_once_with(
+            ["git", "-C", str(repo), "diff", "--quiet"],
+            cwd=repo,
+            env=child_env,
+        )
+
+    def test_check_clean_preserves_dirty_result(self) -> None:
+        repo = Path("/repo")
+        with mock.patch.object(
+            sync_go_modules.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 1),
+        ):
+            with self.assertRaisesRegex(
+                sync_go_modules.CommandError,
+                "Repository has changes after sync",
+            ):
+                sync_go_modules.check_clean(repo)
+
+    def test_run_logged_preserves_non_git_environment(self) -> None:
+        repo = Path("/repo")
+        env = {"GOTOOLCHAIN": "local", "KEEP_ME": "yes"}
+        with mock.patch.object(sync_go_modules, "run") as run:
+            with mock.patch("sys.stdout", new=io.StringIO()):
+                sync_go_modules.run_logged(
+                    ["go", "mod", "verify"],
+                    cwd=repo,
+                    env=env,
+                    dry_run=False,
+                )
+
+        run.assert_called_once_with(
+            ["go", "mod", "verify"],
+            cwd=repo,
+            env=env,
+        )
+        self.assertNotIn("GIT_OPTIONAL_LOCKS", env)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Hardens the shared image-CVE remediation skills against helper-owned optional Git index locks:

- scopes `GIT_OPTIONAL_LOCKS=0` to every read-only Git subprocess in `fix-image-cves` and `sync-go-modules`;
- preserves the caller environment for Go, Bash, Make, Trivy, and Git mutations that require normal locking;
- adds remediation-level lock checks before Git mutations and after long-running helpers;
- adds focused regression coverage and shared-skill authoring guidance.

Validation:

- `fix-image-cves`: 29 tests passed
- `sync-go-modules`: 5 tests passed
- `build-images`: 30 regression tests passed
- boilerplate, skill metadata, protected-call audit, and `git diff --check` passed
- context-isolated old/new skill evaluations: improved 100%, old 35%

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

The override is intentionally command-scoped to helper-owned read-only Git calls. It does not weaken required locking for checkout, staging, commits, pushes, or ref updates, and it cannot prevent an unrelated external repository observer from locking the same worktree.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
