### PR TITLE
fix: update Go builders for CVE directive bumps

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -34,7 +34,7 @@ level small:
 - `create-release-note-doc-pr`: generate a documentation-site release note for
   a tag and open a documentation PR
 - `fix-image-cves`: scan a built image with Trivy, plan fixable Go-module and
-  base-image CVE remediation, apply the source changes, and verify the result
+  base-image CVE remediation, update required Go builders, and verify the fixes
 - `remediate-image-cves`: orchestrate builds, repeated CVE remediation and
   verification for CCM, CNM, and health-probe-proxy on `master` or a
   `release-X.Y` branch, then validate, clean up, push, and open the remediation

--- a/.agents/skills/fix-image-cves/SKILL.md
+++ b/.agents/skills/fix-image-cves/SKILL.md
@@ -36,6 +36,15 @@ the repository. If it reports a Go directive bump, select a locally installed
 Go version that is at least the planned target before continuing. Keep
 `GOTOOLCHAIN=local`; do not rely on an automatic toolchain download.
 
+Also bump older Go builder tags and digests in Dockerfiles that build the
+affected module; host Go selection does not change container Go. Keep the
+registry, repository, and OS variant; verify a stable builder Go version at
+least as new as the planned directive, target-platform support, and the digest.
+Pass each target to `apply` as
+`--base-image-target Dockerfile:builder=<image>@sha256:<digest>` (repeat for
+`cloud-node-manager.Dockerfile:builder` when the root module changes). The
+helper records and verifies these edits with the dependency changes.
+
 3. Review the plan before changing files. When base-image CVEs are in scope,
    decide the deterministic replacement image and digest yourself. Then apply
    the plan:
@@ -102,6 +111,8 @@ python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
   never passed to `go mod edit`, `go list -m`, or module verification.
   `apply`, `verify`, and rescan also filter these pseudo-packages defensively
   when reading a plan saved by an older version of the skill.
+  Builder updates required by planned Go directive bumps are separate from
+  these report-only compiler CVEs.
 - OTHER findings with a non-empty `FixedVersion` are unsupported fixable
   findings. They require manual remediation and must not be treated as a clean
   verification result.

--- a/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
@@ -1229,8 +1229,24 @@ def command_apply(args: argparse.Namespace) -> int:
             state["plan"] = plan
             save_state(repo_root, state)
     go_directive_actions = plan.get("go_directive_actions") or []
-    base_actions = plan.get("base_image_actions") or []
+    base_actions = list(plan.get("base_image_actions") or [])
     targets = parse_base_image_targets(args.base_image_target or [])
+    allow_default_base_target = len(base_actions) <= 1
+    for key, image in targets.items():
+        if not key.endswith(":builder"):
+            continue
+        if not go_directive_actions:
+            raise CommandError("Builder image updates require planned Go directive actions.")
+        dockerfile = key.removesuffix(":builder")
+        stages = [
+            match for line in abs_from_repo(repo_root, dockerfile).read_text(encoding="utf-8").splitlines()
+            if (match := FROM_RE.match(line))
+        ]
+        if len(stages) < 2 or not re.fullmatch(r"\s+AS\s+builder\s*", stages[0]["suffix"], re.IGNORECASE):
+            raise CommandError(f"{dockerfile} must start with a named builder stage.")
+        if not re.fullmatch(r"[^\s]+@sha256:[0-9a-f]{64}", image):
+            raise CommandError("Builder image targets must include a sha256 digest.")
+        base_actions.append({"dockerfile": dockerfile, "stage": "builder"})
     preexisting_paths = git_status_paths(repo_root)
     module_roots = {action["module_root"] for action in go_actions}
     module_roots.update(action["module_root"] for action in go_directive_actions)
@@ -1325,7 +1341,6 @@ def command_apply(args: argparse.Namespace) -> int:
                 go_commands.append({"cwd": ".", "cmd": ["go", "mod", "verify"]})
 
     base_image_updates: list[dict[str, Any]] = []
-    allow_default_base_target = len(base_actions) <= 1
     for action in base_actions:
         selected = select_base_image_target(
             action,

--- a/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
@@ -360,6 +360,80 @@ class FixImageCVEsTest(unittest.TestCase):
         ensure_command.assert_not_called()
         discover_modules.assert_not_called()
 
+    def test_apply_builder_targets_are_recorded_and_verified(self) -> None:
+        builder = "mcr.microsoft.com/oss/go/microsoft/golang:1.26.0-bookworm@sha256:" + "a" * 64
+        runtime = "gcr.io/distroless/base@sha256:" + "b" * 64
+        original = "FROM --platform=linux/amd64 golang:1.25.11 AS builder\nFROM distroless:old\n"
+        dockerfiles = ["Dockerfile", "cloud-node-manager.Dockerfile"]
+        for dry_run in (True, False):
+            with self.subTest(dry_run=dry_run), tempfile.TemporaryDirectory() as temp_dir:
+                repo = Path(temp_dir)
+                for name in dockerfiles:
+                    (repo / name).write_text(original, encoding="utf-8")
+                state = {
+                    "scan": {"module_root": ".", "dockerfile": "Dockerfile"},
+                    "plan": {
+                        "go_directive_actions": [{"module_root": ".", "target_version": "1.26.0"}],
+                        "base_image_actions": [{"dockerfile": "Dockerfile", "stage": "runtime"}],
+                    },
+                }
+                args = fix_image_cves.build_parser().parse_args(
+                    ["apply", "--repo", str(repo), "--base-image-target", runtime]
+                    + [arg for name in dockerfiles for arg in
+                       ("--base-image-target", f"{name}:builder={builder}")]
+                    + (["--dry-run"] if dry_run else [])
+                )
+                with mock.patch.object(fix_image_cves, "ensure_repo_root", return_value=repo), \
+                     mock.patch.object(fix_image_cves, "load_state", return_value=state), \
+                     mock.patch.object(fix_image_cves, "save_state") as save_state, \
+                     mock.patch.object(fix_image_cves, "git_status_paths",
+                                       side_effect=[set(), set(dockerfiles) | {"go.mod"}]), \
+                     mock.patch.object(fix_image_cves, "run") as run, \
+                     mock.patch("sys.stdout", io.StringIO()):
+                    self.assertEqual(fix_image_cves.command_apply(args), 0)
+                self.assertEqual(len(state["plan"]["base_image_actions"]), 1)
+                if dry_run:
+                    save_state.assert_not_called()
+                    run.assert_not_called()
+                    for name in dockerfiles:
+                        self.assertEqual((repo / name).read_text(), original)
+                else:
+                    applied = save_state.call_args.args[1]["apply"]
+                    self.assertEqual(set(applied["modified_files"]), set(dockerfiles) | {"go.mod"})
+                    results = {}
+                    self.assertTrue(fix_image_cves.verify_dockerfile_actions(repo, applied, results))
+                    self.assertEqual(len(results["dockerfile_checks"]), 3)
+                    for name in dockerfiles:
+                        lines = (repo / name).read_text().splitlines()
+                        self.assertEqual(lines[0], f"FROM --platform=linux/amd64 {builder} AS builder")
+                        self.assertEqual(lines[-1], f"FROM {runtime}" if name == "Dockerfile" else "FROM distroless:old")
+
+    def test_apply_rejects_invalid_builder_targets_before_mutation(self) -> None:
+        pinned = "golang:1.26.0@sha256:" + "a" * 64
+        original = "FROM golang:1.25.11 AS builder\nFROM distroless:old\n"
+        directive = {"module_root": ".", "target_version": "1.26.0"}
+        for directives, text, target, dirty, error in [
+            ([], original, pinned, set(), "planned Go directive"),
+            ([directive], "FROM distroless:old\n", pinned, set(), "named builder stage"),
+            ([directive], original, "golang:1.26.0", set(), "sha256 digest"),
+            ([directive], original, pinned, {"Dockerfile"}, "already dirty"),
+        ]:
+            with self.subTest(error=error), tempfile.TemporaryDirectory() as temp_dir:
+                repo = Path(temp_dir)
+                (repo / "Dockerfile").write_text(text, encoding="utf-8")
+                state = {"scan": {"module_root": "."}, "plan": {"go_directive_actions": directives}}
+                args = Namespace(repo=str(repo), base_image_target=[f"Dockerfile:builder={target}"], dry_run=False)
+                with mock.patch.object(fix_image_cves, "ensure_repo_root", return_value=repo), \
+                     mock.patch.object(fix_image_cves, "load_state", return_value=state), \
+                     mock.patch.object(fix_image_cves, "git_status_paths", return_value=dirty), \
+                     mock.patch.object(fix_image_cves, "run") as run, \
+                     mock.patch.object(fix_image_cves, "save_state") as save_state:
+                    with self.assertRaisesRegex(fix_image_cves.CommandError, error):
+                        fix_image_cves.command_apply(args)
+                run.assert_not_called()
+                save_state.assert_not_called()
+                self.assertEqual((repo / "Dockerfile").read_text(), text)
+
     def test_apply_retidies_root_after_vendor_license_update(self) -> None:
         state = {
             "scan": {"module_root": ".", "dockerfile": "Dockerfile"},

--- a/.agents/skills/remediate-image-cves/SKILL.md
+++ b/.agents/skills/remediate-image-cves/SKILL.md
@@ -162,10 +162,13 @@ table order:
 2. Review every fresh plan. If it contains Go directive actions, select a
    locally installed Go version at least as new as the highest target before
    apply, and keep `GOTOOLCHAIN=local`. Apply Go-module and directive fixes
-   through `fix-image-cves`. For a fixable runtime base-image finding,
-   automatically replace only the digest of the existing registry, repository,
-   and tag. If remediation would change the image family or tag, stop for
-   review. Stop and report any other permission, judgment, or
+   through `fix-image-cves`, including compatible pinned Go builder targets
+   for every affected verification Dockerfile (both CCM and CNM for the root
+   module). Follow the fix skill's `Dockerfile:builder` target policy; keep
+   already-compatible builders unchanged. For a fixable runtime base-image
+   finding, automatically replace only the digest of the existing registry,
+   repository, and tag. If runtime base-image remediation would change the
+   image family or tag, stop for review. Stop and report any other permission, judgment, or
    conflict-resolution requirement instead of guessing.
 3. If the fresh plan contains no Go-module or base-image actions and no
    unsupported fixable findings, record its residual risks, run `clean`, and


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Keep Docker's Go builders compatible when CVE fixes raise a module's Go directive.

Reuse explicit `--base-image-target Dockerfile:builder=...` targets so builder tag/digest updates are protected, recorded, verified, and committed with the dependency fixes. Cover both CCM and CNM for root-module changes; leave compatible builders and compiler-only CVE policy unchanged.

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

- 38 CVE-helper, 30 build-helper, and 5 module-sync tests pass.
- New regression cases fail against the original helper.
- YAML frontmatter and `git diff --check` pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
