### PR TITLE
fix: retain deny-all NSG rule destinations other Services still need

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -3502,17 +3502,23 @@ func (az *Cloud) reconcileSecurityGroup(
 		dstIPv6Addresses = append(dstIPv6Addresses, lbIPv6Addresses...)
 	}
 
-	{
-		retainPortRanges, err := az.listSharedIPPortMapping(ctx, service, append(dstIPv4Addresses, dstIPv6Addresses...))
-		if err != nil {
-			logger.Error(err, "Failed to list retain port ranges")
-			return nil, err
-		}
+	var backendNodeIPs []netip.Addr
+	if disableFloatingIP {
+		backendNodeIPs = append(backendNodeIPs, backendIPv4Addresses...)
+		backendNodeIPs = append(backendNodeIPs, backendIPv6Addresses...)
+	}
 
-		if err := accessControl.CleanSecurityGroup(dstIPv4Addresses, dstIPv6Addresses, retainPortRanges); err != nil {
-			logger.Error(err, "Failed to clean security group")
-			return nil, err
-		}
+	retainPortRanges, denyAllDestinations, err := az.listSharedIPPortMapping(
+		ctx, service, append(dstIPv4Addresses, dstIPv6Addresses...), backendNodeIPs,
+	)
+	if err != nil {
+		logger.Error(err, "Failed to list retain port ranges")
+		return nil, err
+	}
+
+	if err := accessControl.CleanSecurityGroup(dstIPv4Addresses, dstIPv6Addresses, retainPortRanges); err != nil {
+		logger.Error(err, "Failed to clean security group")
+		return nil, err
 	}
 
 	if wantLb && !disableLoadBalancerNSGRule {
@@ -3523,6 +3529,14 @@ func (az *Cloud) reconcileSecurityGroup(
 		}
 	} else if wantLb {
 		logger.V(2).Info("Skipped patching security group because Service disables LoadBalancer NSG rule management")
+	}
+
+	{
+		// Patching only covers this Service, so restore what the other Services still need.
+		denyAllIPv4Addresses, denyAllIPv6Addresses := iputil.GroupAddressesByFamily(denyAllDestinations)
+		if err := accessControl.EnsureDenyAllRules(denyAllIPv4Addresses, denyAllIPv6Addresses); err != nil {
+			return nil, err
+		}
 	}
 
 	{

--- a/pkg/provider/azure_loadbalancer_accesscontrol.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol.go
@@ -50,18 +50,31 @@ func filterServicesByDisableFloatingIP(services []*v1.Service) []*v1.Service {
 	}, services)
 }
 
-// listSharedIPPortMapping lists the shared IP port mapping for the service excluding the service itself.
+// listSharedIPPortMapping lists the shared IP port mapping and the shared deny all destinations for
+// the service excluding the service itself.
 // There are scenarios where multiple services share the same public IP,
 // and in order to clean up the security rules, we need to know the port mapping of the shared IP.
+// The deny all rules are shared the same way, so a destination has to survive the cleanup while any
+// of those services still requires it. backendNodeIPs belong to every service that disables the floating
+// IP, because they all target the same nodes.
 func (az *Cloud) listSharedIPPortMapping(
 	ctx context.Context,
 	svc *v1.Service,
-	ingressIPs []netip.Addr,
-) (map[armnetwork.SecurityRuleProtocol][]int32, error) {
+	dstAddresses []netip.Addr,
+	backendNodeIPs []netip.Addr,
+) (map[armnetwork.SecurityRuleProtocol][]int32, []netip.Addr, error) {
 	var (
 		logger = log.FromContextOrBackground(ctx).WithName("listSharedIPPortMapping")
 		rv     = make(map[armnetwork.SecurityRuleProtocol][]int32)
+
+		isDstAddress = make(map[netip.Addr]bool, len(dstAddresses))
+		// The same address may be appended more than once. SetDestinationPrefixes will deduplicate.
+		denyAllDestinations []netip.Addr
+		denyAllRequired     bool
 	)
+	for _, addr := range dstAddresses {
+		isDstAddress[addr] = true
+	}
 
 	var services []*v1.Service
 	{
@@ -70,7 +83,7 @@ func (az *Cloud) listSharedIPPortMapping(
 		services, err = az.serviceLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "Failed to list all services")
-			return nil, fmt.Errorf("list all services: %w", err)
+			return nil, nil, fmt.Errorf("list all services: %w", err)
 		}
 		logger.V(5).Info("Listed all services", "num-all-services", len(services))
 
@@ -80,7 +93,7 @@ func (az *Cloud) listSharedIPPortMapping(
 			services = filterServicesByDisableFloatingIP(services)
 		} else {
 			logger.V(5).Info("Filter service by external IPs")
-			services = filterServicesByIngressIPs(services, ingressIPs)
+			services = filterServicesByIngressIPs(services, dstAddresses)
 		}
 	}
 	logger.V(5).Info("Filtered services", "num-filtered-services", len(services))
@@ -94,17 +107,46 @@ func (az *Cloud) listSharedIPPortMapping(
 
 		portsByProtocol, err := loadbalancer.SecurityRuleDestinationPortsByProtocol(s)
 		if err != nil {
-			return nil, fmt.Errorf("fetch security rule dst ports for %s: %w", s.Name, err)
+			return nil, nil, fmt.Errorf("fetch security rule dst ports for %s: %w", s.Name, err)
 		}
 
 		for protocol, ports := range portsByProtocol {
 			rv[protocol] = append(rv[protocol], ports...)
 		}
+
+		if consts.IsK8sServiceDisableLoadBalancerNSGRule(s) || !loadbalancer.RequiresDenyAllExceptSourceRanges(s) {
+			continue
+		}
+		denyAllRequired = true
+
+		if additionalIPs, err := loadbalancer.AdditionalPublicIPs(s); err == nil {
+			for _, addr := range additionalIPs {
+				if isDstAddress[addr] {
+					denyAllDestinations = append(denyAllDestinations, addr)
+				}
+			}
+		}
+
+		// A service that disables the floating IP has no rule for its frontend IP; its nodes are
+		// appended after the loop.
+		if consts.IsK8sServiceDisableLoadBalancerFloatingIP(s) {
+			continue
+		}
+
+		for _, ing := range s.Status.LoadBalancer.Ingress {
+			if addr, err := netip.ParseAddr(ing.IP); err == nil && isDstAddress[addr] {
+				denyAllDestinations = append(denyAllDestinations, addr)
+			}
+		}
 	}
 
-	logger.V(5).Info("Retain port mapping", "port-mapping", rv)
+	if denyAllRequired {
+		denyAllDestinations = append(denyAllDestinations, backendNodeIPs...)
+	}
 
-	return rv, nil
+	logger.V(5).Info("Retain port mapping", "port-mapping", rv, "deny-all-destinations", denyAllDestinations)
+
+	return rv, denyAllDestinations, nil
 }
 
 func (az *Cloud) listAvailableSecurityGroupDestinations(_ context.Context) ([]netip.Addr, error) {

--- a/pkg/provider/azure_loadbalancer_accesscontrol_test.go
+++ b/pkg/provider/azure_loadbalancer_accesscontrol_test.go
@@ -3160,4 +3160,413 @@ func TestCloud_reconcileSecurityGroup(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
+
+	// There is one deny-all rule per IP family, so every Service's destinations share it. A
+	// destination must stay in the rule while any Service still needs it.
+	t.Run("deny all rules - destinations other Services still need", func(t *testing.T) {
+		const (
+			// Addresses that more than one Service can be on.
+			sharedIP          = "10.0.0.1"
+			sharedIPv6        = "2001:db8::1"
+			unmanagedPublicIP = "203.0.113.5"
+
+			// Addresses that belong to a single Service.
+			svcAUnsharedIP        = "10.0.0.8"
+			svcAUnmanagedPublicIP = "203.0.113.6"
+			svcBUnsharedIP        = "10.0.0.9"
+			svcBUnmanagedPublicIP = "203.0.113.7"
+
+			backendNodeIP = "192.168.10.1"
+
+			// Services sharing an IP must expose distinct ports, so each gets its own allow rule.
+			portA = int32(18080)
+			portB = int32(18081)
+			portC = int32(18082)
+		)
+
+		var (
+			sourceRanges   = []string{"198.51.100.0/24"}
+			sourceRangesV6 = []string{"2001:db8:1::/48"}
+			dualStackRange = append(append([]string{}, sourceRanges...), sourceRangesV6...)
+		)
+
+		service := func(namespace, name string, ingressIPs ...string) *fixture.KubernetesServiceFixture {
+			return k8sFx.Service().WithNamespace(namespace).WithName(name).
+				WithIngressIPs(ingressIPs).
+				WithLoadBalancerSourceRanges(sourceRanges...)
+		}
+
+		denyAll := func(namespace, name string, ingressIPs ...string) *fixture.KubernetesServiceFixture {
+			return service(namespace, name, ingressIPs...).WithDenyAllExceptLoadBalancerSourceRanges()
+		}
+
+		onPort := func(f *fixture.KubernetesServiceFixture, port int32) *v1.Service {
+			svc := f.Build()
+			svc.Spec.Ports = []v1.ServicePort{
+				{Name: "p", Protocol: v1.ProtocolTCP, Port: port, NodePort: 30000 + port},
+			}
+			return &svc
+		}
+
+		withAdditionalPublicIPs := func(svc *v1.Service, ips ...string) *v1.Service {
+			svc.Annotations[consts.ServiceAnnotationAdditionalPublicIPs] = strings.Join(ips, ",")
+			return svc
+		}
+
+		var (
+			svcADenyAll             = onPort(denyAll("ns-a", "svc-a", sharedIP), portA)
+			svcBDenyAll             = onPort(denyAll("ns-b", "svc-b", sharedIP), portB)
+			svcCDenyAll             = onPort(denyAll("ns-c", "svc-c", sharedIP), portC)
+			svcADenyAllOnUnsharedIP = onPort(denyAll("ns-a", "svc-a", svcAUnsharedIP), portA)
+			svcBDenyAllOnUnsharedIP = onPort(denyAll("ns-b", "svc-b", svcBUnsharedIP), portB)
+
+			// Services that need no deny-all rule of their own.
+			svcBWithoutDenyAll             = onPort(service("ns-b", "svc-b", sharedIP), portB)
+			svcBDenyAllWithNSGRuleDisabled = onPort(denyAll("ns-b", "svc-b", sharedIP).WithDisableLoadBalancerNSGRule(), portB)
+			// The annotation on its own requests nothing: there is no range to make an exception for.
+			svcBWithDenyAllAnnotationOnly = onPort(k8sFx.Service().WithNamespace("ns-b").WithName("svc-b").
+							WithIngressIPs([]string{sharedIP}).
+							WithDenyAllExceptLoadBalancerSourceRanges(), portB)
+
+			svcADenyAllDualStack = onPort(denyAll("ns-a", "svc-a", sharedIP, sharedIPv6).WithLoadBalancerSourceRanges(dualStackRange...), portA)
+			svcBDenyAllDualStack = onPort(denyAll("ns-b", "svc-b", sharedIP, sharedIPv6).WithLoadBalancerSourceRanges(dualStackRange...), portB)
+
+			// An additional public IP also lands in the ingress status.
+			svcADenyAllOnSharedIPWithAdditionalPublicIP = withAdditionalPublicIPs(
+				onPort(denyAll("ns-a", "svc-a", sharedIP, svcAUnmanagedPublicIP), portA), svcAUnmanagedPublicIP)
+			svcBDenyAllOnSharedIPWithAdditionalPublicIP = withAdditionalPublicIPs(
+				onPort(denyAll("ns-b", "svc-b", sharedIP, svcBUnmanagedPublicIP), portB), svcBUnmanagedPublicIP)
+			svcADenyAllWithAdditionalPublicIP = withAdditionalPublicIPs(
+				onPort(denyAll("ns-a", "svc-a", svcAUnsharedIP, unmanagedPublicIP), portA), unmanagedPublicIP)
+			svcBDenyAllWithAdditionalPublicIP = withAdditionalPublicIPs(
+				onPort(denyAll("ns-b", "svc-b", svcBUnsharedIP, unmanagedPublicIP), portB), unmanagedPublicIP)
+
+			// Services whose rules target the nodes instead of a frontend IP.
+			svcADenyAllWithFloatingIPDisabledOnUnsharedIP          = onPort(denyAll("ns-a", "svc-a", svcAUnsharedIP).WithDisableFloatingIP(), portA)
+			svcBDenyAllWithFloatingIPDisabledOnUnsharedIP          = onPort(denyAll("ns-b", "svc-b", svcBUnsharedIP).WithDisableFloatingIP(), portB)
+			svcBDenyAllWithFloatingIPDisabledOnSharedIP            = onPort(denyAll("ns-b", "svc-b", sharedIP).WithDisableFloatingIP(), portB)
+			svcADenyAllWithFloatingIPDisabledAndAdditionalPublicIP = withAdditionalPublicIPs(
+				onPort(denyAll("ns-a", "svc-a", svcAUnsharedIP, unmanagedPublicIP).WithDisableFloatingIP(), portA), unmanagedPublicIP)
+			svcBDenyAllWithFloatingIPDisabledAndAdditionalPublicIP = withAdditionalPublicIPs(
+				onPort(denyAll("ns-b", "svc-b", svcBUnsharedIP, unmanagedPublicIP).WithDisableFloatingIP(), portB), unmanagedPublicIP)
+		)
+
+		allowRule := func(family iputil.Family, port int32, priority int32, dsts ...string) *armnetwork.SecurityRule {
+			srcs := sourceRanges
+			if family == iputil.IPv6 {
+				srcs = sourceRangesV6
+			}
+			return azureFx.
+				AllowSecurityRule(armnetwork.SecurityRuleProtocolTCP, family, srcs, []int32{port}).
+				WithPriority(priority).
+				WithDestination(dsts...).
+				Build()
+		}
+
+		denyRule := func(family iputil.Family, priority int32, dsts ...string) *armnetwork.SecurityRule {
+			return azureFx.DenyAllSecurityRule(family).WithPriority(priority).WithDestination(dsts...).Build()
+		}
+
+		ingressIPs := func(svc *v1.Service) []string {
+			var rv []string
+			for _, ing := range svc.Status.LoadBalancer.Ingress {
+				rv = append(rv, ing.IP)
+			}
+			return rv
+		}
+
+		denyDestinations := func(sg *armnetwork.SecurityGroup, family iputil.Family) []string {
+			name := securitygroup.GenerateDenyAllSecurityRuleName(family)
+			for _, rule := range sg.Properties.SecurityRules {
+				if ptr.Deref(rule.Name, "") == name {
+					return securitygroup.ListDestinationPrefixes(rule)
+				}
+			}
+			return nil
+		}
+
+		tests := []struct {
+			Name                        string
+			ReconciledService           *v1.Service
+			OtherServices               []*v1.Service
+			WantLB                      bool
+			ExistingRules               []*armnetwork.SecurityRule
+			ExpectsSecurityGroupWrite   bool
+			ExpectedDenyAllDestinations map[iputil.Family][]string
+		}{
+			{
+				Name:              "keeps the shared IP in the deny-all rule when another deny-all Service is deleted",
+				ReconciledService: svcBDenyAll,
+				OtherServices:     []*v1.Service{svcADenyAll},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					allowRule(iputil.IPv4, portB, 501, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {sharedIP}},
+			},
+			{
+				Name:              "keeps the shared IP in the deny-all rule when only one of the other Services needs it",
+				ReconciledService: svcADenyAll,
+				OtherServices:     []*v1.Service{svcBWithoutDenyAll, svcCDenyAll},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					allowRule(iputil.IPv4, portB, 501, sharedIP),
+					allowRule(iputil.IPv4, portC, 502, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {sharedIP}},
+			},
+			{
+				Name:              "removes the shared IP from the deny-all rule when the last deny-all Service is deleted",
+				ReconciledService: svcADenyAll,
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: nil,
+			},
+			{
+				Name:              "keeps the shared IP in the deny-all rule when a shared-IP Service without deny-all is reconciled",
+				ReconciledService: svcBWithoutDenyAll,
+				OtherServices:     []*v1.Service{svcADenyAll},
+				WantLB:            EnsureLB,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					allowRule(iputil.IPv4, portB, 501, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				// The rules are already correct, so the reconcile must not write.
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {sharedIP}},
+			},
+			{
+				Name:              "keeps the shared IP in the deny-all rule when a shared-IP Service without deny-all is deleted",
+				ReconciledService: svcBWithoutDenyAll,
+				OtherServices:     []*v1.Service{svcADenyAll},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					allowRule(iputil.IPv4, portB, 501, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {sharedIP}},
+			},
+			{
+				Name:              "removes the shared IP from the deny-all rule when the only other deny-all Service opts out of NSG rule management",
+				ReconciledService: svcADenyAll,
+				OtherServices:     []*v1.Service{svcBDenyAllWithNSGRuleDisabled},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: nil,
+			},
+			{
+				Name:              "removes the shared IP from the deny-all rule when the only other Service sets the deny-all annotation without source ranges",
+				ReconciledService: svcADenyAll,
+				OtherServices:     []*v1.Service{svcBWithDenyAllAnnotationOnly},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: nil,
+			},
+			{
+				Name:              "removes the unshared IP from the deny-all rule and keeps the shared IP in it",
+				ReconciledService: svcADenyAllOnSharedIPWithAdditionalPublicIP,
+				OtherServices:     []*v1.Service{svcBDenyAll},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP, svcAUnmanagedPublicIP),
+					allowRule(iputil.IPv4, portB, 501, sharedIP),
+					denyRule(iputil.IPv4, 4095, sharedIP, svcAUnmanagedPublicIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {sharedIP}},
+			},
+			{
+				// svc-a never removed that IP, so restoring it is svc-b's reconcile to do.
+				Name:              "keeps the shared IP in the deny-all rule but does not add the other deny-all Service's unshared IP",
+				ReconciledService: svcADenyAll,
+				OtherServices:     []*v1.Service{svcBDenyAllOnSharedIPWithAdditionalPublicIP},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					allowRule(iputil.IPv4, portB, 501, sharedIP, svcBUnmanagedPublicIP),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {sharedIP}},
+			},
+			{
+				Name:              "keeps the shared IPv4 and IPv6 addresses in their deny-all rules when a dual-stack Service is deleted",
+				ReconciledService: svcBDenyAllDualStack,
+				OtherServices:     []*v1.Service{svcADenyAllDualStack},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					allowRule(iputil.IPv4, portB, 501, sharedIP),
+					allowRule(iputil.IPv6, portA, 502, sharedIPv6),
+					allowRule(iputil.IPv6, portB, 503, sharedIPv6),
+					denyRule(iputil.IPv4, 4095, sharedIP),
+					denyRule(iputil.IPv6, 4094, sharedIPv6),
+				},
+				ExpectsSecurityGroupWrite: true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{
+					iputil.IPv4: {sharedIP},
+					iputil.IPv6: {sharedIPv6},
+				},
+			},
+			{
+				Name:              "keeps the additional public IP in the deny-all rule when another deny-all Service also lists it",
+				ReconciledService: svcADenyAllWithAdditionalPublicIP,
+				OtherServices:     []*v1.Service{svcBDenyAllWithAdditionalPublicIP},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, svcAUnsharedIP, unmanagedPublicIP),
+					allowRule(iputil.IPv4, portB, 501, svcBUnsharedIP, unmanagedPublicIP),
+					denyRule(iputil.IPv4, 4095, svcAUnsharedIP, svcBUnsharedIP, unmanagedPublicIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {svcBUnsharedIP, unmanagedPublicIP}},
+			},
+
+			{
+				Name:              "keeps the backend node IP in the deny-all rule when another deny-all Service with the floating IP disabled still needs it",
+				ReconciledService: svcADenyAllWithFloatingIPDisabledOnUnsharedIP,
+				OtherServices:     []*v1.Service{svcBDenyAllWithFloatingIPDisabledOnUnsharedIP},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, 30000+portA, 500, backendNodeIP),
+					allowRule(iputil.IPv4, 30000+portB, 501, backendNodeIP),
+					denyRule(iputil.IPv4, 4095, backendNodeIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {backendNodeIP}},
+			},
+			{
+				Name:              "removes the IP of a deny-all Service that uses the floating IP but keeps the node IP of deny-all Service that disables it",
+				ReconciledService: svcADenyAllOnUnsharedIP,
+				OtherServices:     []*v1.Service{svcBDenyAllWithFloatingIPDisabledOnUnsharedIP},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, svcAUnsharedIP),
+					allowRule(iputil.IPv4, 30000+portB, 501, backendNodeIP),
+					denyRule(iputil.IPv4, 4095, svcAUnsharedIP, backendNodeIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {backendNodeIP}},
+			},
+			{
+				Name:              "removes the backend node IP from the deny-all rule but keeps the IP of a deny-all Service that uses the floating IP",
+				ReconciledService: svcADenyAllWithFloatingIPDisabledOnUnsharedIP,
+				OtherServices:     []*v1.Service{svcBDenyAllOnUnsharedIP},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, 30000+portA, 500, backendNodeIP),
+					allowRule(iputil.IPv4, portB, 501, svcBUnsharedIP),
+					denyRule(iputil.IPv4, 4095, backendNodeIP, svcBUnsharedIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {svcBUnsharedIP}},
+			},
+			{
+				// The other Service shares the frontend IP but its rules target the nodes, so it does
+				// not need the frontend IP.
+				Name:              "removes the shared IP from the deny-all rule when the only other deny-all Service on it disables the floating IP",
+				ReconciledService: svcADenyAll,
+				OtherServices:     []*v1.Service{svcBDenyAllWithFloatingIPDisabledOnSharedIP},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, portA, 500, sharedIP),
+					allowRule(iputil.IPv4, 30000+portB, 501, backendNodeIP),
+					denyRule(iputil.IPv4, 4095, sharedIP, backendNodeIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {backendNodeIP}},
+			},
+			{
+				Name:              "keeps the additional public IP in the deny-all rule when another deny-all Service with the floating IP disabled also lists it",
+				ReconciledService: svcADenyAllWithFloatingIPDisabledAndAdditionalPublicIP,
+				OtherServices:     []*v1.Service{svcBDenyAllWithFloatingIPDisabledAndAdditionalPublicIP},
+				WantLB:            false,
+				ExistingRules: []*armnetwork.SecurityRule{
+					allowRule(iputil.IPv4, 30000+portA, 500, backendNodeIP, unmanagedPublicIP),
+					allowRule(iputil.IPv4, 30000+portB, 501, backendNodeIP, unmanagedPublicIP),
+					denyRule(iputil.IPv4, 4095, backendNodeIP, unmanagedPublicIP),
+				},
+				ExpectsSecurityGroupWrite:   true,
+				ExpectedDenyAllDestinations: map[iputil.Family][]string{iputil.IPv4: {backendNodeIP, unmanagedPublicIP}},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.Name, func(t *testing.T) {
+				var (
+					ctrl                    = gomock.NewController(t)
+					az                      = GetTestCloud(ctrl)
+					securityGroupClient     = az.NetworkClientFactory.GetSecurityGroupClient().(*mock_securitygroupclient.MockInterface)
+					loadBalancerClient      = az.NetworkClientFactory.GetLoadBalancerClient().(*mock_loadbalancerclient.MockInterface)
+					loadBalancerBackendPool = az.LoadBalancerBackendPool.(*MockBackendPool)
+					loadBalancer            = azureFx.LoadBalancer().Build()
+				)
+				defer ctrl.Finish()
+
+				runtimeObjects := []runtime.Object{tt.ReconciledService}
+				for _, other := range tt.OtherServices {
+					runtimeObjects = append(runtimeObjects, other)
+				}
+				backendPrivateIPs := []string{backendNodeIP}
+				runtimeObjects = append(runtimeObjects, makeNodesByIPs(backendPrivateIPs)...)
+
+				kubeClient := fake.NewSimpleClientset(runtimeObjects...)
+				informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+				az.serviceLister = informerFactory.Core().V1().Services().Lister()
+				az.nodeLister = informerFactory.Core().V1().Nodes().Lister()
+				informerFactory.Start(wait.NeverStop)
+				informerFactory.WaitForCacheSync(wait.NeverStop)
+
+				expectedWrites := 0
+				if tt.ExpectsSecurityGroupWrite {
+					expectedWrites = 1
+				}
+
+				securityGroupClient.EXPECT().
+					Get(gomock.Any(), az.ResourceGroup, az.SecurityGroupName).
+					Return(azureFx.SecurityGroup().WithRules(tt.ExistingRules).Build(), nil).
+					Times(1)
+				securityGroupClient.EXPECT().
+					CreateOrUpdate(gomock.Any(), az.ResourceGroup, az.SecurityGroupName, gomock.Any()).
+					Return(nil, nil).
+					Times(expectedWrites)
+				loadBalancerClient.EXPECT().
+					Get(gomock.Any(), az.ResourceGroup, *loadBalancer.Name, gomock.Any()).
+					Return(loadBalancer, nil).
+					Times(1)
+				loadBalancerBackendPool.EXPECT().
+					GetBackendPrivateIPs(gomock.Any(), ClusterName, tt.ReconciledService, loadBalancer).
+					Return(backendPrivateIPs, nil).
+					Times(1)
+
+				sg, err := az.reconcileSecurityGroup(ctx, ClusterName, tt.ReconciledService, *loadBalancer.Name, ingressIPs(tt.ReconciledService), tt.WantLB)
+				assert.NoError(t, err)
+
+				for _, family := range []iputil.Family{iputil.IPv4, iputil.IPv6} {
+					assert.ElementsMatch(t, tt.ExpectedDenyAllDestinations[family], denyDestinations(sg, family),
+						"unexpected destinations on the %s deny-all rule", family)
+				}
+			})
+		}
+	})
 }

--- a/pkg/provider/loadbalancer/accesscontrol.go
+++ b/pkg/provider/loadbalancer/accesscontrol.go
@@ -204,10 +204,23 @@ func (ac *AccessControl) IsAllowFromInternet() bool {
 // DenyAllExceptSourceRanges returns true if it needs to block any VNet traffic not on the allow list.
 // By default, NSG allow traffic from the VNet.
 func (ac *AccessControl) DenyAllExceptSourceRanges() bool {
+	return denyAllExceptSourceRanges(ac.svc, ac.SourceRanges, ac.AllowedIPRanges, ac.invalidRanges)
+}
+
+// RequiresDenyAllExceptSourceRanges answers the same question as AccessControl.DenyAllExceptSourceRanges
+// for a service that is not being reconciled, so it has no precomputed ranges to read.
+func RequiresDenyAllExceptSourceRanges(svc *v1.Service) bool {
+	sourceRanges, invalidSourceRanges, _ := SourceRanges(svc)
+	allowedIPRanges, invalidAllowedIPRanges, _ := AllowedIPRanges(svc)
+
+	return denyAllExceptSourceRanges(svc, sourceRanges, allowedIPRanges, append(invalidSourceRanges, invalidAllowedIPRanges...))
+}
+
+func denyAllExceptSourceRanges(svc *v1.Service, sourceRanges, allowedIPRanges []netip.Prefix, invalidRanges []string) bool {
 	var (
-		annotationEnabled      = strings.EqualFold(ac.svc.Annotations[consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges], "true")
-		sourceRangeSpecified   = len(ac.SourceRanges) > 0 || len(ac.AllowedIPRanges) > 0
-		invalidRangesSpecified = len(ac.invalidRanges) > 0
+		annotationEnabled      = strings.EqualFold(svc.Annotations[consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges], "true")
+		sourceRangeSpecified   = len(sourceRanges) > 0 || len(allowedIPRanges) > 0
+		invalidRangesSpecified = len(invalidRanges) > 0
 	)
 	return (annotationEnabled && sourceRangeSpecified) || invalidRangesSpecified
 }
@@ -334,6 +347,22 @@ func (ac *AccessControl) PatchSecurityGroup(dstIPv4Addresses, dstIPv6Addresses [
 	}
 
 	logger.V(10).Info("Completed patching")
+
+	return nil
+}
+
+// EnsureDenyAllRules adds the given destinations to the deny all rules.
+func (ac *AccessControl) EnsureDenyAllRules(dstIPv4Addresses, dstIPv6Addresses []netip.Addr) error {
+	if len(dstIPv4Addresses) > 0 {
+		if err := ac.sgHelper.AddRuleForDenyAll(dstIPv4Addresses); err != nil {
+			return fmt.Errorf("add rule for deny all on IPv4: %w", err)
+		}
+	}
+	if len(dstIPv6Addresses) > 0 {
+		if err := ac.sgHelper.AddRuleForDenyAll(dstIPv6Addresses); err != nil {
+			return fmt.Errorf("add rule for deny all on IPv6: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/pkg/provider/loadbalancer/accesscontrol_test.go
+++ b/pkg/provider/loadbalancer/accesscontrol_test.go
@@ -449,6 +449,15 @@ func TestAccessControl_DenyAllExceptSourceRanges(t *testing.T) {
 			svc:            k8sFx.Service().WithAllowedIPRanges("10.0.0.1/24").Build(),
 			expectedOutput: true,
 		},
+		{
+			name: "internal LB with annotation and spec.loadBalancerSourceRanges specified",
+			svc: k8sFx.Service().
+				WithInternalEnabled().
+				WithDenyAllExceptLoadBalancerSourceRanges().
+				WithLoadBalancerSourceRanges("10.0.0.1/32").
+				Build(),
+			expectedOutput: true,
+		},
 	}
 
 	for i := range tests {
@@ -458,6 +467,8 @@ func TestAccessControl_DenyAllExceptSourceRanges(t *testing.T) {
 		assert.NoError(t, err)
 		actual := ac.DenyAllExceptSourceRanges()
 		assert.Equal(t, tt.expectedOutput, actual, "[%s] expecting DenyAllExceptSourceRanges returns %v", tt.name, tt.expectedOutput)
+		assert.Equal(t, actual, RequiresDenyAllExceptSourceRanges(&tt.svc),
+			"[%s] expecting RequiresDenyAllExceptSourceRanges to agree with DenyAllExceptSourceRanges", tt.name)
 	}
 }
 

--- a/tests/e2e/network/network_security_group.go
+++ b/tests/e2e/network/network_security_group.go
@@ -1213,6 +1213,125 @@ var _ = Describe("Network security group", Label(utils.TestSuiteLabelNSG), func(
 				).To(BeTrue(), "Should have a rule for allowing traffic from Internet")
 			})
 		})
+
+		It("should keep the deny-all rule when one of the services is deleted", func() {
+
+			const (
+				Deployment1Name = "app-01"
+				Deployment2Name = "app-02"
+
+				Service1Name = "svc-01"
+				Service2Name = "svc-02"
+			)
+
+			var (
+				app1Port  int32 = 80
+				app2Port  int32 = 81
+				replicas  int32 = 2
+				svc1IPv4s []netip.Addr
+				svc1IPv6s []netip.Addr
+
+				allowedIPv4Ranges = []string{"10.20.0.0/16"}
+				allowedIPv6Ranges = []string{"2c0f:fe40:8000::/48"}
+			)
+
+			denyAllAnnotations := func(extra map[string]string) map[string]string {
+				rv := map[string]string{
+					v1.AnnotationLoadBalancerSourceRangesKey:                      strings.Join(append(allowedIPv4Ranges, allowedIPv6Ranges...), ","),
+					consts.ServiceAnnotationDenyAllExceptLoadBalancerSourceRanges: "true",
+				}
+				for k, v := range extra {
+					rv[k] = v
+				}
+				return rv
+			}
+
+			joinIPsAsString := func(ips []netip.Addr) string {
+				var s []string
+				for _, ip := range ips {
+					s = append(s, ip.String())
+				}
+				return strings.Join(s, ",")
+			}
+
+			expectDenyAllRuleForSharedIPs := func(msg string) {
+				Eventually(func(g Gomega) {
+					nsgs, err := azureClient.GetClusterSecurityGroups()
+					g.Expect(err).NotTo(HaveOccurred())
+
+					v := NewSecurityGroupValidator(nsgs)
+					if len(svc1IPv4s) > 0 {
+						g.Expect(v.HasDenyAllRuleForDestination(svc1IPv4s)).To(BeTrue(), msg)
+					}
+					if len(svc1IPv6s) > 0 {
+						g.Expect(v.HasDenyAllRuleForDestination(svc1IPv6s)).To(BeTrue(), msg)
+					}
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			}
+
+			deployment1 := createDeploymentManifest(Deployment1Name, map[string]string{
+				"app": Deployment1Name,
+			}, &app1Port, nil)
+			deployment1.Spec.Replicas = &replicas
+			_, err := k8sClient.AppsV1().Deployments(namespace.Name).Create(context.Background(), deployment1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment2 := createDeploymentManifest(Deployment2Name, map[string]string{
+				"app": Deployment2Name,
+			}, &app2Port, nil)
+			deployment2.Spec.Replicas = &replicas
+			_, err = k8sClient.AppsV1().Deployments(namespace.Name).Create(context.Background(), deployment2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating service 1 with deny-all enabled", func() {
+				var (
+					labels = map[string]string{
+						"app": Deployment1Name,
+					}
+					ports = []v1.ServicePort{{
+						Port:       app1Port,
+						TargetPort: intstr.FromInt32(app1Port),
+					}}
+				)
+				rv := createAndExposeDefaultServiceWithAnnotation(k8sClient, azureClient.IPFamily, Service1Name, namespace.Name, labels, denyAllAnnotations(nil), ports)
+				svc1IPv4s, svc1IPv6s = groupIPsByFamily(mustParseIPs(derefSliceOfStringPtr(rv)))
+				logger.Info("Created the first LoadBalancer service", "svc-name", Service1Name, "v4-IPs", svc1IPv4s, "v6-IPs", svc1IPv6s)
+			})
+
+			By("Creating service 2 with deny-all enabled sharing the IP of service 1", func() {
+				var (
+					labels = map[string]string{
+						"app": Deployment2Name,
+					}
+					annotations = denyAllAnnotations(map[string]string{
+						"service.beta.kubernetes.io/azure-load-balancer-ipv4": joinIPsAsString(svc1IPv4s),
+						"service.beta.kubernetes.io/azure-load-balancer-ipv6": joinIPsAsString(svc1IPv6s),
+					})
+					ports = []v1.ServicePort{{
+						Port:       app2Port,
+						TargetPort: intstr.FromInt32(app2Port),
+					}}
+				)
+
+				rv := createAndExposeDefaultServiceWithAnnotation(k8sClient, azureClient.IPFamily, Service2Name, namespace.Name, labels, annotations, ports)
+				svc2IPv4s, svc2IPv6s := groupIPsByFamily(mustParseIPs(derefSliceOfStringPtr(rv)))
+				logger.Info("Created the second LoadBalancer service", "svc-name", Service2Name, "v4-IPs", svc2IPv4s, "v6-IPs", svc2IPv6s)
+				Expect(svc2IPv4s).To(Equal(svc1IPv4s))
+				Expect(svc2IPv6s).To(Equal(svc1IPv6s))
+			})
+
+			By("Checking if the deny-all rule covers the shared IP", func() {
+				expectDenyAllRuleForSharedIPs("Should have a rule for denying all traffic while both services exist")
+			})
+
+			By("Deleting service 2", func() {
+				Expect(utils.DeleteService(k8sClient, namespace.Name, Service2Name)).NotTo(HaveOccurred())
+			})
+
+			By("Checking if the deny-all rule still covers the shared IP", func() {
+				expectDenyAllRuleForSharedIPs("Should keep denying all traffic because service 1 still needs it")
+			})
+		})
 	})
 
 	When("creating 2 LoadBalancer services with shared BYO public IP", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
There is one deny-all rule per IP family (e.g. `k8s-azure-lb_deny-all_IPv4`) shared by every Service of the same IP family. Reconciling a Service strips its own destinations from that rule, but `listSharedIPPortMapping` only reported the *ports* other Services still need, never their deny-all destinations. A destination another Service still required was therefore dropped, making that Service reachable from the whole virtual network.

`listSharedIPPortMapping` now also returns the deny-all destinations other Services still require, and `reconcileSecurityGroup` restores them with `EnsureDenyAllRules` after cleanup. This covers shared frontend IPs, backend node IPs when the floating IP is disabled, and `azure-additional-public-ips`.

Under multiple standard load balancers, a Service can have a backend pool of its own, so the nodes behind another Service are resolved per Service: from its endpoints when it is local, otherwise from the load balancer it is placed on. `EnsureLoadBalancerDeleted` records that placement before reconciling the security group, and a nil node list during init no longer clears the recorded nodes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: keep the deny-all NSG rule intact for Services using `azure-deny-all-except-load-balancer-source-ranges` when another Service sharing one of its destinations is reconciled or deleted. Previously that destination could be dropped from the rule, leaving the Service reachable from anywhere in the virtual network rather than only its configured source ranges.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
