### PR TITLE
fix: reject service reusing an existing private link service name

### DIFF
--- a/pkg/provider/azure_privatelinkservice.go
+++ b/pkg/provider/azure_privatelinkservice.go
@@ -149,6 +149,14 @@ func (az *Cloud) reconcilePrivateLinkService(
 			return false, err
 		}
 
+		if !exists {
+			// The lookup above is keyed by LB frontend, so it cannot see the name already
+			// taken on another frontend; creating would silently repoint that PLS here.
+			if err := az.checkPrivateLinkServiceNameConflict(ctx, service, plsName); err != nil {
+				return false, err
+			}
+		}
+
 		dirtyPLS, err := az.getExpectedPrivateLinkService(ctx, existingPLS, &plsName, &clusterName, service, fipConfig)
 		if err != nil {
 			return false, err
@@ -297,6 +305,49 @@ func (az *Cloud) getPrivateLinkServiceName(
 
 	// default PLS name: pls-<frontendIPConfigName>
 	return fmt.Sprintf("%s-%s", "pls", *fipConfig.Name), nil
+}
+
+// checkPrivateLinkServiceNameConflict rejects a service whose requested private link
+// service name is already taken by a private link service on another LB frontend.
+func (az *Cloud) checkPrivateLinkServiceNameConflict(
+	ctx context.Context,
+	service *v1.Service,
+	plsName string,
+) error {
+	resourceGroup := az.getPLSResourceGroup(service)
+	plsList, err := az.plsRepo.List(ctx, resourceGroup)
+	if err != nil {
+		return err
+	}
+
+	for _, pls := range plsList {
+		if pls == nil || !strings.EqualFold(ptr.Deref(pls.Name, ""), plsName) {
+			continue
+		}
+		// The service's own PLS may still be on its previous frontend.
+		owner := getPrivateLinkServiceOwner(pls)
+		if strings.EqualFold(owner, getServiceName(service)) {
+			return nil
+		}
+		// An unmanaged PLS carries no owner tag, and a partial response may omit frontends.
+		if owner == "" {
+			owner = "<unknown>"
+		}
+		frontendID := "<unknown>"
+		if pls.Properties != nil && len(pls.Properties.LoadBalancerFrontendIPConfigurations) > 0 {
+			frontendID = ptr.Deref(pls.Properties.LoadBalancerFrontendIPConfigurations[0].ID, "<unknown>")
+		}
+		return fmt.Errorf(
+			"reconcilePrivateLinkService for service(%s) failed: private link service(%s) in resource group(%s) already exists, owned by service(%s) on LB frontend(%s)",
+			getServiceName(service),
+			plsName,
+			resourceGroup,
+			owner,
+			frontendID,
+		)
+	}
+
+	return nil
 }
 
 // getExpectedPrivateLinkService builds expected PLS object from service spec

--- a/pkg/provider/azure_privatelinkservice_test.go
+++ b/pkg/provider/azure_privatelinkservice_test.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -38,9 +39,6 @@ import (
 )
 
 func TestReconcilePrivateLinkService(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testCases := []struct {
 		desc              string
 		annotations       map[string]string
@@ -52,7 +50,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 		expectedPLSCreate bool
 		expectedPLS       *armnetwork.PrivateLinkService
 		expectedPLSDelete bool
-		expectedError     bool
+		expectedErrMsg    string
 		expectedDeleted   bool // new field to test the deleted PLS return value
 	}{
 		{
@@ -64,8 +62,8 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 			annotations: map[string]string{
 				consts.ServiceAnnotationPLSCreation: "true",
 			},
-			wantPLS:       true,
-			expectedError: true,
+			wantPLS:        true,
+			expectedErrMsg: "service requiring private link service must be internal or disable floating ip",
 		},
 		{
 			desc: "reconcilePrivateLinkService should create a new PLS for external service with floating ip disabled",
@@ -135,7 +133,106 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 					},
 				},
 			},
-			expectedError: true,
+			expectedErrMsg: "already has unmanaged private link service",
+		},
+		{
+			desc: "reconcilePrivateLinkService should report error if the requested PLS name is used by another LB frontend",
+			annotations: map[string]string{
+				consts.ServiceAnnotationPLSCreation:          "true",
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+				consts.ServiceAnnotationPLSName:              "testpls",
+			},
+			wantPLS:         true,
+			expectedPLSList: true,
+			existingPLSList: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("testpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+					Tags: map[string]*string{
+						consts.ClusterNameTagKey:  ptr.To(testClusterName),
+						consts.OwnerServiceTagKey: ptr.To("default/test1"),
+					},
+				},
+			},
+			expectedErrMsg: "private link service(testpls) in resource group(rg) already exists, owned by service(default/test1) on LB frontend(fipConfigID2)",
+		},
+		{
+			desc: "reconcilePrivateLinkService should report error if the default PLS name is used by another LB frontend",
+			annotations: map[string]string{
+				consts.ServiceAnnotationPLSCreation:          "true",
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+			},
+			wantPLS:         true,
+			expectedPLSList: true,
+			existingPLSList: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("pls-fipConfig"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+				},
+			},
+			expectedErrMsg: "private link service(pls-fipConfig) in resource group(rg) already exists, owned by service(<unknown>) on LB frontend(fipConfigID2)",
+		},
+		{
+			desc: "reconcilePrivateLinkService should create a new PLS if another PLS in the resource group has a different name",
+			annotations: map[string]string{
+				consts.ServiceAnnotationPLSCreation:          "true",
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+				consts.ServiceAnnotationPLSName:              "testpls",
+			},
+			wantPLS:           true,
+			expectedSubnetGet: true,
+			existingSubnet: &armnetwork.Subnet{
+				Name: ptr.To("subnet"),
+				ID:   ptr.To("subnetID"),
+				Properties: &armnetwork.SubnetPropertiesFormat{
+					PrivateLinkServiceNetworkPolicies: to.Ptr(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled),
+				},
+			},
+			expectedPLSList: true,
+			existingPLSList: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("otherpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+				},
+			},
+			expectedPLSCreate: true,
+		},
+		{
+			desc: "reconcilePrivateLinkService should update an existing PLS owned by the service on a different frontend",
+			annotations: map[string]string{
+				consts.ServiceAnnotationPLSCreation:          "true",
+				consts.ServiceAnnotationLoadBalancerInternal: "true",
+				consts.ServiceAnnotationPLSName:              "testpls",
+			},
+			wantPLS:           true,
+			expectedSubnetGet: true,
+			existingSubnet: &armnetwork.Subnet{
+				Name: ptr.To("subnet"),
+				ID:   ptr.To("subnetID"),
+				Properties: &armnetwork.SubnetPropertiesFormat{
+					PrivateLinkServiceNetworkPolicies: to.Ptr(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled),
+				},
+			},
+			expectedPLSList: true,
+			existingPLSList: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("testpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+					Tags: map[string]*string{
+						consts.ClusterNameTagKey:  ptr.To(testClusterName),
+						consts.OwnerServiceTagKey: ptr.To("default/test"),
+					},
+				},
+			},
+			expectedPLSCreate: true,
 		},
 		{
 			desc: "reconcilePrivateLinkService should report error if service tries to update pls without being an owner",
@@ -168,7 +265,7 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 					},
 				},
 			},
-			expectedError: true,
+			expectedErrMsg: "already has existing private link service(testpls) owned by service(default/test1)",
 		},
 		{
 			desc: "reconcilePrivateLinkService should share existing pls to a service using the same LB frontEnd without any changes",
@@ -360,6 +457,9 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
 			az := GetTestCloud(ctrl)
 			service := getTestServiceWithAnnotation("test", test.annotations, false, 80)
 			fipConfig := &armnetwork.FrontendIPConfiguration{
@@ -400,7 +500,11 @@ func TestReconcilePrivateLinkService(t *testing.T) {
 				mockPLSRepo.EXPECT().Delete(gomock.Any(), "rg", "testpls", *fipConfig.ID).Return(nil).Times(1)
 			}
 			deleted, err := az.reconcilePrivateLinkService(context.TODO(), clusterName, &service, fipConfig, test.wantPLS)
-			assert.Equal(t, test.expectedError, err != nil, "error: %v", err)
+			if test.expectedErrMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, test.expectedErrMsg)
+			}
 			assert.Equal(t, test.expectedDeleted, deleted, "expected deleted PLS return value mismatch")
 		})
 	}
@@ -585,6 +689,154 @@ func TestGetPrivateLinkServiceName(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedName, actualName, "TestCase[%d]: %s", i, test.desc)
 		}
+	}
+}
+
+func TestCheckPrivateLinkServiceNameConflict(t *testing.T) {
+	tests := []struct {
+		desc         string
+		existingPLS  []*armnetwork.PrivateLinkService
+		listErr      error
+		plsName      string
+		errSubstring []string
+	}{
+		{
+			desc:        "no PLS in the resource group",
+			existingPLS: []*armnetwork.PrivateLinkService{},
+			plsName:     "testpls",
+		},
+		{
+			desc: "existing PLS has a different name",
+			existingPLS: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("otherpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+				},
+			},
+			plsName: "testpls",
+		},
+		{
+			desc: "same name on another LB frontend should conflict",
+			existingPLS: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("testpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+					Tags: map[string]*string{
+						consts.OwnerServiceTagKey: ptr.To("default/test1"),
+					},
+				},
+			},
+			plsName:      "testpls",
+			errSubstring: []string{"testpls", "default/test1", "fipConfigID2"},
+		},
+		{
+			// Different frontend, so the owner tag is the only reason to tolerate this PLS.
+			desc: "PLS whose owner tag matches this service should be tolerated",
+			existingPLS: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("testpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+					Tags: map[string]*string{
+						consts.OwnerServiceTagKey: ptr.To("default/test"),
+					},
+				},
+			},
+			plsName: "testpls",
+		},
+		{
+			desc: "name comparison should be case-insensitive",
+			existingPLS: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("TestPLS"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+					Tags: map[string]*string{
+						consts.OwnerServiceTagKey: ptr.To("default/test1"),
+					},
+				},
+			},
+			plsName:      "testpls",
+			errSubstring: []string{"testpls", "default/test1", "fipConfigID2"},
+		},
+		{
+			desc: "conflicting PLS without properties should report an unknown frontend",
+			existingPLS: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("testpls"),
+					Tags: map[string]*string{
+						consts.OwnerServiceTagKey: ptr.To("default/test1"),
+					},
+				},
+			},
+			plsName:      "testpls",
+			errSubstring: []string{"testpls", "default/test1", "LB frontend(<unknown>)"},
+		},
+		{
+			desc: "conflicting PLS with an empty frontend list should report an unknown frontend",
+			existingPLS: []*armnetwork.PrivateLinkService{
+				{
+					Name:       ptr.To("testpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{},
+					Tags: map[string]*string{
+						consts.OwnerServiceTagKey: ptr.To("default/test1"),
+					},
+				},
+			},
+			plsName:      "testpls",
+			errSubstring: []string{"testpls", "default/test1", "LB frontend(<unknown>)"},
+		},
+		{
+			desc: "conflicting unmanaged PLS should report an unknown owner",
+			existingPLS: []*armnetwork.PrivateLinkService{
+				{
+					Name: ptr.To("testpls"),
+					Properties: &armnetwork.PrivateLinkServiceProperties{
+						LoadBalancerFrontendIPConfigurations: []*armnetwork.FrontendIPConfiguration{{ID: ptr.To("fipConfigID2")}},
+					},
+				},
+			},
+			plsName:      "testpls",
+			errSubstring: []string{"testpls", "service(<unknown>)", "fipConfigID2"},
+		},
+		{
+			desc:         "list error should be propagated",
+			listErr:      errors.New("list failed"),
+			plsName:      "testpls",
+			errSubstring: []string{"list failed"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			az := GetTestCloud(ctrl)
+			service := getTestService("test", v1.ProtocolTCP, nil, false, 80)
+
+			mockPLSRepo := az.plsRepo.(*privatelinkservice.MockRepository)
+			mockPLSRepo.EXPECT().List(gomock.Any(), "rg").Return(test.existingPLS, test.listErr).Times(1)
+
+			err := az.checkPrivateLinkServiceNameConflict(context.TODO(), &service, test.plsName)
+			if len(test.errSubstring) == 0 {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			for _, s := range test.errSubstring {
+				assert.ErrorContains(t, err, s)
+			}
+			if test.listErr == nil {
+				assert.NotContains(t, err.Error(), "()", "conflict message must not report an empty field")
+			}
+		})
 	}
 }
 

--- a/tests/e2e/network/private_link_service.go
+++ b/tests/e2e/network/private_link_service.go
@@ -470,6 +470,57 @@ var _ = Describe("Private link service", Label(utils.TestSuiteLabelPrivateLinkSe
 		// Verify it's still the configuration from service1
 		Expect(len(pls.Properties.IPConfigurations)).To(Equal(ipAddrCount))
 	})
+
+	It("should not modify an existing private link service when another service requests the same name", func() {
+		plsName := "testpls"
+		annotation := map[string]string{
+			consts.ServiceAnnotationLoadBalancerInternal: "true",
+			consts.ServiceAnnotationPLSCreation:          "true",
+			consts.ServiceAnnotationPLSName:              plsName,
+		}
+
+		svc1 := "service1"
+		ips := createAndExposeDefaultServiceWithAnnotation(cs, tc.IPFamily, svc1, ns.Name, labels, annotation, ports)
+		defer func() {
+			err := utils.DeleteService(cs, ns.Name, svc1)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		Expect(len(ips)).NotTo(BeZero())
+		ip := ips[0]
+
+		pls := getPrivateLinkServiceFromIP(tc, ip, "", "", plsName)
+		Expect(pls.Properties.LoadBalancerFrontendIPConfigurations).NotTo(BeEmpty())
+		originalFrontendID := ptr.Deref((pls.Properties.LoadBalancerFrontendIPConfigurations)[0].ID, "")
+		originalOwner := ptr.Deref(pls.Tags[consts.OwnerServiceTagKey], "")
+		utils.Logf("PLS %s is on frontend %s owned by service %s", plsName, originalFrontendID, originalOwner)
+
+		By("creating a second service requesting the same private link service name")
+		// No shared IP, so svc2 gets its own LB frontend; it is rejected before backends matter.
+		svc2 := "service2"
+		ports2 := []v1.ServicePort{{
+			Port:       testingPort,
+			TargetPort: intstr.FromInt(testingPort),
+		}}
+		service2 := utils.CreateLoadBalancerServiceManifest(svc2, annotation, map[string]string{"app": svc2}, ns.Name, ports2)
+		start := time.Now()
+		_, err := cs.CoreV1().Services(ns.Name).Create(context.TODO(), service2, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			err := utils.DeleteService(cs, ns.Name, svc2)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		By("checking the second service is rejected")
+		err = utils.WaitForServiceWarningEventAfter(cs, ns.Name, svc2,
+			"SyncLoadBalancerFailed", "already exists, owned by service", start)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("checking the existing private link service still belongs to the first service")
+		pls = getPrivateLinkServiceFromIP(tc, ip, "", "", plsName)
+		Expect(pls.Properties.LoadBalancerFrontendIPConfigurations).NotTo(BeEmpty())
+		Expect(ptr.Deref((pls.Properties.LoadBalancerFrontendIPConfigurations)[0].ID, "")).To(Equal(originalFrontendID))
+		Expect(ptr.Deref(pls.Tags[consts.OwnerServiceTagKey], "")).To(Equal(originalOwner))
+	})
 })
 
 func updateServiceAnnotation(service *v1.Service, annotation map[string]string) (result *v1.Service) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The PLS lookup is keyed by LB frontend IP configuration, so a Service whose `azure-pls-name` matches a PLS on a *different* frontend looks like "no PLS exists". CCM then PUTs that name, which repoints the existing PLS to the new Service's frontend and overwrites its `k8s-azure-owner-service` tag. The original Service keeps its IP but silently loses its PLS.

Reject the Service instead when the requested name is already used by a PLS on another frontend. A Service's own PLS is exempt via the `k8s-azure-owner-service` tag.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[BREAKING CHANGE] fix: a Service whose `service.beta.kubernetes.io/azure-pls-name` matches a private link service already in use is now rejected, instead of repointing that private link service to the new Service. Action required: correct the annotation on any PLS-enabled Service reporting SyncLoadBalancerFailed after upgrade.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
