### PR TITLE
refactor: use lowest fixed versions in image CVE plans

### DIFF
--- a/.agents/skills/fix-image-cves/SKILL.md
+++ b/.agents/skills/fix-image-cves/SKILL.md
@@ -5,164 +5,71 @@ description: Scan a built container image with Trivy, classify fixable Go-module
 
 # Fix Image CVEs
 
-## When To Use
+Use `scripts/fix_image_cves.py` for dependency selection, source updates, and
+verification. The helper implements the lowest-fixed-version policy and manages
+module, vendor, and license updates; it does not build or push images.
 
-Use this skill when you need to scan a built container image with Trivy,
-identify fixable CVEs from embedded Go modules or the runtime base image, apply
-the source changes in this repo, and verify that the planned fixes landed.
+Run from the repository root, replacing `<SKILL_DIR>` with this skill directory.
+When running elsewhere, add `--repo <worktree>` to each command.
 
 ## Workflow
 
-Replace `<SKILL_DIR>` with the path to this skill directory.
+1. Scan the built image, specifying the owning module and runtime Dockerfile,
+   then inspect the plan:
 
-1. Scan the built image first. Pass the module root that owns the binary and
-   the Dockerfile that owns the runtime `FROM` line:
+   ```bash
+   python3 <SKILL_DIR>/scripts/fix_image_cves.py scan <image> \
+     --module-root <module-dir> --dockerfile <Dockerfile>
+   python3 <SKILL_DIR>/scripts/fix_image_cves.py plan
+   ```
 
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py scan \
-  <image> \
-  --module-root <module-dir> \
-  --dockerfile <Dockerfile>
-```
+2. Review the plan before changing files and choose any required image targets:
 
-2. Build the actionable plan from the saved scan state:
+   - Select a locally installed Go version satisfying the repository and planned
+     Go directives; do not rely on automatic toolchain downloads.
+   - For a Go directive bump, update older builders for every affected Dockerfile
+     to a stable Go version at least as new as the target. Preserve the builder's
+     registry, repository, and OS variant. Include both `Dockerfile:builder` and
+     `cloud-node-manager.Dockerfile:builder` when the root module needs new builders.
+   - For runtime CVEs, select a fixed base image. Verify target-platform support
+     and the actual digest for every image target; these are agent decisions.
 
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py plan
-```
+3. Preview and apply. Append one
+   `--base-image-target <Dockerfile>:<stage>=<image>@sha256:<digest>` per chosen
+   target to both commands; use `builder` or `runtime` for the stage. Omit the
+   option when no image change is needed.
 
-The plan resolves the target Go modules' own `go` directives without changing
-the repository. If it reports a Go directive bump, select a locally installed
-Go version that is at least the planned target before continuing. Keep
-`GOTOOLCHAIN=local`; do not rely on an automatic toolchain download.
+   ```bash
+   python3 <SKILL_DIR>/scripts/fix_image_cves.py apply --dry-run
+   python3 <SKILL_DIR>/scripts/fix_image_cves.py apply
+   ```
 
-Also bump older Go builder tags and digests in Dockerfiles that build the
-affected module; host Go selection does not change container Go. Keep the
-registry, repository, and OS variant; verify a stable builder Go version at
-least as new as the planned directive, target-platform support, and the digest.
-Pass each target to `apply` as
-`--base-image-target Dockerfile:builder=<image>@sha256:<digest>` (repeat for
-`cloud-node-manager.Dockerfile:builder` when the root module changes). The
-helper records and verifies these edits with the dependency changes.
+4. Verify the source changes:
 
-3. Review the plan before changing files. When base-image CVEs are in scope,
-   decide the deterministic replacement image and digest yourself. Then apply
-   the plan:
+   ```bash
+   python3 <SKILL_DIR>/scripts/fix_image_cves.py verify
+   ```
 
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py apply \
-  --base-image-target <image>@sha256:<digest>
-```
+5. Rebuild the image outside this helper, then rescan that rebuilt image:
 
-Preview the apply step without changing files:
+   ```bash
+   python3 <SKILL_DIR>/scripts/fix_image_cves.py verify \
+     --rescan --image <rebuilt-image>
+   ```
 
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py apply --dry-run
-```
+6. Record results before starting another scan. Clean up after success or an
+   intentional workflow reset:
 
-For multiple Dockerfiles or stages, key each target explicitly:
+   ```bash
+   python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
+   ```
 
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py apply \
-  --base-image-target Dockerfile:runtime=<image>@sha256:<digest>
-```
+## Failures and Reporting
 
-4. Verify the file-level changes. The script checks the resolved Go module
-   versions, `vendor/modules.txt`, Dockerfile `FROM` lines, multi-module
-   `go mod verify`, and a diff scoped to the files recorded during `apply`:
-
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py verify
-```
-
-5. After rebuilding the image outside the skill, verify the image-level result
-   with a Trivy rescan:
-
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py verify \
-  --rescan \
-  --image <rebuilt-image>
-```
-
-6. Remove the state file and any temporary artifacts once the task is done or
-   if you want to reset the workflow:
-
-```bash
-python3 <SKILL_DIR>/scripts/fix_image_cves.py clean
-```
-
-## Notes
-
-- The workflow is intentionally split into `scan`, `plan`, `apply`, `verify`,
-  and `clean` so the agent can inspect the planned dependency and base-image
-  changes before mutating files.
-- `scan` runs `trivy image --detection-priority comprehensive --format json`
-  and records both fixable findings and findings without a `FixedVersion`.
-  `plan` preserves findings without a fixed version as residual risks and never
-  turns them into apply actions.
-- Findings are classified as:
-  `GO_MODULE` for `Class="lang-pkgs"` and `Type="gobinary"`, except for the
-  `stdlib` and `toolchain` pseudo-packages,
-  `GO_TOOLCHAIN` for the `stdlib` and `toolchain` Go runtime pseudo-packages,
-  `BASE_IMAGE` for `Class="os-pkgs"`,
-  `OTHER` for everything else.
-- GO_TOOLCHAIN findings are report-only because they require upgrading the Go
-  compiler or pinned builder image and rebuilding the affected image. They are
-  never passed to `go mod edit`, `go list -m`, or module verification.
-  `apply`, `verify`, and rescan also filter these pseudo-packages defensively
-  when reading a plan saved by an older version of the skill.
-  Builder updates required by planned Go directive bumps are separate from
-  these report-only compiler CVEs.
-- OTHER findings with a non-empty `FixedVersion` are unsupported fixable
-  findings. They require manual remediation and must not be treated as a clean
-  verification result.
-- `plan` groups multiple GO_MODULE CVEs by module path, chooses the highest
-  `FixedVersion` as the minimum required version, and adds Go's required `v`
-  prefix when Trivy reports a digit-leading version. It queries each target
-  module version outside the repository with `GOTOOLCHAIN=local`, groups any
-  newer `go` directive requirements by module root, and plans the highest
-  required directive. BASE_IMAGE findings are grouped into a recommendation
-  that requires an explicit `--base-image-target`.
-- `apply` first verifies that the selected local Go version satisfies both the
-  current repository and planned directives. It applies each planned directive
-  with `go mod edit -go=<version>` before staging every unresolved Go module
-  minimum for the same module root in one `go mod edit` command, then lets
-  `go mod tidy` resolve the complete module graph using Minimal Version
-  Selection. This avoids treating command-line versions as conflicting exact
-  `go get` requests. It then mirrors the repo CI behavior by discovering all
-  tracked `go.mod` files and running `go mod tidy` plus `go mod verify` in every
-  module before `go mod vendor`.
-- When vendoring is enabled at the repo root, `apply` also runs
-  `hack/update-azure-vendor-licenses.sh` so `LICENSES/` stays in sync with
-  `vendor/` and the resulting PR is self-contained. The upstream license
-  generator runs `go list -m all`, which can add otherwise-unused checksums to
-  the root `go.sum`, so `apply` reruns root `go mod tidy` and `go mod verify`
-  after license generation. This keeps the recorded changes clean under the
-  repository's `go-mod-consistency` workflow.
-- `verify` requires each planned `go` directive and resolved or vendored Go
-  module version to be equal to or higher than its planned minimum. It does not
-  assume a clean worktree and compares the current repo diff against the
-  pre-existing changed files plus the files recorded during `apply` so
-  unrelated user edits do not trigger false failures.
-- `apply` refuses planned Go modules with `replace` directives, and `verify`
-  fails resolved or vendored replacements. A replacement module's version does
-  not prove that the original module meets its CVE fix threshold; update or
-  remove the replacement explicitly before using this workflow.
-- The state file is resolved with
-  `git rev-parse --git-path fix-image-cves.json` so it stays untracked and each
-  linked worktree gets isolated scan, plan, apply, and verification state.
-- Helper-owned Git commands are read-only and run with
-  `GIT_OPTIONAL_LOCKS=0`. This prevents `git status` from refreshing the index
-  as an optional side effect without weakening required locking for later
-  checkout, staging, commit, push, or ref-update operations.
-- `verify --rescan` expects the agent to rebuild the image first. The skill
-  does not build or push images.
-- `clean` removes the state file and cleans up any temporary helper artifacts
-  left behind by vendor-license regeneration.
-- `plan`, `apply`, and `verify` set `GOTOOLCHAIN=local` for all Go subprocess calls to
-  match CI behavior (`actions/setup-go` uses `GOTOOLCHAIN=local`). This
-  prevents toolchain auto-download from producing extra `go.sum` entries that
-  fail the Go Module Consistency check. The skill requires a locally installed
-  Go version that satisfies the current and planned repo `go` directives;
-  `apply` performs a preflight check and fails before source mutation with a
-  clear message if the local Go is too old.
+- If the helper stops, preserve its evidence and any partial changes, report the
+  cause, and resolve it before retrying. Do not edit saved state to bypass checks.
+- Report Go toolchain findings (`stdlib`/`toolchain`) and findings without a fixed
+  version as residual risks; the helper does not auto-fix them. Unsupported
+  fixable findings require manual remediation and must not be reported as clean.
+- Distinguish file checks from rebuilt-image verification. A rescan verifies the
+  planned CVEs, not that the entire image is free of vulnerabilities.

--- a/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/fix_image_cves.py
@@ -379,6 +379,28 @@ def highest_fixed_version(values: list[str]) -> str:
     return highest
 
 
+def lowest_fixed_version(fixed_version: str, installed_version: str) -> str:
+    """Select the smallest reported fix strictly newer than the vulnerable version."""
+    installed = normalize_go_version(installed_version)
+    if parse_go_semver(installed) is None:
+        raise CommandError(f"Invalid installed Go version {installed_version!r}; manual review required")
+
+    lowest: str | None = None
+    for value in parse_fixed_version_candidates(fixed_version):
+        candidate = normalize_go_version(value)
+        if parse_go_semver(candidate) is None:
+            raise CommandError(f"Invalid fixed Go version {value!r}; manual review required")
+        if compare_fixed_versions(candidate, installed) <= 0:
+            continue
+        if lowest is None or compare_fixed_versions(candidate, lowest) < 0:
+            lowest = candidate
+    if lowest is None:
+        raise CommandError(
+            f"No fixed version newer than {installed!r} in {fixed_version!r}; manual review required"
+        )
+    return lowest
+
+
 def version_at_least(actual: str, minimum: str) -> bool:
     normalized_actual = normalize_go_version(actual)
     normalized_minimum = normalize_go_version(minimum)
@@ -619,6 +641,10 @@ def build_plan(scan: dict[str, Any]) -> dict[str, Any]:
             finding = {**finding, "category": category}
         if category == "GO_MODULE":
             package = finding["package"]
+            try:
+                minimum = lowest_fixed_version(finding["fixed_version"], finding["installed_version"])
+            except CommandError as exc:
+                raise CommandError(f"Cannot plan {package} ({finding['id']}): {exc}") from exc
             group = go_groups.setdefault(
                 package,
                 {
@@ -627,12 +653,12 @@ def build_plan(scan: dict[str, Any]) -> dict[str, Any]:
                     "module_root": finding["module_root"],
                     "target": finding["target"],
                     "installed_versions": set(),
-                    "fixed_versions": [],
+                    "minimum_fixed_versions": [],
                     "cves": [],
                 },
             )
             group["installed_versions"].add(finding["installed_version"])
-            group["fixed_versions"].append(finding["fixed_version"])
+            group["minimum_fixed_versions"].append(minimum)
             group["cves"].append(finding["id"])
             evidence.append(
                 {
@@ -682,7 +708,7 @@ def build_plan(scan: dict[str, Any]) -> dict[str, Any]:
 
     go_actions = []
     for package, group in sorted(go_groups.items()):
-        fixed_version = highest_fixed_version(group["fixed_versions"])
+        fixed_version = highest_fixed_version(group["minimum_fixed_versions"])
         go_actions.append(
             {
                 "module": package,

--- a/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
+++ b/.agents/skills/fix-image-cves/scripts/test_fix_image_cves.py
@@ -325,6 +325,27 @@ class FixImageCVEsTest(unittest.TestCase):
         self.assertEqual(plan["planned_vulnerability_keys"], [])
         self.assertEqual(plan["other_findings"][0]["category"], "GO_TOOLCHAIN")
 
+    def test_toolchain_findings_do_not_require_a_newer_module_fix(self) -> None:
+        for category in ("GO_MODULE", "GO_TOOLCHAIN"):
+            for package in ("stdlib", "toolchain"):
+                with self.subTest(category=category, package=package):
+                    finding = {
+                        "category": category,
+                        "package": package,
+                        "module_root": ".",
+                        "target": "cloud-controller-manager",
+                        "installed_version": "v1.24.6",
+                        "fixed_version": "1.23.12, 1.24.6",
+                        "id": "CVE-2026-0003",
+                    }
+                    with mock.patch.object(fix_image_cves, "lowest_fixed_version") as select:
+                        plan = fix_image_cves.build_plan({"findings": [finding]})
+
+                    select.assert_not_called()
+                    self.assertEqual(plan["go_module_actions"], [])
+                    self.assertEqual(plan["planned_vulnerability_keys"], [])
+                    self.assertEqual(plan["other_findings"][0]["category"], "GO_TOOLCHAIN")
+
     def test_apply_ignores_toolchain_action_from_older_plan_state(self) -> None:
         state = {
             "scan": {"module_root": ".", "dockerfile": "Dockerfile"},
@@ -779,6 +800,44 @@ class FixImageCVEsTest(unittest.TestCase):
             with self.subTest(versions=versions):
                 self.assertEqual(fix_image_cves.highest_fixed_version(versions), expected)
 
+    def test_lowest_fixed_version_normalizes_and_uses_go_semver_order(self) -> None:
+        cases = [
+            ("0.55.0", "v0.49.0", "v0.55.0"),
+            ("v1.10.0, 1.9.9", "1.9.0", "v1.9.9"),
+            (" , v0.55.0, 0.54.0,, 0.54.0, ", "v0.49.0", "v0.54.0"),
+            ("v1.2.3-rc.2, v1.2.3, v1.2.3-rc.1", "v1.2.2", "v1.2.3-rc.1"),
+            ("v1.2.3-rc.1, v1.2.3, v1.2.3-rc.2", "v1.2.3-rc.1", "v1.2.3-rc.2"),
+            (
+                "v0.0.0-20250101000000-bbbbbbbbbbbb, v0.0.0-20240101000000-aaaaaaaaaaaa",
+                "v0.0.0-20230101000000-cccccccccccc",
+                "v0.0.0-20240101000000-aaaaaaaaaaaa",
+            ),
+            ("2.0.1+incompatible, 2.1.0+incompatible", "v2.0.0+incompatible", "v2.0.1+incompatible"),
+        ]
+        for fixed, installed, expected in cases:
+            with self.subTest(fixed=fixed, installed=installed):
+                self.assertEqual(fix_image_cves.lowest_fixed_version(fixed, installed), expected)
+
+    def test_lowest_fixed_version_rejects_invalid_versions(self) -> None:
+        cases = [
+            ("v1.2.3", ""),
+            ("v1.2.3", "(devel)"),
+            ("", "v1.2.0"),
+            (", ,", "v1.2.0"),
+            ("not-a-version", "v1.2.0"),
+            ("v1.2.3, not-a-version", "v1.2.0"),
+        ]
+        for fixed, installed in cases:
+            with self.subTest(fixed=fixed, installed=installed):
+                with self.assertRaisesRegex(fix_image_cves.CommandError, "Invalid .* Go version"):
+                    fix_image_cves.lowest_fixed_version(fixed, installed)
+
+    def test_lowest_fixed_version_rejects_candidates_at_or_below_installed(self) -> None:
+        for fixed in ("v1.8.7", "v1.9.0", "v1.8.7, v1.9.0", "v1.9.0+build"):
+            with self.subTest(fixed=fixed):
+                with self.assertRaisesRegex(fix_image_cves.CommandError, "No fixed version newer than"):
+                    fix_image_cves.lowest_fixed_version(fixed, "v1.9.0")
+
     def test_build_plan_persists_canonical_go_version(self) -> None:
         plan = fix_image_cves.build_plan(
             {
@@ -797,6 +856,179 @@ class FixImageCVEsTest(unittest.TestCase):
         )
 
         self.assertEqual(plan["go_module_actions"][0]["fixed_version"], "v0.55.0")
+
+    def test_build_plan_uses_lowest_upgrade_for_each_finding(self) -> None:
+        cases = [
+            ([("v1.8.0", "1.9.3, 1.8.7")], "v1.8.7"),
+            (
+                [("v1.8.0", "1.8.7, 1.9.3"), ("v1.8.0", "1.8.8, 1.9.4")],
+                "v1.8.8",
+            ),
+            ([("v1.9.0", "1.8.7, 1.9.3")], "v1.9.3"),
+            (
+                [("v1.8.0", "1.8.7, 1.9.3"), ("v1.9.0", "1.8.8, 1.9.4")],
+                "v1.9.4",
+            ),
+            ([("v0.49.0", "0.54.0"), ("v0.49.0", "0.55.0")], "v0.55.0"),
+        ]
+        for versions, expected in cases:
+            with self.subTest(versions=versions):
+                findings = [
+                    {
+                        "category": "GO_MODULE",
+                        "package": "example.com/dependency",
+                        "module_root": ".",
+                        "target": "cloud-controller-manager",
+                        "installed_version": installed,
+                        "fixed_version": fixed,
+                        "id": f"CVE-2026-{index:04d}",
+                    }
+                    for index, (installed, fixed) in enumerate(versions)
+                ]
+                for ordered in (findings, list(reversed(findings))):
+                    plan = fix_image_cves.build_plan({"findings": ordered})
+                    actions = plan["go_module_actions"]
+                    self.assertEqual(len(actions), 1)
+                    self.assertEqual(actions[0]["fixed_version"], expected)
+                    self.assertEqual(actions[0]["cves"], sorted(f["id"] for f in findings))
+                    self.assertEqual(
+                        plan["planned_vulnerability_keys"],
+                        sorted(fix_image_cves.vuln_key(f) for f in findings),
+                    )
+                    self.assertEqual(
+                        fix_image_cves.build_go_requirement_commands(
+                            actions,
+                            {(".", "example.com/dependency"): versions[-1][0]},
+                        ),
+                        [{
+                            "cwd": ".",
+                            "cmd": [
+                                "go", "mod", "edit",
+                                f"-require=example.com/dependency@{expected}",
+                            ],
+                        }],
+                    )
+
+    def test_cross_branch_plan_still_requires_all_cves_to_disappear_on_rescan(self) -> None:
+        findings = [
+            {
+                "category": "GO_MODULE",
+                "package": "example.com/dependency",
+                "module_root": ".",
+                "target": "cloud-controller-manager",
+                "installed_version": "v1.8.0",
+                "fixed_version": fixed,
+                "id": f"CVE-2026-{index:04d}",
+            }
+            for index, fixed in enumerate(("v1.8.7", "v1.9.4"))
+        ]
+        plan = fix_image_cves.build_plan({"findings": findings})
+        self.assertEqual(plan["go_module_actions"][0]["fixed_version"], "v1.9.4")
+        # A numerically higher release need not include another branch's fix.
+        payload = {"Results": [{
+            "Class": "lang-pkgs",
+            "Type": "gobinary",
+            "Target": "cloud-controller-manager",
+            "Vulnerabilities": [{
+                "PkgName": "example.com/dependency",
+                "InstalledVersion": "v1.9.4",
+                "FixedVersion": "v1.8.7",
+                "VulnerabilityID": findings[0]["id"],
+            }],
+        }]}
+        results = {}
+        with mock.patch.object(
+            fix_image_cves, "ensure_command"
+        ), mock.patch.object(
+            fix_image_cves, "detect_trivy_db_staleness"
+        ), mock.patch.object(fix_image_cves, "run", return_value=json.dumps(payload)):
+            self.assertFalse(fix_image_cves.run_rescan(
+                Path("/repo"), image="local/test:rebuilt", module_root=".",
+                dockerfile="Dockerfile",
+                planned_keys=fix_image_cves.actionable_vulnerability_keys(plan),
+                results=results,
+            ))
+
+        self.assertEqual(
+            results["rescan"]["remaining_vulnerability_keys"],
+            [fix_image_cves.vuln_key(findings[0])],
+        )
+
+    def test_build_plan_rejects_finding_without_a_newer_fix(self) -> None:
+        finding = {
+            "category": "GO_MODULE",
+            "package": "example.com/dependency",
+            "module_root": ".",
+            "target": "cloud-controller-manager",
+            "installed_version": "v1.9.0",
+            "fixed_version": "1.8.7, 1.9.0",
+            "id": "CVE-2026-0001",
+        }
+        with self.assertRaisesRegex(
+            fix_image_cves.CommandError,
+            "example.com/dependency.*CVE-2026-0001.*newer than",
+        ):
+            fix_image_cves.build_plan({"findings": [finding]})
+
+    def test_command_plan_stops_before_saving_unusable_version_metadata(self) -> None:
+        state = {
+            "scan": {
+                "findings": [{
+                    "category": "GO_MODULE",
+                    "package": "example.com/dependency",
+                    "module_root": ".",
+                    "target": "cloud-controller-manager",
+                    "installed_version": "(devel)",
+                    "fixed_version": "v1.2.3",
+                    "id": "CVE-2026-0001",
+                }],
+            },
+        }
+        with mock.patch.object(
+            fix_image_cves, "ensure_repo_root", return_value=Path("/repo")
+        ), mock.patch.object(
+            fix_image_cves, "load_state", return_value=state
+        ), mock.patch.object(
+            fix_image_cves, "build_go_directive_actions"
+        ) as directives, mock.patch.object(
+            fix_image_cves, "save_state"
+        ) as save_state:
+            with self.assertRaisesRegex(
+                fix_image_cves.CommandError, "example.com/dependency.*CVE-2026-0001.*Invalid installed"
+            ):
+                fix_image_cves.command_plan(Namespace(repo="."))
+
+        directives.assert_not_called()
+        save_state.assert_not_called()
+
+    def test_selected_lowest_fix_drives_go_directive_requirement(self) -> None:
+        plan = fix_image_cves.build_plan({
+            "findings": [{
+                "category": "GO_MODULE",
+                "package": "example.com/dependency",
+                "module_root": ".",
+                "target": "cloud-controller-manager",
+                "installed_version": "v1.8.0",
+                "fixed_version": "v1.8.7, v1.9.3",
+                "id": "CVE-2026-0001",
+            }],
+        })
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            (repo_root / "go.mod").write_text(
+                "module example.com/main\n\ngo 1.25.0\n", encoding="utf-8"
+            )
+            with mock.patch.object(
+                fix_image_cves,
+                "target_module_go_directive",
+                side_effect=lambda module, version: {"v1.8.7": "1.25.0", "v1.9.3": "1.26.0"}[version],
+            ) as target_directive:
+                self.assertEqual(
+                    fix_image_cves.build_go_directive_actions(repo_root, plan["go_module_actions"]),
+                    [],
+                )
+
+        target_directive.assert_called_once_with("example.com/dependency", "v1.8.7")
 
     def test_target_module_go_directive_reads_go_mod_without_repo_context(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use the lowest reported fixed version strictly newer than the installed version for each Go module finding, instead of the highest reported alternative. Combine findings for the same module by taking the maximum of those selected minima so every finding's upgrade requirement is retained.

- Stop planning with module and CVE context when version metadata is invalid or no newer fix is available.
- Add regression coverage for version ordering, multi-finding aggregation, Go directive selection, toolchain exclusions, and rescan safeguards.
- Simplify the skill instructions by removing implementation details already enforced by the helper while retaining agent-owned decisions and reporting boundaries.

#### Which issue(s) this PR fixes:

Related: #10054

#### Special notes for your reviewer:

This changes only the shared skill, its helper, and its tests. It does not update provider runtime code, application dependencies, or container images. Go dependency resolution can still select a higher version, and rebuilt-image rescanning remains necessary to verify the planned CVEs are gone.

Validation:

- `python3 -B -m unittest discover -s .agents/skills/fix-image-cves/scripts -p 'test_*.py'` — all 47 tests passed, including the offline Go dependency-resolution test.
- Skill YAML metadata and placeholder checks passed.
- `git diff --check` passed.

No live images were built or scanned for this tooling change; the rescan regression uses mocked Trivy output.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
