### PR TITLE
fix: retry loadbalancer metadata on transient IMDS failures

### DIFF
--- a/.agents/references/etag-cache.md
+++ b/.agents/references/etag-cache.md
@@ -1,5 +1,15 @@
 # ETag & Cache Invalidation
 
+## IMDS Partial Metadata
+
+`InstanceMetadataService` caches valid instance metadata together with an
+`LBMetadataError` when the load balancer endpoint returns a transient failure.
+Compute and identity reads remain usable. Local `NodeAddresses` returns the
+cached error without invalidating the entry, so node status addresses remain
+unchanged and repeated reads do not trigger an IMDS request burst. Normal cache
+expiry refreshes both endpoints; a successful refresh clears the error. Remote
+node address lookups through ARM are not blocked by the local LB error.
+
 ## Problem Overview
 
 Azure uses ETags for optimistic concurrency control. When the SDK sends a

--- a/pkg/nodemanager/nodemanager_test.go
+++ b/pkg/nodemanager/nodemanager_test.go
@@ -676,6 +676,53 @@ func TestUpdateNodeAddresses(t *testing.T) {
 	assert.Equal(t, 2, len(updatedNodes[0].Status.Addresses), "Node Addresses not correctly updated")
 }
 
+func TestUpdateNodeAddressesPreservesExternalIPOnMetadataError(t *testing.T) {
+	ctx := context.Background()
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node0"},
+		Spec:       v1.NodeSpec{ProviderID: "node0"},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: "node0"},
+				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: v1.NodeExternalIP, Address: "20.0.0.1"},
+			},
+		},
+	}
+	originalNode := node.DeepCopy()
+	updatedAddresses := append([]v1.NodeAddress(nil), node.Status.Addresses...)
+	updatedAddresses[2].Address = "20.0.0.2"
+	metadataError := errors.New("loadbalancer metadata temporarily unavailable")
+	mockNP := mocknodeprovider.NewMockNodeProvider(gomock.NewController(t))
+	gomock.InOrder(
+		mockNP.EXPECT().NodeAddresses(ctx, types.NodeName("node0")).Return(node.Status.Addresses, nil),
+		mockNP.EXPECT().NodeAddresses(ctx, types.NodeName("node0")).Return(nil, metadataError).Times(2),
+		mockNP.EXPECT().NodeAddresses(ctx, types.NodeName("node0")).Return(updatedAddresses, nil),
+	)
+	client := fake.NewSimpleClientset(node)
+	controller := &CloudNodeController{kubeClient: client, nodeProvider: mockNP}
+
+	assert.NoError(t, controller.updateNodeAddress(ctx, node))
+	assert.Empty(t, client.Actions())
+	for attempt := 0; attempt < 2; attempt++ {
+		assert.ErrorIs(t, controller.updateNodeAddress(ctx, node), metadataError)
+		assert.Empty(t, client.Actions())
+		assert.Equal(t, originalNode, node)
+	}
+
+	assert.NoError(t, controller.updateNodeAddress(ctx, node))
+	actions := client.Actions()
+	if assert.Len(t, actions, 1) {
+		assert.Equal(t, "patch", actions[0].GetVerb())
+		assert.Equal(t, "status", actions[0].GetSubresource())
+	}
+	updatedNode, err := client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, updatedAddresses, updatedNode.Status.Addresses)
+	}
+	assert.Equal(t, originalNode, node)
+}
+
 // This test checks that a node with the external cloud provider taint is cloudprovider initialized and
 // and the provided node ip is validated with the cloudprovider and nodeAddresses are updated from the cloudprovider
 func TestNodeProvidedIPAddresses(t *testing.T) {

--- a/pkg/provider/azure_instance_metadata.go
+++ b/pkg/provider/azure_instance_metadata.go
@@ -114,6 +114,33 @@ type InstanceMetadataService struct {
 	imsCache   azcache.Resource
 }
 
+// imdsResponseError is returned when IMDS responds with a non-200 status code.
+type imdsResponseError struct {
+	statusCode int
+}
+
+func (e *imdsResponseError) Error() string {
+	return fmt.Sprintf("failure of getting loadbalancer metadata, status code %d", e.statusCode)
+}
+
+// isTransientIMDSError reports whether an error from getLoadBalancerMetadata is a
+// transient failure that should be retried, as opposed to a benign response that
+// simply means the VM is not part of a standard load balancer backend pool.
+//
+// Server-side (5xx), throttling (429) and request-timeout (408) responses are
+// treated as transient, as are non-HTTP errors such as connection resets,
+// timeouts, and malformed responses. Other 4xx responses are treated as benign.
+func isTransientIMDSError(err error) bool {
+	var respErr *imdsResponseError
+	if errors.As(err, &respErr) {
+		return respErr.statusCode >= 500 ||
+			respErr.statusCode == http.StatusTooManyRequests ||
+			respErr.statusCode == http.StatusRequestTimeout
+	}
+	// Non-HTTP errors (network failure, timeout, JSON parse) are transient.
+	return true
+}
+
 // NewInstanceMetadataService creates an instance of the InstanceMetadataService accessor object.
 func NewInstanceMetadataService(imdsServer string) (*InstanceMetadataService, error) {
 	ims := &InstanceMetadataService{
@@ -172,10 +199,21 @@ func (ims *InstanceMetadataService) getMetadata(ctx context.Context, key string)
 		}
 
 		loadBalancerMetadata, err := ims.getLoadBalancerMetadata()
-		if err != nil || loadBalancerMetadata == nil || loadBalancerMetadata.LoadBalancer == nil {
-			// Log a warning since loadbalancer metadata may not be available when the VM
-			// is not in standard LoadBalancer backend address pool.
+		if err != nil {
+			if isTransientIMDSError(err) {
+				// Propagate transient failures so teh caller retries instead of
+				// publishing node metadata without the load balancer public IP.
+				// Returning instance metadata here would transiently drop the
+				// node's ExternalIP until the next successful reconcile
+				return nil, fmt.Errorf("failed to get loadbalancer metadata: %w", err)
+			}
+			// Benigng: loadbalancer metadata is not available when the VM is not in
+			// a standard LoadBalancer backend address pool. Proceed with instance
+			// metadata as before.
 			logger.V(4).Info("Warning: failed to get loadbalancer metadata", "error", err)
+			return instanceMetadata, nil
+		}
+		if loadBalancerMetadata == nil || loadBalancerMetadata.LoadBalancer == nil {
 			return instanceMetadata, nil
 		}
 
@@ -245,7 +283,8 @@ func (ims *InstanceMetadataService) getLoadBalancerMetadata() (*LoadBalancerMeta
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failure of getting loadbalancer metadata with response %q", resp.Status)
+		// Return an imdsResponseError to indicate that this is a non-200 response from IMDS.
+		return nil, &imdsResponseError{statusCode: resp.StatusCode}
 	}
 
 	data, err := io.ReadAll(resp.Body)

--- a/pkg/provider/azure_instance_metadata.go
+++ b/pkg/provider/azure_instance_metadata.go
@@ -88,8 +88,9 @@ type ComputeMetadata struct {
 
 // InstanceMetadata represents instance information.
 type InstanceMetadata struct {
-	Compute *ComputeMetadata `json:"compute,omitempty"`
-	Network *NetworkMetadata `json:"network,omitempty"`
+	Compute         *ComputeMetadata `json:"compute,omitempty"`
+	Network         *NetworkMetadata `json:"network,omitempty"`
+	LBMetadataError error            `json:"-"`
 }
 
 // PublicIPMetadata represents the public IP metadata.
@@ -201,13 +202,10 @@ func (ims *InstanceMetadataService) getMetadata(ctx context.Context, key string)
 		loadBalancerMetadata, err := ims.getLoadBalancerMetadata()
 		if err != nil {
 			if isTransientIMDSError(err) {
-				// Propagate transient failures so teh caller retries instead of
-				// publishing node metadata without the load balancer public IP.
-				// Returning instance metadata here would transiently drop the
-				// node's ExternalIP until the next successful reconcile
-				return nil, fmt.Errorf("failed to get loadbalancer metadata: %w", err)
+				instanceMetadata.LBMetadataError = fmt.Errorf("failed to get loadbalancer metadata: %w", err)
+				return instanceMetadata, nil
 			}
-			// Benigng: loadbalancer metadata is not available when the VM is not in
+			// Benign: loadbalancer metadata is not available when the VM is not in
 			// a standard LoadBalancer backend address pool. Proceed with instance
 			// metadata as before.
 			logger.V(4).Info("Warning: failed to get loadbalancer metadata", "error", err)

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -466,6 +466,7 @@ func TestNodeAddresses(t *testing.T) {
 		useCustomImsCache   bool
 		nilVMSet            bool
 		expectedErrMsg      error
+		lbStatusCode        int
 	}{
 		{
 			name:                "NodeAddresses should report error if metadata.Network is nil",
@@ -602,6 +603,39 @@ func TestNodeAddresses(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                "NodeAddresses should report error when loadbalancer metadata returns a transient failure",
+			nodeName:            "vm1",
+			metadataName:        "vm1",
+			vmType:              consts.VMTypeStandard,
+			ipV4:                "10.240.0.1",
+			ipV4Public:          "192.168.1.12",
+			loadBalancerSKU:     "standard",
+			lbStatusCode:        http.StatusServiceUnavailable,
+			useInstanceMetadata: true,
+			expectedErrMsg:      fmt.Errorf("failed to get loadbalancer metadata: %w", &imdsResponseError{statusCode: http.StatusServiceUnavailable}),
+		},
+		{
+			name:                "NodeAddresses should not report error and keep instance addresses when the VM is not in a standard LB backend pool",
+			nodeName:            "vm1",
+			metadataName:        "vm1",
+			vmType:              consts.VMTypeStandard,
+			ipV4:                "10.240.0.1",
+			ipV4Public:          "192.168.1.12",
+			loadBalancerSKU:     "standard",
+			lbStatusCode:        http.StatusNotFound,
+			useInstanceMetadata: true,
+			expectedAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeHostName,
+					Address: "vm1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.240.0.1",
+				},
+			},
+		},
 	}
 
 	for _, test := range testcases {
@@ -620,6 +654,10 @@ func TestNodeAddresses(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(r.RequestURI, consts.ImdsLoadBalancerURI) {
+				if test.lbStatusCode != 0 {
+					w.WriteHeader(test.lbStatusCode)
+					return
+				}
 				fmt.Fprintf(w, loadbalancerTemplate, test.ipV4Public, test.ipV4, test.ipV6Public, test.ipV6)
 				return
 			}

--- a/pkg/provider/azure_instances_test.go
+++ b/pkg/provider/azure_instances_test.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -536,6 +538,17 @@ func TestNodeAddresses(t *testing.T) {
 			expectedAddress: expectedNodeAddress,
 		},
 		{
+			name:                "NodeAddresses should get remote instance addresses from Azure API despite a local loadbalancer metadata failure",
+			nodeName:            "vm1",
+			metadataName:        "vm2",
+			vmType:              consts.VMTypeStandard,
+			ipV4:                "10.240.0.2",
+			loadBalancerSKU:     "standard",
+			lbStatusCode:        http.StatusServiceUnavailable,
+			useInstanceMetadata: true,
+			expectedAddress:     expectedNodeAddress,
+		},
+		{
 			name:                "NodeAddresses should get IP addresses from local IMDS if node's name is equal to metadataName",
 			nodeName:            "vm1",
 			metadataName:        "vm1",
@@ -703,6 +716,164 @@ func TestNodeAddresses(t *testing.T) {
 		ipAddresses, err := cloud.NodeAddresses(context.Background(), types.NodeName(test.nodeName))
 		assert.Equal(t, test.expectedErrMsg, err, test.name)
 		assert.Equal(t, test.expectedAddress, ipAddresses, test.name)
+	}
+}
+
+func TestNodeAddressesCachesLoadBalancerMetadataError(t *testing.T) {
+	for _, statusCode := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			cloud := GetTestCloud(gomock.NewController(t))
+			cloud.UseInstanceMetadata = true
+			resourceID := "/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"
+			var instanceRequests, loadBalancerRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if strings.Contains(request.URL.Path, consts.ImdsLoadBalancerURI) {
+					loadBalancerRequests.Add(1)
+					writer.WriteHeader(statusCode)
+					return
+				}
+				instanceRequests.Add(1)
+				fmt.Fprintf(writer, `{"compute":{"name":"vm1","resourceId":"%s"},"network":{"interface":[{"ipv4":{"ipAddress":[{"privateIpAddress":"10.240.0.1"}]}}]}}`, resourceID)
+			}))
+			t.Cleanup(server.Close)
+
+			var err error
+			cloud.Metadata, err = NewInstanceMetadataService(server.URL + "/")
+			if !assert.NoError(t, err) {
+				return
+			}
+			ctx := context.Background()
+			for attempt := 0; attempt < 3; attempt++ {
+				instanceID, err := cloud.InstanceID(ctx, "vm1")
+				assert.NoError(t, err)
+				assert.Equal(t, resourceID, instanceID)
+
+				metadata, err := cloud.Metadata.GetMetadata(ctx, azcache.CacheReadTypeDefault)
+				if !assert.NoError(t, err) || !assert.NotNil(t, metadata) {
+					return
+				}
+				assert.NotNil(t, metadata.Compute)
+				assert.NotNil(t, metadata.Network)
+				var responseError *imdsResponseError
+				if !assert.ErrorAs(t, metadata.LBMetadataError, &responseError) {
+					return
+				}
+				assert.Equal(t, statusCode, responseError.statusCode)
+
+				addresses, err := cloud.NodeAddresses(ctx, "vm1")
+				assert.ErrorIs(t, err, metadata.LBMetadataError)
+				assert.Nil(t, addresses)
+			}
+			assert.Equal(t, int32(1), instanceRequests.Load())
+			assert.Equal(t, int32(1), loadBalancerRequests.Load())
+		})
+	}
+}
+
+func TestNodeAddressesLoadBalancerMetadataRecovery(t *testing.T) {
+	for _, statusCode := range []int{http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			cloud := GetTestCloud(gomock.NewController(t))
+			cloud.UseInstanceMetadata = true
+			var phase, instanceRequests, loadBalancerRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if strings.Contains(request.URL.Path, consts.ImdsLoadBalancerURI) {
+					loadBalancerRequests.Add(1)
+					switch phase.Load() {
+					case 0:
+						fmt.Fprint(writer, `{"loadbalancer":{"publicIpAddresses":[{"frontendIpAddress":"192.168.1.12","privateIpAddress":"10.240.0.1"}]}}`)
+					case 1:
+						writer.WriteHeader(statusCode)
+					case 2:
+						fmt.Fprint(writer, `{"loadbalancer":{"publicIpAddresses":[{"frontendIpAddress":"192.168.1.13","privateIpAddress":"10.240.0.1"}]}}`)
+					case 3:
+						fmt.Fprint(writer, `{"loadbalancer":{"publicIpAddresses":[]}}`)
+					}
+					return
+				}
+				instanceRequests.Add(1)
+				fmt.Fprint(writer, `{"compute":{"name":"vm1"},"network":{"interface":[{"ipv4":{"ipAddress":[{"privateIpAddress":"10.240.0.1"}]}}]}}`)
+			}))
+			t.Cleanup(server.Close)
+
+			var err error
+			cloud.Metadata, err = NewInstanceMetadataService(server.URL + "/")
+			if !assert.NoError(t, err) {
+				return
+			}
+			ctx := context.Background()
+			expectedAddresses := []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: "vm1"},
+				{Type: v1.NodeInternalIP, Address: "10.240.0.1"},
+				{Type: v1.NodeExternalIP, Address: "192.168.1.12"},
+			}
+			addresses, err := cloud.NodeAddresses(ctx, "vm1")
+			assert.NoError(t, err)
+			assert.Equal(t, expectedAddresses, addresses)
+			lastGoodMetadata, err := cloud.Metadata.GetMetadata(ctx, azcache.CacheReadTypeDefault)
+			if !assert.NoError(t, err) || !assert.NotNil(t, lastGoodMetadata) {
+				return
+			}
+
+			cachedEntry, exists, err := cloud.Metadata.imsCache.GetStore().GetByKey(consts.MetadataCacheKey)
+			if !assert.NoError(t, err) || !assert.True(t, exists) {
+				return
+			}
+			entry := cachedEntry.(*azcache.AzureCacheEntry)
+			expireMetadata := func() {
+				entry.Lock.Lock()
+				defer entry.Lock.Unlock()
+				entry.CreatedOn = time.Now().Add(-consts.MetadataCacheTTL)
+			}
+
+			phase.Store(1)
+			expireMetadata()
+			addresses, err = cloud.NodeAddresses(ctx, "vm1")
+			var responseError *imdsResponseError
+			if assert.ErrorAs(t, err, &responseError) {
+				assert.Equal(t, statusCode, responseError.statusCode)
+			}
+			assert.Nil(t, addresses)
+			failedMetadata, err := cloud.Metadata.GetMetadata(ctx, azcache.CacheReadTypeDefault)
+			if !assert.NoError(t, err) || !assert.NotNil(t, failedMetadata) {
+				return
+			}
+			assert.Equal(t, lastGoodMetadata.Compute, failedMetadata.Compute)
+			assert.Equal(t, "192.168.1.12", lastGoodMetadata.Network.Interface[0].IPV4.IPAddress[0].PublicIP)
+			assert.NoError(t, lastGoodMetadata.LBMetadataError)
+
+			phase.Store(2)
+			for attempt := 0; attempt < 3; attempt++ {
+				addresses, err = cloud.NodeAddresses(ctx, "vm1")
+				assert.ErrorIs(t, err, failedMetadata.LBMetadataError)
+				assert.Nil(t, addresses)
+				metadata, err := cloud.Metadata.GetMetadata(ctx, azcache.CacheReadTypeDefault)
+				assert.NoError(t, err)
+				assert.Same(t, failedMetadata, metadata)
+			}
+			assert.Equal(t, int32(2), instanceRequests.Load())
+			assert.Equal(t, int32(2), loadBalancerRequests.Load())
+
+			expireMetadata()
+			addresses, err = cloud.NodeAddresses(ctx, "vm1")
+			assert.NoError(t, err)
+			expectedAddresses[2].Address = "192.168.1.13"
+			assert.Equal(t, expectedAddresses, addresses)
+			recoveredMetadata, err := cloud.Metadata.GetMetadata(ctx, azcache.CacheReadTypeDefault)
+			if assert.NoError(t, err) && assert.NotNil(t, recoveredMetadata) {
+				assert.NoError(t, recoveredMetadata.LBMetadataError)
+			}
+			assert.Equal(t, int32(3), instanceRequests.Load())
+			assert.Equal(t, int32(3), loadBalancerRequests.Load())
+
+			phase.Store(3)
+			expireMetadata()
+			addresses, err = cloud.NodeAddresses(ctx, "vm1")
+			assert.NoError(t, err)
+			assert.Equal(t, expectedAddresses[:2], addresses)
+			assert.Equal(t, int32(4), instanceRequests.Load())
+			assert.Equal(t, int32(4), loadBalancerRequests.Load())
+		})
 	}
 }
 

--- a/pkg/provider/azure_instances_v1.go
+++ b/pkg/provider/azure_instances_v1.go
@@ -103,6 +103,10 @@ func (az *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.N
 			return nil, fmt.Errorf("no credentials provided for Azure cloud provider")
 		}
 
+		if metadata.LBMetadataError != nil {
+			return nil, metadata.LBMetadataError
+		}
+
 		return az.getLocalInstanceNodeAddresses(metadata.Network.Interface, string(name))
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Right now `getMetadata` collapses two very different situations into the
same "benign" branch. When it calls `getLoadBalancerMetadata` and gets an
error, it just logs a `V(4)` warning and returns instance metadata without
the load balancer public IP. The comment says this is for the case where
the VM isn't part of a standard LoadBalancer backend pool, which is fair,
but the same branch also catches transient IMDS failures.

The way I read it, that's the bug: on a transient IMDS blip (a 503, a 429,
a request timeout, a dropped connection) the node ends up publishing its
addresses without the `NodeExternalIP`. The address only comes back on the
next successful reconcile, which with the default node-status update
frequency is about 5 minutes later. So from the outside it looks like a
node randomly loses its ExternalIP and gets it back exactly ~300s later.

This PR keeps the benign behaviour but stops swallowing the transient
failures:

- `getLoadBalancerMetadata` returns a typed `imdsResponseError` (carrying
  the status code) on a non-200 response, instead of a formatted string.
- `isTransientIMDSError` classifies `5xx`, `429`, `408`, and any non-HTTP
  error (network failure, timeout, JSON parse) as transient. Other `4xx`
  responses are treated as benign.
- On a transient error, `getMetadata` propagates it (wrapped) so the caller
  retries and the cache keeps the last good value. The benign path is
  untouched: it still logs the `V(4)` warning and returns instance metadata
  as before.

One thing I want to be upfront about: in practice the genuine "not in an LB
backend pool" case doesn't even hit the error branch. IMDS returns `200`
with an empty `publicIpAddresses` list rather than a `4xx`. So the benign
`4xx` handling here is really a safeguard for robustness, not the common
path. I kept it (and added a test for it) so the intent is explicit and
nobody folds it back into the transient branch later.

#### Which issue(s) this PR fixes:
Fixes #10944

#### Special notes for your reviewer:

New unit tests in `TestNodeAddresses` cover both cases:
- a `503` on the loadbalancer metadata endpoint now surfaces an error and
  the node addresses are not published without the ExternalIP.
- a `404` (standing in for "not in a standard LB backend pool") returns no
  error and keeps Hostname + InternalIP, as before.

`go build`, `go vet`, `gofmt -l`, and `go test ./pkg/provider/ -run
TestNodeAddresses` are all clean locally.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue where a transient IMDS failure while fetching load balancer
metadata could cause a node to temporarily lose its ExternalIP until the
next reconcile. Transient failures are now retried instead of publishing
node metadata without the load balancer public IP.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
