### PR TITLE
agents: bump Go directives for dependency CVE fixes

### DIFF
--- a/.agents/skills/fix-image-cves/SKILL.md
+++ b/.agents/skills/fix-image-cves/SKILL.md
@@ -31,6 +31,11 @@ python3 <SKILL_DIR>/scripts/fix_image_cves.py scan \
 python3 <SKILL_DIR>/scripts/fix_image_cves.py plan
 ```
 
+The plan resolves the target Go modules' own `go` directives without changing
+the repository. If it reports a Go directive bump, select a locally installed
+Go version that is at least the planned target before continuing. Keep
+`GOTOOLCHAIN=local`; do not rely on an automatic toolchain download.
+
 3. Review the plan before changing files. When base-image CVEs are in scope,
    decide the deterministic replacement image and digest yourself. Then apply
    the plan:
@@ -102,15 +107,20 @@ python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
   verification result.
 - `plan` groups multiple GO_MODULE CVEs by module path, chooses the highest
   `FixedVersion` as the minimum required version, and adds Go's required `v`
-  prefix when Trivy reports a digit-leading version. BASE_IMAGE findings are
-  grouped into a recommendation that requires an explicit
-  `--base-image-target`.
-- `apply` stages every unresolved Go module minimum for the same module root in
-  one `go mod edit` command, then lets `go mod tidy` resolve the complete module
-  graph using Minimal Version Selection. This avoids treating command-line
-  versions as conflicting exact `go get` requests. It then mirrors the repo CI
-  behavior by discovering all tracked `go.mod` files and running `go mod tidy`
-  plus `go mod verify` in every module before `go mod vendor`.
+  prefix when Trivy reports a digit-leading version. It queries each target
+  module version outside the repository with `GOTOOLCHAIN=local`, groups any
+  newer `go` directive requirements by module root, and plans the highest
+  required directive. BASE_IMAGE findings are grouped into a recommendation
+  that requires an explicit `--base-image-target`.
+- `apply` first verifies that the selected local Go version satisfies both the
+  current repository and planned directives. It applies each planned directive
+  with `go mod edit -go=<version>` before staging every unresolved Go module
+  minimum for the same module root in one `go mod edit` command, then lets
+  `go mod tidy` resolve the complete module graph using Minimal Version
+  Selection. This avoids treating command-line versions as conflicting exact
+  `go get` requests. It then mirrors the repo CI behavior by discovering all
+  tracked `go.mod` files and running `go mod tidy` plus `go mod verify` in every
+  module before `go mod vendor`.
 - When vendoring is enabled at the repo root, `apply` also runs
   `hack/update-azure-vendor-licenses.sh` so `LICENSES/` stays in sync with
   `vendor/` and the resulting PR is self-contained. The upstream license
@@ -118,11 +128,11 @@ python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
   the root `go.sum`, so `apply` reruns root `go mod tidy` and `go mod verify`
   after license generation. This keeps the recorded changes clean under the
   repository's `go-mod-consistency` workflow.
-- `verify` accepts resolved and vendored Go module versions that are equal to or
-  higher than each planned minimum. It does not assume a clean worktree and
-  compares the current repo diff against the pre-existing changed files plus
-  the files recorded during `apply` so unrelated user edits do not trigger
-  false failures.
+- `verify` requires each planned `go` directive and resolved or vendored Go
+  module version to be equal to or higher than its planned minimum. It does not
+  assume a clean worktree and compares the current repo diff against the
+  pre-existing changed files plus the files recorded during `apply` so
+  unrelated user edits do not trigger false failures.
 - `apply` refuses planned Go modules with `replace` directives, and `verify`
   fails resolved or vendored replacements. A replacement module's version does
   not prove that the original module meets its CVE fix threshold; update or
@@ -138,10 +148,10 @@ python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
   does not build or push images.
 - `clean` removes the state file and cleans up any temporary helper artifacts
   left behind by vendor-license regeneration.
-- `apply` and `verify` set `GOTOOLCHAIN=local` for all Go subprocess calls to
+- `plan`, `apply`, and `verify` set `GOTOOLCHAIN=local` for all Go subprocess calls to
   match CI behavior (`actions/setup-go` uses `GOTOOLCHAIN=local`). This
   prevents toolchain auto-download from producing extra `go.sum` entries that
   fail the Go Module Consistency check. The skill requires a locally installed
-  Go version that satisfies the repo's `go` directive; `apply` performs a
-  preflight check and fails early with a clear message if the local Go is too
-  old.
+  Go version that satisfies the current and planned repo `go` directives;
+  `apply` performs a preflight check and fails before source mutation with a
+  clear message if the local Go is too old.

--- a/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
@@ -23,6 +23,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -116,18 +117,35 @@ def _go_env() -> dict[str, str]:
     return {**os.environ, "GOTOOLCHAIN": "local"}
 
 
-def _check_local_go_version(repo_root: Path, go_env: dict[str, str]) -> None:
-    """Raise CommandError if the local Go is older than the repo requires."""
+def read_go_directive(go_mod: Path) -> str:
+    """Return the Go language version declared by a go.mod file."""
+    if not go_mod.is_file():
+        raise CommandError(f"Go module file does not exist: {go_mod}")
+    for line in go_mod.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[0] == "go":
+            return parts[1]
+    return ""
+
+
+def _check_local_go_version(
+    repo_root: Path,
+    go_env: dict[str, str],
+    go_directive_actions: list[dict[str, Any]] | None = None,
+) -> None:
+    """Raise CommandError if local Go is older than current or planned directives."""
     max_required = "0"
     for module in discover_go_modules(repo_root):
         mod_file = repo_root / module / "go.mod"
         if not mod_file.is_file():
             continue
-        for line in mod_file.read_text(encoding="utf-8").splitlines():
-            parts = line.split()
-            if len(parts) == 2 and parts[0] == "go":
-                if _version_tuple(parts[1]) > _version_tuple(max_required):
-                    max_required = parts[1]
+        current = read_go_directive(mod_file)
+        if current and compare_fixed_versions(current, max_required) > 0:
+            max_required = current
+    for action in go_directive_actions or []:
+        target = str(action.get("target_version") or "")
+        if target and compare_fixed_versions(target, max_required) > 0:
+            max_required = target
     if max_required == "0":
         return
     proc = subprocess.run(
@@ -142,23 +160,12 @@ def _check_local_go_version(repo_root: Path, go_env: dict[str, str]) -> None:
         if part.startswith("go") and part != "go":
             local_ver = part[2:]
             break
-    if _version_tuple(local_ver) < _version_tuple(max_required):
+    if not version_at_least(local_ver, max_required):
         raise CommandError(
-            f"Local Go version {local_ver} is older than the repo requires "
-            f"({max_required}). Install Go >= {max_required} or set "
-            f"GOTOOLCHAIN=auto to allow automatic toolchain download."
+            f"Local Go version {local_ver} is older than the current or planned "
+            f"repository Go requirement ({max_required}). Select or install a local "
+            f"Go version >= {max_required} before apply; GOTOOLCHAIN remains local."
         )
-
-
-def _version_tuple(version: str) -> tuple[int, ...]:
-    """Parse a version string like '1.25.0' into a comparable tuple."""
-    parts = []
-    for segment in version.split("."):
-        try:
-            parts.append(int(segment))
-        except ValueError:
-            break
-    return tuple(parts)
 
 
 def ensure_command(name: str) -> None:
@@ -404,6 +411,103 @@ def build_go_requirement_commands(
     return commands
 
 
+def target_module_go_directive(module: str, version: str) -> str:
+    """Resolve the Go directive for an explicit module version without a repo mutation."""
+    query = f"{module}@{normalize_go_version(version)}"
+    env = {
+        **_go_env(),
+        "GO111MODULE": "on",
+        "GOWORK": "off",
+    }
+    with tempfile.TemporaryDirectory(prefix="fix-image-cves-go-module-") as temp_dir:
+        output = run(
+            ["go", "list", "-m", "-json", query],
+            cwd=Path(temp_dir),
+            capture=True,
+            env=env,
+        )
+        try:
+            payload = json.loads(output)
+        except json.JSONDecodeError as exc:
+            raise CommandError(
+                f"go list returned invalid JSON for module {query}: {exc}"
+            ) from exc
+        go_mod_value = str(payload.get("GoMod") or "")
+        if not go_mod_value:
+            raise CommandError(f"go list did not return a GoMod path for module {query}")
+        go_mod = Path(go_mod_value)
+        if not go_mod.is_absolute():
+            go_mod = Path(temp_dir) / go_mod
+        return read_go_directive(go_mod)
+
+
+def build_go_directive_actions(
+    repo_root: Path,
+    go_actions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Plan go.mod language-version bumps required by target dependencies."""
+    grouped: dict[str, dict[str, Any]] = {}
+    for action in go_actions:
+        module_root = action["module_root"]
+        module = action["module"]
+        version = normalize_go_version(action["fixed_version"])
+        required = target_module_go_directive(module, version)
+        if not required:
+            continue
+        if module_root not in grouped:
+            grouped[module_root] = {
+                "module_root": module_root,
+                "current_version": read_go_directive(
+                    abs_from_repo(repo_root, module_root) / "go.mod"
+                ),
+                "requirements": [],
+            }
+        group = grouped[module_root]
+        if not version_at_least(group["current_version"], required):
+            group["requirements"].append(
+                {
+                    "module": module,
+                    "version": version,
+                    "required_go_version": required,
+                }
+            )
+
+    actions: list[dict[str, Any]] = []
+    for module_root, group in sorted(grouped.items()):
+        requirements = group["requirements"]
+        if not requirements:
+            continue
+        target = requirements[0]["required_go_version"]
+        for requirement in requirements[1:]:
+            candidate = requirement["required_go_version"]
+            if compare_fixed_versions(candidate, target) > 0:
+                target = candidate
+        actions.append(
+            {
+                "module_root": module_root,
+                "current_version": group["current_version"],
+                "target_version": target,
+                "required_by": sorted(
+                    f"{requirement['module']}@{requirement['version']}"
+                    for requirement in requirements
+                ),
+            }
+        )
+    return actions
+
+
+def build_go_directive_commands(
+    actions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "cwd": action["module_root"],
+            "cmd": ["go", "mod", "edit", f"-go={action['target_version']}"],
+        }
+        for action in sorted(actions, key=lambda item: item["module_root"])
+    ]
+
+
 def sanitize_dockerfile_stage(result: dict[str, Any]) -> str:
     return "runtime" if result.get("Class") == "os-pkgs" else "unknown"
 
@@ -623,6 +727,7 @@ def unsupported_fixable_findings(plan: dict[str, Any]) -> list[dict[str, Any]]:
 
 def summarize_plan(plan: dict[str, Any]) -> None:
     go_actions = plan.get("go_module_actions") or []
+    go_directive_actions = plan.get("go_directive_actions") or []
     base_actions = plan.get("base_image_actions") or []
     other_findings = plan.get("other_findings") or []
     toolchain_findings = [
@@ -634,6 +739,7 @@ def summarize_plan(plan: dict[str, Any]) -> None:
     print("Plan Summary")
     print("============")
     print(f"Go module actions: {len(go_actions)}")
+    print(f"Go directive actions: {len(go_directive_actions)}")
     print(f"Base image actions: {len(base_actions)}")
     print(f"Go toolchain findings: {len(toolchain_findings)}")
     print(f"Unsupported fixable findings: {len(unsupported_findings)}")
@@ -646,6 +752,16 @@ def summarize_plan(plan: dict[str, Any]) -> None:
             print(
                 f"{action['module']} -> {action['fixed_version']} "
                 f"(module root: {action['module_root']})"
+            )
+    if go_directive_actions:
+        print("")
+        print("Go Directive Bumps")
+        print("------------------")
+        for action in go_directive_actions:
+            required_by = ", ".join(action["required_by"])
+            print(
+                f"{action['module_root']}/go.mod {action['current_version']} -> "
+                f"{action['target_version']} (required by: {required_by})"
             )
     if base_actions:
         print("")
@@ -923,6 +1039,30 @@ def verify_go_module_actions(repo_root: Path, plan: dict[str, Any], results: dic
     return ok
 
 
+def verify_go_directive_actions(
+    repo_root: Path,
+    plan: dict[str, Any],
+    results: dict[str, Any],
+) -> bool:
+    ok = True
+    for action in plan.get("go_directive_actions") or []:
+        module_root = action["module_root"]
+        expected = action["target_version"]
+        actual = read_go_directive(abs_from_repo(repo_root, module_root) / "go.mod")
+        passed = version_at_least(actual, expected)
+        results.setdefault("go_directive_checks", []).append(
+            {
+                "module_root": module_root,
+                "expected_version": expected,
+                "actual_version": actual,
+                "passed": passed,
+            }
+        )
+        if not passed:
+            ok = False
+    return ok
+
+
 def verify_dockerfile_actions(repo_root: Path, apply_state: dict[str, Any], results: dict[str, Any]) -> bool:
     ok = True
     for applied in apply_state.get("base_image_updates") or []:
@@ -1028,6 +1168,12 @@ def command_plan(args: argparse.Namespace) -> int:
     if not scan:
         raise CommandError("State file has no scan results. Run scan first.")
     plan = build_plan(scan)
+    go_actions = actionable_go_module_actions(plan)
+    if go_actions:
+        ensure_command("go")
+        plan["go_directive_actions"] = build_go_directive_actions(repo_root, go_actions)
+    else:
+        plan["go_directive_actions"] = []
     plan["generated_at"] = int(time.time())
     state["plan"] = plan
     state.pop("apply", None)
@@ -1074,10 +1220,20 @@ def command_apply(args: argparse.Namespace) -> int:
         raise CommandError("State file must contain scan and plan results. Run scan and plan first.")
 
     go_actions = actionable_go_module_actions(plan)
+    go_env: dict[str, str] | None = None
+    if go_actions:
+        ensure_command("go")
+        go_env = _go_env()
+        if "go_directive_actions" not in plan:
+            plan["go_directive_actions"] = build_go_directive_actions(repo_root, go_actions)
+            state["plan"] = plan
+            save_state(repo_root, state)
+    go_directive_actions = plan.get("go_directive_actions") or []
     base_actions = plan.get("base_image_actions") or []
     targets = parse_base_image_targets(args.base_image_target or [])
     preexisting_paths = git_status_paths(repo_root)
     module_roots = {action["module_root"] for action in go_actions}
+    module_roots.update(action["module_root"] for action in go_directive_actions)
     dockerfiles = {action["dockerfile"] for action in base_actions}
     vendor_enabled = bool(go_actions) and has_vendor_tree(repo_root)
     protect_apply_targets(
@@ -1087,11 +1243,8 @@ def command_apply(args: argparse.Namespace) -> int:
         vendor_enabled=vendor_enabled,
     )
 
-    go_env: dict[str, str] | None = None
     if go_actions:
-        ensure_command("go")
-        go_env = _go_env()
-        _check_local_go_version(repo_root, go_env)
+        _check_local_go_version(repo_root, go_env, go_directive_actions)
 
     resolved_versions: dict[tuple[str, str], str] = {}
     for action in go_actions:
@@ -1106,6 +1259,16 @@ def command_apply(args: argparse.Namespace) -> int:
         resolved_versions[key] = module_info["version"]
 
     go_commands: list[dict[str, Any]] = []
+    for command in build_go_directive_commands(go_directive_actions):
+        module_dir = abs_from_repo(repo_root, command["cwd"])
+        cmd = command["cmd"]
+        if args.dry_run:
+            print_cmd(cmd, cwd=module_dir)
+        else:
+            info(f"Running {quote_cmd(cmd)} in {command['cwd']}")
+            run(cmd, cwd=module_dir, env=go_env)
+        go_commands.append(command)
+
     for command in build_go_requirement_commands(go_actions, resolved_versions):
         module_dir = abs_from_repo(repo_root, command["cwd"])
         cmd = command["cmd"]
@@ -1224,6 +1387,8 @@ def command_verify(args: argparse.Namespace) -> int:
 
     results: dict[str, Any] = {"checked_at": int(time.time())}
     ok = True
+    if not verify_go_directive_actions(repo_root, plan, results):
+        ok = False
     if not verify_go_module_actions(repo_root, plan, results):
         ok = False
     if not verify_dockerfile_actions(repo_root, apply_state, results):
@@ -1263,6 +1428,11 @@ def command_verify(args: argparse.Namespace) -> int:
 
     print("Verify Summary")
     print("==============")
+    for item in results.get("go_directive_checks", []):
+        print(
+            f"{item['module_root']}/go.mod minimum={item['expected_version']} "
+            f"actual={item['actual_version']} passed={item['passed']}"
+        )
     for item in results.get("go_module_checks", []):
         replacement_note = ""
         if item.get("replacement_path"):

--- a/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import io
+import json
 import os
 import shutil
 import subprocess
@@ -370,6 +371,7 @@ class FixImageCVEsTest(unittest.TestCase):
                         "fixed_version": "v0.56.0",
                     }
                 ],
+                "go_directive_actions": [],
                 "base_image_actions": [],
             },
         }
@@ -437,6 +439,190 @@ class FixImageCVEsTest(unittest.TestCase):
         self.assertGreater(root_verify_indices[-1], root_tidy_indices[-1])
         applied = save_state.call_args.args[1]["apply"]
         self.assertEqual(applied["modified_files"], ["go.mod", "go.sum"])
+
+    def test_apply_rejects_old_local_go_before_source_mutation(self) -> None:
+        state = {
+            "scan": {"module_root": ".", "dockerfile": "Dockerfile"},
+            "plan": {
+                "go_module_actions": [
+                    {
+                        "module": "golang.org/x/crypto",
+                        "module_root": ".",
+                        "fixed_version": "v0.56.0",
+                    }
+                ],
+                "go_directive_actions": [
+                    {
+                        "module_root": ".",
+                        "current_version": "1.25.0",
+                        "target_version": "1.26.0",
+                        "required_by": ["golang.org/x/crypto@v0.56.0"],
+                    }
+                ],
+                "base_image_actions": [],
+            },
+        }
+        args = Namespace(repo=".", base_image_target=[], dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            (repo_root / "go.mod").write_text(
+                "module example.com/root\n\ngo 1.25.0\n",
+                encoding="utf-8",
+            )
+            go_version = subprocess.CompletedProcess(
+                ["go", "version"],
+                0,
+                stdout="go version go1.25.9 darwin/arm64\n",
+                stderr="",
+            )
+            with mock.patch.object(
+                fix_image_cves, "ensure_repo_root", return_value=repo_root
+            ), mock.patch.object(
+                fix_image_cves, "load_state", return_value=state
+            ), mock.patch.object(
+                fix_image_cves, "git_status_paths", return_value=set()
+            ), mock.patch.object(
+                fix_image_cves, "discover_go_modules", return_value=["."]
+            ), mock.patch.object(
+                fix_image_cves, "ensure_command"
+            ), mock.patch.object(
+                fix_image_cves.subprocess, "run", return_value=go_version
+            ), mock.patch.object(
+                fix_image_cves, "go_list_module_info"
+            ) as go_list, mock.patch.object(
+                fix_image_cves, "run"
+            ) as run:
+                with self.assertRaisesRegex(
+                    fix_image_cves.CommandError,
+                    r"Local Go version 1\.25\.9.*1\.26\.0",
+                ):
+                    fix_image_cves.command_apply(args)
+
+        go_list.assert_not_called()
+        run.assert_not_called()
+
+    def test_apply_bumps_go_directive_before_dependency_requirements(self) -> None:
+        state = {
+            "scan": {"module_root": ".", "dockerfile": "Dockerfile"},
+            "plan": {
+                "go_module_actions": [
+                    {
+                        "module": "golang.org/x/crypto",
+                        "module_root": ".",
+                        "fixed_version": "v0.56.0",
+                    }
+                ],
+                "go_directive_actions": [
+                    {
+                        "module_root": ".",
+                        "current_version": "1.25.0",
+                        "target_version": "1.26.0",
+                        "required_by": ["golang.org/x/crypto@v0.56.0"],
+                    }
+                ],
+                "base_image_actions": [],
+            },
+        }
+        args = Namespace(repo=".", base_image_target=[], dry_run=False)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            with mock.patch.object(
+                fix_image_cves, "ensure_repo_root", return_value=repo_root
+            ), mock.patch.object(
+                fix_image_cves, "load_state", return_value=state
+            ), mock.patch.object(
+                fix_image_cves, "save_state"
+            ) as save_state, mock.patch.object(
+                fix_image_cves,
+                "git_status_paths",
+                side_effect=[set(), {"go.mod", "go.sum"}],
+            ), mock.patch.object(
+                fix_image_cves, "discover_go_modules", return_value=[]
+            ), mock.patch.object(
+                fix_image_cves,
+                "go_list_module_info",
+                return_value=module_info("v0.55.0"),
+            ), mock.patch.object(
+                fix_image_cves, "ensure_command"
+            ), mock.patch.object(
+                fix_image_cves, "_check_local_go_version"
+            ), mock.patch.object(
+                fix_image_cves, "run", return_value=""
+            ) as run, mock.patch(
+                "sys.stdout", io.StringIO()
+            ):
+                self.assertEqual(fix_image_cves.command_apply(args), 0)
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual(
+            commands[:2],
+            [
+                ["go", "mod", "edit", "-go=1.26.0"],
+                ["go", "mod", "edit", "-require=golang.org/x/crypto@v0.56.0"],
+            ],
+        )
+        self.assertEqual(save_state.call_args.args[1]["apply"]["go_commands"][:2], [
+            {"cwd": ".", "cmd": commands[0]},
+            {"cwd": ".", "cmd": commands[1]},
+        ])
+
+    def test_apply_enriches_older_plan_before_dry_run(self) -> None:
+        state = {
+            "scan": {"module_root": ".", "dockerfile": "Dockerfile"},
+            "plan": {
+                "go_module_actions": [
+                    {
+                        "module": "golang.org/x/crypto",
+                        "module_root": ".",
+                        "fixed_version": "v0.56.0",
+                    }
+                ],
+                "base_image_actions": [],
+            },
+        }
+        directive_action = {
+            "module_root": ".",
+            "current_version": "1.25.0",
+            "target_version": "1.26.0",
+            "required_by": ["golang.org/x/crypto@v0.56.0"],
+        }
+        args = Namespace(repo=".", base_image_target=[], dry_run=True)
+        output = io.StringIO()
+
+        with mock.patch.object(
+            fix_image_cves, "ensure_repo_root", return_value=Path("/repo")
+        ), mock.patch.object(
+            fix_image_cves, "load_state", return_value=state
+        ), mock.patch.object(
+            fix_image_cves,
+            "build_go_directive_actions",
+            return_value=[directive_action],
+        ) as build_directives, mock.patch.object(
+            fix_image_cves, "save_state"
+        ) as save_state, mock.patch.object(
+            fix_image_cves, "git_status_paths", return_value=set()
+        ), mock.patch.object(
+            fix_image_cves,
+            "go_list_module_info",
+            return_value=module_info("v0.55.0"),
+        ), mock.patch.object(
+            fix_image_cves, "discover_go_modules", return_value=[]
+        ), mock.patch.object(
+            fix_image_cves, "ensure_command"
+        ), mock.patch.object(
+            fix_image_cves, "_check_local_go_version"
+        ), mock.patch(
+            "sys.stdout", output
+        ):
+            self.assertEqual(fix_image_cves.command_apply(args), 0)
+
+        build_directives.assert_called_once()
+        self.assertEqual(save_state.call_args_list[0].args[1]["plan"]["go_directive_actions"], [
+            directive_action
+        ])
+        self.assertIn("go mod edit -go=1.26.0", output.getvalue())
 
     def test_verify_ignores_toolchain_action_from_older_plan_state(self) -> None:
         plan = {
@@ -537,6 +723,144 @@ class FixImageCVEsTest(unittest.TestCase):
         )
 
         self.assertEqual(plan["go_module_actions"][0]["fixed_version"], "v0.55.0")
+
+    def test_target_module_go_directive_reads_go_mod_without_repo_context(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            go_mod = Path(temp_dir) / "x-crypto-v0.56.0.mod"
+            go_mod.write_text(
+                "module golang.org/x/crypto\n\ngo 1.26.0\n",
+                encoding="utf-8",
+            )
+            payload = json.dumps(
+                {
+                    "Path": "golang.org/x/crypto",
+                    "Version": "v0.56.0",
+                    "GoMod": str(go_mod),
+                }
+            )
+            with mock.patch.object(
+                fix_image_cves,
+                "run",
+                return_value=payload,
+            ) as run:
+                self.assertEqual(
+                    fix_image_cves.target_module_go_directive(
+                        "golang.org/x/crypto",
+                        "v0.56.0",
+                    ),
+                    "1.26.0",
+                )
+
+        call = run.call_args
+        self.assertEqual(
+            call.args[0],
+            ["go", "list", "-m", "-json", "golang.org/x/crypto@v0.56.0"],
+        )
+        self.assertNotEqual(call.kwargs["cwd"], Path.cwd())
+        self.assertEqual(call.kwargs["env"]["GOTOOLCHAIN"], "local")
+        self.assertEqual(call.kwargs["env"]["GO111MODULE"], "on")
+        self.assertEqual(call.kwargs["env"]["GOWORK"], "off")
+        self.assertEqual(call.kwargs["env"]["PATH"], os.environ["PATH"])
+
+    def test_build_go_directive_actions_groups_by_root_and_uses_highest_requirement(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            (repo_root / "go.mod").write_text(
+                "module example.com/root\n\ngo 1.25.0\n",
+                encoding="utf-8",
+            )
+            nested = repo_root / "health-probe-proxy"
+            nested.mkdir()
+            (nested / "go.mod").write_text(
+                "module example.com/hpp\n\ngo 1.26.0\n",
+                encoding="utf-8",
+            )
+            actions = [
+                {
+                    "module": "golang.org/x/crypto",
+                    "module_root": ".",
+                    "fixed_version": "v0.56.0",
+                },
+                {
+                    "module": "golang.org/x/net",
+                    "module_root": ".",
+                    "fixed_version": "v0.58.0",
+                },
+                {
+                    "module": "golang.org/x/sys",
+                    "module_root": "health-probe-proxy",
+                    "fixed_version": "v0.46.0",
+                },
+            ]
+            with mock.patch.object(
+                fix_image_cves,
+                "target_module_go_directive",
+                side_effect=["1.26.0", "1.27.0", "1.26.0"],
+            ):
+                directive_actions = fix_image_cves.build_go_directive_actions(
+                    repo_root,
+                    actions,
+                )
+
+        self.assertEqual(
+            directive_actions,
+            [
+                {
+                    "module_root": ".",
+                    "current_version": "1.25.0",
+                    "target_version": "1.27.0",
+                    "required_by": [
+                        "golang.org/x/crypto@v0.56.0",
+                        "golang.org/x/net@v0.58.0",
+                    ],
+                }
+            ],
+        )
+
+    def test_command_plan_persists_and_displays_go_directive_action(self) -> None:
+        state = {
+            "scan": {
+                "findings": [
+                    {
+                        "category": "GO_MODULE",
+                        "package": "golang.org/x/crypto",
+                        "module_root": ".",
+                        "target": "cloud-controller-manager",
+                        "installed_version": "v0.55.0",
+                        "fixed_version": "v0.56.0",
+                        "id": "CVE-2026-0001",
+                    }
+                ]
+            }
+        }
+        directive_action = {
+            "module_root": ".",
+            "current_version": "1.25.0",
+            "target_version": "1.26.0",
+            "required_by": ["golang.org/x/crypto@v0.56.0"],
+        }
+        output = io.StringIO()
+        with mock.patch.object(
+            fix_image_cves, "ensure_repo_root", return_value=Path("/repo")
+        ), mock.patch.object(
+            fix_image_cves, "load_state", return_value=state
+        ), mock.patch.object(
+            fix_image_cves,
+            "build_go_directive_actions",
+            return_value=[directive_action],
+        ), mock.patch.object(
+            fix_image_cves, "ensure_command"
+        ), mock.patch.object(
+            fix_image_cves, "save_state"
+        ) as save_state, mock.patch(
+            "sys.stdout", output
+        ):
+            self.assertEqual(fix_image_cves.command_plan(Namespace(repo=".")), 0)
+
+        saved_plan = save_state.call_args.args[1]["plan"]
+        self.assertEqual(saved_plan["go_directive_actions"], [directive_action])
+        self.assertIn("Go Directive Bumps", output.getvalue())
+        self.assertIn("./go.mod 1.25.0 -> 1.26.0", output.getvalue())
 
     def test_build_go_requirement_commands_batches_and_sorts_by_module_root(self) -> None:
         actions = [
@@ -695,6 +1019,42 @@ replace example.com/sys v0.45.0 => ./sys45
             with self.subTest(actual=actual, minimum=minimum):
                 self.assertEqual(
                     fix_image_cves.version_at_least(actual, minimum),
+                    expected,
+                )
+
+    def test_verify_go_directive_accepts_equal_or_higher_and_rejects_lower(self) -> None:
+        plan = {
+            "go_directive_actions": [
+                {
+                    "module_root": ".",
+                    "current_version": "1.25.0",
+                    "target_version": "1.26.0",
+                    "required_by": ["golang.org/x/crypto@v0.56.0"],
+                }
+            ]
+        }
+        for actual, expected in (
+            ("1.26.0", True),
+            ("1.27.0", True),
+            ("1.25.9", False),
+        ):
+            with self.subTest(actual=actual), tempfile.TemporaryDirectory() as temp_dir:
+                repo_root = Path(temp_dir)
+                (repo_root / "go.mod").write_text(
+                    f"module example.com/root\n\ngo {actual}\n",
+                    encoding="utf-8",
+                )
+                results = {}
+                self.assertEqual(
+                    fix_image_cves.verify_go_directive_actions(
+                        repo_root,
+                        plan,
+                        results,
+                    ),
+                    expected,
+                )
+                self.assertEqual(
+                    results["go_directive_checks"][0]["passed"],
                     expected,
                 )
 

--- a/.agents/skills/remediate-image-cves/SKILL.md
+++ b/.agents/skills/remediate-image-cves/SKILL.md
@@ -57,7 +57,9 @@ rename, bypass, or work around it as part of this skill.
    work; never reset, discard, or overwrite it.
 2. Fail fast if Git, GitHub CLI, Trivy, Docker with Buildx or Podman with native
    build support, or a local Go version compatible with the checked-out branch
-   is unavailable. Do not install or upgrade host software.
+   is unavailable. Before each CVE apply, also require an available local Go
+   version compatible with the fresh plan's Go directive actions. Do not
+   install or upgrade host software or enable automatic toolchain downloads.
 3. Require both `git var GIT_AUTHOR_IDENT` and
    `git var GIT_COMMITTER_IDENT` to succeed before any build so checkpoint
    commits cannot fail after remediation has started.
@@ -157,12 +159,14 @@ table order:
 1. Rebuild the image from the current source and resolve its canonical runtime
    reference. Run a fresh `scan` and `plan`; do not apply the saved baseline
    plan because an earlier image may already have changed a shared module.
-2. Review every fresh plan. Apply Go-module fixes through `fix-image-cves`. For
-   a fixable runtime base-image finding, automatically replace only the digest
-   of the existing registry, repository, and tag. If remediation would change
-   the image family or tag, stop for review. Stop and report any other
-   permission, judgment, or conflict-resolution requirement instead of
-   guessing.
+2. Review every fresh plan. If it contains Go directive actions, select a
+   locally installed Go version at least as new as the highest target before
+   apply, and keep `GOTOOLCHAIN=local`. Apply Go-module and directive fixes
+   through `fix-image-cves`. For a fixable runtime base-image finding,
+   automatically replace only the digest of the existing registry, repository,
+   and tag. If remediation would change the image family or tag, stop for
+   review. Stop and report any other permission, judgment, or
+   conflict-resolution requirement instead of guessing.
 3. If the fresh plan contains no Go-module or base-image actions and no
    unsupported fixable findings, record its residual risks, run `clean`, and
    continue to the next image. Skip `apply`, file verification, remediation


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Improves the shared image-CVE remediation skills so a dependency fix also bumps the affected module's `go` directive when the target dependency requires a newer Go version.

The `fix-image-cves` plan now resolves each target module's declared Go version before source mutation, groups required directive bumps by module root, and reports the highest required version. Apply then validates the selected local toolchain, runs `go mod edit -go=<version>` before dependency edits, and verification checks that the resulting directive meets the plan. Older saved plans are enriched during apply for backward compatibility.

This covers the observed `golang.org/x/crypto@v0.56.0` case, which requires Go 1.26.0 while the affected branch declares Go 1.25.0. The orchestration guidance now selects a compatible locally installed Go version while preserving `GOTOOLCHAIN=local`.

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

Validation:

- 36 `fix-image-cves` tests
- 30 build-image helper tests
- 5 Go-module sync helper tests
- real metadata probe confirming `golang.org/x/crypto@v0.56.0` declares `go 1.26.0`
- boilerplate and `git diff --check`
- shared-skill metadata validation with the repository's Ruby YAML fallback because PyYAML is unavailable

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
