### PR TITLE
chore: fix cves for release-1.31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # syntax=docker/dockerfile:1
 
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.25.11-bookworm@sha256:458de9482c2cbab0debe4d3f64fd10acca756f8b42d19f85e0b5535a5f65bfcd AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.0-bookworm@sha256:9644874dae39c9ef28b59836911bc859c0a6c5c1c1d76429063f4b435275815b AS builder
 
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH=amd64

--- a/cloud-node-manager.Dockerfile
+++ b/cloud-node-manager.Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.25.11-bookworm@sha256:458de9482c2cbab0debe4d3f64fd10acca756f8b42d19f85e0b5535a5f65bfcd AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.26.0-bookworm@sha256:9644874dae39c9ef28b59836911bc859c0a6c5c1c1d76429063f4b435275815b AS builder
 
 ARG ENABLE_GIT_COMMAND=true
 ARG ARCH=amd64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cloud-provider-azure
 
-go 1.25.0
+go 1.26.0
 
 godebug winsymlink=0
 
@@ -138,16 +138,16 @@ require (
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
-	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.83.1 // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 h1:nDVHiLt8aIbd/VzvPWN6kSOPE7+F/fNFDSXLVYkE/Iw=
 golang.org/x/exp v0.0.0-20250305212735-054e65f0b394/go.mod h1:sIifuuw/Yco/y6yb6+bDNfyeQ/MdPUy/hKEMYQV17cM=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -352,8 +352,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
-golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
+golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -418,8 +418,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vendor/golang.org/x/net/http/httpproxy/proxy.go
+++ b/vendor/golang.org/x/net/http/httpproxy/proxy.go
@@ -80,18 +80,19 @@ type config struct {
 	domainMatchers []matcher
 }
 
-// FromEnvironment returns a Config instance populated from the
-// environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the
-// lowercase versions thereof).
+// FromEnvironment returns a Config instance populated from the environment
+// variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions
+// thereof). When both the uppercase and lowercase versions are provided, the
+// lowercase versions are prioritized.
 //
 // The environment values may be either a complete URL or a
 // "host[:port]", in which case the "http" scheme is assumed. An error
 // is returned if the value is a different form.
 func FromEnvironment() *Config {
 	return &Config{
-		HTTPProxy:  getEnvAny("HTTP_PROXY", "http_proxy"),
-		HTTPSProxy: getEnvAny("HTTPS_PROXY", "https_proxy"),
-		NoProxy:    getEnvAny("NO_PROXY", "no_proxy"),
+		HTTPProxy:  getEnvAny("http_proxy", "HTTP_PROXY"),
+		HTTPSProxy: getEnvAny("https_proxy", "HTTPS_PROXY"),
+		NoProxy:    getEnvAny("no_proxy", "NO_PROXY"),
 		CGI:        os.Getenv("REQUEST_METHOD") != "",
 	}
 }

--- a/vendor/golang.org/x/net/http2/hpack/encode.go
+++ b/vendor/golang.org/x/net/http2/hpack/encode.go
@@ -39,7 +39,6 @@ func NewEncoder(w io.Writer) *Encoder {
 		tableSizeUpdate: false,
 		w:               w,
 	}
-	e.dynTab.table.init()
 	e.dynTab.setMaxSize(initialHeaderTableSize)
 	return e
 }

--- a/vendor/golang.org/x/net/http2/hpack/hpack.go
+++ b/vendor/golang.org/x/net/http2/hpack/hpack.go
@@ -105,7 +105,6 @@ func NewDecoder(maxDynamicTableSize uint32, emitFunc func(f HeaderField)) *Decod
 		emitEnabled: true,
 		firstField:  true,
 	}
-	d.dynTab.table.init()
 	d.dynTab.allowedMaxSize = maxDynamicTableSize
 	d.dynTab.setMaxSize(maxDynamicTableSize)
 	return d

--- a/vendor/golang.org/x/net/http2/hpack/tables.go
+++ b/vendor/golang.org/x/net/http2/hpack/tables.go
@@ -31,10 +31,18 @@ type headerFieldTable struct {
 
 	// byName maps a HeaderField name to the unique id of the newest entry with
 	// the same name. See above for a definition of "unique id".
+	//
+	// byName and byNameValue are used only by search, which is only called
+	// for tables used by encoders. For tables used only by decoders, the
+	// maps are never built, as a memory optimization for servers with many
+	// mostly-idle connections, each pinning a dynamic table. The maps are
+	// built lazily by the first search call and are nil until then. The two
+	// maps are always both nil or both non-nil.
 	byName map[string]uint64
 
 	// byNameValue maps a HeaderField name/value pair to the unique id of the newest
 	// entry with the same name and value. See above for a definition of "unique id".
+	// See byName for when this map is non-nil.
 	byNameValue map[pairNameValue]uint64
 }
 
@@ -42,9 +50,17 @@ type pairNameValue struct {
 	name, value string
 }
 
-func (t *headerFieldTable) init() {
-	t.byName = make(map[string]uint64)
-	t.byNameValue = make(map[pairNameValue]uint64)
+// buildMaps initializes byName and byNameValue from ents.
+func (t *headerFieldTable) buildMaps() {
+	t.byName = make(map[string]uint64, len(t.ents))
+	t.byNameValue = make(map[pairNameValue]uint64, len(t.ents))
+	for k, f := range t.ents {
+		// Map to the newest matching entry: later (newer) entries
+		// overwrite earlier ones, matching addEntry's behavior.
+		id := t.evictCount + uint64(k) + 1
+		t.byName[f.Name] = id
+		t.byNameValue[pairNameValue{f.Name, f.Value}] = id
+	}
 }
 
 // len reports the number of entries in the table.
@@ -54,9 +70,11 @@ func (t *headerFieldTable) len() int {
 
 // addEntry adds a new entry.
 func (t *headerFieldTable) addEntry(f HeaderField) {
-	id := uint64(t.len()) + t.evictCount + 1
-	t.byName[f.Name] = id
-	t.byNameValue[pairNameValue{f.Name, f.Value}] = id
+	if t.byName != nil {
+		id := uint64(t.len()) + t.evictCount + 1
+		t.byName[f.Name] = id
+		t.byNameValue[pairNameValue{f.Name, f.Value}] = id
+	}
 	t.ents = append(t.ents, f)
 }
 
@@ -65,14 +83,16 @@ func (t *headerFieldTable) evictOldest(n int) {
 	if n > t.len() {
 		panic(fmt.Sprintf("evictOldest(%v) on table with %v entries", n, t.len()))
 	}
-	for k := 0; k < n; k++ {
-		f := t.ents[k]
-		id := t.evictCount + uint64(k) + 1
-		if t.byName[f.Name] == id {
-			delete(t.byName, f.Name)
-		}
-		if p := (pairNameValue{f.Name, f.Value}); t.byNameValue[p] == id {
-			delete(t.byNameValue, p)
+	if t.byName != nil {
+		for k := 0; k < n; k++ {
+			f := t.ents[k]
+			id := t.evictCount + uint64(k) + 1
+			if t.byName[f.Name] == id {
+				delete(t.byName, f.Name)
+			}
+			if p := (pairNameValue{f.Name, f.Value}); t.byNameValue[p] == id {
+				delete(t.byNameValue, p)
+			}
 		}
 	}
 	copy(t.ents, t.ents[n:])
@@ -100,6 +120,9 @@ func (t *headerFieldTable) evictOldest(n int) {
 //
 // See Section 2.3.3.
 func (t *headerFieldTable) search(f HeaderField) (i uint64, nameValueMatch bool) {
+	if t.byName == nil {
+		t.buildMaps()
+	}
 	if !f.Sensitive {
 		if id := t.byNameValue[pairNameValue{f.Name, f.Value}]; id != 0 {
 			return t.idToIndex(id), true

--- a/vendor/golang.org/x/net/http2/transport_wrap.go
+++ b/vendor/golang.org/x/net/http2/transport_wrap.go
@@ -237,31 +237,39 @@ type ClientConn struct {
 }
 
 func (cc *ClientConn) roundTrip(req *http.Request) (*http.Response, error) {
-	err := func() error {
+	haveReservation, err := func() (bool, error) {
 		cc.mu.Lock()
 		defer cc.mu.Unlock()
 		if cc.doNotReuse {
-			return errClientConnUnusable
+			return false, errClientConnUnusable
 		}
-		cc.roundTrips++
-		if cc.reserved > 0 {
-			// We've already reserved a concurrency slot for this request.
-			cc.reserved--
-		} else if cc.cc.Reserve() != nil {
-			// We don't seem to have an available concurrency slot,
-			// so bump the pending count (requests waiting for a slot).
-			cc.pending++
-		}
+
 		// ClientConn.Shutdown will not shut down the conn while
 		// cc.starting > 0 or cc.cc.InFlight() > 0.
 		//
 		// The starting state covers the gap between us deciding to
 		// start sending the request, and actually sending it.
 		cc.starting++
-		return nil
+
+		cc.roundTrips++
+		if cc.reserved == 0 {
+			// We do not have a concurrency slot reserved for this request.
+			return false, nil
+		}
+		cc.reserved--
+		return true, nil
 	}()
 	if err != nil {
 		return nil, err
+	}
+	// If we have no reservation, try to acquire one.
+	// (This must be done without cc.mu held, since Reserve may call back to the state hook.)
+	if !haveReservation && cc.cc.Reserve() != nil {
+		// We could not acquire a concurrency slot, so bump the pending count
+		// (requests waiting for a slot).
+		cc.mu.Lock()
+		cc.pending++
+		cc.mu.Unlock()
 	}
 	resp, err := cc.cc.RoundTrip(req)
 	cc.mu.Lock()
@@ -293,16 +301,21 @@ func (cc *ClientConn) ping(ctx context.Context) error {
 }
 
 func (cc *ClientConn) reserveNewRequest() bool {
-	cc.mu.Lock()
-	defer cc.mu.Unlock()
-	if cc.doNotReuse {
-		return false
-	}
 	if err := cc.cc.Reserve(); err != nil {
 		return false
 	}
-	cc.reserved++
-	return true
+	reserved := true
+	cc.mu.Lock()
+	if cc.doNotReuse {
+		reserved = false
+	} else {
+		cc.reserved++
+	}
+	cc.mu.Unlock()
+	if !reserved {
+		cc.cc.Release()
+	}
+	return reserved
 }
 
 func (cc *ClientConn) setDoNotReuse() {

--- a/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
@@ -522,6 +522,12 @@ func (t *http2Server) operateHeaders(ctx context.Context, frame *http2.MetaHeade
 		delete(mdata, "host")
 	}
 
+	// If :authority is still missing, i.e. no host or :authority header is
+	// present, reject the request as invalid.
+	if len(mdata[":authority"]) == 0 {
+		t.writeEarlyAbort(streamID, s.contentSubtype, status.New(codes.Internal, "no host or :authority header present"), http.StatusBadRequest, !frame.StreamEnded())
+		return nil
+	}
 	if frame.StreamEnded() {
 		// s is just created by the caller. No lock needed.
 		s.state = streamReadDone

--- a/vendor/google.golang.org/grpc/version.go
+++ b/vendor/google.golang.org/grpc/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.83.1"
+const Version = "1.83.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -592,8 +592,8 @@ go.uber.org/zap/internal/pool
 go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
-# golang.org/x/crypto v0.55.0
-## explicit; go 1.25.0
+# golang.org/x/crypto v0.56.0
+## explicit; go 1.26.0
 golang.org/x/crypto/cryptobyte
 golang.org/x/crypto/cryptobyte/asn1
 golang.org/x/crypto/hkdf
@@ -607,7 +607,7 @@ golang.org/x/crypto/salsa20/salsa
 ## explicit; go 1.23.0
 golang.org/x/exp/constraints
 golang.org/x/exp/slices
-# golang.org/x/net v0.57.0
+# golang.org/x/net v0.58.0
 ## explicit; go 1.25.0
 golang.org/x/net/context
 golang.org/x/net/html
@@ -693,7 +693,7 @@ google.golang.org/genproto/googleapis/api/httpbody
 ## explicit; go 1.25.0
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.83.1
+# google.golang.org/grpc v1.83.2
 ## explicit; go 1.25.0
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remediates actionable Go-module vulnerabilities in the Linux CCM and CNM images for release-1.31, with verification of all three Linux images.

- Update `golang.org/x/crypto` to `v0.56.0`, `golang.org/x/net` to `v0.58.0`, and `google.golang.org/grpc` to stable `v1.83.2`.
- Use the stable gRPC security patch to retain compatible `otelhttp v0.61.0` without upgrading Kubernetes dependencies.
- Raise the root Go directive and pinned CCM/CNM Go builders to `1.26.0`, as required by `x/crypto v0.56.0`.
- Regenerate module metadata and vendor files.

| Image | Baseline actionable findings | Applied fixes | Final image verification |
|---|---|---|---|
| CCM | 3 fixable Go-module findings | Shared dependency updates and compatible pinned Go builder | Build passed; zero fixable non-toolchain findings |
| CNM | 3 fixable Go-module findings | Same shared dependency updates and compatible pinned Go builder | Build passed; zero fixable non-toolchain findings |
| health-probe-proxy | 0 actionable findings | No module changes | Build passed; zero fixable non-toolchain findings |

CVE-2026-56855, CVE-2026-78662, and CVE-2026-84445 are absent from the rebuilt CCM/CNM images.

Validation:
- All three Linux image builds passed.
- Trivy comprehensive JSON scans completed for all three rebuilt images.
- `make test-unit` passed with the repository's normal `-race` loop: 43 test-bearing packages.
- `sync-go-modules --check-clean` passed on the committed tree.
- `git diff --check` passed.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Compiler findings remain report-only for this module remediation: Trivy reports 33 Go-toolchain findings in each Go 1.26.0 image, compared with 9 in the original CCM/CNM baseline and 20 in the original health-probe-proxy baseline. Compiler patch-version remediation is not included in this PR.

Findings without a fixed version also remain: 21 in CCM/CNM and 20 in health-probe-proxy. This is not a zero-CVE result. Runtime base-image digests and Kubernetes dependency versions are unchanged.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```

