### PR TITLE
fix: classify standalone VMs on node name paths

### DIFF
--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1546,9 +1546,6 @@ func (ss *ScaleSet) ensureHostsInPool(ctx context.Context, service *v1.Service, 
 // participating in the specified LoadBalancer Backend Pool.
 func (ss *ScaleSet) EnsureHostsInPool(ctx context.Context, service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetNameOfLB string) error {
 	logger := log.FromContextOrBackground(ctx).WithName("EnsureHostsInPool")
-	if ss.DisableAvailabilitySetNodes && !ss.EnableVmssFlexNodes {
-		return ss.ensureHostsInPool(ctx, service, nodes, backendPoolID, vmSetNameOfLB)
-	}
 	vmssUniformNodes := make([]*v1.Node, 0)
 	vmssFlexNodes := make([]*v1.Node, 0)
 	vmasNodes := make([]*v1.Node, 0)
@@ -1571,9 +1568,14 @@ func (ss *ScaleSet) EnsureHostsInPool(ctx context.Context, service *v1.Service, 
 			continue
 		}
 
-		vmManagementType, err := ss.getVMManagementTypeByNodeName(ctx, localNodeName, azcache.CacheReadTypeDefault)
+		var vmManagementType VMManagementType
+		if ss.DisableAvailabilitySetNodes && !ss.EnableVmssFlexNodes && node.Spec.ProviderID != "" {
+			vmManagementType, err = ss.getVMManagementTypeByProviderID(ctx, node.Spec.ProviderID, azcache.CacheReadTypeDefault)
+		} else {
+			vmManagementType, err = ss.getVMManagementTypeByNodeName(ctx, localNodeName, azcache.CacheReadTypeDefault)
+		}
 		if err != nil {
-			logger.Error(err, "Failed to check vmManagementType by node name", "node", localNodeName)
+			logger.Error(err, "Failed to check VM management type", "node", localNodeName)
 			errors = append(errors, err)
 			continue
 		}

--- a/pkg/provider/azure_vmss_cache.go
+++ b/pkg/provider/azure_vmss_cache.go
@@ -395,6 +395,19 @@ func (ss *ScaleSet) newNonVmssUniformNodesCache() (azcache.Resource, error) {
 func (ss *ScaleSet) getVMManagementTypeByNodeName(ctx context.Context, nodeName string, crt azcache.AzureCacheReadType) (VMManagementType, error) {
 	logger := log.FromContextOrBackground(ctx).WithName("getVMManagementTypeByNodeName")
 	if ss.DisableAvailabilitySetNodes && !ss.EnableVmssFlexNodes {
+		if ss.nodeLister == nil {
+			return ManagedByVmssUniform, nil
+		}
+
+		node, err := ss.nodeLister.Get(nodeName)
+		if err == nil && node.Spec.ProviderID != "" {
+			return ss.getVMManagementTypeByProviderID(
+				ctx,
+				node.Spec.ProviderID,
+				crt,
+			)
+		}
+
 		return ManagedByVmssUniform, nil
 	}
 	ss.lockMap.LockEntry(consts.VMManagementTypeLockKey)

--- a/pkg/provider/azure_vmss_cache_test.go
+++ b/pkg/provider/azure_vmss_cache_test.go
@@ -31,6 +31,10 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	k8scache "k8s.io/client-go/tools/cache"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/utils/ptr"
 
@@ -175,6 +179,8 @@ func TestGetVMManagementTypeByNodeName(t *testing.T) {
 	testCases := []struct {
 		description                 string
 		nodeName                    string
+		providerID                  string
+		nodeListerNil               bool
 		DisableAvailabilitySetNodes bool
 		EnableVmssFlexNodes         bool
 		vmListErr                   error
@@ -203,8 +209,28 @@ func TestGetVMManagementTypeByNodeName(t *testing.T) {
 			expectedErr:              nil,
 		},
 		{
-			description:                 "getVMManagementTypeByNodeName should return ManagedByVmssUniform if DisableAvailabilitySetNodes is set to true and EnableVmssFlexNodes is set to false",
+			description:                 "getVMManagementTypeByNodeName should return ManagedByAvSet for standalone VM when availability set nodes are disabled",
+			nodeName:                    "standalone-vm",
+			providerID:                  "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/standalone-vm",
+			DisableAvailabilitySetNodes: true,
+			EnableVmssFlexNodes:         false,
+			vmListErr:                   nil,
+			expectedVMManagementType:    ManagedByAvSet,
+			expectedErr:                 nil,
+		},
+		{
+			description:                 "getVMManagementTypeByNodeName should fall back to ManagedByVmssUniform when node metadata is unavailable",
 			nodeName:                    "anyName",
+			DisableAvailabilitySetNodes: true,
+			EnableVmssFlexNodes:         false,
+			vmListErr:                   nil,
+			expectedVMManagementType:    ManagedByVmssUniform,
+			expectedErr:                 nil,
+		},
+		{
+			description:                 "getVMManagementTypeByNodeName should fall back to ManagedByVmssUniform when node lister is unavailable",
+			nodeName:                    "anyName",
+			nodeListerNil:               true,
 			DisableAvailabilitySetNodes: true,
 			EnableVmssFlexNodes:         false,
 			vmListErr:                   nil,
@@ -230,6 +256,18 @@ func TestGetVMManagementTypeByNodeName(t *testing.T) {
 
 			ss.DisableAvailabilitySetNodes = tc.DisableAvailabilitySetNodes
 			ss.EnableVmssFlexNodes = tc.EnableVmssFlexNodes
+			if tc.nodeListerNil {
+				ss.nodeLister = nil
+			}
+			if tc.providerID != "" {
+				indexer := k8scache.NewIndexer(k8scache.MetaNamespaceKeyFunc, k8scache.Indexers{})
+				err = indexer.Add(&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: tc.nodeName},
+					Spec:       v1.NodeSpec{ProviderID: tc.providerID},
+				})
+				assert.NoError(t, err, tc.description)
+				ss.nodeLister = corelisters.NewNodeLister(indexer)
+			}
 
 			mockVMClient := ss.ComputeClientFactory.GetVirtualMachineClient().(*mock_virtualmachineclient.MockInterface)
 			mockVMClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(testVMList, tc.vmListErr).AnyTimes()

--- a/pkg/provider/azure_vmss_test.go
+++ b/pkg/provider/azure_vmss_test.go
@@ -3108,6 +3108,35 @@ func TestEnsureHostsInPool(t *testing.T) {
 	}
 }
 
+func TestEnsureHostsInPoolRoutesStandaloneVM(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ss, err := NewTestScaleSet(ctrl)
+	assert.NoError(t, err)
+	ss.DisableAvailabilitySetNodes = true
+	ss.EnableVmssFlexNodes = false
+	ss.LoadBalancerSKU = consts.LoadBalancerSKUStandard
+
+	nodes := []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "standalone-vm"},
+			Spec: v1.NodeSpec{
+				ProviderID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/standalone-vm",
+			},
+		},
+	}
+	service := &v1.Service{}
+	availabilitySet := NewMockVMSet(ctrl)
+	availabilitySet.EXPECT().EnsureHostsInPool(
+		gomock.Any(), service, nodes, testLBBackendpoolID1, testVMSSName,
+	).Return(nil)
+	ss.availabilitySet = availabilitySet
+
+	err = ss.EnsureHostsInPool(context.Background(), service, nodes, testLBBackendpoolID1, testVMSSName)
+	assert.NoError(t, err)
+}
+
 func TestEnsureHostsInPoolEtagMismatch(t *testing.T) {
 	testCases := []struct {
 		description            string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Classifies standalone VM nodes using the Kubernetes Node provider ID when availability-set nodes and VMSS Flex nodes are disabled. This preserves the no-VM-list optimization while preventing standalone VMs from being routed through the VMSS Uniform handler.

It also classifies nodes by provider ID in `EnsureHostsInPool` for the affected configuration so standalone VM NICs are updated through the correct handler.

#### Which issue(s) this PR fixes:

Fixes #10217

#### Special notes for your reviewer:

AI assistance was used to analyze the routing flow and draft tests. I reviewed the changes and validated them with targeted, package, race, static, and lint checks.

Tests:

- `GOWORK=off go test -v ./pkg/provider -run '^(TestGetVMManagementTypeByNodeName|TestEnsureHostsInPool.*)$' -count=1`
- `GOWORK=off go test ./pkg/provider/... -count=1`
- `GOWORK=off go test -race ./pkg/provider -run '^(TestGetVMManagementTypeByNodeName|TestEnsureHostsInPoolRoutesStandaloneVM)$' -count=1`
- `make test-check`
- `GOWORK=off make lint`

#### Does this PR introduce a user-facing change?

```release-note
Fixed standalone VM nodes being misclassified as VMSS Uniform on node-name and load balancer backend-pool paths when availability-set and VMSS Flex nodes are disabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
