### PR TITLE
docs: recreate manually edited Dependabot PRs

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -48,7 +48,9 @@ level small:
 - `sync-go-modules`: unblock `go-mod-consistency` by tidying and verifying all
   tracked Go modules, then refreshing the main module's `vendor/` tree
 - `unblock-dependabot-pr`: diagnose failed Dependabot PR CI, reuse the Go module
-  sync workflow, close Kubernetes minor-version bumps, retest Azure public-IP
+  sync workflow, close Kubernetes minor-version bumps, refresh conflicting
+  branches with rebase for Dependabot-only commits or recreate when manual
+  edits are present (discarding those edits), retest Azure public-IP
   quota e2e flakes without consuming the automated retry budget, add `/lgtm`
   when only Tide is pending, and escalate dependency/toolchain blockers for
   discussion

--- a/.agents/skills/unblock-dependabot-pr/SKILL.md
+++ b/.agents/skills/unblock-dependabot-pr/SKILL.md
@@ -40,15 +40,15 @@ gh pr view <pr> --json number,title,headRefName,headRepositoryOwner,headRefOid,b
 ```
 
 When each guard row is reached, its linked Details fetch any extra allowed
-input, such as the `go.mod` diff or PR comment history, in priority order.
+input, such as the `go.mod` diff or PR comment/commit history, in priority order.
 
 Then walk the catalog as an explicit staged algorithm:
 
-> **Guard stage — metadata/diff/comment-history only.** Before running
+> **Guard stage — metadata/diff/comment/commit-history only.** Before running
 > `gh pr checks`, reading `statusCheckRollup`, or fetching any Prow log,
 > evaluate every guard row whose Signal is computable from PR metadata, the
-> `go.mod` diff, and PR comment history alone. If a guard row matches and is
-> marked Stop, follow its linked Details action
+> `go.mod` diff, and PR comment/commit history alone. If a guard row matches
+> and is marked Stop, follow its linked Details action
 > (e.g. `/close`) and **end triage immediately** — do not inspect CI, sync
 > modules, retest, `/lgtm`, or report no-action.
 >
@@ -95,9 +95,9 @@ or overwrite unrelated files.
   compatibility issue, commit SHA, changed files, and validation result.
 - Use specific staging commands, never `git add .`.
 - Push only the current task's files.
-- Resolve guard rows from PR metadata, the `go.mod` diff, and PR comment history
-  before any CI or log I/O. When a guard row marked Stop matches, follow its
-  linked Details action and end triage immediately — do not inspect CI, sync
+- Resolve guard rows from PR metadata, the `go.mod` diff, and PR comment/commit
+  history before any CI or log I/O. When a guard row marked Stop matches,
+  follow its linked Details action and end triage immediately — do not inspect CI, sync
   modules, retest, comment `/lgtm`, or report that no action is needed.
 - After the guard stage, handle failed required jobs one by one. For each failed
   job, walk act rows in ascending Priority and take a row's linked Details
@@ -110,10 +110,11 @@ or overwrite unrelated files.
 - One retry-budgeted automated unblock round consumes one attempt from one
   PR-comment-backed counter. Public-IP quota e2e reruns are unbudgeted: a
   quota-only triage creates no attempt stamp, while a mixed triage summarizes
-  only its budgeted actions. Read the counter once before any rebase or CI/log
-  I/O and reuse it throughout the triage. Rebase and budgeted act-stage paths
-  must never create two attempt stamps in one triage. When the retry budget is
-  exhausted, mutate nothing and escalate for human review. Do not invent a
+  only its budgeted actions. Read the counter once before any rebase/recreate
+  directive or CI/log I/O and reuse it throughout the triage. Guard directives
+  and budgeted act-stage paths must never create two attempt stamps in one
+  triage. When the retry budget is exhausted, mutate nothing and escalate for
+  human review. Do not invent a
   second counter; the guard and shared-action references own the policy and
   write mechanics.
 - A row marked Stop ends triage after it is handled.

--- a/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/failure-patterns.md
@@ -16,7 +16,7 @@ or acting on a row.
 | Column | Purpose |
 |--------|---------|
 | **Priority** | Gap-numbered (10, 20, 30…). Within a stage, the engine acts on matched rows low→high. New patterns slot into gaps without renumbering. |
-| **Stage** | `guard` (metadata/diff/comment-history only) or `act` (CI/log/artifact-based action). After the guard stage, the engine processes failed required jobs one at a time instead of classifying every failure up front. |
+| **Stage** | `guard` (metadata/diff/comment/commit-history only) or `act` (CI/log/artifact-based action). After the guard stage, the engine processes failed required jobs one at a time instead of classifying every failure up front. |
 | **Pattern** | Short human name. |
 | **Signal** | Compact routing hint: the diff marker, failing job name, or log fingerprint. A guard signal must be computable before CI/log I/O. |
 | **Autonomy** | `close` / `auto-fix` / `escalate` / `bot-rebase`. Governs whether the agent acts alone (see Autonomy values below). |
@@ -35,11 +35,14 @@ or acting on a row.
   final output. Used both as a guard when the automated retry budget is spent
   (Retry budget exhausted) and as an act-stage flag when a blocker needs a
   human policy or toolchain decision (Toolchain / SDK / policy).
-- `bot-rebase` — post a bot directive (`@dependabot rebase`) that regenerates
-  the branch, then stop; distinct from `escalate` because it directs another
-  bot to regenerate the branch rather than handing the PR to a human reviewer.
+- `bot-rebase` — post the commit-history-selected bot directive
+  (`@dependabot rebase` or `@dependabot recreate`) to refresh the branch, then
+  stop; distinct from `escalate` because it directs Dependabot to refresh the
+  branch rather than handing the PR to a human reviewer. The
+  [Needs rebase details](guard-patterns.md#details-needs-rebase) own selection
+  and the manual-edit overwrite policy.
   The needs-rebase row uses this as a guard: a conflicting branch is detected
-  from metadata and handed to Dependabot before any CI/log I/O, since a rebase
+  from metadata and handed to Dependabot before any CI/log I/O, since a refresh
   invalidates a stale CI run anyway. The directive consumes one shared unblock
   attempt and carries its attempt stamp in the same comment.
 

--- a/.agents/skills/unblock-dependabot-pr/references/guard-patterns.md
+++ b/.agents/skills/unblock-dependabot-pr/references/guard-patterns.md
@@ -71,8 +71,8 @@ times without success, a fourth automated attempt is unlikely to help, so the
 PR goes to human reviewers instead of burning more CI on the same failing jobs.
 
 The count comes from the one `Unblock attempt: N` stamp that each completed
-retry-budgeted triage leaves on the PR: the rebase directive carries its own
-stamp, while budgeted act-stage actions use one summary (see
+retry-budgeted triage leaves on the PR: the rebase/recreate directive carries
+its own stamp, while budgeted act-stage actions use one summary (see
 [Attempt stamp](shared-actions.md#details-attempt-stamp)). Public-IP quota
 reruns do not write this stamp. Read the highest stamp already present:
 
@@ -90,8 +90,8 @@ Let `N` be that maximum. The budget is three attempts, so:
   [Attempt stamp](shared-actions.md#details-attempt-stamp) rule. Quota-only
   reruns post no summary and leave `N` unchanged.
 - `N >= 3` — the budget is spent (a fourth attempt would exceed three). Stop
-  working the PR: make no automated change, including no rebase directive, and
-  report it as needing human review in the final output.
+  working the PR: make no automated change, including no rebase/recreate
+  directive, and report it as needing human review in the final output.
 
 Escalation makes no change to the PR — no comment, no checks, no module sync, no
 push, no `/lgtm`. Because it posts nothing, it leaves no `Unblock attempt:` stamp
@@ -107,17 +107,57 @@ this report.
 Evaluate this guard from PR metadata after the
 [Retry budget exhausted](#details-retry-budget-exhausted) guard and before
 reading CI status or any Prow log. If the PR carries the `needs-rebase` label or
-`gh pr view` reports `mergeable` = `CONFLICTING`, the branch is out of date and
-`@dependabot rebase` will regenerate it — so classifying CI, syncing modules, or
-pushing a local fix first would be wasted work against a stale branch.
+`gh pr view` reports `mergeable` = `CONFLICTING`, the branch needs a refresh —
+so classifying CI, syncing modules, or pushing a local fix first would be
+wasted work against a stale branch. If neither signal is present, continue
+triage without fetching commit history or requesting a refresh.
 
-Reuse `N`, the highest attempt stamp read by the retry-budget guard. Ask
-Dependabot to rebase the branch instead of manually rewriting the generated PR
-branch. Follow the guard-stage rebase form in the shared
+Only after this guard matches and the retry-budget guard has passed, inspect
+the current PR's complete commit history (all pages, not just the latest
+commit). Commit attribution is guard-stage metadata, not CI/log I/O:
+
+```bash
+gh api 'repos/kubernetes-sigs/cloud-provider-azure/pulls/<pr>' \
+  --jq '{head: .head.sha, commitCount: .commits}'
+gh api --paginate 'repos/kubernetes-sigs/cloud-provider-azure/pulls/<pr>/commits?per_page=100' \
+  --jq '.[] | {sha, author: .author.login, committer: .committer.login}'
+```
+
+Before declaring the history complete, check that the distinct returned SHA
+count equals `commitCount` and the reported head and final commit SHA match
+the initial `headRefOid`. Pagination alone does not prove completeness; a
+truncated list or changed head cannot establish a Dependabot-only history.
+
+Choose exactly one directive:
+
+- **Any manual commit/edit:** use `@dependabot recreate` directly. A commit
+  authored by anyone other than `dependabot[bot]`, or committed by an actor
+  other than `dependabot[bot]` or GitHub's `web-flow`, is evidence of a manual
+  edit. This includes module-sync fixes from a previous unblock round. Do not
+  first try `@dependabot rebase`, which cannot handle manual edits.
+- **All commits from Dependabot:** use `@dependabot rebase` only when every
+  commit is attributed to `dependabot[bot]`. A Dependabot-authored commit may
+  have `web-flow` as its committer for GitHub signing; that alone is not a
+  manual edit.
+- **Unknown attribution or incomplete history:** if no manual edit is proven
+  and the history cannot establish that all commits are from Dependabot, stop
+  and report the missing evidence. A null login is unknown, not proof of a
+  manual edit; do not infer authorship from the PR author or commit message.
+
+Recreation intentionally discards manual edits and regenerates the Dependabot
+branch from scratch. This is the skill's selected policy for manually edited
+PRs that need a refresh; state that consequence in the request and final
+report. Do not manually replay the discarded edits in this triage. If the
+caller requires preserving those edits, stop for that PR instead of recreating.
+
+Reuse `N`, the highest attempt stamp read by the retry-budget guard. Follow the
+selected guard-directive form in the shared
 [Attempt stamp](shared-actions.md#details-attempt-stamp) rule so the directive
-and its `N + 1` accounting remain atomic.
+and its `N + 1` accounting remain atomic. Rebase and recreate share the same
+counter; recreation does not reset or bypass an exhausted retry budget.
 
 After posting the comment, stop triage for this PR. Do not inspect CI, sync
-modules, retest, comment `/lgtm`, or report no-action; Dependabot will push a
-rebased branch and a fresh CI run to triage next time. The rebase directive is
-one automated unblock attempt; do not post a separate attempt-summary comment.
+modules, retest, comment `/lgtm`, or report no-action. Report the refresh as
+requested, not completed, until Dependabot actually updates the branch. Either
+directive consumes one automated unblock attempt; do not post a separate
+attempt-summary comment or a second directive in this triage.

--- a/.agents/skills/unblock-dependabot-pr/references/shared-actions.md
+++ b/.agents/skills/unblock-dependabot-pr/references/shared-actions.md
@@ -64,9 +64,9 @@ stamp.
 
 The skill keeps no state between runs, so the attempt count lives in the PR's
 own comment history. Count retry-budgeted triage **rounds**, not actions or
-comments: a rebase directive is one attempt, while one act-stage triage may push
-a module-sync fix and rerun three budgeted e2e jobs but is still one attempt
-with one summary comment.
+comments: a rebase or recreate directive is one attempt, while one act-stage
+triage may push a module-sync fix and rerun three budgeted e2e jobs but is still
+one attempt with one summary comment.
 
 Compute the next attempt number once, before taking any retry-budgeted automated
 unblock action this round:
@@ -78,16 +78,31 @@ gh pr view <pr> --json comments \
 ```
 
 Let `N` be that maximum. This round's attempt number is `N + 1`. For a
-guard-stage rebase, ask Dependabot to rebase the branch instead of manually
-rewriting the generated PR branch. Put `@dependabot rebase` on the first line,
-explain why it is needed, and put `Unblock attempt: <N+1>` in the same comment
-so the action and its accounting are atomic:
+guard-stage refresh, use the directive selected by
+[Needs rebase](guard-patterns.md#details-needs-rebase) from commit history.
+Put that directive on the first line, explain why it is needed, and put
+`Unblock attempt: <N+1>` in the same comment so the action and its accounting
+are atomic. Choose only one of these forms.
+
+All commits from Dependabot:
 
 ```bash
 gh pr comment <pr> --body-file - <<'EOF'
 @dependabot rebase
 
-Reason: the PR is in a needs-rebase or conflicting state and must be rebased before Tide can merge it.
+Reason: the PR needs a refresh before Tide can merge it, and all commits are from Dependabot.
+Unblock attempt: <N+1>
+EOF
+```
+
+Manual edits present:
+
+```bash
+gh pr comment <pr> --body-file - <<'EOF'
+@dependabot recreate
+
+Reason: the PR needs a refresh and contains manual edits, so Dependabot cannot rebase it. Recreate it from scratch, discarding those edits.
+Manual commits: <commit SHAs and authors/committers establishing manual edits>
 Unblock attempt: <N+1>
 EOF
 ```
@@ -110,9 +125,9 @@ Post no summary when the triage takes no retry-budgeted act-stage non-final
 action. In particular, one or more
 [Public-IP quota e2e](act-patterns.md#details-public-ip-quota-e2e) reruns alone
 do not consume an attempt; in a mixed triage, summarize only the budgeted
-actions. A rebase directive causes no separate summary because its comment
-already carries the attempt stamp. Terminal actions do not cause a summary or
-consume an attempt: `/close` (K8s guard), the `escalate`
+actions. A rebase or recreate directive causes no separate summary because its
+comment already carries the attempt stamp. Terminal actions do not cause a
+summary or consume an attempt: `/close` (K8s guard), the `escalate`
 [Toolchain / SDK / policy](act-patterns.md#details-toolchain--sdk--policy) and
 [Retry budget exhausted](guard-patterns.md#details-retry-budget-exhausted)
 handoffs, and the


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Teach the Dependabot unblock skill to choose the branch-refresh command from commit history:

- Use `@dependabot recreate` when any manual edit is present, including module-sync fixes from an earlier unblock attempt. Explicitly disclose that recreation discards those edits.
- Use `@dependabot rebase` only when the complete history is attributable to Dependabot. Check author and committer attribution, the distinct commit count, and the current head; stop when evidence is incomplete or ambiguous.
- Preserve guard ordering, the shared three-attempt retry budget, one atomic attempt stamp per directive, and immediate termination before CI inspection.
- Keep the entrypoint, catalog, shared comment templates, and skill README consistent.

Dependabot refuses to rebase manually edited branches. Selecting recreation directly avoids spending a retry on a command that cannot handle those edits.

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

- Documentation-only policy change; this PR does not execute Dependabot directives on existing PRs or override any retry budget.
- Recreation intentionally discards manual edits. An explicit request to preserve edits still stops the workflow for human review.
- An independent read-only review approved nine offline scenarios covering bot-only history, older manual commits, exhausted budgets, mergeable branches, unknown attribution, incomplete history, human committers, preservation requests, and Kubernetes minor-version rejection.
- Validation passed: `git diff --check`, dependency-free frontmatter/link/fence checks, catalog guard priorities, and one attempt stamp in each directive example. The bundled skill validator could not run because PyYAML is unavailable. No Go tests were run for these Markdown-only changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
